### PR TITLE
Remove private route53 and replace to public route53 #251

### DIFF
--- a/aws/codebuild/github_action/applications/java_modules/welcome-lib/pom.xml
+++ b/aws/codebuild/github_action/applications/java_modules/welcome-lib/pom.xml
@@ -30,18 +30,4 @@
       <url>https://nexus.choilab.xyz/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
-
-  <repositories>
-    <repository>
-      <id>private-nexus-releases</id>
-      <name>Private Nexus Release Repository</name>
-      <url>http://nexus.internal.com/repository/maven-releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 </project>

--- a/aws/codebuild/github_action/applications/springboot_app/codebuild/pom.xml
+++ b/aws/codebuild/github_action/applications/springboot_app/codebuild/pom.xml
@@ -34,7 +34,7 @@
 		<repository>
 			<id>private-nexus-releases</id>
 			<name>Private Nexus Release Repository</name>
-			<url>http://nexus.internal.com/repository/maven-releases/</url>
+			<url>https://nexus-internal.choilab.xyz/repository/maven-releases/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/aws/codebuild/github_action/terraform/_modules/outputs.tf
+++ b/aws/codebuild/github_action/terraform/_modules/outputs.tf
@@ -42,3 +42,13 @@ output "nexus_url" {
   description = "Nexus URL"
   value       = "https://${aws_route53_record.nexus.name}"
 }
+
+output "nexus_internal_url" {
+  description = "Nexus internal URL"
+  value       = "https://${aws_route53_record.nexus_internal.name}"
+}
+
+output "private_alb_dns_name" {
+  description = "Private ALB DNS name"
+  value       = aws_lb.nexus_private.dns_name
+}

--- a/aws/codebuild/github_action/terraform/_modules/private_alb.tf
+++ b/aws/codebuild/github_action/terraform/_modules/private_alb.tf
@@ -1,0 +1,103 @@
+resource "aws_security_group" "private_alb" {
+  name        = "${var.name_prefix}-private-alb-sg"
+  description = "Security group for Private ALB"
+  vpc_id      = var.vpc_id
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-private-alb-sg"
+    }
+  )
+}
+
+resource "aws_vpc_security_group_ingress_rule" "private_alb_https" {
+  security_group_id = aws_security_group.private_alb.id
+  description       = "Allow HTTPS from VPC"
+  cidr_ipv4         = var.vpc_cidr
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+
+  tags = {
+    Name = "private-alb-https"
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "private_alb_all" {
+  security_group_id = aws_security_group.private_alb.id
+  description       = "Allow all outbound traffic"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+
+  tags = {
+    Name = "private-alb-egress-all"
+  }
+}
+
+resource "aws_lb" "nexus_private" {
+  name               = "${var.name_prefix}-nexus-private-alb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.private_alb.id]
+  subnets            = var.private_subnets
+
+  enable_deletion_protection = false
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-nexus-private-alb"
+    }
+  )
+}
+
+resource "aws_lb_target_group" "nexus_private" {
+  name     = "${var.name_prefix}-nexus-private-tg"
+  port     = 8081
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    path                = "/"
+    matcher             = "200,303"
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-nexus-private-tg"
+    }
+  )
+}
+
+resource "aws_lb_target_group_attachment" "nexus_private" {
+  target_group_arn = aws_lb_target_group.nexus_private.arn
+  target_id        = aws_instance.nexus.id
+  port             = 8081
+}
+
+resource "aws_lb_listener" "nexus_private_https" {
+  load_balancer_arn = aws_lb.nexus_private.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.private_acm_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.nexus_private.arn
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.name_prefix}-nexus-private-listener"
+    }
+  )
+}

--- a/aws/codebuild/github_action/terraform/_modules/route53.tf
+++ b/aws/codebuild/github_action/terraform/_modules/route53.tf
@@ -14,3 +14,15 @@ resource "aws_route53_record" "nexus" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "nexus_internal" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = "${var.nexus_internal_subdomain}.${var.route53_zone_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.nexus_private.dns_name
+    zone_id                = aws_lb.nexus_private.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/aws/codebuild/github_action/terraform/_modules/security_groups.tf
+++ b/aws/codebuild/github_action/terraform/_modules/security_groups.tf
@@ -52,14 +52,27 @@ resource "aws_security_group" "nexus_ec2" {
 
 resource "aws_vpc_security_group_ingress_rule" "nexus_from_alb" {
   security_group_id            = aws_security_group.nexus_ec2.id
-  description                  = "Allow traffic from ALB"
+  description                  = "Allow traffic from public ALB"
   referenced_security_group_id = aws_security_group.alb.id
   from_port                    = 8081
   to_port                      = 8081
   ip_protocol                  = "tcp"
 
   tags = {
-    Name = "nexus-from-alb"
+    Name = "nexus-from-public-alb"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "nexus_from_private_alb" {
+  security_group_id            = aws_security_group.nexus_ec2.id
+  description                  = "Allow traffic from private ALB"
+  referenced_security_group_id = aws_security_group.private_alb.id
+  from_port                    = 8081
+  to_port                      = 8081
+  ip_protocol                  = "tcp"
+
+  tags = {
+    Name = "nexus-from-private-alb"
   }
 }
 

--- a/aws/codebuild/github_action/terraform/_modules/variables.tf
+++ b/aws/codebuild/github_action/terraform/_modules/variables.tf
@@ -40,7 +40,7 @@ variable "nexus_root_volume_size" {
 }
 
 variable "acm_certificate_arn" {
-  description = "ACM certificate ARN"
+  description = "ACM certificate ARN for public ALB"
   type        = string
 }
 
@@ -54,8 +54,29 @@ variable "nexus_subdomain" {
   type        = string
 }
 
+variable "nexus_internal_subdomain" {
+  description = "Subdomain for internal Nexus (e.g., nexus-internal)"
+  type        = string
+  default     = "nexus-internal"
+}
+
+variable "private_acm_certificate_arn" {
+  description = "ACM certificate ARN for private ALB"
+  type        = string
+}
+
 variable "tags" {
   description = "Tags to apply to resources"
   type        = map(string)
   default     = {}
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR block"
+  type        = string
+}
+
+variable "private_subnets" {
+  description = "Private subnet IDs for Private ALB and CodeBuild"
+  type        = list(string)
 }

--- a/aws/codebuild/github_action/terraform/codebuild.tf
+++ b/aws/codebuild/github_action/terraform/codebuild.tf
@@ -1,0 +1,157 @@
+resource "aws_security_group" "codebuild" {
+  name        = "${local.name_prefix}-codebuild"
+  description = "Security group for CodeBuild"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = merge(
+    local.common_tags,
+    {
+      Name = "${local.name_prefix}-codebuild"
+    }
+  )
+}
+
+resource "aws_vpc_security_group_egress_rule" "codebuild_all" {
+  security_group_id = aws_security_group.codebuild.id
+  description       = "Allow all outbound traffic"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+
+  tags = {
+    Name = "codebuild-egress-all"
+  }
+}
+
+data "aws_iam_policy_document" "codebuild_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["codebuild.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "codebuild" {
+  name               = "${local.name_prefix}-codebuild-role"
+  assume_role_policy = data.aws_iam_policy_document.codebuild_assume_role.json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "codebuild" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      "arn:aws:logs:${var.aws_region}:*:log-group:/aws/codebuild/${local.name_prefix}-*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeDhcpOptions",
+      "ec2:DescribeVpcs",
+      "ec2:CreateNetworkInterfacePermission"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "codeconnections:GetConnectionToken",
+      "codeconnections:GetConnection",
+      "codeconnections:UseConnection"
+    ]
+    resources = [var.codebuild_source_identifier]
+  }
+}
+
+resource "aws_iam_role_policy" "codebuild" {
+  role   = aws_iam_role.codebuild.name
+  policy = data.aws_iam_policy_document.codebuild.json
+}
+
+resource "aws_cloudwatch_log_group" "codebuild" {
+  name              = "/aws/codebuild/${local.name_prefix}-github-action"
+  retention_in_days = 7
+
+  tags = local.common_tags
+}
+
+resource "aws_codebuild_project" "github_action" {
+  name          = "${local.name_prefix}-github-action"
+  description   = "CodeBuild project for GitHub Actions"
+  service_role  = aws_iam_role.codebuild.arn
+  build_timeout = 60
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = var.codebuild_compute_type
+    image                       = "aws/codebuild/amazonlinux2-aarch64-standard:3.0"
+    type                        = "ARM_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = false
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = var.github_repository_url
+    git_clone_depth = 1
+
+    git_submodules_config {
+      fetch_submodules = false
+    }
+
+    auth {
+      type     = "CODECONNECTIONS"
+      resource = var.codebuild_source_identifier
+    }
+  }
+
+  source_version = var.github_branch
+
+  vpc_config {
+    vpc_id             = module.vpc.vpc_id
+    subnets            = module.vpc.private_subnets
+    security_group_ids = [aws_security_group.codebuild.id]
+  }
+
+  logs_config {
+    cloudwatch_logs {
+      status     = "ENABLED"
+      group_name = aws_cloudwatch_log_group.codebuild.name
+    }
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_codebuild_webhook" "github_action" {
+  project_name = aws_codebuild_project.github_action.name
+  build_type   = "BUILD"
+
+  filter_group {
+    filter {
+      type    = "EVENT"
+      pattern = "WORKFLOW_JOB_QUEUED"
+    }
+  }
+}

--- a/aws/codebuild/github_action/terraform/nexus.tf
+++ b/aws/codebuild/github_action/terraform/nexus.tf
@@ -12,42 +12,26 @@ locals {
   }
 }
 
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.0"
-
-  name = local.name_prefix
-  cidr = var.vpc_cidr
-
-  azs             = var.azs
-  private_subnets = var.private_subnets
-  public_subnets  = var.public_subnets
-
-  enable_nat_gateway = true
-  single_nat_gateway = true
-
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  tags = local.common_tags
-}
-
 module "nexus" {
   source = "./_modules"
 
   name_prefix       = local.name_prefix
   vpc_id            = module.vpc.vpc_id
+  vpc_cidr          = var.vpc_cidr
   public_subnets    = module.vpc.public_subnets
+  private_subnets   = module.vpc.private_subnets
   nexus_subnet_id   = module.vpc.private_subnets[0]
-  alb_allowed_cidrs = concat([module.vpc.vpc_cidr_block], var.alb_allowed_cidrs)
+  alb_allowed_cidrs = concat(var.alb_allowed_cidrs)
 
   nexus_instance_type    = var.nexus_instance_type
   nexus_admin_password   = var.nexus_admin_password
   nexus_root_volume_size = var.nexus_root_volume_size
 
-  acm_certificate_arn = data.aws_acm_certificate.this.arn
-  route53_zone_name   = var.route53_zone_name
-  nexus_subdomain     = var.nexus_subdomain
+  acm_certificate_arn         = data.aws_acm_certificate.this.arn
+  private_acm_certificate_arn = data.aws_acm_certificate.this.arn
+  route53_zone_name           = var.route53_zone_name
+  nexus_subdomain             = var.nexus_subdomain
+  nexus_internal_subdomain    = var.nexus_internal_subdomain
 
   tags = local.common_tags
 }

--- a/aws/codebuild/github_action/terraform/outputs.tf
+++ b/aws/codebuild/github_action/terraform/outputs.tf
@@ -32,3 +32,28 @@ output "nexus_url" {
   description = "Nexus URL"
   value       = module.nexus.nexus_url
 }
+
+output "nexus_internal_url" {
+  description = "Nexus internal URL for CodeBuild"
+  value       = module.nexus.nexus_internal_url
+}
+
+output "private_alb_dns_name" {
+  description = "Private ALB DNS name"
+  value       = module.nexus.private_alb_dns_name
+}
+
+output "codebuild_project_name" {
+  description = "CodeBuild project name"
+  value       = aws_codebuild_project.github_action.name
+}
+
+output "codebuild_project_arn" {
+  description = "CodeBuild project ARN"
+  value       = aws_codebuild_project.github_action.arn
+}
+
+output "codebuild_role_arn" {
+  description = "CodeBuild IAM role ARN"
+  value       = aws_iam_role.codebuild.arn
+}

--- a/aws/codebuild/github_action/terraform/terraform.tfvars.example
+++ b/aws/codebuild/github_action/terraform/terraform.tfvars.example
@@ -13,6 +13,12 @@ nexus_root_volume_size = 30
 # "YOUR_HOME_IP/32"
 alb_allowed_cidrs = []
 
-route53_zone_name = "example.xyz"
-acm_domain_name   = "*.example.xyz"
-nexus_subdomain   = "nexus"
+route53_zone_name        = "example.xyz"
+acm_domain_name          = "*.example.xyz"
+nexus_subdomain          = "nexus"
+nexus_internal_subdomain = "nexus-internal"
+
+github_repository_url       = "https://github.com/your-org/your-repo"
+github_branch               = "master"
+codebuild_source_identifier = "arn:aws:codeconnections:ap-northeast-2:123456789012:connection/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+codebuild_compute_type      = "BUILD_GENERAL1_SMALL"

--- a/aws/codebuild/github_action/terraform/variables.tf
+++ b/aws/codebuild/github_action/terraform/variables.tf
@@ -67,8 +67,36 @@ variable "nexus_subdomain" {
   default     = "nexus"
 }
 
+variable "nexus_internal_subdomain" {
+  description = "Subdomain for internal Nexus (e.g., nexus-internal)"
+  type        = string
+  default     = "nexus-internal"
+}
+
 variable "nexus_root_volume_size" {
   description = "Root volume size for Nexus EC2 in GB"
   type        = number
   default     = 30
+}
+
+variable "github_repository_url" {
+  description = "GitHub repository URL"
+  type        = string
+}
+
+variable "github_branch" {
+  description = "GitHub branch to build"
+  type        = string
+  default     = "master"
+}
+
+variable "codebuild_source_identifier" {
+  description = "CodeBuild source connection ARN (created manually in AWS Console)"
+  type        = string
+}
+
+variable "codebuild_compute_type" {
+  description = "CodeBuild Fleet compute type"
+  type        = string
+  default     = "BUILD_GENERAL1_SMALL"
 }

--- a/aws/codebuild/github_action/terraform/vpc.tf
+++ b/aws/codebuild/github_action/terraform/vpc.tf
@@ -1,0 +1,19 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name_prefix
+  cidr = var.vpc_cidr
+
+  azs             = var.azs
+  private_subnets = var.private_subnets
+  public_subnets  = var.public_subnets
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = local.common_tags
+}


### PR DESCRIPTION
- codebuild 예제에서 테라폼으로 codebuild를 생성하는 코드를 생성합니다.
- private route53으로 설정했던 ineternal nexus endpoint를 public route53으로 변경합니다. nexus가 http는 block하고 있어 ACM이 있는 public route53으로 변경했습니다.

<img width="3626" height="1120" alt="CleanShot-2025-10-19-at-17-55-44@2x" src="https://github.com/user-attachments/assets/8362d2d2-5ef9-4fe2-97f0-416bb3d71734" />
