### PR TITLE
KAN-213 Update chroot Readme

### DIFF
--- a/computer_science/linux_namespace/chroot/README.md
+++ b/computer_science/linux_namespace/chroot/README.md
@@ -42,6 +42,7 @@ ls -l ./etc/nginx/conf.d/
 4. nginx 디렉터리에서 nginx를 실행 -> nginx 실행되지 않음
 
 ```sh
+mknod -m 666 /dev/null c 1 3
 cd ./nginx
 nginx
 ```
@@ -56,6 +57,10 @@ $ pwd
 $ unshare --mount chroot nginx /bin/bash
 $ nginx -version
 nginx version: nginx/1.27.1
+
+# nginx 실행
+$ mknod -m 666 /dev/null c 1 3
+$ nginx
 ```
 
 ![](./imgs/chroot_with_mount.png)


### PR DESCRIPTION
- chroot로 nginx를 실행할 때 /dev/null이 필요하여, /dev/null파일 생성 명령어를 추가합니다.