### PR TITLE
Fix: disable EKS auto mode config on gpu example

### DIFF
--- a/kubernetes/eks/gpu_node/terraform/terraform.tfvars
+++ b/kubernetes/eks/gpu_node/terraform/terraform.tfvars
@@ -15,10 +15,7 @@ enable_amp = false
 
 auto_mode_enabled = false
 
-cluster_compute_config = {
-  enabled    = false
-  node_pools = ["general-purpose", "system"]
-}
+cluster_compute_config = {}
 
 ######################################################################
 # Managed Node Groups


### PR DESCRIPTION
EKS gpu 예제에서 auto mode 컴퓨팅 자원 옵션을 제거합니다.