### PR TITLE
KAN-217 Update cgroup cpu manifests

### DIFF
--- a/computer_science/linux_cgroup/cpu/README.md
+++ b/computer_science/linux_cgroup/cpu/README.md
@@ -19,10 +19,19 @@ docker run -d --rm  --cpu-shares 512 --cpus "1" --cpuset-cpus 0-0 busybox sh -c 
 
 ```sh
 helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
-helm upgrade --install -f metrics-server/values.yaml -n kube-system metrics-server metrics-server/metrics-server
+helm upgrade --install -f ./manifests/metrics-server/values.yaml -n kube-system metrics-server metrics-server/metrics-server
+kubectl -n kube-system get pod -l app.kubernetes.io/instance=metrics-server
 ```
 
-## 4.2 pod 실행
+## 4.2 cgroup-cpu-worker2 노드에 cpu 제한
+
+```sh
+docker update --cpus "1" --cpuset-cpus "0" cgroup-cpu-worker2
+
+```
+
+
+## 4.3 pod 실행
 
 ```sh
 # pod 실행

--- a/computer_science/linux_cgroup/cpu/kind-config.yaml
+++ b/computer_science/linux_cgroup/cpu/kind-config.yaml
@@ -10,12 +10,5 @@ nodes:
     tier: infra
 - role: worker
   image: kindest/node:v1.29.1
-  kubeadmConfigPatches:
-  - |
-    kind: JoinConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "tier=service-a"
-        cpu-manager-policy: static
-        reserved-cpus: "0"
-        system-reserved: "cpu=1"
+  labels:
+    tier: service-a

--- a/computer_science/linux_cgroup/cpu/manifests/request_cpu/pod2.yaml
+++ b/computer_science/linux_cgroup/cpu/manifests/request_cpu/pod2.yaml
@@ -31,4 +31,4 @@ spec:
         - while :; do :; done
         resources:
           requests:
-            cpu: "0.3"
+            cpu: "0.5"


### PR DESCRIPTION
- cpu cgroup 예제를 수정합니다.
- worker2번 노드가 1cpu만 설정하도록 제한합니다.