### PR TITLE
Add JVM Heap Xms vs Xmx comparison test project

### DIFF
--- a/backend/jvm_heap_xms/Dockerfile
+++ b/backend/jvm_heap_xms/Dockerfile
@@ -1,0 +1,13 @@
+FROM gradle:8.10-jdk17 AS builder
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY src ./src
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# JVM 옵션은 환경변수 JAVA_OPTS로 주입
+ENV JAVA_OPTS=""
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/backend/jvm_heap_xms/README.md
+++ b/backend/jvm_heap_xms/README.md
@@ -1,0 +1,155 @@
+# JVM Heap Xms vs Xmx 차이 테스트
+
+JVM의 `-Xms`(초기 힙 크기)와 `-Xmx`(최대 힙 크기) 설정이 애플리케이션 성능에 미치는 영향을 비교 테스트하는 프로젝트.
+
+## 핵심 차이점
+
+| 설정 | Xms == Xmx (`-Xms256m -Xmx256m`) | Xms < Xmx (`-Xms64m -Xmx256m`) |
+|------|-----------------------------------|----------------------------------|
+| 초기 힙 크기 | 256MB (전체 확보) | 64MB (최소한으로 시작) |
+| 힙 리사이징 | 없음 | 부하 시 동적으로 확장 |
+| GC 빈도 | 상대적으로 낮음 | 힙이 작을 때 빈번하게 발생 |
+| 응답 시간 | 안정적 | 힙 확장 시 jitter 발생 |
+| 메모리 효율 | 시작부터 전체 점유 | 필요할 때만 확장 |
+
+## 프로젝트 구조
+
+```
+backend/jvm_heap_xms/
+├── src/                          # Spring Boot 소스
+├── k8s/                          # Kubernetes 매니페스트
+│   ├── kind-config.yaml          # Kind 클러스터 설정 (NodePort 매핑)
+│   ├── namespace.yaml
+│   ├── deployment-xms-equal-xmx.yaml   # Xms == Xmx 디플로이먼트
+│   ├── deployment-xms-less-xmx.yaml    # Xms < Xmx 디플로이먼트
+│   ├── service-xms-equal-xmx.yaml      # NodePort 30081
+│   └── service-xms-less-xmx.yaml       # NodePort 30082
+├── k6/                           # k6 부하 테스트 스크립트
+│   ├── scenario1-allocate.js     # 대량 할당/해제 시나리오
+│   ├── scenario2-hold.js         # 메모리 점유 시나리오
+│   └── scenario3-mixed.js        # 혼합 시나리오
+├── Dockerfile
+├── docker-compose.yml
+└── build.gradle
+```
+
+## API 엔드포인트
+
+| 엔드포인트 | 설명 | 파라미터 |
+|------------|------|---------|
+| `GET /allocate` | 메모리 할당 후 즉시 해제 | `sizeMb` (기본 10), `count` (기본 50) |
+| `GET /hold` | 메모리를 일정 시간 유지 | `sizeMb` (기본 5), `holdMs` (기본 500) |
+| `GET /heap` | 현재 힙 메모리 상태 조회 | 없음 |
+| `GET /actuator/health/liveness` | Liveness probe | 없음 |
+| `GET /actuator/health/readiness` | Readiness probe | 없음 |
+
+## 실행 방법
+
+### 1. Docker Compose로 실행 (로컬 테스트)
+
+```bash
+cd backend/jvm_heap_xms
+
+# 빌드 및 실행
+docker compose up --build -d
+
+# 확인
+curl http://localhost:8081/heap   # Xms == Xmx
+curl http://localhost:8082/heap   # Xms < Xmx
+```
+
+### 2. Kind 클러스터에서 실행
+
+```bash
+# Kind 클러스터 생성
+kind create cluster --name heap-test --config k8s/kind-config.yaml
+
+# Docker 이미지 빌드
+docker build -t heap-test:latest .
+
+# Kind에 이미지 로드
+kind load docker-image heap-test:latest --name heap-test
+
+# Kubernetes 리소스 배포
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/deployment-xms-equal-xmx.yaml
+kubectl apply -f k8s/deployment-xms-less-xmx.yaml
+kubectl apply -f k8s/service-xms-equal-xmx.yaml
+kubectl apply -f k8s/service-xms-less-xmx.yaml
+
+# Pod 상태 확인
+kubectl get pods -n heap-test -w
+
+# 접속 확인
+curl http://localhost:30081/heap   # Xms == Xmx
+curl http://localhost:30082/heap   # Xms < Xmx
+```
+
+### 3. k6 부하 테스트 실행
+
+```bash
+# 시나리오 1: 대량 할당/해제 (Xms == Xmx)
+k6 run --env TARGET=http://localhost:30081 k6/scenario1-allocate.js
+
+# 시나리오 1: 대량 할당/해제 (Xms < Xmx)
+k6 run --env TARGET=http://localhost:30082 k6/scenario1-allocate.js
+
+# 시나리오 2: 메모리 점유 (Xms == Xmx)
+k6 run --env TARGET=http://localhost:30081 k6/scenario2-hold.js
+
+# 시나리오 2: 메모리 점유 (Xms < Xmx)
+k6 run --env TARGET=http://localhost:30082 k6/scenario2-hold.js
+
+# 시나리오 3: 혼합 부하 (Xms == Xmx)
+k6 run --env TARGET=http://localhost:30081 k6/scenario3-mixed.js
+
+# 시나리오 3: 혼합 부하 (Xms < Xmx)
+k6 run --env TARGET=http://localhost:30082 k6/scenario3-mixed.js
+```
+
+## 테스트 시나리오 설명
+
+### 시나리오 1: allocate & release (`scenario1-allocate.js`)
+- 10MB 바이트 배열을 50회 반복 할당 후 해제
+- **관측 포인트**: 힙 확장(heap resizing)으로 인한 응답 시간 차이
+- **예상 결과**: `Xms < Xmx`에서 p99 응답 시간이 더 높게 나타남
+
+### 시나리오 2: allocate & hold (`scenario2-hold.js`)
+- 5MB를 할당하고 500ms 동안 유지
+- 동시 요청이 많아지면 힙 사용량이 누적됨
+- **관측 포인트**: 동시 메모리 점유 시 GC 빈도와 stop-the-world 시간
+- **예상 결과**: `Xms < Xmx`에서 응답 시간 변동폭(jitter)이 더 큼
+
+### 시나리오 3: 혼합 부하 (`scenario3-mixed.js`)
+- allocate와 hold를 동시에 실행하는 혼합 워크로드
+- **관측 포인트**: Xms/Xmx 차이가 가장 극적으로 드러나는 시나리오
+- **예상 결과**: `Xms < Xmx`에서 Full GC가 발생할 가능성이 높음
+
+## 관측 방법
+
+### GC 로그 확인
+```bash
+# Docker
+docker logs heap-test-equal 2>&1 | grep "GC"
+docker logs heap-test-different 2>&1 | grep "GC"
+
+# Kubernetes
+kubectl logs -n heap-test deployment/heap-test-equal | grep "GC"
+kubectl logs -n heap-test deployment/heap-test-different | grep "GC"
+```
+
+### Prometheus 메트릭
+```bash
+curl http://localhost:30081/actuator/prometheus | grep jvm_memory
+curl http://localhost:30082/actuator/prometheus | grep jvm_memory
+```
+
+## 정리
+
+```bash
+# Kind 클러스터 삭제
+kind delete cluster --name heap-test
+
+# Docker Compose 정리
+docker compose down
+```

--- a/backend/jvm_heap_xms/build.gradle
+++ b/backend/jvm_heap_xms/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.6'
+    id 'io.spring.dependency-management' version '1.1.6'
+}
+
+group = 'com.example'
+version = '0.0.1'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+}

--- a/backend/jvm_heap_xms/docker-compose.yml
+++ b/backend/jvm_heap_xms/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  # Case 1: Xms == Xmx (힙 리사이징 없음)
+  app-equal:
+    build: .
+    container_name: heap-test-equal
+    ports:
+      - "8081:8080"
+    environment:
+      JAVA_OPTS: "-Xms256m -Xmx256m -XX:+PrintGCDetails -Xlog:gc*:stdout"
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "1.0"
+
+  # Case 2: Xms < Xmx (힙 리사이징 발생)
+  app-different:
+    build: .
+    container_name: heap-test-different
+    ports:
+      - "8082:8080"
+    environment:
+      JAVA_OPTS: "-Xms64m -Xmx256m -XX:+PrintGCDetails -Xlog:gc*:stdout"
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: "1.0"

--- a/backend/jvm_heap_xms/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/jvm_heap_xms/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/backend/jvm_heap_xms/k6/scenario1-allocate.js
+++ b/backend/jvm_heap_xms/k6/scenario1-allocate.js
@@ -1,0 +1,44 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Counter } from 'k6/metrics';
+
+/**
+ * 시나리오 1: allocate & release 부하 테스트
+ *
+ * 대량의 객체를 할당하고 즉시 해제하는 패턴.
+ * Xms < Xmx 환경에서는 힙이 작은 크기에서 시작하므로
+ * 할당 시마다 힙 확장(heap resizing)과 GC가 빈번하게 발생한다.
+ *
+ * 비교 대상:
+ *   - Xms == Xmx (port 30081): 힙 리사이징 없음 → 안정적인 응답 시간
+ *   - Xms < Xmx  (port 30082): 힙 리사이징 발생 → 응답 시간 불안정, p99 증가
+ *
+ * 사용법:
+ *   k6 run --env TARGET=http://localhost:30081 k6/scenario1-allocate.js
+ *   k6 run --env TARGET=http://localhost:30082 k6/scenario1-allocate.js
+ */
+
+const BASE_URL = __ENV.TARGET || 'http://localhost:8080';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 20 },   // ramp-up
+    { duration: '1m',  target: 50 },   // sustained load
+    { duration: '30s', target: 100 },  // peak load
+    { duration: '30s', target: 0 },    // ramp-down
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<3000', 'p(99)<5000'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+export default function () {
+  // sizeMb=10, count=50 → 반복적으로 10MB 배열 50회 할당/해제
+  const res = http.get(`${BASE_URL}/allocate?sizeMb=10&count=50`);
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response has elapsedMs': (r) => JSON.parse(r.body).elapsedMs !== undefined,
+  });
+  sleep(0.1);
+}

--- a/backend/jvm_heap_xms/k6/scenario2-hold.js
+++ b/backend/jvm_heap_xms/k6/scenario2-hold.js
@@ -1,0 +1,54 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+/**
+ * 시나리오 2: allocate & hold 부하 테스트
+ *
+ * 메모리를 할당한 뒤 일정 시간 유지하는 패턴.
+ * 동시 요청이 늘어나면 힙 사용량이 누적된다.
+ *
+ * Xms < Xmx 환경에서는:
+ *   - 초기 힙이 작아 빠르게 소진됨
+ *   - 힙 확장과 GC가 동시에 발생하며 stop-the-world 시간이 길어짐
+ *   - 응답 시간의 jitter(변동폭)가 크게 증가
+ *
+ * Xms == Xmx 환경에서는:
+ *   - 처음부터 전체 힙이 확보되어 있어 리사이징이 없음
+ *   - GC는 발생하지만 힙 확장으로 인한 추가 비용이 없음
+ *   - 응답 시간이 상대적으로 안정적
+ *
+ * 사용법:
+ *   k6 run --env TARGET=http://localhost:30081 k6/scenario2-hold.js
+ *   k6 run --env TARGET=http://localhost:30082 k6/scenario2-hold.js
+ */
+
+const BASE_URL = __ENV.TARGET || 'http://localhost:8080';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 30 },   // ramp-up
+    { duration: '1m',  target: 80 },   // sustained load (동시에 80명이 메모리를 점유)
+    { duration: '30s', target: 150 },  // peak load
+    { duration: '30s', target: 0 },    // ramp-down
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<5000', 'p(99)<10000'],
+    http_req_failed: ['rate<0.10'],
+  },
+};
+
+export default function () {
+  // sizeMb=5, holdMs=500 → 5MB를 500ms 동안 유지
+  const res = http.get(`${BASE_URL}/hold?sizeMb=5&holdMs=500`);
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response has elapsedMs': (r) => {
+      try {
+        return JSON.parse(r.body).elapsedMs !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+  sleep(0.2);
+}

--- a/backend/jvm_heap_xms/k6/scenario3-mixed.js
+++ b/backend/jvm_heap_xms/k6/scenario3-mixed.js
@@ -1,0 +1,66 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { SharedArray } from 'k6/data';
+
+/**
+ * 시나리오 3: 혼합 부하 테스트
+ *
+ * allocate + hold를 동시에 호출하여 실제 워크로드에 가까운 상황을 재현한다.
+ * 이 시나리오에서 Xms/Xmx 차이가 가장 극적으로 드러난다.
+ *
+ * Xms < Xmx: 힙 확장 + 메모리 점유가 겹치면서 Full GC가 발생할 수 있음
+ * Xms == Xmx: 힙이 이미 확보되어 있으므로 GC만 관리하면 됨
+ *
+ * 사용법:
+ *   k6 run --env TARGET=http://localhost:30081 k6/scenario3-mixed.js
+ *   k6 run --env TARGET=http://localhost:30082 k6/scenario3-mixed.js
+ */
+
+const BASE_URL = __ENV.TARGET || 'http://localhost:8080';
+
+export const options = {
+  scenarios: {
+    allocate: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 20 },
+        { duration: '1m',  target: 40 },
+        { duration: '30s', target: 60 },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'allocateTest',
+    },
+    hold: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '30s', target: 15 },
+        { duration: '1m',  target: 30 },
+        { duration: '30s', target: 50 },
+        { duration: '30s', target: 0 },
+      ],
+      exec: 'holdTest',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<5000', 'p(99)<10000'],
+    http_req_failed: ['rate<0.10'],
+  },
+};
+
+export function allocateTest() {
+  const res = http.get(`${BASE_URL}/allocate?sizeMb=10&count=30`);
+  check(res, {
+    'allocate: status 200': (r) => r.status === 200,
+  });
+  sleep(0.1);
+}
+
+export function holdTest() {
+  const res = http.get(`${BASE_URL}/hold?sizeMb=5&holdMs=300`);
+  check(res, {
+    'hold: status 200': (r) => r.status === 200,
+  });
+  sleep(0.2);
+}

--- a/backend/jvm_heap_xms/k8s/deployment-xms-equal-xmx.yaml
+++ b/backend/jvm_heap_xms/k8s/deployment-xms-equal-xmx.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: heap-test-equal
+  namespace: heap-test
+  labels:
+    app: heap-test
+    variant: xms-equal-xmx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: heap-test
+      variant: xms-equal-xmx
+  template:
+    metadata:
+      labels:
+        app: heap-test
+        variant: xms-equal-xmx
+    spec:
+      containers:
+        - name: app
+          image: heap-test:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          env:
+            - name: JAVA_OPTS
+              value: "-Xms256m -Xmx256m -XX:+PrintGCDetails -Xlog:gc*:stdout"
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "500m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 3

--- a/backend/jvm_heap_xms/k8s/deployment-xms-less-xmx.yaml
+++ b/backend/jvm_heap_xms/k8s/deployment-xms-less-xmx.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: heap-test-different
+  namespace: heap-test
+  labels:
+    app: heap-test
+    variant: xms-less-xmx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: heap-test
+      variant: xms-less-xmx
+  template:
+    metadata:
+      labels:
+        app: heap-test
+        variant: xms-less-xmx
+    spec:
+      containers:
+        - name: app
+          image: heap-test:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8080
+          env:
+            - name: JAVA_OPTS
+              value: "-Xms64m -Xmx256m -XX:+PrintGCDetails -Xlog:gc*:stdout"
+          resources:
+            requests:
+              memory: "384Mi"
+              cpu: "500m"
+            limits:
+              memory: "512Mi"
+              cpu: "1000m"
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            failureThreshold: 3

--- a/backend/jvm_heap_xms/k8s/kind-config.yaml
+++ b/backend/jvm_heap_xms/k8s/kind-config.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      # Xms == Xmx 서비스 NodePort
+      - containerPort: 30081
+        hostPort: 30081
+        protocol: TCP
+      # Xms < Xmx 서비스 NodePort
+      - containerPort: 30082
+        hostPort: 30082
+        protocol: TCP

--- a/backend/jvm_heap_xms/k8s/namespace.yaml
+++ b/backend/jvm_heap_xms/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: heap-test

--- a/backend/jvm_heap_xms/k8s/service-xms-equal-xmx.yaml
+++ b/backend/jvm_heap_xms/k8s/service-xms-equal-xmx.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: heap-test-equal
+  namespace: heap-test
+spec:
+  type: NodePort
+  selector:
+    app: heap-test
+    variant: xms-equal-xmx
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30081

--- a/backend/jvm_heap_xms/k8s/service-xms-less-xmx.yaml
+++ b/backend/jvm_heap_xms/k8s/service-xms-less-xmx.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: heap-test-different
+  namespace: heap-test
+spec:
+  type: NodePort
+  selector:
+    app: heap-test
+    variant: xms-less-xmx
+  ports:
+    - port: 8080
+      targetPort: 8080
+      nodePort: 30082

--- a/backend/jvm_heap_xms/settings.gradle
+++ b/backend/jvm_heap_xms/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'heap-test'

--- a/backend/jvm_heap_xms/src/main/java/com/example/heaptest/HeapTestApplication.java
+++ b/backend/jvm_heap_xms/src/main/java/com/example/heaptest/HeapTestApplication.java
@@ -1,0 +1,12 @@
+package com.example.heaptest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HeapTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(HeapTestApplication.class, args);
+    }
+}

--- a/backend/jvm_heap_xms/src/main/java/com/example/heaptest/controller/HeapTestController.java
+++ b/backend/jvm_heap_xms/src/main/java/com/example/heaptest/controller/HeapTestController.java
@@ -1,0 +1,55 @@
+package com.example.heaptest.controller;
+
+import com.example.heaptest.service.MemoryStressService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class HeapTestController {
+
+    private final MemoryStressService memoryStressService;
+
+    public HeapTestController(MemoryStressService memoryStressService) {
+        this.memoryStressService = memoryStressService;
+    }
+
+    /**
+     * 짧은 시간 동안 객체를 대량 할당 후 해제하는 엔드포인트.
+     * Xms < Xmx일 때 힙이 반복적으로 확장/축소되며 GC 오버헤드가 발생한다.
+     * Xms == Xmx일 때는 힙 리사이징 없이 안정적으로 동작한다.
+     *
+     * @param sizeMb 할당할 메모리 크기(MB). 기본값 10MB.
+     * @param count  할당 반복 횟수. 기본값 50.
+     */
+    @GetMapping("/allocate")
+    public Map<String, Object> allocate(
+            @RequestParam(defaultValue = "10") int sizeMb,
+            @RequestParam(defaultValue = "50") int count) {
+        return memoryStressService.allocateAndRelease(sizeMb, count);
+    }
+
+    /**
+     * 객체를 일정 시간 유지하여 힙 사용량을 높게 유지하는 엔드포인트.
+     * Xms < Xmx일 때 힙 확장이 빈번해지고, GC가 더 자주 발생한다.
+     *
+     * @param sizeMb   할당할 메모리 크기(MB). 기본값 5MB.
+     * @param holdMs   메모리 유지 시간(ms). 기본값 500ms.
+     */
+    @GetMapping("/hold")
+    public Map<String, Object> hold(
+            @RequestParam(defaultValue = "5") int sizeMb,
+            @RequestParam(defaultValue = "500") int holdMs) {
+        return memoryStressService.allocateAndHold(sizeMb, holdMs);
+    }
+
+    /**
+     * 현재 JVM 힙 메모리 상태를 조회하는 엔드포인트.
+     */
+    @GetMapping("/heap")
+    public Map<String, Object> heapInfo() {
+        return memoryStressService.getHeapInfo();
+    }
+}

--- a/backend/jvm_heap_xms/src/main/java/com/example/heaptest/service/MemoryStressService.java
+++ b/backend/jvm_heap_xms/src/main/java/com/example/heaptest/service/MemoryStressService.java
@@ -1,0 +1,95 @@
+package com.example.heaptest.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MemoryStressService {
+
+    /**
+     * 대량의 byte 배열을 할당하고 즉시 해제한다.
+     * Xms < Xmx 환경에서는 힙이 초기 크기(Xms)에서 시작하므로,
+     * 할당 시 힙 확장(heap resizing)이 발생하고 이로 인해 GC 오버헤드가 커진다.
+     * Xms == Xmx 환경에서는 이미 전체 힙이 확보되어 있어 리사이징이 없다.
+     */
+    public Map<String, Object> allocateAndRelease(int sizeMb, int count) {
+        Runtime rt = Runtime.getRuntime();
+        long beforeUsed = rt.totalMemory() - rt.freeMemory();
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < count; i++) {
+            byte[] data = new byte[sizeMb * 1024 * 1024];
+            // 할당 직후 참조 해제 → GC 대상
+            data[0] = 1;
+        }
+
+        long elapsed = (System.nanoTime() - startTime) / 1_000_000;
+        long afterUsed = rt.totalMemory() - rt.freeMemory();
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("action", "allocate_and_release");
+        result.put("sizeMb", sizeMb);
+        result.put("count", count);
+        result.put("elapsedMs", elapsed);
+        result.put("heapUsedBeforeMb", beforeUsed / (1024 * 1024));
+        result.put("heapUsedAfterMb", afterUsed / (1024 * 1024));
+        result.put("heapTotalMb", rt.totalMemory() / (1024 * 1024));
+        result.put("heapMaxMb", rt.maxMemory() / (1024 * 1024));
+        return result;
+    }
+
+    /**
+     * byte 배열을 할당하고 일정 시간 동안 참조를 유지한다.
+     * 동시 요청이 많을수록 힙 사용량이 누적되어,
+     * Xms < Xmx 환경에서는 힙 확장과 GC가 빈번하게 발생한다.
+     */
+    public Map<String, Object> allocateAndHold(int sizeMb, int holdMs) {
+        Runtime rt = Runtime.getRuntime();
+        long beforeUsed = rt.totalMemory() - rt.freeMemory();
+        long startTime = System.nanoTime();
+
+        // 리스트에 담아 GC 되지 않도록 유지
+        List<byte[]> holder = new ArrayList<>();
+        holder.add(new byte[sizeMb * 1024 * 1024]);
+
+        try {
+            Thread.sleep(holdMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        long elapsed = (System.nanoTime() - startTime) / 1_000_000;
+        long afterUsed = rt.totalMemory() - rt.freeMemory();
+
+        // 참조 해제
+        holder.clear();
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("action", "allocate_and_hold");
+        result.put("sizeMb", sizeMb);
+        result.put("holdMs", holdMs);
+        result.put("elapsedMs", elapsed);
+        result.put("heapUsedBeforeMb", beforeUsed / (1024 * 1024));
+        result.put("heapUsedAfterMb", afterUsed / (1024 * 1024));
+        result.put("heapTotalMb", rt.totalMemory() / (1024 * 1024));
+        result.put("heapMaxMb", rt.maxMemory() / (1024 * 1024));
+        return result;
+    }
+
+    /**
+     * 현재 JVM 힙 메모리 상태를 반환한다.
+     */
+    public Map<String, Object> getHeapInfo() {
+        Runtime rt = Runtime.getRuntime();
+        Map<String, Object> info = new LinkedHashMap<>();
+        info.put("heapMaxMb", rt.maxMemory() / (1024 * 1024));
+        info.put("heapTotalMb", rt.totalMemory() / (1024 * 1024));
+        info.put("heapUsedMb", (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024));
+        info.put("heapFreeMb", rt.freeMemory() / (1024 * 1024));
+        return info;
+    }
+}

--- a/backend/jvm_heap_xms/src/main/resources/application.yml
+++ b/backend/jvm_heap_xms/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+server:
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, metrics
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: always
+  health:
+    livenessstate:
+      enabled: true
+    readinessstate:
+      enabled: true


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive testing project to compare the performance impact of different JVM heap configuration strategies (`-Xms == -Xmx` vs `-Xms < -Xmx`) on application behavior under various load conditions.

## Key Changes

### Core Application
- **Spring Boot REST API** with three memory stress endpoints:
  - `/allocate`: Allocates and immediately releases large byte arrays to trigger heap resizing
  - `/hold`: Allocates memory and holds it for a specified duration to simulate sustained load
  - `/heap`: Exposes current JVM heap memory statistics

- **MemoryStressService**: Implements memory allocation patterns with detailed metrics collection:
  - Tracks heap usage before/after operations
  - Measures elapsed time for performance comparison
  - Provides runtime heap information (max, total, used, free)

### Testing Infrastructure
- **Three k6 load test scenarios**:
  - `scenario1-allocate.js`: Rapid allocate/release pattern to stress heap resizing
  - `scenario2-hold.js`: Sustained memory holding to test GC under load
  - `scenario3-mixed.js`: Combined allocate and hold patterns for realistic workloads

- **Kubernetes deployment manifests**:
  - Separate deployments for each JVM configuration variant
  - NodePort services for external access (ports 30081 and 30082)
  - Health probes (liveness and readiness) for pod lifecycle management
  - Kind cluster configuration with port mappings for local testing

- **Docker Compose setup**: Local testing environment with both variants running side-by-side

### Configuration & Documentation
- Comprehensive README with:
  - Detailed comparison table of Xms/Xmx differences
  - Step-by-step execution instructions for Docker and Kubernetes
  - Explanation of each test scenario and expected outcomes
  - GC log and metrics observation methods
  - Cleanup procedures

## Notable Implementation Details

- **Heap resizing observation**: The allocate/release pattern specifically targets the performance impact of dynamic heap expansion when `Xms < Xmx`
- **Concurrent load simulation**: The mixed scenario runs allocate and hold operations simultaneously to reveal performance degradation under realistic conditions
- **Metrics exposure**: Prometheus metrics endpoint enabled for monitoring JVM memory behavior during tests
- **GC logging**: Both deployments include detailed GC logging (`-XX:+PrintGCDetails -Xlog:gc*:stdout`) to observe garbage collection behavior differences

https://claude.ai/code/session_01QbeAX2bRD4g8gnM5CD5Gje