### PR TITLE
Add cache warmup demo with K8s, Prometheus, and K6 load testing

### DIFF
--- a/computer_science/cache_warmup/README.md
+++ b/computer_science/cache_warmup/README.md
@@ -1,0 +1,184 @@
+# Cache Warmup 효과를 눈으로 확인하는 데모
+
+## 요약
+
+- **캐시 워밍업(Cache Warmup)은 애플리케이션 시작 시점에 캐시를 미리 채워두는 기법**
+- 워밍업이 없으면 첫 요청들이 모두 DB를 조회해서 느림 (cold start)
+- 워밍업이 있으면 첫 요청부터 캐시 히트로 빠른 응답
+- 이 데모는 Kind 클러스터에 두 버전을 동시에 배포하고, K6 부하 테스트 + Grafana 대시보드로 차이를 비교
+
+## 목차
+
+- [캐시 워밍업이란?](#캐시-워밍업이란)
+- [프로젝트 구조](#프로젝트-구조)
+- [사전 준비](#사전-준비)
+- [실습](#실습)
+- [K6 부하 테스트](#k6-부하-테스트)
+- [Grafana 대시보드](#grafana-대시보드)
+- [정리](#정리)
+- [참고자료](#참고자료)
+
+## 캐시 워밍업이란?
+
+Cache Warmup은 두 단어를 합친 용어입니다. Cache + Warmup
+
+1. Cache: 자주 조회하는 데이터를 메모리에 저장해두는 저장소
+2. Warmup: 미리 데이터를 채워두는 행위
+3. Cache Warmup: **애플리케이션이 시작될 때, 트래픽을 받기 전에 캐시를 미리 채워두는 기법**
+
+### 워밍업이 없으면 어떤 일이 생길까?
+
+애플리케이션이 시작된 직후 캐시는 비어 있습니다. 모든 요청이 DB를 직접 조회하게 됩니다.
+
+```
+요청 → 캐시 확인 (비어있음) → DB 조회 (느림) → 캐시 저장 → 응답
+```
+
+트래픽이 많은 서비스에서 배포 직후 모든 요청이 DB로 몰리면 latency spike가 발생합니다.
+
+### 워밍업을 하면?
+
+시작 시점에 캐시를 채워두면 첫 요청부터 캐시 히트입니다.
+
+```
+[시작 시] DB 조회 → 캐시에 미리 저장
+[요청 시] 요청 → 캐시 확인 (히트!) → 즉시 응답
+```
+
+## 프로젝트 구조
+
+```
+cache_warmup/
+├── app/
+│   ├── main.py              # FastAPI 애플리케이션
+│   ├── run_with_warmup.py   # 워밍업 활성화 진입점
+│   ├── requirements.txt
+│   └── Dockerfile
+├── k8s/
+│   ├── app/
+│   │   ├── deployment-no-warmup.yaml
+│   │   ├── deployment-with-warmup.yaml
+│   │   └── service.yaml
+│   └── monitoring/
+│       ├── prometheus-config.yaml
+│       ├── prometheus.yaml
+│       ├── grafana.yaml
+│       ├── grafana-datasource.yaml
+│       └── grafana-dashboard.yaml
+├── k6/
+│   ├── load-test.js         # 일정 부하 테스트
+│   └── spike-test.js        # 스파이크 부하 테스트
+├── kind-config.yaml
+├── setup.sh                 # 한방 배포 스크립트
+└── cleanup.sh               # 클러스터 삭제
+```
+
+두 개의 동일한 API를 배포합니다. 차이는 딱 하나, 시작할 때 캐시를 채우느냐 안 채우느냐입니다.
+
+| 항목 | No Warmup | With Warmup |
+|------|-----------|-------------|
+| 시작 시 캐시 | 비어있음 | 100개 상품 미리 로드 |
+| 첫 요청 latency | ~50ms (DB 조회) | ~0.1ms (캐시 히트) |
+| NodePort | 30080 | 30081 |
+
+## 사전 준비
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [K6](https://k6.io/docs/get-started/installation/)
+
+## 실습
+
+### 1. 클러스터 생성 + 배포
+
+`setup.sh` 하나로 Kind 클러스터 생성, 이미지 빌드, 앱 배포, 모니터링 배포까지 완료됩니다.
+
+```bash
+./setup.sh
+```
+
+### 2. 배포 확인
+
+```bash
+kubectl get pods
+```
+
+Pod 4개가 Running이면 정상입니다.
+
+| Pod | 역할 |
+|-----|------|
+| product-api-no-warmup-* | 워밍업 없는 API |
+| product-api-with-warmup-* | 워밍업 있는 API |
+| prometheus-* | 메트릭 수집 |
+| grafana-* | 대시보드 |
+
+### 3. API 동작 확인
+
+워밍업 없는 버전은 첫 요청에서 cache miss가 발생합니다.
+
+```bash
+curl http://localhost:30080/products/1
+# {"data": {...}, "cache": "miss", "latency_ms": 50.xx}
+```
+
+워밍업 있는 버전은 첫 요청부터 cache hit입니다.
+
+```bash
+curl http://localhost:30081/products/1
+# {"data": {...}, "cache": "hit", "latency_ms": 0.xx}
+```
+
+## K6 부하 테스트
+
+### Load Test (일정 부하)
+
+두 API에 초당 20개 요청을 60초간 보냅니다.
+
+```bash
+k6 run k6/load-test.js
+```
+
+### Spike Test (스파이크 부하)
+
+초당 5 → 100 요청으로 급격히 증가하는 시나리오입니다. 배포 직후 트래픽이 몰리는 상황을 시뮬레이션합니다.
+
+```bash
+k6 run k6/spike-test.js
+```
+
+**스파이크 테스트에서 워밍업의 효과가 가장 두드러집니다.** 워밍업이 없으면 모든 요청이 DB를 조회하면서 latency가 치솟습니다.
+
+## Grafana 대시보드
+
+http://localhost:30030 에 접속하면 "Cache Warmup Comparison" 대시보드가 자동으로 프로비저닝되어 있습니다.
+
+| 패널 | 설명 |
+|------|------|
+| P50 Latency Comparison | 중간값 latency 비교 |
+| P99 Latency Comparison | 꼬리 latency 비교 |
+| Request Rate | 초당 요청 수 (cache hit/miss 구분) |
+| Cache Hit Rate | 캐시 적중률 (%) |
+| Latency Heatmap | latency 분포를 히트맵으로 시각화 |
+
+### 어떤 차이가 보일까?
+
+- **No Warmup**: 초반에 cache miss가 대량 발생하면서 P99 latency가 50ms 이상
+- **With Warmup**: 처음부터 cache hit이므로 P99 latency가 1ms 미만
+- 시간이 지나면 No Warmup도 캐시가 채워지면서 latency가 떨어짐 → 하지만 이미 초반 사용자는 느린 응답을 경험
+
+## 정리
+
+```bash
+./cleanup.sh
+```
+
+Kind 클러스터가 삭제됩니다.
+
+## 참고자료
+
+- https://fastapi.tiangolo.com/advanced/events/#lifespan
+- https://kind.sigs.k8s.io/
+- https://k6.io/docs/
+- https://prometheus.io/docs/introduction/overview/
+- https://grafana.com/docs/grafana/latest/

--- a/computer_science/cache_warmup/app/Dockerfile
+++ b/computer_science/cache_warmup/app/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/computer_science/cache_warmup/app/main.py
+++ b/computer_science/cache_warmup/app/main.py
@@ -1,0 +1,96 @@
+import time
+import asyncio
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from prometheus_client import Histogram, Counter, generate_latest, CONTENT_TYPE_LATEST
+from starlette.responses import Response
+
+LATENCY = Histogram(
+  "request_latency_seconds",
+  "Request latency",
+  ["endpoint", "cache_status"],
+  buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0],
+)
+REQUEST_COUNT = Counter(
+  "request_total",
+  "Total requests",
+  ["endpoint", "cache_status"],
+)
+
+cache: dict[str, dict] = {}
+
+PRODUCTS = {
+  str(i): {
+    "id": i,
+    "name": f"Product-{i}",
+    "price": round(10.0 + i * 1.5, 2),
+    "description": f"Detailed description for product {i}",
+  }
+  for i in range(1, 101)
+}
+
+
+def simulate_db_query(product_id: str) -> dict | None:
+  time.sleep(0.05)
+  return PRODUCTS.get(product_id)
+
+
+def warmup_cache():
+  for pid, product in PRODUCTS.items():
+    cache[pid] = product
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+  if app.state.enable_warmup:
+    warmup_cache()
+  yield
+  cache.clear()
+
+
+app = FastAPI(lifespan=lifespan)
+app.state.enable_warmup = False
+
+
+@app.get("/products/{product_id}")
+async def get_product(product_id: str):
+  start = time.perf_counter()
+
+  if product_id in cache:
+    latency = time.perf_counter() - start
+    LATENCY.labels(endpoint="/products", cache_status="hit").observe(latency)
+    REQUEST_COUNT.labels(endpoint="/products", cache_status="hit").inc()
+    return {"data": cache[product_id], "cache": "hit", "latency_ms": round(latency * 1000, 2)}
+
+  product = await asyncio.to_thread(simulate_db_query, product_id)
+  if not product:
+    return {"error": "not found"}, 404
+
+  cache[product_id] = product
+  latency = time.perf_counter() - start
+  LATENCY.labels(endpoint="/products", cache_status="miss").observe(latency)
+  REQUEST_COUNT.labels(endpoint="/products", cache_status="miss").inc()
+  return {"data": product, "cache": "miss", "latency_ms": round(latency * 1000, 2)}
+
+
+@app.get("/health")
+async def health():
+  return {"status": "ok", "cache_size": len(cache)}
+
+
+@app.post("/admin/warmup")
+async def manual_warmup():
+  warmup_cache()
+  return {"status": "warmed", "cache_size": len(cache)}
+
+
+@app.post("/admin/clear-cache")
+async def clear_cache():
+  cache.clear()
+  return {"status": "cleared"}
+
+
+@app.get("/metrics")
+async def metrics():
+  return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/computer_science/cache_warmup/app/requirements.txt
+++ b/computer_science/cache_warmup/app/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+prometheus-client==0.21.1

--- a/computer_science/cache_warmup/app/run_with_warmup.py
+++ b/computer_science/cache_warmup/app/run_with_warmup.py
@@ -1,0 +1,7 @@
+import uvicorn
+from main import app
+
+app.state.enable_warmup = True
+
+if __name__ == "__main__":
+  uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/computer_science/cache_warmup/cleanup.sh
+++ b/computer_science/cache_warmup/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+kind delete cluster --name cache-warmup
+echo "클러스터 삭제 완료"

--- a/computer_science/cache_warmup/k6/load-test.js
+++ b/computer_science/cache_warmup/k6/load-test.js
@@ -1,0 +1,64 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend, Rate } from "k6/metrics";
+
+const latencyTrend = new Trend("product_latency_ms");
+const cacheHitRate = new Rate("cache_hit_rate");
+
+const BASE_NO_WARMUP = __ENV.NO_WARMUP_URL || "http://localhost:30080";
+const BASE_WITH_WARMUP = __ENV.WITH_WARMUP_URL || "http://localhost:30081";
+
+export const options = {
+  scenarios: {
+    no_warmup: {
+      executor: "constant-rate",
+      rate: 20,
+      timeUnit: "1s",
+      duration: "60s",
+      preAllocatedVUs: 50,
+      exec: "testNoWarmup",
+    },
+    with_warmup: {
+      executor: "constant-rate",
+      rate: 20,
+      timeUnit: "1s",
+      duration: "60s",
+      preAllocatedVUs: 50,
+      exec: "testWithWarmup",
+    },
+  },
+  thresholds: {
+    "product_latency_ms{variant:with-warmup}": ["p(99)<50"],
+    "product_latency_ms{variant:no-warmup}": ["p(99)<200"],
+  },
+};
+
+function randomProductId() {
+  return Math.floor(Math.random() * 100) + 1;
+}
+
+export function testNoWarmup() {
+  const id = randomProductId();
+  const res = http.get(`${BASE_NO_WARMUP}/products/${id}`, {
+    tags: { variant: "no-warmup" },
+  });
+  check(res, { "status 200": (r) => r.status === 200 });
+
+  const body = res.json();
+  latencyTrend.add(body.latency_ms || 0, { variant: "no-warmup" });
+  cacheHitRate.add(body.cache === "hit", { variant: "no-warmup" });
+  sleep(0.1);
+}
+
+export function testWithWarmup() {
+  const id = randomProductId();
+  const res = http.get(`${BASE_WITH_WARMUP}/products/${id}`, {
+    tags: { variant: "with-warmup" },
+  });
+  check(res, { "status 200": (r) => r.status === 200 });
+
+  const body = res.json();
+  latencyTrend.add(body.latency_ms || 0, { variant: "with-warmup" });
+  cacheHitRate.add(body.cache === "hit", { variant: "with-warmup" });
+  sleep(0.1);
+}

--- a/computer_science/cache_warmup/k6/spike-test.js
+++ b/computer_science/cache_warmup/k6/spike-test.js
@@ -1,0 +1,61 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Trend } from "k6/metrics";
+
+const latency = new Trend("product_latency_ms");
+
+const BASE_NO_WARMUP = __ENV.NO_WARMUP_URL || "http://localhost:30080";
+const BASE_WITH_WARMUP = __ENV.WITH_WARMUP_URL || "http://localhost:30081";
+
+export const options = {
+  scenarios: {
+    no_warmup_spike: {
+      executor: "ramping-rate",
+      startRate: 5,
+      timeUnit: "1s",
+      stages: [
+        { target: 5, duration: "10s" },
+        { target: 100, duration: "5s" },
+        { target: 100, duration: "30s" },
+        { target: 5, duration: "10s" },
+      ],
+      preAllocatedVUs: 200,
+      exec: "testNoWarmup",
+    },
+    with_warmup_spike: {
+      executor: "ramping-rate",
+      startRate: 5,
+      timeUnit: "1s",
+      stages: [
+        { target: 5, duration: "10s" },
+        { target: 100, duration: "5s" },
+        { target: 100, duration: "30s" },
+        { target: 5, duration: "10s" },
+      ],
+      preAllocatedVUs: 200,
+      exec: "testWithWarmup",
+    },
+  },
+};
+
+function randomProductId() {
+  return Math.floor(Math.random() * 100) + 1;
+}
+
+export function testNoWarmup() {
+  const id = randomProductId();
+  const res = http.get(`${BASE_NO_WARMUP}/products/${id}`);
+  check(res, { "status 200": (r) => r.status === 200 });
+  const body = res.json();
+  latency.add(body.latency_ms || 0, { variant: "no-warmup" });
+  sleep(0.05);
+}
+
+export function testWithWarmup() {
+  const id = randomProductId();
+  const res = http.get(`${BASE_WITH_WARMUP}/products/${id}`);
+  check(res, { "status 200": (r) => r.status === 200 });
+  const body = res.json();
+  latency.add(body.latency_ms || 0, { variant: "with-warmup" });
+  sleep(0.05);
+}

--- a/computer_science/cache_warmup/k8s/app/deployment-no-warmup.yaml
+++ b/computer_science/cache_warmup/k8s/app/deployment-no-warmup.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-api-no-warmup
+  labels:
+    app: product-api
+    variant: no-warmup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: product-api
+      variant: no-warmup
+  template:
+    metadata:
+      labels:
+        app: product-api
+        variant: no-warmup
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: api
+          image: product-api:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8000
+          command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/computer_science/cache_warmup/k8s/app/deployment-with-warmup.yaml
+++ b/computer_science/cache_warmup/k8s/app/deployment-with-warmup.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-api-with-warmup
+  labels:
+    app: product-api
+    variant: with-warmup
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: product-api
+      variant: with-warmup
+  template:
+    metadata:
+      labels:
+        app: product-api
+        variant: with-warmup
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: api
+          image: product-api:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8000
+          command: ["python", "run_with_warmup.py"]
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/computer_science/cache_warmup/k8s/app/service.yaml
+++ b/computer_science/cache_warmup/k8s/app/service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-api-no-warmup
+  labels:
+    app: product-api
+    variant: no-warmup
+spec:
+  selector:
+    app: product-api
+    variant: no-warmup
+  ports:
+    - port: 8000
+      targetPort: 8000
+      nodePort: 30080
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-api-with-warmup
+  labels:
+    app: product-api
+    variant: with-warmup
+spec:
+  selector:
+    app: product-api
+    variant: with-warmup
+  ports:
+    - port: 8000
+      targetPort: 8000
+      nodePort: 30081
+  type: NodePort

--- a/computer_science/cache_warmup/k8s/monitoring/grafana-dashboard.yaml
+++ b/computer_science/cache_warmup/k8s/monitoring/grafana-dashboard.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+data:
+  dashboard.yml: |
+    apiVersion: 1
+    providers:
+      - name: default
+        orgId: 1
+        folder: ""
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-json
+data:
+  cache-warmup.json: |
+    {
+      "title": "Cache Warmup Comparison",
+      "uid": "cache-warmup",
+      "panels": [
+        {
+          "title": "P50 Latency Comparison",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum(rate(request_latency_seconds_bucket[30s])) by (le, job))",
+              "legendFormat": "p50 - {{job}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "s" }
+          }
+        },
+        {
+          "title": "P99 Latency Comparison",
+          "type": "timeseries",
+          "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(request_latency_seconds_bucket[30s])) by (le, job))",
+              "legendFormat": "p99 - {{job}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "s" }
+          }
+        },
+        {
+          "title": "Request Rate",
+          "type": "timeseries",
+          "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "sum(rate(request_total[30s])) by (job, cache_status)",
+              "legendFormat": "{{job}} - {{cache_status}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "reqps" }
+          }
+        },
+        {
+          "title": "Cache Hit Rate",
+          "type": "gauge",
+          "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "sum(rate(request_total{cache_status=\"hit\"}[1m])) by (job) / sum(rate(request_total[1m])) by (job) * 100",
+              "legendFormat": "{{job}}"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": { "unit": "percent", "min": 0, "max": 100 }
+          }
+        },
+        {
+          "title": "Latency Heatmap (No Warmup)",
+          "type": "heatmap",
+          "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "sum(rate(request_latency_seconds_bucket{job=\"product-api-no-warmup\"}[30s])) by (le)",
+              "legendFormat": "{{le}}",
+              "format": "heatmap"
+            }
+          ]
+        },
+        {
+          "title": "Latency Heatmap (With Warmup)",
+          "type": "heatmap",
+          "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+          "targets": [
+            {
+              "expr": "sum(rate(request_latency_seconds_bucket{job=\"product-api-with-warmup\"}[30s])) by (le)",
+              "legendFormat": "{{le}}",
+              "format": "heatmap"
+            }
+          ]
+        }
+      ],
+      "time": { "from": "now-5m", "to": "now" },
+      "refresh": "5s",
+      "schemaVersion": 39
+    }

--- a/computer_science/cache_warmup/k8s/monitoring/grafana-datasource.yaml
+++ b/computer_science/cache_warmup/k8s/monitoring/grafana-datasource.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+data:
+  datasource.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true

--- a/computer_science/cache_warmup/k8s/monitoring/grafana.yaml
+++ b/computer_science/cache_warmup/k8s/monitoring/grafana.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.0
+          ports:
+            - containerPort: 3000
+          env:
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: "Admin"
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              value: "admin"
+          volumeMounts:
+            - name: datasource
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+            - name: dashboard-json
+              mountPath: /var/lib/grafana/dashboards
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+      volumes:
+        - name: datasource
+          configMap:
+            name: grafana-datasource
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboard-json
+          configMap:
+            name: grafana-dashboard-json
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+    - port: 3000
+      targetPort: 3000
+      nodePort: 30030
+  type: NodePort

--- a/computer_science/cache_warmup/k8s/monitoring/prometheus-config.yaml
+++ b/computer_science/cache_warmup/k8s/monitoring/prometheus-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+
+    scrape_configs:
+      - job_name: "product-api-no-warmup"
+        static_configs:
+          - targets: ["product-api-no-warmup:8000"]
+            labels:
+              variant: "no-warmup"
+
+      - job_name: "product-api-with-warmup"
+        static_configs:
+          - targets: ["product-api-with-warmup:8000"]
+            labels:
+              variant: "with-warmup"

--- a/computer_science/cache_warmup/k8s/monitoring/prometheus.yaml
+++ b/computer_science/cache_warmup/k8s/monitoring/prometheus.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.51.0
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - port: 9090
+      targetPort: 9090
+      nodePort: 30090
+  type: NodePort

--- a/computer_science/cache_warmup/kind-config.yaml
+++ b/computer_science/cache_warmup/kind-config.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30080
+        hostPort: 30080
+      - containerPort: 30081
+        hostPort: 30081
+      - containerPort: 30090
+        hostPort: 30090
+      - containerPort: 30030
+        hostPort: 30030

--- a/computer_science/cache_warmup/setup.sh
+++ b/computer_science/cache_warmup/setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME="cache-warmup"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== 1. Kind 클러스터 생성 ==="
+if kind get clusters 2>/dev/null | grep -q "$CLUSTER_NAME"; then
+  echo "클러스터 '$CLUSTER_NAME' 이미 존재. 삭제 후 재생성합니다."
+  kind delete cluster --name "$CLUSTER_NAME"
+fi
+kind create cluster --name "$CLUSTER_NAME" --config "$SCRIPT_DIR/kind-config.yaml"
+
+echo "=== 2. Docker 이미지 빌드 ==="
+docker build -t product-api:latest "$SCRIPT_DIR/app"
+
+echo "=== 3. Kind에 이미지 로드 ==="
+kind load docker-image product-api:latest --name "$CLUSTER_NAME"
+
+echo "=== 4. 모니터링 스택 배포 ==="
+kubectl apply -f "$SCRIPT_DIR/k8s/monitoring/prometheus-config.yaml"
+kubectl apply -f "$SCRIPT_DIR/k8s/monitoring/prometheus.yaml"
+kubectl apply -f "$SCRIPT_DIR/k8s/monitoring/grafana-datasource.yaml"
+kubectl apply -f "$SCRIPT_DIR/k8s/monitoring/grafana-dashboard.yaml"
+kubectl apply -f "$SCRIPT_DIR/k8s/monitoring/grafana.yaml"
+
+echo "=== 5. 애플리케이션 배포 ==="
+kubectl apply -f "$SCRIPT_DIR/k8s/app/service.yaml"
+kubectl apply -f "$SCRIPT_DIR/k8s/app/deployment-no-warmup.yaml"
+kubectl apply -f "$SCRIPT_DIR/k8s/app/deployment-with-warmup.yaml"
+
+echo "=== 6. Pod 준비 대기 ==="
+kubectl wait --for=condition=ready pod -l app=product-api --timeout=120s
+kubectl wait --for=condition=ready pod -l app=prometheus --timeout=120s
+kubectl wait --for=condition=ready pod -l app=grafana --timeout=120s
+
+echo ""
+echo "=== 배포 완료 ==="
+echo "No Warmup API : http://localhost:30080/products/1"
+echo "With Warmup API: http://localhost:30081/products/1"
+echo "Prometheus     : http://localhost:30090"
+echo "Grafana        : http://localhost:30030 (admin/admin)"
+echo ""
+echo "K6 부하 테스트 실행:"
+echo "  k6 run k6/load-test.js"
+echo "  k6 run k6/spike-test.js"


### PR DESCRIPTION
## Summary

This PR adds a comprehensive educational demo showcasing the impact of cache warmup on application performance. The demo deploys two identical FastAPI applications to a Kind cluster—one with cache warmup enabled and one without—and uses K6 load testing with Prometheus/Grafana monitoring to visualize the performance differences.

## Key Changes

- **FastAPI Application** (`app/main.py`): 
  - Implements a product API with in-memory caching and simulated DB queries (50ms latency)
  - Exposes Prometheus metrics for request latency (histogram) and request counts (counter) with cache hit/miss labels
  - Uses FastAPI lifespan events to conditionally warm up cache on startup
  - Includes health check and admin endpoints for cache management

- **Cache Warmup Entry Point** (`app/run_with_warmup.py`):
  - Separate entry point that enables cache warmup before starting the server
  - Allows running the same application code with different startup behaviors

- **Kubernetes Deployments**:
  - Two deployments (`deployment-no-warmup.yaml`, `deployment-with-warmup.yaml`) running the same image with different startup commands
  - Services exposing each variant on separate NodePorts (30080, 30081)
  - Prometheus and Grafana deployments for monitoring

- **Monitoring Stack**:
  - Prometheus configuration scraping metrics from both API variants
  - Grafana dashboard with 6 panels comparing P50/P99 latency, request rates, cache hit rates, and latency heatmaps
  - Auto-provisioned dashboard configuration

- **Load Testing** (`k6/load-test.js`, `k6/spike-test.js`):
  - Load test: constant 20 req/s for 60 seconds
  - Spike test: ramping from 5 to 100 req/s to simulate deployment traffic surge
  - Both tests run against both API variants simultaneously for direct comparison

- **Automation**:
  - `setup.sh`: One-command deployment of Kind cluster, Docker image build, and all services
  - `cleanup.sh`: Cluster teardown
  - `kind-config.yaml`: Port mappings for local access to all services

## Notable Implementation Details

- Cache warmup loads all 100 products into memory during startup, eliminating cache misses for initial requests
- Latency measurements include both cache hits (~0.1ms) and misses (~50ms) to demonstrate the performance impact
- Prometheus metrics use labels to distinguish between cache hit/miss and deployment variants, enabling side-by-side comparison in Grafana
- The demo is fully self-contained and can be run locally with just Kind, Docker, and K6

https://claude.ai/code/session_01MDo7omw6bAEZK5uCnvYVp3