### PR TITLE
feat(cache-control): add CloudFront + S3 Cache-Control directive comparison hands-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 62. Cilium CNI network policy added 26.3.2 - [링크](./kubernetes/cilium/examples/networkpolicy/networkpolicy.md)
 63. Argo CD preview github action added 26.3.8 - [링크](https://github.com/choisungwook/argocd-practice/tree/main/argocd-diff-preview)
 64. CDN cache를 잘못설정하면 위험한 케이스 26.3.22 - [링크](./computer_science/dangerous_cache/)
+65. Cache-Control 의미 26.3.22 - [링크](./computer_science/cache_control/)
 
 ## 다른 정리된 문서 링크
 

--- a/computer_science/cache_control/AGENTS.md
+++ b/computer_science/cache_control/AGENTS.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - computer_science/dangerous_cache/
+---
+
+# Cache-Control 디렉티브별 동작 핸즈온 — Agent Guide
+
+Cache-Control 헤더가 브라우저와 CDN 캐시를 어떻게 제어하는지 디렉티브별로 비교하는 프로젝트다. AWS CloudFront + S3 환경에서 실습한다.
+
+- GitHub Issue: #356
+- 글로벌 워크플로우는 `@../../AGENTS.md`를 따른다.
+
+## 프로젝트 구조
+
+```
+s3-objects/     S3에 업로드할 HTML 파일 (오브젝트별 다른 Cache-Control 메타데이터)
+terraform/      CloudFront + S3 인프라
+docs/           개념 문서, Docker 실습, CloudFront 실습 가이드
+```
+
+## Used Skills
+
+| 작업 | Skill |
+|------|-------|
+| 문서 작성 | `writing-with-akbunstyle` |
+| 문서 리뷰 | `docs_reviewer` |
+| PR 생성 | `create-github-pr` |
+| 커밋 메시지 | `suggest-git-commit-message` |
+| Terraform | `terraform-style` |

--- a/computer_science/cache_control/CLAUDE.md
+++ b/computer_science/cache_control/CLAUDE.md
@@ -1,0 +1,3 @@
+---
+description: This agent file defers to AGENTS.md; follow AGENTS.md.
+---

--- a/computer_science/cache_control/README.md
+++ b/computer_science/cache_control/README.md
@@ -1,0 +1,26 @@
+# Cache-Control 디렉티브별 동작 비교
+
+## 개요
+
+Cache-Control 헤더가 CDN뿐 아니라 브라우저 캐시까지 제어한다는 점을 실습으로 확인합니다. max-age, s-maxage, no-cache, no-store, public, private, ETag 기반 validation을 AWS CloudFront 환경에서 비교합니다.
+
+- 블로그 정리: https://malwareanalysis.tistory.com/908
+
+## 이 글을 읽고 답할 수 있는 질문
+
+1. Cache-Control은 무엇이고 어떤 곳에 영향을 받고, Cache control 설정은 누가 정할까요?
+2. max-age와 s-maxage의 차이는 무엇인가요?
+3. no-cache와 no-store의 차이는 무엇인가요?
+4. CDN Invalidation을 해도 캐시가 남아있는 이유는 무엇인가요?
+5. 브라우저는 캐시를 어떻게 validation(재검증)하나요?
+
+## 문서 목차
+
+| 문서 | 분류 | 설명 |
+|------|------|------|
+| [CloudFront 실습](docs/cloudfront-lab.md) | 실습 | Terraform으로 CloudFront + S3 배포, S3 캐시 정책별 동작 비교 |
+
+## 참고자료
+
+- [토스 기술블로그 - 웹 서비스 캐시 똑똑하게 다루기](https://toss.tech/article/smart-web-service-cache)
+- [MDN - Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)

--- a/computer_science/cache_control/docs/cloudfront-lab.md
+++ b/computer_science/cache_control/docs/cloudfront-lab.md
@@ -1,0 +1,293 @@
+# CloudFront + S3 실습 - Cache-Control 디렉티브별 동작 비교
+
+## 목차
+
+- [공부 배경](#공부-배경)
+- [이 글을 읽고 답할 수 있는 질문](#이-글을-읽고-답할-수-있는-질문)
+- [사전 준비](#사전-준비)
+- [아키텍처](#아키텍처)
+- [Terraform 배포](#terraform-배포)
+- [실습 1: max-age vs s-maxage 비교](#실습-1-max-age-vs-s-maxage-비교)
+- [실습 2: no-cache vs no-store 비교](#실습-2-no-cache-vs-no-store-비교)
+- [실습 3: private](#실습-3-private)
+- [리소스 삭제](#리소스-삭제)
+- [결론](#결론)
+- [참고자료](#참고자료)
+
+## 이 글을 읽고 답할 수 있는 질문
+
+1. CloudFront에서 `max-age`와 `s-maxage`는 `x-cache` 헤더에 어떤 차이를 만드는가?
+2. `no-cache`와 `no-store`를 설정하면 CloudFront는 매번 Origin(S3)에서 가져오는가?
+3. `private` 디렉티브를 설정하면 CloudFront는 캐시하는가, 안 하는가?
+4. CloudFront 캐시 정책에서 `min_ttl=0`은 어떤 역할을 하는가?
+5. Terraform으로 CloudFront + S3 환경을 어떻게 배포하는가?
+
+## 사전 준비
+
+AWS CLI와 Terraform이 필요합니다.
+
+AWS CLI 설치 및 자격 증명 설정 확인 명령어입니다.
+
+```bash
+aws sts get-caller-identity
+```
+
+Terraform 버전을 확인합니다. 1.11 이상이 필요합니다.
+
+```bash
+terraform version
+```
+
+## 아키텍처
+
+CloudFront가 S3를 Origin으로 사용하는 구조입니다.
+
+```
+Client (curl)
+      │
+      ▼
+┌──────────────┐
+│  CloudFront  │  ← 캐시 정책: Origin의 Cache-Control 존중 (min_ttl=0)
+│              │  ← x-cache 헤더로 HIT/MISS 확인
+└──────┬───────┘
+       │  OAC (Origin Access Control)
+       ▼
+┌──────────────┐
+│     S3       │  ← 오브젝트마다 다른 Cache-Control 메타데이터
+│   (Origin)   │
+└──────────────┘
+```
+
+CloudFront 캐시 정책은 `min_ttl=0`으로 설정되어 있어서, Origin이 응답하는 Cache-Control 헤더를 그대로 존중합니다. `min_ttl`이 0보다 크면 Origin의 Cache-Control 디렉티브를 무시하고 최소 TTL만큼 강제 캐시하기 때문에, 이 실습에서는 반드시 0이어야 합니다.
+
+### S3 오브젝트별 Cache-Control 설정
+
+S3에 업로드하는 HTML 파일 5개에 각각 다른 Cache-Control 메타데이터를 설정합니다.
+
+| S3 오브젝트 | Cache-Control | CloudFront 동작 |
+|---|---|---|
+| `max-age.html` | `public, max-age=60` | CloudFront + 브라우저 모두 60초 캐시 |
+| `s-maxage.html` | `public, s-maxage=60, max-age=0` | CloudFront 60초 캐시, 브라우저 매번 재검증 |
+| `no-cache.html` | `no-cache` | CloudFront 매번 Origin 재검증 |
+| `no-store.html` | `no-store` | CloudFront 캐시 안 함, 매번 S3 호출 |
+| `private.html` | `private, max-age=60` | CloudFront 캐시 안 함, 브라우저만 캐시 |
+
+## Terraform 배포
+
+저장소를 클론하고 terraform 디렉터리로 이동합니다.
+
+```bash
+git clone https://github.com/choisungwook/portfolio.git
+cd portfolio/computer_science/cache_control/terraform
+```
+
+Terraform을 초기화하고 배포합니다.
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+배포가 완료되면 CloudFront 도메인을 확인합니다.
+
+```bash
+terraform output cloudfront_domain_name
+```
+
+DOMAIN 변수에 저장해 둡니다. 이후 모든 실습에서 이 변수를 사용합니다.
+
+```bash
+DOMAIN=$(terraform output -raw cloudfront_domain_name)
+echo $DOMAIN
+```
+
+CloudFront 배포에는 5~10분 정도 소요됩니다. `terraform apply`가 완료되어도 CloudFront 엣지 서버에 설정이 전파되기까지 시간이 걸릴 수 있습니다. 배포 직후 요청이 실패하면 몇 분 기다린 후 다시 시도합니다.
+
+## 실습 1: max-age vs s-maxage 비교
+
+`max-age`와 `s-maxage`가 CloudFront 캐시 동작에 어떤 차이를 만드는지 확인합니다.
+
+### max-age: CloudFront + 브라우저 모두 캐시
+
+첫 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/max-age.html" -o /dev/null | grep -i "x-cache\|cache-control"
+```
+
+기대 결과입니다.
+
+```
+cache-control: public, max-age=60
+x-cache: Miss from cloudfront
+```
+
+첫 요청이므로 CloudFront에 캐시가 없어서 `Miss`가 나옵니다. S3에서 직접 가져옵니다.
+
+두 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/max-age.html" -o /dev/null | grep -i "x-cache\|cache-control"
+```
+
+기대 결과입니다.
+
+```
+cache-control: public, max-age=60
+x-cache: Hit from cloudfront
+```
+
+`x-cache: Hit from cloudfront`가 나옵니다. CloudFront가 첫 번째 요청에서 받은 응답을 캐시했기 때문입니다. `max-age=60`이므로 60초 동안 CloudFront와 브라우저 모두 캐시를 사용합니다.
+
+### s-maxage: CloudFront만 캐시, 브라우저는 매번 확인
+
+첫 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/s-maxage.html" -o /dev/null | grep -i "x-cache\|cache-control"
+```
+
+기대 결과입니다.
+
+```
+cache-control: public, s-maxage=60, max-age=0
+x-cache: Miss from cloudfront
+```
+
+두 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/s-maxage.html" -o /dev/null | grep -i "x-cache\|cache-control"
+```
+
+기대 결과입니다.
+
+```
+cache-control: public, s-maxage=60, max-age=0
+x-cache: Hit from cloudfront
+```
+
+CloudFront는 `s-maxage=60`을 보고 60초 동안 캐시합니다. 따라서 두 번째 요청에서 `Hit`가 나옵니다.
+
+**curl에서는 `max-age`와 `s-maxage` 모두 두 번째 요청에서 Hit가 나옵니다.** curl은 브라우저 캐시가 없어서 매번 CloudFront까지 요청이 도달하기 때문입니다. 진짜 차이는 브라우저에서 드러납니다. `max-age=60`은 브라우저가 60초 동안 서버에 요청 자체를 보내지 않지만, `max-age=0`은 브라우저가 매번 CloudFront에 요청을 보냅니다. CDN 캐시는 유지하면서 브라우저에는 항상 최신 데이터를 보여줘야 할 때 `s-maxage` + `max-age=0` 조합을 사용합니다.
+
+## 실습 2: no-cache vs no-store 비교
+
+`no-cache`와 `no-store`가 CloudFront에서 어떻게 다르게 동작하는지 확인합니다.
+
+### no-store: 항상 Miss
+
+첫 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/no-store.html" -o /dev/null | grep -i "x-cache"
+```
+
+기대 결과입니다.
+
+```
+x-cache: Miss from cloudfront
+```
+
+두 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/no-store.html" -o /dev/null | grep -i "x-cache"
+```
+
+기대 결과입니다.
+
+```
+x-cache: Miss from cloudfront
+```
+
+몇 번을 요청해도 항상 `Miss`입니다. `no-store`는 CloudFront가 응답을 캐시에 저장하지 않으므로 매번 S3에서 새로 가져옵니다.
+
+### no-cache: 매번 재검증
+
+첫 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/no-cache.html" -o /dev/null | grep -i "x-cache"
+```
+
+기대 결과입니다.
+
+```
+x-cache: Miss from cloudfront
+```
+
+두 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/no-cache.html" -o /dev/null | grep -i "x-cache"
+```
+
+기대 결과입니다.
+
+```
+x-cache: RefreshHit from cloudfront
+```
+
+`RefreshHit`는 CloudFront가 캐시에 저장된 응답을 사용하기 전에 Origin(S3)에 재검증 요청을 보냈고, 콘텐츠가 변경되지 않았음을 확인한 뒤 캐시된 응답을 반환했다는 의미입니다. 일반 `Hit`와 달리 매번 Origin에 확인 요청이 발생합니다.
+
+`no-cache`는 캐시에 저장은 하되, 사용하기 전에 Origin에 재검증을 요청합니다. CloudFront가 S3에 조건부 요청(If-None-Match 등)을 보내서 콘텐츠가 변경되지 않았으면 캐시된 응답을 사용합니다.
+
+**`no-store`는 "저장하지 마"이고, `no-cache`는 "저장은 하되 매번 확인해"입니다.** 개인정보나 결제 정보처럼 어디에도 남으면 안 되는 데이터에는 `no-store`, 최신 상태를 보장하면서 네트워크 비용을 줄이려면 `no-cache`를 사용합니다.
+
+## 실습 3: private
+
+`private` 디렉티브가 CloudFront 캐시에 어떤 영향을 주는지 확인합니다.
+
+첫 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/private.html" -o /dev/null | grep -i "x-cache\|cache-control"
+```
+
+기대 결과입니다.
+
+```
+cache-control: private, max-age=60
+x-cache: Miss from cloudfront
+```
+
+두 번째 요청을 보냅니다.
+
+```bash
+curl -s -D - "http://$DOMAIN/private.html" -o /dev/null | grep -i "x-cache\|cache-control"
+```
+
+기대 결과입니다.
+
+```
+cache-control: private, max-age=60
+x-cache: Miss from cloudfront
+```
+
+몇 번을 요청해도 `x-cache: Miss from cloudfront`입니다. `private` 디렉티브는 shared cache(CDN)에 저장을 금지합니다. CloudFront는 이 응답을 캐시하지 않고, 매번 S3에서 가져옵니다.
+
+**`private`는 "브라우저(개인 캐시)만 캐시하고, CDN은 캐시하지 마"라는 뜻입니다.** 브라우저 DevTools에서 확인하면 `max-age=60`에 따라 브라우저는 로컬에 캐시합니다(Size 컬럼에 `disk cache` 표시). 사용자별로 다른 데이터(마이페이지, 장바구니 등)에 적합한 디렉티브입니다.
+
+## 리소스 삭제
+
+실습이 끝나면 반드시 리소스를 삭제합니다. CloudFront + S3 조합은 요청 수에 따라 비용이 발생합니다.
+
+```bash
+cd portfolio/computer_science/cache_control/terraform
+terraform destroy
+```
+
+`terraform destroy` 실행 시 확인 메시지가 나오면 `yes`를 입력합니다. CloudFront 배포 삭제에도 수 분이 소요될 수 있습니다.
+
+## 결론
+
+CloudFront에서 Cache-Control 디렉티브별 동작을 직접 확인해 보면, `x-cache` 헤더 하나로 CDN 캐시 HIT/MISS를 명확하게 판단할 수 있습니다. Docker 실습에서 Nginx로 확인한 것과 동일한 원리가 실제 CDN에서도 그대로 적용됩니다. 결국 핵심은 "누가 캐시하고, 언제 확인하는가"이며, `s-maxage`로 CDN과 브라우저를 분리 제어하는 전략이 실서비스에서 가장 실용적입니다.
+
+## 참고자료
+
+- <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html>
+- <https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/understanding-the-cache-key.html>
+- <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control>
+- <https://web.dev/articles/http-cache>

--- a/computer_science/cache_control/s3-objects/max-age.html
+++ b/computer_science/cache_control/s3-objects/max-age.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Cache-Control: max-age</title></head>
+<body>
+  <h1>Cache-Control: public, max-age=60</h1>
+  <p>This page is cached by <strong>both CloudFront (CDN) and the browser</strong> for 60 seconds.</p>
+  <p>Check <code>x-cache</code> response header to verify CloudFront cache status.</p>
+</body>
+</html>

--- a/computer_science/cache_control/s3-objects/no-cache.html
+++ b/computer_science/cache_control/s3-objects/no-cache.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Cache-Control: no-cache</title></head>
+<body>
+  <h1>Cache-Control: no-cache</h1>
+  <p>Caches <strong>store</strong> this response but must <strong>revalidate</strong> with the origin before each use.</p>
+  <p>CloudFront sends a conditional request (If-None-Match) to S3 on every request.</p>
+</body>
+</html>

--- a/computer_science/cache_control/s3-objects/no-store.html
+++ b/computer_science/cache_control/s3-objects/no-store.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Cache-Control: no-store</title></head>
+<body>
+  <h1>Cache-Control: no-store</h1>
+  <p><strong>No cache</strong> (browser or CDN) is allowed to store this response.</p>
+  <p>Every request goes all the way to the origin (S3).</p>
+</body>
+</html>

--- a/computer_science/cache_control/s3-objects/private.html
+++ b/computer_science/cache_control/s3-objects/private.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Cache-Control: private</title></head>
+<body>
+  <h1>Cache-Control: private, max-age=60</h1>
+  <p>Only the <strong>browser</strong> can cache this response (60 seconds).</p>
+  <p><strong>CloudFront (shared cache)</strong> must not store it.</p>
+</body>
+</html>

--- a/computer_science/cache_control/s3-objects/s-maxage.html
+++ b/computer_science/cache_control/s3-objects/s-maxage.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Cache-Control: s-maxage</title></head>
+<body>
+  <h1>Cache-Control: public, s-maxage=60, max-age=0</h1>
+  <p><strong>CloudFront (CDN)</strong> caches this page for 60 seconds.</p>
+  <p>The <strong>browser</strong> revalidates every request (max-age=0).</p>
+</body>
+</html>

--- a/computer_science/cache_control/terraform/cloudfront.tf
+++ b/computer_science/cache_control/terraform/cloudfront.tf
@@ -1,0 +1,84 @@
+resource "aws_cloudfront_origin_access_control" "s3" {
+  name                              = "${var.project_name}-s3-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_cache_policy" "respect_origin" {
+  name        = "${var.project_name}-respect-origin"
+  comment     = "Respects Origin Cache-Control headers (min_ttl=0)"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 0
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "none"
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  default_root_object = "max-age.html"
+  comment             = "Cache-Control directive comparison lab"
+
+  origin {
+    domain_name              = aws_s3_bucket.origin.bucket_regional_domain_name
+    origin_id                = "s3-origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.s3.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "s3-origin"
+    viewer_protocol_policy = "allow-all"
+    cache_policy_id        = aws_cloudfront_cache_policy.respect_origin.id
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Name = "${var.project_name}-distribution"
+  }
+}
+
+resource "aws_s3_bucket_policy" "origin" {
+  bucket = aws_s3_bucket.origin.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontOAC"
+        Effect    = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.origin.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.main.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/computer_science/cache_control/terraform/outputs.tf
+++ b/computer_science/cache_control/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_domain_name" {
+  description = "CloudFront distribution domain name"
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "s3_bucket_name" {
+  description = "S3 bucket name"
+  value       = aws_s3_bucket.origin.id
+}

--- a/computer_science/cache_control/terraform/s3.tf
+++ b/computer_science/cache_control/terraform/s3.tf
@@ -1,0 +1,79 @@
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+resource "aws_s3_bucket" "origin" {
+  bucket = "${var.project_name}-origin-${random_id.suffix.hex}"
+}
+
+resource "aws_s3_bucket_versioning" "origin" {
+  bucket = aws_s3_bucket.origin.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "origin" {
+  bucket = aws_s3_bucket.origin.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "origin" {
+  bucket = aws_s3_bucket.origin.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_object" "max_age" {
+  bucket        = aws_s3_bucket.origin.id
+  key           = "max-age.html"
+  source        = "${path.module}/../s3-objects/max-age.html"
+  content_type  = "text/html"
+  cache_control = "public, max-age=60"
+  etag          = filemd5("${path.module}/../s3-objects/max-age.html")
+}
+
+resource "aws_s3_object" "s_maxage" {
+  bucket        = aws_s3_bucket.origin.id
+  key           = "s-maxage.html"
+  source        = "${path.module}/../s3-objects/s-maxage.html"
+  content_type  = "text/html"
+  cache_control = "public, s-maxage=60, max-age=0"
+  etag          = filemd5("${path.module}/../s3-objects/s-maxage.html")
+}
+
+resource "aws_s3_object" "no_cache" {
+  bucket        = aws_s3_bucket.origin.id
+  key           = "no-cache.html"
+  source        = "${path.module}/../s3-objects/no-cache.html"
+  content_type  = "text/html"
+  cache_control = "no-cache"
+  etag          = filemd5("${path.module}/../s3-objects/no-cache.html")
+}
+
+resource "aws_s3_object" "no_store" {
+  bucket        = aws_s3_bucket.origin.id
+  key           = "no-store.html"
+  source        = "${path.module}/../s3-objects/no-store.html"
+  content_type  = "text/html"
+  cache_control = "no-store"
+  etag          = filemd5("${path.module}/../s3-objects/no-store.html")
+}
+
+resource "aws_s3_object" "private" {
+  bucket        = aws_s3_bucket.origin.id
+  key           = "private.html"
+  source        = "${path.module}/../s3-objects/private.html"
+  content_type  = "text/html"
+  cache_control = "private, max-age=60"
+  etag          = filemd5("${path.module}/../s3-objects/private.html")
+}

--- a/computer_science/cache_control/terraform/terraform.tf
+++ b/computer_science/cache_control/terraform/terraform.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/computer_science/cache_control/terraform/variables.tf
+++ b/computer_science/cache_control/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region for resource deployment"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "cache-control-lab"
+}


### PR DESCRIPTION
## 작업 내용
Cache-Control 헤더가 CDN과 브라우저 캐시를 어떻게 제어하는지 디렉티브별로 비교하는 핸즈온 프로젝트를 추가합니다. max-age, s-maxage, no-cache, no-store, private 5가지 디렉티브를 AWS CloudFront + S3 환경에서 실습합니다.
- github issue: #356 

## 주요 변경 사항
- Terraform으로 CloudFront + S3 OAC 인프라 구성 (min_ttl=0으로 Origin Cache-Control 존중)
- S3 오브젝트 5개에 각각 다른 Cache-Control 메타데이터 설정
- CloudFront 실습 가이드 문서 작성 (curl로 x-cache 헤더 확인)
- 루트 README.md 인덱스에 항목 추가
