### PR TITLE
feat(vscode-theme): add Akbun Theme with dark/light variants

### DIFF
--- a/tools/akbun-vscode-theme/CLAUDE.md
+++ b/tools/akbun-vscode-theme/CLAUDE.md
@@ -1,0 +1,88 @@
+# Akbun VS Code Theme
+
+## 프로젝트 개요
+
+HCL(Terraform), Ansible, Python, JavaScript 개발자를 위한 VS Code 테마 확장.
+밝은 환경에서는 Light, 어두운 환경에서는 Dark 테마를 사용하여 눈 피로를 줄이는 것이 목적.
+
+## 테마 디자인 원칙
+
+### Dark (Akbun Dark)
+- **베이스**: Catppuccin Mocha 컬러 팔레트 기반
+- **배경**: `#1e1e2e` (Mocha Base) - 따뜻한 다크 톤
+- **텍스트**: `#cdd6f4` (Mocha Text)
+- **액센트**: Mauve(`#cba6f7`) - 탭 상단 보더, 버튼, 배지
+- **특징**: 파스텔 톤 syntax color로 장시간 코딩 시 눈 피로 최소화
+
+### Light (Akbun Light)
+- **베이스**: Catppuccin Latte 팔레트 + Claude 모바일앱 디자인
+- **배경**: `#faf9f5` (Claude 모바일앱 warm off-white)
+- **사이드바**: `#f5f4ed` (Claude 모바일앱 warm grey)
+- **텍스트**: `#4c4f69` (Latte Text - dark charcoal)
+- **액센트**: `#a84e30` (Claude terracotta, WCAG-darkened) - 탭 상단 보더, 버튼, 배지
+- **특징**: 따뜻한 크림톤 배경으로 차가운 흰색 대비 눈 피로 감소
+- **중요**: Latte 팔레트를 warm off-white 배경에 맞게 WCAG AA 4.5:1 이상으로 darkened
+
+## 언어별 Syntax 컬러 매핑
+
+Light 테마의 색상은 Catppuccin Latte 기반이지만, `#faf9f5` 배경에서 WCAG AA 4.5:1 대비율을 충족하도록 어둡게 조정.
+
+| 요소             | Dark              | Light             |
+|------------------|-------------------|-------------------|
+| 키워드           | Mauve `#cba6f7`   | Mauve `#7630c5`   |
+| 함수 이름        | Blue `#89b4fa`    | Blue `#1858d9`    |
+| 함수 파라미터    | Flamingo `#f2cdcd`| Flamingo `#b04e4e`|
+| 문자열           | Green `#a6e3a1`   | Green `#2e7d20`   |
+| 숫자             | Peach `#fab387`   | Peach `#b84800`   |
+| 클래스/타입      | Yellow `#f9e2af`  | Yellow `#9a650f`  |
+| 프로퍼티         | Lavender `#b4befe`| Lavender `#4c5ec8`|
+| 주석             | Overlay `#838799` | Subtext0 `#6c6f85`|
+| 연산자           | Sky `#89dceb`     | Teal `#0d6d73`    |
+| self/this        | Red `#f38ba8`     | Red `#d20f39`     |
+| 데코레이터       | Peach `#fab387`   | Peach `#b84800`   |
+
+## 파일 구조
+
+```
+tools/akbun-vscode-theme/
+├── CLAUDE.md              # 이 파일
+├── package.json           # VS Code 확장 매니페스트
+├── themes/
+│   ├── akbun-dark.json    # 다크 테마 정의
+│   └── akbun-light.json   # 라이트 테마 정의
+├── test/
+│   ├── theme-validator.js   # 테마 JSON 구조/필수 키 검증
+│   ├── contrast-checker.js  # WCAG 대비율 검증
+│   └── samples/             # 테스트용 샘플 코드 파일
+│       ├── sample.py
+│       ├── sample.js
+│       ├── sample.tf
+│       └── sample.yaml
+└── images/                # 스크린샷 (선택)
+```
+
+## 빌드 & 테스트
+
+```bash
+# 테마 JSON 구조 검증
+node test/theme-validator.js
+
+# WCAG 대비율 검증
+node test/contrast-checker.js
+
+# 전체 테스트
+npm test
+
+# VS Code에서 테마 직접 테스트
+# 1. 이 폴더를 VS Code로 열기
+# 2. F5 (Extension Development Host 실행)
+# 3. Ctrl+K Ctrl+T 로 "Akbun Dark" 또는 "Akbun Light" 선택
+# 4. test/samples/ 폴더의 샘플 파일을 열어 syntax highlighting 확인
+```
+
+## 수정 시 주의사항
+
+- `themes/*.json` 파일 수정 후 반드시 `npm test` 실행하여 검증
+- 새로운 색상 추가 시 WCAG AA 기준(일반 텍스트 4.5:1, 큰 텍스트 3:1) 충족 확인
+- Dark/Light 테마의 동일 요소는 동일한 Catppuccin 색상 이름(다른 명도)을 사용
+- HCL, Ansible, Python, JavaScript 4개 언어의 syntax highlighting 일관성 유지

--- a/tools/akbun-vscode-theme/package.json
+++ b/tools/akbun-vscode-theme/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "akbun-theme",
+  "displayName": "Akbun Theme",
+  "description": "A soothing VS Code theme with dark (Catppuccin-inspired) and light (Claude-inspired warm) variants. Optimized for HCL, Ansible, Python, and JavaScript with low eye-strain contrast.",
+  "version": "0.1.0",
+  "publisher": "choisungwook",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.74.0"
+  },
+  "categories": [
+    "Themes"
+  ],
+  "keywords": [
+    "theme",
+    "dark",
+    "light",
+    "catppuccin",
+    "claude",
+    "akbun",
+    "hcl",
+    "terraform",
+    "ansible",
+    "python",
+    "javascript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/choisungwook/portfolio"
+  },
+  "contributes": {
+    "themes": [
+      {
+        "label": "Akbun Dark",
+        "uiTheme": "vs-dark",
+        "path": "./themes/akbun-dark.json"
+      },
+      {
+        "label": "Akbun Light",
+        "uiTheme": "vs",
+        "path": "./themes/akbun-light.json"
+      }
+    ]
+  },
+  "scripts": {
+    "test": "node test/theme-validator.js",
+    "test:contrast": "node test/contrast-checker.js",
+    "test:all": "node test/theme-validator.js && node test/contrast-checker.js"
+  },
+  "devDependencies": {}
+}

--- a/tools/akbun-vscode-theme/test/contrast-checker.js
+++ b/tools/akbun-vscode-theme/test/contrast-checker.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * WCAG Contrast Ratio Checker - Akbun VS Code Theme
+ *
+ * Verifies that foreground/background color combinations meet
+ * WCAG AA accessibility standards:
+ * - Normal text: minimum 4.5:1 contrast ratio
+ * - Large text / UI components: minimum 3:1 contrast ratio
+ *
+ * References:
+ * - https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const THEMES_DIR = path.join(__dirname, "..", "themes");
+
+// Minimum contrast ratios (WCAG AA)
+const MIN_NORMAL_TEXT = 4.5;
+const MIN_LARGE_TEXT = 3.0;
+
+let totalErrors = 0;
+let totalWarnings = 0;
+let totalChecks = 0;
+
+function error(msg) {
+  totalErrors++;
+  console.error(`  FAIL: ${msg}`);
+}
+
+function warn(msg) {
+  totalWarnings++;
+  console.warn(`  WARN: ${msg}`);
+}
+
+function pass(msg) {
+  totalChecks++;
+  console.log(`  PASS: ${msg}`);
+}
+
+/**
+ * Parse hex color to RGB values.
+ * Supports #RRGGBB and #RRGGBBAA (alpha is ignored for contrast).
+ */
+function hexToRgb(hex) {
+  const cleaned = hex.replace("#", "");
+  return {
+    r: parseInt(cleaned.substring(0, 2), 16),
+    g: parseInt(cleaned.substring(2, 4), 16),
+    b: parseInt(cleaned.substring(4, 6), 16),
+  };
+}
+
+/**
+ * Calculate relative luminance per WCAG 2.1
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+function relativeLuminance(rgb) {
+  const [rs, gs, bs] = [rgb.r / 255, rgb.g / 255, rgb.b / 255];
+  const r = rs <= 0.03928 ? rs / 12.92 : Math.pow((rs + 0.055) / 1.055, 2.4);
+  const g = gs <= 0.03928 ? gs / 12.92 : Math.pow((gs + 0.055) / 1.055, 2.4);
+  const b = bs <= 0.03928 ? bs / 12.92 : Math.pow((bs + 0.055) / 1.055, 2.4);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Calculate contrast ratio between two colors
+ * https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+ */
+function contrastRatio(hex1, hex2) {
+  const l1 = relativeLuminance(hexToRgb(hex1));
+  const l2 = relativeLuminance(hexToRgb(hex2));
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Check a foreground/background pair against a minimum ratio
+ */
+function checkContrast(fg, bg, label, minRatio) {
+  // Strip alpha channel for contrast calculation
+  const fgClean = fg.substring(0, 7);
+  const bgClean = bg.substring(0, 7);
+  const ratio = contrastRatio(fgClean, bgClean);
+  const ratioStr = ratio.toFixed(2);
+
+  if (ratio >= minRatio) {
+    pass(`${label}: ${ratioStr}:1 (min ${minRatio}:1) [${fgClean} on ${bgClean}]`);
+  } else {
+    error(`${label}: ${ratioStr}:1 < ${minRatio}:1 [${fgClean} on ${bgClean}]`);
+  }
+}
+
+function checkTheme(filePath) {
+  const fileName = path.basename(filePath);
+  console.log(`\n--- Contrast check: ${fileName} ---`);
+
+  let theme;
+  try {
+    theme = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (e) {
+    error(`Cannot parse theme: ${e.message}`);
+    return;
+  }
+
+  const colors = theme.colors || {};
+  const bg = colors["editor.background"];
+  const fg = colors["editor.foreground"];
+
+  if (!bg || !fg) {
+    error("Missing editor.background or editor.foreground");
+    return;
+  }
+
+  // 1. Editor text on editor background (normal text)
+  checkContrast(fg, bg, "Editor text", MIN_NORMAL_TEXT);
+
+  // 2. Line numbers on editor background (large text / UI)
+  if (colors["editorLineNumber.foreground"]) {
+    checkContrast(colors["editorLineNumber.foreground"], bg, "Line number (inactive)", MIN_LARGE_TEXT);
+  }
+  if (colors["editorLineNumber.activeForeground"]) {
+    checkContrast(colors["editorLineNumber.activeForeground"], bg, "Line number (active)", MIN_NORMAL_TEXT);
+  }
+
+  // 3. Sidebar text on sidebar background
+  const sidebarBg = colors["sideBar.background"] || bg;
+  const sidebarFg = colors["sideBar.foreground"] || fg;
+  checkContrast(sidebarFg, sidebarBg, "Sidebar text", MIN_NORMAL_TEXT);
+
+  // 4. Tab text on tab background
+  if (colors["tab.activeForeground"] && colors["tab.activeBackground"]) {
+    checkContrast(colors["tab.activeForeground"], colors["tab.activeBackground"], "Active tab", MIN_NORMAL_TEXT);
+  }
+  if (colors["tab.inactiveForeground"] && colors["tab.inactiveBackground"]) {
+    checkContrast(colors["tab.inactiveForeground"], colors["tab.inactiveBackground"], "Inactive tab", MIN_LARGE_TEXT);
+  }
+
+  // 5. StatusBar text on background
+  if (colors["statusBar.foreground"] && colors["statusBar.background"]) {
+    checkContrast(colors["statusBar.foreground"], colors["statusBar.background"], "Status bar", MIN_NORMAL_TEXT);
+  }
+
+  // 6. Terminal foreground on background
+  if (colors["terminal.foreground"] && colors["terminal.background"]) {
+    checkContrast(colors["terminal.foreground"], colors["terminal.background"], "Terminal text", MIN_NORMAL_TEXT);
+  }
+
+  // 7. Button text on button background
+  if (colors["button.foreground"] && colors["button.background"]) {
+    checkContrast(colors["button.foreground"], colors["button.background"], "Button text", MIN_NORMAL_TEXT);
+  }
+
+  // 8. Badge text on badge background
+  if (colors["badge.foreground"] && colors["badge.background"]) {
+    checkContrast(colors["badge.foreground"], colors["badge.background"], "Badge", MIN_NORMAL_TEXT);
+  }
+
+  // 9. Syntax token colors on editor background
+  console.log(`\n  -- Syntax colors on editor background --`);
+  const tokenColors = theme.tokenColors || [];
+  for (const tc of tokenColors) {
+    if (tc.settings && tc.settings.foreground && tc.name) {
+      const tokenFg = tc.settings.foreground;
+      // Skip colors with alpha < FF (semi-transparent)
+      if (tokenFg.length > 7) continue;
+      checkContrast(tokenFg, bg, `Syntax: ${tc.name}`, MIN_NORMAL_TEXT);
+    }
+  }
+
+  // 10. ActivityBar badge contrast
+  if (colors["activityBarBadge.foreground"] && colors["activityBarBadge.background"]) {
+    checkContrast(
+      colors["activityBarBadge.foreground"],
+      colors["activityBarBadge.background"],
+      "Activity bar badge",
+      MIN_NORMAL_TEXT
+    );
+  }
+}
+
+// Run
+console.log("=== Akbun Theme WCAG Contrast Checker ===");
+
+checkTheme(path.join(THEMES_DIR, "akbun-dark.json"));
+checkTheme(path.join(THEMES_DIR, "akbun-light.json"));
+
+console.log(`\n=== Results: ${totalErrors} failures, ${totalWarnings} warnings, ${totalChecks} passed ===`);
+
+if (totalErrors > 0) {
+  console.error("\nCONTRAST CHECK HAS FAILURES - review colors above");
+  process.exit(1);
+} else {
+  console.log("\nALL CONTRAST CHECKS PASSED");
+  process.exit(0);
+}

--- a/tools/akbun-vscode-theme/test/samples/sample.js
+++ b/tools/akbun-vscode-theme/test/samples/sample.js
@@ -1,0 +1,162 @@
+/**
+ * Sample JavaScript file for Akbun Theme syntax highlighting test.
+ * Covers: classes, arrow functions, template literals, async/await,
+ *         destructuring, spread, modules, etc.
+ */
+
+import { EventEmitter } from "events";
+
+// Constants
+const MAX_CONNECTIONS = 100;
+const DEFAULT_PORT = 3000;
+const API_VERSION = "v2";
+
+/**
+ * Rate limiter using token bucket algorithm.
+ */
+class RateLimiter {
+  #tokens;
+  #maxTokens;
+  #refillRate;
+  #lastRefill;
+
+  constructor(maxTokens = 10, refillRate = 1) {
+    this.#tokens = maxTokens;
+    this.#maxTokens = maxTokens;
+    this.#refillRate = refillRate;
+    this.#lastRefill = Date.now();
+  }
+
+  tryConsume(count = 1) {
+    this.#refill();
+    if (this.#tokens >= count) {
+      this.#tokens -= count;
+      return true;
+    }
+    return false;
+  }
+
+  #refill() {
+    const now = Date.now();
+    const elapsed = (now - this.#lastRefill) / 1000;
+    this.#tokens = Math.min(
+      this.#maxTokens,
+      this.#tokens + elapsed * this.#refillRate
+    );
+    this.#lastRefill = now;
+  }
+
+  get available() {
+    return Math.floor(this.#tokens);
+  }
+}
+
+/**
+ * Server with middleware support.
+ */
+class Server extends EventEmitter {
+  constructor({ port = DEFAULT_PORT, host = "0.0.0.0" } = {}) {
+    super();
+    this.port = port;
+    this.host = host;
+    this.middlewares = [];
+    this.limiter = new RateLimiter(MAX_CONNECTIONS);
+  }
+
+  use(middleware) {
+    this.middlewares.push(middleware);
+    return this;
+  }
+
+  async handleRequest(req) {
+    if (!this.limiter.tryConsume()) {
+      return { status: 429, body: "Too Many Requests" };
+    }
+
+    let context = { req, res: {} };
+    for (const mw of this.middlewares) {
+      context = await mw(context);
+      if (context.res.status) break;
+    }
+
+    this.emit("request", { path: req.path, status: context.res.status });
+    return context.res;
+  }
+
+  start() {
+    console.log(`Server listening on ${this.host}:${this.port}`);
+    this.emit("start", { port: this.port });
+  }
+}
+
+// Middleware: logging
+const logger = async (ctx) => {
+  const start = performance.now();
+  console.log(`[${new Date().toISOString()}] ${ctx.req.method} ${ctx.req.path}`);
+  return { ...ctx, _startTime: start };
+};
+
+// Middleware: JSON parser
+const jsonParser = async (ctx) => {
+  const { body, headers } = ctx.req;
+  if (headers?.["content-type"] === "application/json" && body) {
+    try {
+      return { ...ctx, req: { ...ctx.req, parsed: JSON.parse(body) } };
+    } catch {
+      return { ...ctx, res: { status: 400, body: "Invalid JSON" } };
+    }
+  }
+  return ctx;
+};
+
+// Route handler using destructuring and template literals
+const handleUsers = async ({ req, ...rest }) => {
+  const { method, path, parsed } = req;
+  const users = [
+    { id: 1, name: "Alice", active: true },
+    { id: 2, name: "Bob", active: false },
+    { id: 3, name: "Charlie", active: true },
+  ];
+
+  if (method === "GET") {
+    const activeOnly = path.includes("?active=true");
+    const filtered = activeOnly ? users.filter((u) => u.active) : users;
+    return { req, ...rest, res: { status: 200, body: JSON.stringify(filtered) } };
+  }
+
+  if (method === "POST" && parsed?.name) {
+    const newUser = { id: users.length + 1, ...parsed, active: true };
+    return { req, ...rest, res: { status: 201, body: JSON.stringify(newUser) } };
+  }
+
+  return { req, ...rest, res: { status: 405, body: "Method Not Allowed" } };
+};
+
+// Utility: debounce
+const debounce = (fn, delay) => {
+  let timer = null;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+};
+
+// Async generator
+async function* streamData(items) {
+  for (const item of items) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    yield { timestamp: Date.now(), data: item };
+  }
+}
+
+// Main
+const server = new Server({ port: 8080 });
+server.use(logger).use(jsonParser).use(handleUsers);
+
+server.on("start", ({ port }) => {
+  console.log(`API ${API_VERSION} ready on port ${port}`);
+});
+
+server.start();
+
+export { Server, RateLimiter, debounce, streamData };

--- a/tools/akbun-vscode-theme/test/samples/sample.py
+++ b/tools/akbun-vscode-theme/test/samples/sample.py
@@ -1,0 +1,117 @@
+"""
+Sample Python file for Akbun Theme syntax highlighting test.
+Covers: classes, functions, decorators, f-strings, self, type hints, etc.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional, List
+import os
+
+# Constants
+MAX_RETRIES = 3
+DEFAULT_TIMEOUT = 30.0
+API_URL = "https://api.example.com/v1"
+
+
+@dataclass
+class ServerConfig:
+    """Server configuration with sensible defaults."""
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+    debug: bool = False
+    workers: int = 4
+    tags: List[str] = field(default_factory=list)
+
+
+class ConnectionPool:
+    """Manages a pool of database connections."""
+
+    _instance: Optional["ConnectionPool"] = None
+
+    def __init__(self, max_size: int = 10):
+        self._pool: List = []
+        self._max_size = max_size
+        self._active = 0
+
+    @classmethod
+    def get_instance(cls) -> "ConnectionPool":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def acquire(self) -> object:
+        """Acquire a connection from the pool."""
+        if self._pool:
+            self._active += 1
+            return self._pool.pop()
+        elif self._active < self._max_size:
+            self._active += 1
+            return self._create_connection()
+        else:
+            raise RuntimeError(f"Pool exhausted: {self._active}/{self._max_size}")
+
+    def release(self, conn: object) -> None:
+        """Return a connection to the pool."""
+        self._active -= 1
+        self._pool.append(conn)
+
+    def _create_connection(self) -> object:
+        return object()
+
+    def __repr__(self) -> str:
+        return f"ConnectionPool(active={self._active}, pooled={len(self._pool)})"
+
+    def __len__(self) -> int:
+        return len(self._pool)
+
+
+def retry(max_attempts: int = MAX_RETRIES):
+    """Decorator that retries a function on failure."""
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            last_error = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    last_error = e
+                    print(f"Attempt {attempt}/{max_attempts} failed: {e}")
+            raise last_error
+
+        return wrapper
+
+    return decorator
+
+
+@retry(max_attempts=3)
+def fetch_data(url: str, timeout: float = DEFAULT_TIMEOUT) -> dict:
+    """Fetch data from an API endpoint."""
+    # Simulated response
+    response = {"status": 200, "data": [1, 2, 3], "url": url}
+    is_valid = response["status"] == 200 and len(response["data"]) > 0
+
+    if not is_valid:
+        raise ValueError(f"Invalid response from {url}")
+
+    return response
+
+
+def process_items(items: List[dict]) -> List[str]:
+    """Process items using list comprehension and lambda."""
+    transform = lambda x: x.get("name", "unknown").upper()
+    filtered = [transform(item) for item in items if item.get("active", False)]
+    return sorted(filtered)
+
+
+if __name__ == "__main__":
+    config = ServerConfig(port=9090, debug=True, tags=["api", "prod"])
+    pool = ConnectionPool.get_instance()
+
+    print(f"Config: {config}")
+    print(f"Pool: {pool}")
+
+    data = fetch_data(API_URL)
+    env_value = os.environ.get("APP_ENV", "development")
+    print(f"Environment: {env_value}, Data: {data}")

--- a/tools/akbun-vscode-theme/test/samples/sample.tf
+++ b/tools/akbun-vscode-theme/test/samples/sample.tf
@@ -1,0 +1,219 @@
+# Sample Terraform/HCL file for Akbun Theme syntax highlighting test.
+# Covers: resources, variables, locals, outputs, data sources, modules,
+#         string interpolation, functions, for_each, dynamic blocks.
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "prod/terraform.tfstate"
+    region         = "ap-northeast-2"
+    encrypt        = true
+    dynamodb_table = "terraform-lock"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Environment = var.environment
+      ManagedBy   = "terraform"
+      Project     = var.project_name
+    }
+  }
+}
+
+# Variables
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+
+  validation {
+    condition     = contains(["development", "staging", "production"], var.environment)
+    error_message = "Environment must be development, staging, or production."
+  }
+}
+
+variable "project_name" {
+  type    = string
+  default = "akbun-app"
+}
+
+variable "instance_config" {
+  description = "EC2 instance configuration"
+  type = object({
+    instance_type = string
+    ami_id        = string
+    volume_size   = number
+    enable_monitoring = bool
+  })
+  default = {
+    instance_type     = "t3.medium"
+    ami_id            = "ami-0c55b159cbfafe1f0"
+    volume_size       = 50
+    enable_monitoring = true
+  }
+}
+
+variable "allowed_cidrs" {
+  type    = list(string)
+  default = ["10.0.0.0/8", "172.16.0.0/12"]
+}
+
+# Locals
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+  common_tags = {
+    Name = local.name_prefix
+    Team = "platform"
+  }
+  az_count = min(length(data.aws_availability_zones.available.names), 3)
+  private_subnets = [for i in range(local.az_count) : cidrsubnet(var.vpc_cidr, 8, i)]
+  public_subnets  = [for i in range(local.az_count) : cidrsubnet(var.vpc_cidr, 8, i + 100)]
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+# Data sources
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+# VPC
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-vpc"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count             = local.az_count
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = local.private_subnets[count.index]
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${local.name_prefix}-private-${count.index + 1}"
+    Tier = "private"
+  }
+}
+
+# Security Group with dynamic blocks
+resource "aws_security_group" "app" {
+  name_prefix = "${local.name_prefix}-app-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for application servers"
+
+  dynamic "ingress" {
+    for_each = [
+      { port = 80, description = "HTTP" },
+      { port = 443, description = "HTTPS" },
+      { port = 8080, description = "App port" },
+    ]
+    content {
+      from_port   = ingress.value.port
+      to_port     = ingress.value.port
+      protocol    = "tcp"
+      cidr_blocks = var.allowed_cidrs
+      description = ingress.value.description
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.common_tags
+}
+
+# EC2 Instance
+resource "aws_instance" "app" {
+  ami                    = coalesce(var.instance_config.ami_id, data.aws_ami.amazon_linux.id)
+  instance_type          = var.instance_config.instance_type
+  subnet_id              = aws_subnet.private[0].id
+  vpc_security_group_ids = [aws_security_group.app.id]
+  monitoring             = var.instance_config.enable_monitoring
+
+  root_block_device {
+    volume_size = var.instance_config.volume_size
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  user_data = <<-EOF
+    #!/bin/bash
+    yum update -y
+    yum install -y docker
+    systemctl enable docker
+    systemctl start docker
+  EOF
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-app"
+    Role = "application"
+  })
+}
+
+# Outputs
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.app.id
+}
+
+output "account_id" {
+  description = "AWS Account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs"
+  value       = aws_subnet.private[*].id
+}

--- a/tools/akbun-vscode-theme/test/samples/sample.yaml
+++ b/tools/akbun-vscode-theme/test/samples/sample.yaml
@@ -1,0 +1,165 @@
+# Sample Ansible playbook for Akbun Theme syntax highlighting test.
+# Covers: plays, tasks, modules, variables, Jinja2 templates,
+#         handlers, loops, conditionals, roles, blocks.
+
+---
+- name: Deploy application to web servers
+  hosts: webservers
+  become: true
+  gather_facts: true
+  vars:
+    app_name: akbun-app
+    app_version: "2.1.0"
+    app_port: 8080
+    deploy_dir: /opt/{{ app_name }}
+    log_dir: /var/log/{{ app_name }}
+    max_retries: 3
+    health_check_url: "http://localhost:{{ app_port }}/health"
+    packages:
+      - python3
+      - python3-pip
+      - nginx
+      - docker-ce
+
+  pre_tasks:
+    - name: Validate required variables
+      ansible.builtin.assert:
+        that:
+          - app_name is defined
+          - app_version is defined
+          - app_port | int > 0
+        fail_msg: "Required variables are not properly defined"
+        success_msg: "All required variables validated"
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+  tasks:
+    - name: Install required packages
+      ansible.builtin.yum:
+        name: "{{ packages }}"
+        state: present
+      register: install_result
+      retries: "{{ max_retries }}"
+      delay: 5
+      until: install_result is succeeded
+      notify: Restart nginx
+
+    - name: Create application directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ app_name }}"
+        group: "{{ app_name }}"
+        mode: "0755"
+      loop:
+        - "{{ deploy_dir }}"
+        - "{{ deploy_dir }}/config"
+        - "{{ deploy_dir }}/bin"
+        - "{{ log_dir }}"
+
+    - name: Deploy application configuration
+      ansible.builtin.template:
+        src: templates/app-config.yml.j2
+        dest: "{{ deploy_dir }}/config/application.yml"
+        owner: "{{ app_name }}"
+        group: "{{ app_name }}"
+        mode: "0640"
+        validate: "python3 -c 'import yaml; yaml.safe_load(open(\"%s\"))'"
+      notify: Restart application
+
+    - name: Configure nginx reverse proxy
+      ansible.builtin.template:
+        src: templates/nginx.conf.j2
+        dest: /etc/nginx/conf.d/{{ app_name }}.conf
+        mode: "0644"
+      notify: Restart nginx
+
+    - name: Pull Docker image
+      community.docker.docker_image:
+        name: "registry.example.com/{{ app_name }}"
+        tag: "{{ app_version }}"
+        source: pull
+        force_source: true
+      register: docker_pull
+
+    - name: Run application container
+      community.docker.docker_container:
+        name: "{{ app_name }}"
+        image: "registry.example.com/{{ app_name }}:{{ app_version }}"
+        state: started
+        restart_policy: unless-stopped
+        ports:
+          - "{{ app_port }}:{{ app_port }}"
+        env:
+          APP_ENV: "{{ ansible_env.APP_ENV | default('production') }}"
+          LOG_LEVEL: "{{ 'debug' if ansible_env.APP_ENV | default('production') == 'development' else 'info' }}"
+        volumes:
+          - "{{ deploy_dir }}/config:/app/config:ro"
+          - "{{ log_dir }}:/app/logs"
+        networks:
+          - name: app-network
+      when: docker_pull is changed
+
+    # Block for health check with rescue
+    - name: Health check block
+      block:
+        - name: Wait for application to start
+          ansible.builtin.uri:
+            url: "{{ health_check_url }}"
+            method: GET
+            status_code: 200
+            return_content: true
+          register: health_result
+          retries: 10
+          delay: 5
+          until: health_result.status == 200
+
+        - name: Display health check result
+          ansible.builtin.debug:
+            msg: >-
+              Application {{ app_name }} v{{ app_version }}
+              is running on port {{ app_port }}.
+              Response: {{ health_result.content }}
+
+      rescue:
+        - name: Health check failed - collect logs
+          ansible.builtin.command:
+            cmd: "docker logs {{ app_name }} --tail 50"
+          register: container_logs
+          changed_when: false
+
+        - name: Display container logs
+          ansible.builtin.debug:
+            var: container_logs.stdout_lines
+
+        - name: Fail with message
+          ansible.builtin.fail:
+            msg: "Health check failed for {{ app_name }}. Check logs above."
+
+  handlers:
+    - name: Restart nginx
+      ansible.builtin.systemd:
+        name: nginx
+        state: restarted
+        enabled: true
+
+    - name: Restart application
+      community.docker.docker_container:
+        name: "{{ app_name }}"
+        state: started
+        restart: true
+
+  post_tasks:
+    - name: Send deployment notification
+      ansible.builtin.uri:
+        url: "https://hooks.slack.com/services/XXX/YYY/ZZZ"
+        method: POST
+        body_format: json
+        body:
+          text: "Deployed {{ app_name }} v{{ app_version }} to {{ inventory_hostname }}"
+      ignore_errors: true
+      tags:
+        - notification
+        - never

--- a/tools/akbun-vscode-theme/test/theme-validator.js
+++ b/tools/akbun-vscode-theme/test/theme-validator.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+/**
+ * Theme Validator - Akbun VS Code Theme
+ *
+ * Validates that both theme JSON files:
+ * 1. Are valid JSON
+ * 2. Have required top-level keys
+ * 3. Have essential VS Code color keys defined
+ * 4. Have tokenColors with proper structure
+ * 5. Use valid hex color format
+ * 6. Have matching syntax categories between dark and light themes
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const THEMES_DIR = path.join(__dirname, "..", "themes");
+const THEME_FILES = ["akbun-dark.json", "akbun-light.json"];
+
+// Required top-level keys in a VS Code theme
+const REQUIRED_TOP_KEYS = ["name", "type", "colors", "tokenColors"];
+
+// Essential VS Code UI color keys that must be present
+const REQUIRED_COLOR_KEYS = [
+  "editor.background",
+  "editor.foreground",
+  "editor.selectionBackground",
+  "editor.lineHighlightBackground",
+  "editorCursor.foreground",
+  "editorLineNumber.foreground",
+  "editorLineNumber.activeForeground",
+  "editorError.foreground",
+  "editorWarning.foreground",
+  "activityBar.background",
+  "activityBar.foreground",
+  "sideBar.background",
+  "sideBar.foreground",
+  "titleBar.activeBackground",
+  "tab.activeBackground",
+  "tab.inactiveBackground",
+  "statusBar.background",
+  "statusBar.foreground",
+  "terminal.background",
+  "terminal.foreground",
+  "terminal.ansiRed",
+  "terminal.ansiGreen",
+  "terminal.ansiBlue",
+  "terminal.ansiYellow",
+  "input.background",
+  "input.foreground",
+  "button.background",
+  "button.foreground",
+  "panel.background",
+  "gitDecoration.addedResourceForeground",
+  "gitDecoration.modifiedResourceForeground",
+  "gitDecoration.deletedResourceForeground",
+];
+
+// Essential syntax scopes that must be highlighted (especially for HCL, Ansible, Python, JS)
+const REQUIRED_SYNTAX_CATEGORIES = [
+  "Comment",
+  "String",
+  "Number",
+  "Keyword",
+  "Function declaration",
+  "Function parameter",
+  "Variable",
+  "Class / Type",
+  "Decorator / Annotation",
+  "Python - Self",
+  "Python - Decorator",
+  "JavaScript/TypeScript - this",
+  "HCL / Terraform - Block type",
+  "HCL / Terraform - Resource name / label",
+  "HCL / Terraform - Attribute name",
+  "YAML key",
+];
+
+const HEX_COLOR_REGEX = /^#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$/;
+
+let totalErrors = 0;
+let totalWarnings = 0;
+
+function error(msg) {
+  totalErrors++;
+  console.error(`  ERROR: ${msg}`);
+}
+
+function warn(msg) {
+  totalWarnings++;
+  console.warn(`  WARN:  ${msg}`);
+}
+
+function pass(msg) {
+  console.log(`  PASS:  ${msg}`);
+}
+
+function validateHexColor(color, context) {
+  if (!HEX_COLOR_REGEX.test(color)) {
+    error(`Invalid hex color "${color}" in ${context}`);
+    return false;
+  }
+  return true;
+}
+
+function validateTheme(filePath) {
+  const fileName = path.basename(filePath);
+  console.log(`\n--- Validating: ${fileName} ---`);
+
+  // 1. Check file exists
+  if (!fs.existsSync(filePath)) {
+    error(`File not found: ${filePath}`);
+    return null;
+  }
+  pass("File exists");
+
+  // 2. Parse JSON
+  let theme;
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    theme = JSON.parse(raw);
+  } catch (e) {
+    error(`Invalid JSON: ${e.message}`);
+    return null;
+  }
+  pass("Valid JSON");
+
+  // 3. Required top-level keys
+  for (const key of REQUIRED_TOP_KEYS) {
+    if (!(key in theme)) {
+      error(`Missing required top-level key: "${key}"`);
+    }
+  }
+  pass("Top-level keys present");
+
+  // 4. Theme type
+  const expectedType = fileName.includes("dark") ? "dark" : "light";
+  if (theme.type !== expectedType) {
+    error(`Theme type should be "${expectedType}", got "${theme.type}"`);
+  } else {
+    pass(`Theme type is "${expectedType}"`);
+  }
+
+  // 5. Required color keys
+  const colors = theme.colors || {};
+  let missingColors = 0;
+  for (const key of REQUIRED_COLOR_KEYS) {
+    if (!(key in colors)) {
+      error(`Missing required color key: "${key}"`);
+      missingColors++;
+    }
+  }
+  if (missingColors === 0) {
+    pass(`All ${REQUIRED_COLOR_KEYS.length} required color keys present`);
+  }
+
+  // 6. Validate hex color format in colors
+  let invalidColors = 0;
+  for (const [key, value] of Object.entries(colors)) {
+    if (!validateHexColor(value, `colors.${key}`)) {
+      invalidColors++;
+    }
+  }
+  if (invalidColors === 0) {
+    pass(`All ${Object.keys(colors).length} color values are valid hex`);
+  }
+
+  // 7. TokenColors structure
+  const tokenColors = theme.tokenColors || [];
+  if (tokenColors.length === 0) {
+    error("tokenColors array is empty");
+  } else {
+    pass(`${tokenColors.length} tokenColor rules defined`);
+  }
+
+  // 8. Validate each tokenColor entry
+  let invalidTokens = 0;
+  for (let i = 0; i < tokenColors.length; i++) {
+    const tc = tokenColors[i];
+    if (!tc.scope) {
+      error(`tokenColors[${i}] (${tc.name || "unnamed"}) missing "scope"`);
+      invalidTokens++;
+    }
+    if (!tc.settings) {
+      error(`tokenColors[${i}] (${tc.name || "unnamed"}) missing "settings"`);
+      invalidTokens++;
+    } else {
+      if (tc.settings.foreground) {
+        if (!validateHexColor(tc.settings.foreground, `tokenColors[${i}].settings.foreground (${tc.name})`)) {
+          invalidTokens++;
+        }
+      }
+    }
+  }
+  if (invalidTokens === 0) {
+    pass("All tokenColor entries have valid structure");
+  }
+
+  // 9. Check required syntax categories
+  const tokenNames = tokenColors.map((tc) => tc.name).filter(Boolean);
+  let missingSyntax = 0;
+  for (const cat of REQUIRED_SYNTAX_CATEGORIES) {
+    if (!tokenNames.includes(cat)) {
+      error(`Missing required syntax category: "${cat}"`);
+      missingSyntax++;
+    }
+  }
+  if (missingSyntax === 0) {
+    pass(`All ${REQUIRED_SYNTAX_CATEGORIES.length} required syntax categories present`);
+  }
+
+  return theme;
+}
+
+function validateConsistency(dark, light) {
+  console.log("\n--- Cross-theme consistency ---");
+
+  if (!dark || !light) {
+    error("Cannot check consistency: one or both themes failed to load");
+    return;
+  }
+
+  // Token color names should match between themes
+  const darkNames = new Set((dark.tokenColors || []).map((tc) => tc.name).filter(Boolean));
+  const lightNames = new Set((light.tokenColors || []).map((tc) => tc.name).filter(Boolean));
+
+  const onlyInDark = [...darkNames].filter((n) => !lightNames.has(n));
+  const onlyInLight = [...lightNames].filter((n) => !darkNames.has(n));
+
+  if (onlyInDark.length > 0) {
+    warn(`Syntax rules only in dark theme: ${onlyInDark.join(", ")}`);
+  }
+  if (onlyInLight.length > 0) {
+    warn(`Syntax rules only in light theme: ${onlyInLight.join(", ")}`);
+  }
+  if (onlyInDark.length === 0 && onlyInLight.length === 0) {
+    pass("Both themes have matching syntax rule names");
+  }
+
+  // Color keys should match between themes
+  const darkColorKeys = new Set(Object.keys(dark.colors || {}));
+  const lightColorKeys = new Set(Object.keys(light.colors || {}));
+
+  const onlyInDarkColors = [...darkColorKeys].filter((k) => !lightColorKeys.has(k));
+  const onlyInLightColors = [...lightColorKeys].filter((k) => !darkColorKeys.has(k));
+
+  if (onlyInDarkColors.length > 0) {
+    warn(`Color keys only in dark theme: ${onlyInDarkColors.join(", ")}`);
+  }
+  if (onlyInLightColors.length > 0) {
+    warn(`Color keys only in light theme: ${onlyInLightColors.join(", ")}`);
+  }
+  if (onlyInDarkColors.length === 0 && onlyInLightColors.length === 0) {
+    pass("Both themes define the same color keys");
+  }
+
+  // Semantic token colors should match
+  const darkSemantic = Object.keys(dark.semanticTokenColors || {});
+  const lightSemantic = Object.keys(light.semanticTokenColors || {});
+  const onlyInDarkSemantic = darkSemantic.filter((k) => !(k in (light.semanticTokenColors || {})));
+  const onlyInLightSemantic = lightSemantic.filter((k) => !(k in (dark.semanticTokenColors || {})));
+
+  if (onlyInDarkSemantic.length > 0) {
+    warn(`Semantic tokens only in dark: ${onlyInDarkSemantic.join(", ")}`);
+  }
+  if (onlyInLightSemantic.length > 0) {
+    warn(`Semantic tokens only in light: ${onlyInLightSemantic.join(", ")}`);
+  }
+  if (onlyInDarkSemantic.length === 0 && onlyInLightSemantic.length === 0) {
+    pass("Both themes define the same semantic token colors");
+  }
+}
+
+// Run
+console.log("=== Akbun Theme Validator ===");
+
+const themes = THEME_FILES.map((f) => validateTheme(path.join(THEMES_DIR, f)));
+validateConsistency(themes[0], themes[1]);
+
+console.log(`\n=== Results: ${totalErrors} errors, ${totalWarnings} warnings ===`);
+
+if (totalErrors > 0) {
+  console.error("\nVALIDATION FAILED");
+  process.exit(1);
+} else {
+  console.log("\nVALIDATION PASSED");
+  process.exit(0);
+}

--- a/tools/akbun-vscode-theme/themes/akbun-dark.json
+++ b/tools/akbun-vscode-theme/themes/akbun-dark.json
@@ -1,0 +1,600 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "Akbun Dark",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "colors": {
+    "editor.background": "#1e1e2e",
+    "editor.foreground": "#cdd6f4",
+    "editor.lineHighlightBackground": "#2a2b3d",
+    "editor.selectionBackground": "#45475a",
+    "editor.selectionHighlightBackground": "#45475a80",
+    "editor.inactiveSelectionBackground": "#45475a60",
+    "editor.findMatchBackground": "#f9e2af40",
+    "editor.findMatchHighlightBackground": "#f9e2af20",
+    "editor.wordHighlightBackground": "#cba6f730",
+    "editor.wordHighlightStrongBackground": "#cba6f750",
+    "editorCursor.foreground": "#f5e0dc",
+    "editorWhitespace.foreground": "#45475a",
+    "editorIndentGuide.background1": "#313244",
+    "editorIndentGuide.activeBackground1": "#45475a",
+    "editorLineNumber.foreground": "#6c7086",
+    "editorLineNumber.activeForeground": "#bac2de",
+    "editorBracketMatch.background": "#45475a50",
+    "editorBracketMatch.border": "#89b4fa",
+    "editorGutter.addedBackground": "#a6e3a1",
+    "editorGutter.modifiedBackground": "#89b4fa",
+    "editorGutter.deletedBackground": "#f38ba8",
+    "editorError.foreground": "#f38ba8",
+    "editorWarning.foreground": "#fab387",
+    "editorInfo.foreground": "#89b4fa",
+
+    "activityBar.background": "#11111b",
+    "activityBar.foreground": "#cdd6f4",
+    "activityBar.inactiveForeground": "#6c7086",
+    "activityBarBadge.background": "#cba6f7",
+    "activityBarBadge.foreground": "#11111b",
+
+    "sideBar.background": "#181825",
+    "sideBar.foreground": "#cdd6f4",
+    "sideBar.border": "#11111b",
+    "sideBarTitle.foreground": "#cdd6f4",
+    "sideBarSectionHeader.background": "#181825",
+    "sideBarSectionHeader.foreground": "#cdd6f4",
+
+    "list.activeSelectionBackground": "#45475a",
+    "list.activeSelectionForeground": "#cdd6f4",
+    "list.hoverBackground": "#313244",
+    "list.inactiveSelectionBackground": "#31324480",
+    "list.highlightForeground": "#cba6f7",
+
+    "titleBar.activeBackground": "#11111b",
+    "titleBar.activeForeground": "#cdd6f4",
+    "titleBar.inactiveBackground": "#11111b",
+    "titleBar.inactiveForeground": "#6c7086",
+
+    "tab.activeBackground": "#1e1e2e",
+    "tab.activeForeground": "#cdd6f4",
+    "tab.inactiveBackground": "#181825",
+    "tab.inactiveForeground": "#6c7086",
+    "tab.border": "#11111b",
+    "tab.activeBorderTop": "#cba6f7",
+
+    "statusBar.background": "#11111b",
+    "statusBar.foreground": "#cdd6f4",
+    "statusBar.debuggingBackground": "#fab387",
+    "statusBar.debuggingForeground": "#11111b",
+    "statusBar.noFolderBackground": "#11111b",
+
+    "terminal.background": "#1e1e2e",
+    "terminal.foreground": "#cdd6f4",
+    "terminal.ansiBlack": "#45475a",
+    "terminal.ansiRed": "#f38ba8",
+    "terminal.ansiGreen": "#a6e3a1",
+    "terminal.ansiYellow": "#f9e2af",
+    "terminal.ansiBlue": "#89b4fa",
+    "terminal.ansiMagenta": "#f5c2e7",
+    "terminal.ansiCyan": "#94e2d5",
+    "terminal.ansiWhite": "#bac2de",
+    "terminal.ansiBrightBlack": "#585b70",
+    "terminal.ansiBrightRed": "#f38ba8",
+    "terminal.ansiBrightGreen": "#a6e3a1",
+    "terminal.ansiBrightYellow": "#f9e2af",
+    "terminal.ansiBrightBlue": "#89b4fa",
+    "terminal.ansiBrightMagenta": "#f5c2e7",
+    "terminal.ansiBrightCyan": "#94e2d5",
+    "terminal.ansiBrightWhite": "#a6adc8",
+
+    "breadcrumb.foreground": "#a6adc8",
+    "breadcrumb.focusForeground": "#cdd6f4",
+    "breadcrumb.activeSelectionForeground": "#cdd6f4",
+    "breadcrumbPicker.background": "#181825",
+
+    "input.background": "#313244",
+    "input.foreground": "#cdd6f4",
+    "input.border": "#45475a",
+    "input.placeholderForeground": "#6c7086",
+    "inputOption.activeBorder": "#cba6f7",
+
+    "dropdown.background": "#313244",
+    "dropdown.foreground": "#cdd6f4",
+    "dropdown.border": "#45475a",
+
+    "button.background": "#cba6f7",
+    "button.foreground": "#11111b",
+    "button.hoverBackground": "#b48cf2",
+
+    "badge.background": "#cba6f7",
+    "badge.foreground": "#11111b",
+
+    "scrollbarSlider.background": "#45475a50",
+    "scrollbarSlider.hoverBackground": "#45475a80",
+    "scrollbarSlider.activeBackground": "#45475aB0",
+
+    "panel.background": "#181825",
+    "panel.border": "#11111b",
+    "panelTitle.activeBorder": "#cba6f7",
+    "panelTitle.activeForeground": "#cdd6f4",
+    "panelTitle.inactiveForeground": "#6c7086",
+
+    "peekView.border": "#cba6f7",
+    "peekViewEditor.background": "#181825",
+    "peekViewResult.background": "#181825",
+    "peekViewTitle.background": "#181825",
+
+    "gitDecoration.addedResourceForeground": "#a6e3a1",
+    "gitDecoration.modifiedResourceForeground": "#89b4fa",
+    "gitDecoration.deletedResourceForeground": "#f38ba8",
+    "gitDecoration.untrackedResourceForeground": "#a6e3a1",
+    "gitDecoration.conflictingResourceForeground": "#fab387",
+
+    "minimap.findMatchHighlight": "#f9e2af40",
+    "minimap.selectionHighlight": "#45475a80",
+    "minimap.errorHighlight": "#f38ba8",
+    "minimap.warningHighlight": "#fab387",
+
+    "diffEditor.insertedTextBackground": "#a6e3a120",
+    "diffEditor.removedTextBackground": "#f38ba820",
+
+    "focusBorder": "#cba6f780",
+    "foreground": "#cdd6f4",
+    "widget.shadow": "#11111b80",
+    "selection.background": "#45475a",
+    "descriptionForeground": "#a6adc8",
+    "icon.foreground": "#cdd6f4",
+
+    "notificationCenterHeader.background": "#181825",
+    "notifications.background": "#181825",
+    "notifications.foreground": "#cdd6f4"
+  },
+  "tokenColors": [
+    {
+      "name": "Comment",
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": {
+        "foreground": "#838799",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "String",
+      "scope": ["string", "string.quoted", "string.template"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "String Escape",
+      "scope": ["constant.character.escape"],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Number",
+      "scope": ["constant.numeric"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Boolean / Null / Undefined",
+      "scope": ["constant.language"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "keyword.operator.logical",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Operator",
+      "scope": ["keyword.operator", "punctuation.accessor"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": [
+        "punctuation",
+        "punctuation.definition.tag",
+        "punctuation.separator",
+        "punctuation.terminator"
+      ],
+      "settings": {
+        "foreground": "#9399b2"
+      }
+    },
+    {
+      "name": "Function declaration",
+      "scope": [
+        "entity.name.function",
+        "meta.function-call entity.name.function",
+        "support.function"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Function call",
+      "scope": [
+        "meta.function-call",
+        "entity.name.function.call"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Method",
+      "scope": [
+        "entity.name.function.member",
+        "meta.method.declaration entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Function parameter",
+      "scope": [
+        "variable.parameter",
+        "meta.function.parameters variable"
+      ],
+      "settings": {
+        "foreground": "#f2cdcd",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": ["variable", "variable.other"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "Variable - Property",
+      "scope": ["variable.other.property", "variable.other.object.property"],
+      "settings": {
+        "foreground": "#b4befe"
+      }
+    },
+    {
+      "name": "Variable - Constant",
+      "scope": ["variable.other.constant"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "Class / Type",
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Interface",
+      "scope": ["entity.name.type.interface"],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Namespace / Module",
+      "scope": ["entity.name.namespace", "entity.name.module"],
+      "settings": {
+        "foreground": "#f5e0dc"
+      }
+    },
+    {
+      "name": "Decorator / Annotation",
+      "scope": [
+        "meta.decorator",
+        "punctuation.decorator",
+        "meta.decorator entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#fab387",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Tag name (HTML/XML)",
+      "scope": ["entity.name.tag"],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Tag attribute",
+      "scope": ["entity.other.attribute-name"],
+      "settings": {
+        "foreground": "#f9e2af",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Import / Include / Require",
+      "scope": [
+        "keyword.control.import",
+        "keyword.control.from",
+        "keyword.other.import",
+        "keyword.control.export"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "Regex",
+      "scope": ["string.regexp"],
+      "settings": {
+        "foreground": "#f5c2e7"
+      }
+    },
+    {
+      "name": "Markdown heading",
+      "scope": ["markup.heading", "entity.name.section.markdown"],
+      "settings": {
+        "foreground": "#cba6f7",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown bold",
+      "scope": ["markup.bold"],
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown italic",
+      "scope": ["markup.italic"],
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Markdown link",
+      "scope": ["markup.underline.link"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Markdown code",
+      "scope": ["markup.inline.raw", "markup.fenced_code"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "JSON key",
+      "scope": ["support.type.property-name.json"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "YAML key",
+      "scope": ["entity.name.tag.yaml"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "YAML anchor / alias",
+      "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "Python - Self",
+      "scope": ["variable.language.special.self.python"],
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python - Magic method",
+      "scope": ["support.function.magic.python"],
+      "settings": {
+        "foreground": "#89b4fa",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python - Decorator",
+      "scope": ["entity.name.function.decorator.python"],
+      "settings": {
+        "foreground": "#fab387",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python - F-string expression",
+      "scope": ["meta.fstring"],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "JavaScript/TypeScript - this",
+      "scope": ["variable.language.this"],
+      "settings": {
+        "foreground": "#f38ba8",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "JavaScript - Template literal expression",
+      "scope": ["meta.template.expression"],
+      "settings": {
+        "foreground": "#cdd6f4"
+      }
+    },
+    {
+      "name": "JavaScript - Arrow function",
+      "scope": ["storage.type.function.arrow"],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "JavaScript/TypeScript - Console",
+      "scope": ["support.class.console"],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Block type",
+      "scope": [
+        "entity.name.type.terraform",
+        "storage.type.hcl",
+        "keyword.other.hcl"
+      ],
+      "settings": {
+        "foreground": "#cba6f7"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Resource name / label",
+      "scope": [
+        "entity.name.label.terraform",
+        "entity.name.resource.terraform",
+        "string.quoted.double.terraform"
+      ],
+      "settings": {
+        "foreground": "#a6e3a1"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Attribute name",
+      "scope": [
+        "variable.other.property.hcl",
+        "variable.declaration.hcl"
+      ],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Interpolation",
+      "scope": [
+        "keyword.other.interpolation.begin.hcl",
+        "keyword.other.interpolation.end.hcl"
+      ],
+      "settings": {
+        "foreground": "#89dceb"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Function",
+      "scope": ["support.function.builtin.terraform"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Ansible - Module name",
+      "scope": ["entity.name.tag.yaml", "keyword.other.definition.yaml"],
+      "settings": {
+        "foreground": "#89b4fa"
+      }
+    },
+    {
+      "name": "Ansible - Jinja2 / Template",
+      "scope": [
+        "keyword.control.flow.jinja",
+        "entity.other.jinja.delimiter.tag",
+        "entity.other.jinja.delimiter.variable"
+      ],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "CSS - Property name",
+      "scope": ["support.type.property-name.css"],
+      "settings": {
+        "foreground": "#b4befe"
+      }
+    },
+    {
+      "name": "CSS - Property value",
+      "scope": ["support.constant.property-value.css"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "CSS - Unit",
+      "scope": ["keyword.other.unit.css"],
+      "settings": {
+        "foreground": "#fab387"
+      }
+    },
+    {
+      "name": "CSS - Selector / Class / ID",
+      "scope": [
+        "entity.other.attribute-name.class.css",
+        "entity.other.attribute-name.id.css"
+      ],
+      "settings": {
+        "foreground": "#f9e2af"
+      }
+    }
+  ],
+  "semanticTokenColors": {
+    "function": "#89b4fa",
+    "function.declaration": "#89b4fa",
+    "method": "#89b4fa",
+    "method.declaration": "#89b4fa",
+    "variable": "#cdd6f4",
+    "variable.readonly": "#fab387",
+    "variable.defaultLibrary": "#f38ba8",
+    "parameter": "#f2cdcd",
+    "property": "#b4befe",
+    "property.declaration": "#b4befe",
+    "class": "#f9e2af",
+    "interface": { "foreground": "#f9e2af", "fontStyle": "italic" },
+    "enum": "#f9e2af",
+    "enumMember": "#94e2d5",
+    "type": "#f9e2af",
+    "namespace": "#f5e0dc",
+    "decorator": { "foreground": "#fab387", "fontStyle": "italic" },
+    "string": "#a6e3a1",
+    "number": "#fab387",
+    "keyword": "#cba6f7",
+    "comment": { "foreground": "#838799", "fontStyle": "italic" },
+    "regexp": "#f5c2e7",
+    "operator": "#89dceb"
+  }
+}

--- a/tools/akbun-vscode-theme/themes/akbun-light.json
+++ b/tools/akbun-vscode-theme/themes/akbun-light.json
@@ -1,0 +1,600 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "Akbun Light",
+  "type": "light",
+  "semanticHighlighting": true,
+  "colors": {
+    "editor.background": "#faf9f5",
+    "editor.foreground": "#4c4f69",
+    "editor.lineHighlightBackground": "#f0efe8",
+    "editor.selectionBackground": "#d4c9a8",
+    "editor.selectionHighlightBackground": "#d4c9a860",
+    "editor.inactiveSelectionBackground": "#d4c9a840",
+    "editor.findMatchBackground": "#9a650f40",
+    "editor.findMatchHighlightBackground": "#9a650f20",
+    "editor.wordHighlightBackground": "#8839ef25",
+    "editor.wordHighlightStrongBackground": "#8839ef40",
+    "editorCursor.foreground": "#a84e30",
+    "editorWhitespace.foreground": "#ccd0da",
+    "editorIndentGuide.background1": "#dcd8c8",
+    "editorIndentGuide.activeBackground1": "#bcc0cc",
+    "editorLineNumber.foreground": "#8c8fa1",
+    "editorLineNumber.activeForeground": "#5c5f77",
+    "editorBracketMatch.background": "#bcc0cc50",
+    "editorBracketMatch.border": "#1e66f5",
+    "editorGutter.addedBackground": "#2e7d20",
+    "editorGutter.modifiedBackground": "#1e66f5",
+    "editorGutter.deletedBackground": "#d20f39",
+    "editorError.foreground": "#d20f39",
+    "editorWarning.foreground": "#b84800",
+    "editorInfo.foreground": "#1e66f5",
+
+    "activityBar.background": "#f0efe8",
+    "activityBar.foreground": "#4c4f69",
+    "activityBar.inactiveForeground": "#8c8fa1",
+    "activityBarBadge.background": "#a84e30",
+    "activityBarBadge.foreground": "#ffffff",
+
+    "sideBar.background": "#f5f4ed",
+    "sideBar.foreground": "#4c4f69",
+    "sideBar.border": "#e6e2d6",
+    "sideBarTitle.foreground": "#4c4f69",
+    "sideBarSectionHeader.background": "#f5f4ed",
+    "sideBarSectionHeader.foreground": "#4c4f69",
+
+    "list.activeSelectionBackground": "#d4c9a8",
+    "list.activeSelectionForeground": "#4c4f69",
+    "list.hoverBackground": "#e8e5d8",
+    "list.inactiveSelectionBackground": "#e8e5d880",
+    "list.highlightForeground": "#a84e30",
+
+    "titleBar.activeBackground": "#f0efe8",
+    "titleBar.activeForeground": "#4c4f69",
+    "titleBar.inactiveBackground": "#f5f4ed",
+    "titleBar.inactiveForeground": "#8c8fa1",
+
+    "tab.activeBackground": "#faf9f5",
+    "tab.activeForeground": "#4c4f69",
+    "tab.inactiveBackground": "#f5f4ed",
+    "tab.inactiveForeground": "#7c7f93",
+    "tab.border": "#e6e2d6",
+    "tab.activeBorderTop": "#a84e30",
+
+    "statusBar.background": "#f0efe8",
+    "statusBar.foreground": "#4c4f69",
+    "statusBar.debuggingBackground": "#b84800",
+    "statusBar.debuggingForeground": "#ffffff",
+    "statusBar.noFolderBackground": "#f0efe8",
+
+    "terminal.background": "#faf9f5",
+    "terminal.foreground": "#4c4f69",
+    "terminal.ansiBlack": "#5c5f77",
+    "terminal.ansiRed": "#d20f39",
+    "terminal.ansiGreen": "#2e7d20",
+    "terminal.ansiYellow": "#9a650f",
+    "terminal.ansiBlue": "#1e66f5",
+    "terminal.ansiMagenta": "#9c3f8b",
+    "terminal.ansiCyan": "#0d6d73",
+    "terminal.ansiWhite": "#acb0be",
+    "terminal.ansiBrightBlack": "#6c6f85",
+    "terminal.ansiBrightRed": "#d20f39",
+    "terminal.ansiBrightGreen": "#2e7d20",
+    "terminal.ansiBrightYellow": "#9a650f",
+    "terminal.ansiBrightBlue": "#1e66f5",
+    "terminal.ansiBrightMagenta": "#9c3f8b",
+    "terminal.ansiBrightCyan": "#0d6d73",
+    "terminal.ansiBrightWhite": "#4c4f69",
+
+    "breadcrumb.foreground": "#6c6f85",
+    "breadcrumb.focusForeground": "#4c4f69",
+    "breadcrumb.activeSelectionForeground": "#4c4f69",
+    "breadcrumbPicker.background": "#f5f4ed",
+
+    "input.background": "#faf9f5",
+    "input.foreground": "#4c4f69",
+    "input.border": "#d4c9a8",
+    "input.placeholderForeground": "#8c8fa1",
+    "inputOption.activeBorder": "#a84e30",
+
+    "dropdown.background": "#faf9f5",
+    "dropdown.foreground": "#4c4f69",
+    "dropdown.border": "#d4c9a8",
+
+    "button.background": "#a84e30",
+    "button.foreground": "#ffffff",
+    "button.hoverBackground": "#8f4228",
+
+    "badge.background": "#a84e30",
+    "badge.foreground": "#ffffff",
+
+    "scrollbarSlider.background": "#bcc0cc50",
+    "scrollbarSlider.hoverBackground": "#bcc0cc80",
+    "scrollbarSlider.activeBackground": "#bcc0ccB0",
+
+    "panel.background": "#f5f4ed",
+    "panel.border": "#e6e2d6",
+    "panelTitle.activeBorder": "#a84e30",
+    "panelTitle.activeForeground": "#4c4f69",
+    "panelTitle.inactiveForeground": "#8c8fa1",
+
+    "peekView.border": "#a84e30",
+    "peekViewEditor.background": "#f5f4ed",
+    "peekViewResult.background": "#f5f4ed",
+    "peekViewTitle.background": "#f5f4ed",
+
+    "gitDecoration.addedResourceForeground": "#2e7d20",
+    "gitDecoration.modifiedResourceForeground": "#1e66f5",
+    "gitDecoration.deletedResourceForeground": "#d20f39",
+    "gitDecoration.untrackedResourceForeground": "#2e7d20",
+    "gitDecoration.conflictingResourceForeground": "#b84800",
+
+    "minimap.findMatchHighlight": "#9a650f40",
+    "minimap.selectionHighlight": "#d4c9a880",
+    "minimap.errorHighlight": "#d20f39",
+    "minimap.warningHighlight": "#b84800",
+
+    "diffEditor.insertedTextBackground": "#2e7d2018",
+    "diffEditor.removedTextBackground": "#d20f3918",
+
+    "focusBorder": "#a84e3080",
+    "foreground": "#4c4f69",
+    "widget.shadow": "#00000015",
+    "selection.background": "#d4c9a8",
+    "descriptionForeground": "#6c6f85",
+    "icon.foreground": "#4c4f69",
+
+    "notificationCenterHeader.background": "#f5f4ed",
+    "notifications.background": "#f5f4ed",
+    "notifications.foreground": "#4c4f69"
+  },
+  "tokenColors": [
+    {
+      "name": "Comment",
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": {
+        "foreground": "#6c6f85",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "String",
+      "scope": ["string", "string.quoted", "string.template"],
+      "settings": {
+        "foreground": "#2e7d20"
+      }
+    },
+    {
+      "name": "String Escape",
+      "scope": ["constant.character.escape"],
+      "settings": {
+        "foreground": "#9c3f8b"
+      }
+    },
+    {
+      "name": "Number",
+      "scope": ["constant.numeric"],
+      "settings": {
+        "foreground": "#b84800"
+      }
+    },
+    {
+      "name": "Boolean / Null / Undefined",
+      "scope": ["constant.language"],
+      "settings": {
+        "foreground": "#b84800"
+      }
+    },
+    {
+      "name": "Keyword",
+      "scope": [
+        "keyword",
+        "keyword.control",
+        "keyword.operator.new",
+        "keyword.operator.expression",
+        "keyword.operator.logical",
+        "storage.type",
+        "storage.modifier"
+      ],
+      "settings": {
+        "foreground": "#7630c5"
+      }
+    },
+    {
+      "name": "Operator",
+      "scope": ["keyword.operator", "punctuation.accessor"],
+      "settings": {
+        "foreground": "#0d6d73"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": [
+        "punctuation",
+        "punctuation.definition.tag",
+        "punctuation.separator",
+        "punctuation.terminator"
+      ],
+      "settings": {
+        "foreground": "#656880"
+      }
+    },
+    {
+      "name": "Function declaration",
+      "scope": [
+        "entity.name.function",
+        "meta.function-call entity.name.function",
+        "support.function"
+      ],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "Function call",
+      "scope": [
+        "meta.function-call",
+        "entity.name.function.call"
+      ],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "Method",
+      "scope": [
+        "entity.name.function.member",
+        "meta.method.declaration entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "Function parameter",
+      "scope": [
+        "variable.parameter",
+        "meta.function.parameters variable"
+      ],
+      "settings": {
+        "foreground": "#b04e4e",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Variable",
+      "scope": ["variable", "variable.other"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "Variable - Property",
+      "scope": ["variable.other.property", "variable.other.object.property"],
+      "settings": {
+        "foreground": "#4c5ec8"
+      }
+    },
+    {
+      "name": "Variable - Constant",
+      "scope": ["variable.other.constant"],
+      "settings": {
+        "foreground": "#b84800"
+      }
+    },
+    {
+      "name": "Class / Type",
+      "scope": [
+        "entity.name.type",
+        "entity.name.class",
+        "support.type",
+        "support.class"
+      ],
+      "settings": {
+        "foreground": "#9a650f"
+      }
+    },
+    {
+      "name": "Interface",
+      "scope": ["entity.name.type.interface"],
+      "settings": {
+        "foreground": "#9a650f",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Namespace / Module",
+      "scope": ["entity.name.namespace", "entity.name.module"],
+      "settings": {
+        "foreground": "#a05545"
+      }
+    },
+    {
+      "name": "Decorator / Annotation",
+      "scope": [
+        "meta.decorator",
+        "punctuation.decorator",
+        "meta.decorator entity.name.function"
+      ],
+      "settings": {
+        "foreground": "#b84800",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Tag name (HTML/XML)",
+      "scope": ["entity.name.tag"],
+      "settings": {
+        "foreground": "#7630c5"
+      }
+    },
+    {
+      "name": "Tag attribute",
+      "scope": ["entity.other.attribute-name"],
+      "settings": {
+        "foreground": "#9a650f",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Import / Include / Require",
+      "scope": [
+        "keyword.control.import",
+        "keyword.control.from",
+        "keyword.other.import",
+        "keyword.control.export"
+      ],
+      "settings": {
+        "foreground": "#7630c5"
+      }
+    },
+    {
+      "name": "Regex",
+      "scope": ["string.regexp"],
+      "settings": {
+        "foreground": "#9c3f8b"
+      }
+    },
+    {
+      "name": "Markdown heading",
+      "scope": ["markup.heading", "entity.name.section.markdown"],
+      "settings": {
+        "foreground": "#7630c5",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown bold",
+      "scope": ["markup.bold"],
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "name": "Markdown italic",
+      "scope": ["markup.italic"],
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Markdown link",
+      "scope": ["markup.underline.link"],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "Markdown code",
+      "scope": ["markup.inline.raw", "markup.fenced_code"],
+      "settings": {
+        "foreground": "#2e7d20"
+      }
+    },
+    {
+      "name": "JSON key",
+      "scope": ["support.type.property-name.json"],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "YAML key",
+      "scope": ["entity.name.tag.yaml"],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "YAML anchor / alias",
+      "scope": ["entity.name.type.anchor.yaml", "variable.other.alias.yaml"],
+      "settings": {
+        "foreground": "#9a650f"
+      }
+    },
+    {
+      "name": "Python - Self",
+      "scope": ["variable.language.special.self.python"],
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python - Magic method",
+      "scope": ["support.function.magic.python"],
+      "settings": {
+        "foreground": "#1858d9",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python - Decorator",
+      "scope": ["entity.name.function.decorator.python"],
+      "settings": {
+        "foreground": "#b84800",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "Python - F-string expression",
+      "scope": ["meta.fstring"],
+      "settings": {
+        "foreground": "#2e7d20"
+      }
+    },
+    {
+      "name": "JavaScript/TypeScript - this",
+      "scope": ["variable.language.this"],
+      "settings": {
+        "foreground": "#d20f39",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "JavaScript - Template literal expression",
+      "scope": ["meta.template.expression"],
+      "settings": {
+        "foreground": "#4c4f69"
+      }
+    },
+    {
+      "name": "JavaScript - Arrow function",
+      "scope": ["storage.type.function.arrow"],
+      "settings": {
+        "foreground": "#0d6d73"
+      }
+    },
+    {
+      "name": "JavaScript/TypeScript - Console",
+      "scope": ["support.class.console"],
+      "settings": {
+        "foreground": "#9a650f"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Block type",
+      "scope": [
+        "entity.name.type.terraform",
+        "storage.type.hcl",
+        "keyword.other.hcl"
+      ],
+      "settings": {
+        "foreground": "#7630c5"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Resource name / label",
+      "scope": [
+        "entity.name.label.terraform",
+        "entity.name.resource.terraform",
+        "string.quoted.double.terraform"
+      ],
+      "settings": {
+        "foreground": "#2e7d20"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Attribute name",
+      "scope": [
+        "variable.other.property.hcl",
+        "variable.declaration.hcl"
+      ],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Interpolation",
+      "scope": [
+        "keyword.other.interpolation.begin.hcl",
+        "keyword.other.interpolation.end.hcl"
+      ],
+      "settings": {
+        "foreground": "#0d6d73"
+      }
+    },
+    {
+      "name": "HCL / Terraform - Function",
+      "scope": ["support.function.builtin.terraform"],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "Ansible - Module name",
+      "scope": ["entity.name.tag.yaml", "keyword.other.definition.yaml"],
+      "settings": {
+        "foreground": "#1858d9"
+      }
+    },
+    {
+      "name": "Ansible - Jinja2 / Template",
+      "scope": [
+        "keyword.control.flow.jinja",
+        "entity.other.jinja.delimiter.tag",
+        "entity.other.jinja.delimiter.variable"
+      ],
+      "settings": {
+        "foreground": "#b84800"
+      }
+    },
+    {
+      "name": "CSS - Property name",
+      "scope": ["support.type.property-name.css"],
+      "settings": {
+        "foreground": "#4c5ec8"
+      }
+    },
+    {
+      "name": "CSS - Property value",
+      "scope": ["support.constant.property-value.css"],
+      "settings": {
+        "foreground": "#b84800"
+      }
+    },
+    {
+      "name": "CSS - Unit",
+      "scope": ["keyword.other.unit.css"],
+      "settings": {
+        "foreground": "#b84800"
+      }
+    },
+    {
+      "name": "CSS - Selector / Class / ID",
+      "scope": [
+        "entity.other.attribute-name.class.css",
+        "entity.other.attribute-name.id.css"
+      ],
+      "settings": {
+        "foreground": "#9a650f"
+      }
+    }
+  ],
+  "semanticTokenColors": {
+    "function": "#1858d9",
+    "function.declaration": "#1858d9",
+    "method": "#1858d9",
+    "method.declaration": "#1858d9",
+    "variable": "#4c4f69",
+    "variable.readonly": "#b84800",
+    "variable.defaultLibrary": "#d20f39",
+    "parameter": "#b04e4e",
+    "property": "#4c5ec8",
+    "property.declaration": "#4c5ec8",
+    "class": "#9a650f",
+    "interface": { "foreground": "#9a650f", "fontStyle": "italic" },
+    "enum": "#9a650f",
+    "enumMember": "#0d6d73",
+    "type": "#9a650f",
+    "namespace": "#a05545",
+    "decorator": { "foreground": "#b84800", "fontStyle": "italic" },
+    "string": "#2e7d20",
+    "number": "#b84800",
+    "keyword": "#7630c5",
+    "comment": { "foreground": "#6c6f85", "fontStyle": "italic" },
+    "regexp": "#9c3f8b",
+    "operator": "#0d6d73"
+  }
+}


### PR DESCRIPTION
Dark theme based on Catppuccin Mocha palette with warm pastel syntax colors.
Light theme combines Catppuccin Latte hues with Claude mobile app warm
off-white background (#faf9f5), darkened to meet WCAG AA 4.5:1 contrast.

Optimized syntax highlighting for HCL/Terraform, Ansible, Python, and
JavaScript. Includes theme validator, WCAG contrast checker, and sample
files for all four languages.
