### PR TITLE
KAN-227 Add istio dashboard provider on grafana helm chart

### DIFF
--- a/kubernetes/istio/install/argocd_bootstrap/values/grafana.yaml
+++ b/kubernetes/istio/install/argocd_bootstrap/values/grafana.yaml
@@ -8,6 +8,19 @@ datasources:
       access: proxy
       isDefault: true
 
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      editable: true
+      options:
+        path: /var/lib/grafana/dashboards/default
+
 dashboards:
   default:
     # reference: https://grafana.com/grafana/dashboards/7639-istio-mesh-dashboard/


### PR DESCRIPTION
grafana helm chart에서 grafana lab dashboard를 사용하기 위해 provider를 설정합니다.