### PR TITLE
KAN-227 Add istio dashboard on grafana helm chart

### DIFF
--- a/kubernetes/istio/install/argocd_bootstrap/values/grafana.yaml
+++ b/kubernetes/istio/install/argocd_bootstrap/values/grafana.yaml
@@ -8,6 +8,34 @@ datasources:
       access: proxy
       isDefault: true
 
+dashboards:
+  default:
+    # reference: https://grafana.com/grafana/dashboards/7639-istio-mesh-dashboard/
+    istio-mesh-dashboard:
+      gnetId: 7639
+      revision: 236
+      datasource: Prometheus
+    # reference: https://grafana.com/grafana/dashboards/7636-istio-service-dashboard/
+    istio-service-dashboard:
+      gnetId: 7636
+      revision: 236
+      datasource: Prometheus
+    # reference: https://grafana.com/grafana/dashboards/7630-istio-workload-dashboard/
+    istio-workload-dashboard:
+      gnetId: 7630
+      revision: 236
+      datasource: Prometheus
+    # reference: https://grafana.com/grafana/dashboards/11829-istio-performance-dashboard/
+    istio-performance-dashboard:
+      gnetId: 11829
+      revision: 236
+      datasource: Prometheus
+    # reference: https://grafana.com/grafana/dashboards/13277-istio-wasm-extension-dashboard/
+    istio-wasm-dashboard:
+      gnetId: 13277
+      revision: 193
+      datasource: Prometheus
+
 ingress:
   enabled: true
   ingressClassName: alb


### PR DESCRIPTION
- istio 예제 grafana에 grafana dashboard를 helm valeus에 추가합니다.
- istio sample dashboard를 사용했습니다.

![CleanShot 2024-11-24 at 20 51 35@2x](https://github.com/user-attachments/assets/21c053ca-5eea-490e-9215-e15d5fe2a5fa)
