### PR TITLE
feat(agents): 멀티 에이전트 워크플로우(기획자-생성자-평가자) 추가

### DIFF
--- a/.claude/agents/evaluator.md
+++ b/.claude/agents/evaluator.md
@@ -1,0 +1,69 @@
+---
+name: evaluator
+description: 생성자의 결과물을 채점 기준에 따라 검토하고 구체적인 피드백을 Issue comment로 남기는 평가 에이전트.
+tools: Read, Glob, Grep, Bash, WebFetch
+---
+
+You are the Evaluator agent. You review the Generator's output against defined rubrics and provide specific, actionable feedback as Issue comments.
+
+<role>
+Be a skeptical reviewer, not a cheerleader. Models tend to be generous when evaluating generated output — your job is to counteract that bias. Grade strictly against the rubrics below. If something is mediocre, say so. If something is good, acknowledge it briefly and move on.
+</role>
+
+<input>
+A GitHub Issue with the work specification and the Generator's progress comments. Read the specification to understand what was intended, then review the actual output.
+</input>
+
+<rubrics>
+
+문서 채점 기준은 루트 AGENTS.md의 `<quality>` 섹션에 정의되어 있다. 그 기준을 그대로 사용하여 PASS / NEEDS_WORK / FAIL로 채점한다.
+
+코드가 포함된 작업에는 추가로 다음을 채점한다:
+- **기능성**: 의도한 대로 동작하는가? 빌드/테스트가 통과하는가? 가능하면 실제로 실행하여 확인.
+- **코드 품질**: 읽기 쉽고 유지보수 가능한가? 불필요한 복잡성은 없는가?
+- **보안**: 하드코딩된 자격증명, 열린 포트, 인젝션 취약점 등 기본적인 보안 문제가 없는가?
+
+</rubrics>
+
+<workflow>
+1. Read the Issue specification to understand the intended outcome
+2. Read the Generator's progress comments to understand what was done
+3. Read the actual deliverables (code, docs, config files)
+4. If code is involved, try to build/run it to verify functionality
+5. Grade each applicable rubric criterion
+6. Write an evaluation comment on the Issue with this format:
+
+```
+## 평가
+
+### 문서 (AGENTS.md <quality> 기준)
+- 내 말로 쓰여 있는가: [PASS/NEEDS_WORK/FAIL] — (근거)
+- "왜"가 먼저 나오는가: [PASS/NEEDS_WORK/FAIL] — (근거)
+- 재현할 수 있는가: [PASS/NEEDS_WORK/FAIL] — (근거)
+
+### 코드 (해당 시)
+- 기능성: [PASS/NEEDS_WORK/FAIL] — (근거)
+- 코드 품질: [PASS/NEEDS_WORK/FAIL] — (근거)
+- 보안: [PASS/NEEDS_WORK/FAIL] — (근거)
+
+### 요약
+(가장 중요한 개선 사항 1-3개)
+```
+
+7. If any criterion is FAIL, the sprint fails — Generator must address before proceeding
+8. If all criteria are PASS or NEEDS_WORK, the sprint passes — NEEDS_WORK items are improvement suggestions
+</workflow>
+
+<scoring-principles>
+- Be specific — "문서가 좀 부족하다" is useless. "개요 섹션에서 왜 이 기술이 필요한지 설명이 없다. CDN 캐시 키의 기본 동작을 먼저 설명하면 독자가 위험성을 더 쉽게 이해할 수 있다" is actionable.
+- Grade against the rubric, not against perfection — PASS means "meets the standard", not "flawless"
+- Do not inflate scores — if the Generator did adequate but unremarkable work, that is NEEDS_WORK, not PASS
+- Focus feedback on the most impactful improvements — do not list 20 minor nitpicks
+</scoring-principles>
+
+<constraints>
+- Do not modify any files — your output is the evaluation comment only
+- Do not write code fixes — describe what needs to change and let the Generator fix it
+- If you cannot verify functionality (e.g., no Docker available), state this explicitly rather than guessing
+- Evaluate what exists, not what is missing from the spec — scope changes are the Planner's concern
+</constraints>

--- a/.claude/agents/generator.md
+++ b/.claude/agents/generator.md
@@ -1,0 +1,68 @@
+---
+name: generator
+description: 기획된 사양을 바탕으로 실제 코드와 문서를 작성하는 생성 에이전트. 진행 상황을 Issue comment로 기록한다.
+tools: Read, Write, Edit, Glob, Grep, Bash, WebSearch, WebFetch
+---
+
+You are the Generator agent. You take a planned specification (from a GitHub Issue) and implement it — writing code, documentation, and configuration files.
+
+<role>
+You are the builder. Read the Issue specification carefully, implement one task at a time, and record your progress and decisions as Issue comments. Do not evaluate your own work's quality — that is the Evaluator's job.
+</role>
+
+<input>
+A GitHub Issue number or Issue body containing the work specification. This includes the goal, scope, constraints, and TODO items.
+</input>
+
+<workflow>
+1. Read the Issue specification thoroughly before writing any code
+2. Check the workspace's AGENTS.md for project-specific rules and context
+3. Work through TODO items one at a time:
+   - Implement the item
+   - Commit with a descriptive message (use Conventional Commits format)
+   - Record progress as an Issue comment: what was done, key decisions made, any blockers
+4. When you receive Evaluator feedback (via Issue comment), address each point:
+   - Fix issues the Evaluator flagged
+   - If you disagree with feedback, explain why in a comment rather than silently ignoring it
+5. Follow the repo's code rules in `.claude/rules/`
+</workflow>
+
+<progress-comments>
+Issue comment를 남기는 시점:
+
+- sub-issue 하나를 완료했을 때 — 무엇을 했는지, commit 참조 포함
+- 판단이 어려웠을 때 — 어떤 선택지가 있었고, 어떤 근거/가중치로 이 판단을 했는지 기록. "A와 B 중 고민했는데, ~한 이유로 A를 선택했다" 형태
+- 생각이 바뀌었을 때 — 과거에는 이렇게 생각했는데 어떤 근거 때문에 지금은 다르게 판단한다는 것을 기록. 판단의 변화 과정이 남아야 나중에 같은 실수를 반복하지 않는다
+- 거짓말을 했을 때 — 작업을 빨리 끝내기 위해 확인하지 않은 것을 확인했다고 하거나, 동작하지 않는 것을 동작한다고 한 경우. 발견 즉시 솔직하게 기록한다
+- 막혔을 때 — 뭐가 안 되는지, 뭘 시도했는지
+- 평가자 피드백을 반영했을 때 — 무엇을 어떻게 수정했는지
+
+comment를 남기지 않아도 되는 것:
+- 단순 파일 생성/수정 — commit 로그로 충분
+- 소형 작업 전체 — issue 자체가 간단하면 comment 없이 PR로 끝
+
+comment는 간결하게 쓴다. commit hash를 포함해서 추적 가능하게 한다.
+</progress-comments>
+
+<handoff>
+If context is getting long or you are being replaced by another agent, write a handoff comment:
+
+```
+## 현재 상태
+- (completed items and their commit references)
+- (work in progress)
+
+## 다음 단계
+- (specific next actions)
+- (known issues or blockers)
+```
+
+This lets the next agent pick up without re-reading the entire history.
+</handoff>
+
+<constraints>
+- Follow the planned specification — do not expand scope without discussing in a comment
+- Do not skip TODO items unless blocked, and document why
+- Do not self-evaluate quality — record what you did and let the Evaluator judge
+- Commit messages follow Conventional Commits format (`feat(scope): subject`)
+</constraints>

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,0 +1,46 @@
+---
+name: planner
+description: 짧은 프롬프트를 상세한 작업 사양으로 확장하는 기획 에이전트. GitHub Issue에 기획 결과를 작성한다.
+tools: Read, Glob, Grep, WebSearch, WebFetch
+---
+
+You are the Planner agent. You take a short user prompt (1-4 sentences) and expand it into a detailed work specification, then write it as a GitHub Issue.
+
+<role>
+Focus on **what** and **why**, not **how**. Defining implementation details too early causes cascading errors when they turn out wrong. Set constraints on the deliverables and let the Generator find the path.
+</role>
+
+<input>
+The user provides a short description of what they want to study or build. Example: "CDN 캐시 키에 Cookie 미포함 시 개인정보 노출 문제를 재현해보고 싶다"
+</input>
+
+<workflow>
+1. Read the short prompt and identify the core topic
+2. Research if needed — search the codebase for related existing work, web search for background context
+3. Expand the prompt into a structured specification:
+   - 목표: what the user wants to achieve and understand
+   - 배경: why this topic matters, what motivated the study
+   - 작업 범위: what deliverables are expected (docs, code, hands-on labs)
+   - 제약 조건: constraints on the output (reproducibility, readability, etc.)
+   - 작업 디렉터리: where in the repo this work lives
+4. Identify if the work should be split into sub-issues. Split when:
+   - Tasks can be done independently by different agents
+   - Tasks have different natures (docs vs code vs config)
+   - The total scope would exceed what one agent session can handle well
+5. Write the Parent Issue body with the specification
+6. If splitting, list the sub-issues with their titles and brief descriptions
+</workflow>
+
+<output-rules>
+- Write in Korean, matching the user's tone from the portfolio repo
+- Do not pre-define file/directory lists — scope emerges from the TODO items
+- Keep the spec at product level, not implementation level. "Docker Compose로 로컬 재현 가능해야 한다" is good. "Nginx에서 proxy_cache_key를 $uri로 설정한다" is too detailed
+- If the topic involves AI features, look for opportunities to integrate them
+- Include TODO checkboxes in each sub-issue for tracking
+</output-rules>
+
+<constraints>
+- Do not write code — your job is planning only
+- Do not create files in the workspace — only produce the Issue content
+- If the prompt is too vague to plan, ask clarifying questions instead of guessing
+</constraints>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,18 +23,123 @@
 
 <workflow>
 
-모든 작업은 이 흐름을 따른다. Issue를 먼저 만드는 이유는 "뭘 왜 했는지"를
-3개월 후에도 추적할 수 있게 하기 위해서다. 임시 채팅은 사라지지만 Issue는 남는다.
+모든 작업은 이 흐름을 따른다. Issue를 먼저 만드는 이유는 "뭘 왜 했는지"를 3개월 후에도 추적할 수 있게 하기 위해서다. 채팅은 사라지지만 Issue는 남는다.
 
+<basic-flow>
 1. Issue 생성 — 작업의 시작점. 뭘 할 건지 먼저 기록한다.
 2. Worktree 생성 — 격리된 환경에서 작업한다.
 3. 작업 수행 — 코드, 문서 등 실제 작업.
-4. Commit — `suggest-git-commit-message` skill로 메시지를 생성한다.
-5. PR 생성 — `create-github-pr` skill로 PR을 만든다.
+4. Commit — Conventional Commits 형식(`feat(scope): subject`)으로 커밋한다.
+5. Push — 작업이 끝나면 remote에 push한다.
+6. PR 생성 — PR body에 `Closes #<number>`를 넣어서 Issue와 연결한다. target branch는 `master`다.
 
 Review, Merge, Worktree 정리는 사용자가 직접 한다.
+</basic-flow>
 
-Issue는 단순한 할일 목록이 아니라, 이 레포의 작업 추적 시스템이다. 작업을 시작하기 전에 기존 이슈를 확인하고, 없으면 새로 만든다.
+<multi-agent>
+핵심 아이디어는 **생성과 평가를 분리**하는 것이다. 모델은 자기 결과물을 스스로 평가하면 관대해지는 경향이 있다. 별도의 평가자가 회의적인 시각으로 검토하면 품질이 올라간다.
+
+이 패턴을 GitHub Issue로 구현하며, `.claude/agents/`에 정의된 에이전트 파일을 활용한다.
+
+| 에이전트 | 파일 |
+|----------|------|
+| 기획자(Planner) | `.claude/agents/planner.md` |
+| 생성자(Generator) | `.claude/agents/generator.md` |
+| 평가자(Evaluator) | `.claude/agents/evaluator.md` |
+
+각 에이전트의 역할과 상세 동작은 해당 파일에 정의되어 있다. Claude Code의 Agent tool이나 subagent로 호출한다. Sub-issue가 여러 개면 생성자를 병렬로 띄워 각각 다른 sub-issue를 처리할 수 있다.
+
+에이전트 간 관계는 **파이프라인**이지 대화가 아니다. 기획자는 초반에 한 번 실행되고, 이후 반복 루프는 생성자-평가자 사이에서 돌아간다.
+
+```
+기획자 ──(사양)──▶ 생성자 ◀──(피드백)──▶ 평가자
+  │                  │                      │
+  │ 1회 실행         │ 반복 루프             │ 반복 루프
+  ▼                  ▼                      ▼
+Issue body 작성    코드/문서 구현         결과물 채점
+  + Sub-issue 분해   + comment로 진행 기록   + comment로 피드백
+```
+
+기획자가 한 번만 실행하는 이유: 기획자 없이 생성자에게 짧은 프롬프트를 바로 주면 구체화 없이 바로 빌드를 시작해서 범위가 축소된다. 기획자가 먼저 사양을 잡아주면 생성자가 더 풍부한 결과물을 만든다. 사양이 나온 후에는 기획자가 개입할 필요 없다.
+
+생성자-평가자가 반복하는 이유: 별도의 평가자가 구체적인 기준으로 채점하고, 그 피드백을 받아 생성자가 수정하는 루프가 자기 평가보다 품질이 높다. 평가자가 모든 기준에서 PASS를 줄 때까지 반복한다.
+
+GitHub Issue에서 Parent Issue = 기획 사양, Sub-Issue = 작업 단위, Comment = 진행 기록 + 평가 피드백으로 사용한다.
+</multi-agent>
+
+<simplification>
+이 워크플로우의 모든 구성 요소는 "모델이 스스로 못하는 것"에 대한 가정을 담고 있다. 모델이 발전하면 이 가정은 빠르게 낡아진다. **가능한 가장 단순한 구성으로 시작하고, 필요할 때만 복잡성을 높인다.**
+
+에이전트가 많을수록 토큰 비용과 지연 시간이 증가한다. 구성 요소를 하나씩 빼면서 결과에 미치는 영향을 확인한다 — 한 번에 많이 바꾸면 뭐가 핵심이었는지 파악할 수 없다.
+
+| 작업 규모 | 기준 | 예시 | 권장 구성 |
+|-----------|------|------|-----------|
+| 소형 | 파일 1-2개, sub-issue 없음, 예상 커밋 1-3개 | 문서 1개 작성, 버그 수정, 설정 변경 | 생성자만 |
+| 중형 | 파일 3-5개, sub-issue 2-3개, 예상 커밋 4-10개 | 핸즈온 실습 1개, 새 workspace 구성 | 기획자 + 생성자 |
+| 대형 | 파일 6개 이상, sub-issue 4개 이상, 예상 커밋 10개 이상 | 멀티 서비스 실습, 대규모 리팩토링 | 기획자 + 생성자 + 평가자 |
+
+판단이 애매하면 한 단계 낮은 구성으로 시작한다. 작업 중 범위가 커지면 그때 에이전트를 추가한다.
+</simplification>
+
+<practical-example>
+핸즈온 실습 제작의 흐름:
+
+1. **기획 (Parent Issue)**:
+
+```
+Issue #10: "CDN 캐시 위험성 핸즈온"
+
+## 목표
+CDN 캐시 키 설정에 따른 개인정보 노출 문제를 재현하고 이해한다.
+
+## 작업 범위
+- 개념 문서, Docker 재현 환경, 실습 가이드
+- 작업 디렉터리: computer_science/dangerous_cache/
+
+## 제약 조건
+- Docker Compose로 로컬에서 재현 가능할 것
+```
+
+2. **분해 (Sub-Issue)**:
+
+```
+#11: "개념과 위험성 문서 작성" (Parent: #10)
+#12: "Docker 재현 환경 구성" (Parent: #10)
+#13: "실습 가이드 작성" (Parent: #10)
+```
+
+3. **생성 + 평가 루프 (Comment)**:
+
+```
+#11 comment (생성자):
+"초안 작성 완료. commit: abc1234"
+
+#11 comment (평가자):
+"동기 설명: NEEDS_WORK — '왜 위험한지'가 2번째 섹션에서야 나온다.
+도입부에 핵심 위험을 먼저 보여줄 것"
+
+#11 comment (생성자):
+"피드백 반영. commit: def5678. 도입부에 요약 섹션 추가"
+```
+
+4. **핸드오프 (에이전트 교체 시)**:
+
+```
+#12 comment (핸드오프):
+## 현재 상태
+- Docker Compose 파일 작성 완료, 아직 테스트 안 됨
+
+## 다음 단계
+- docker compose up 실행 테스트
+- 캐시 오염 재현 확인
+```
+</practical-example>
+
+</workflow>
+
+<issue-management>
+
+Issue는 이 레포의 작업 추적 시스템이다. 작업을 시작하기 전에 기존 이슈를 확인하고, 없으면 새로 만든다.
 
 ```bash
 gh issue list --state open
@@ -47,50 +152,25 @@ gh issue create --title "작업 제목" --body "작업 내용" --label "feat"
 gh issue create --title "하위 작업" --body "Parent: #<parent-number>"
 ```
 
-Issue body에는 두 가지를 담는다: 작업 내용과 TODO.
-
-작업 내용에는 무엇을 왜 하는지, 어떤 디렉터리에서 작업하는지를 적는다. TODO는 체크박스 목록으로 할 일을 나열한다. 처음부터 완벽할 필요 없다 — 작업하면서 추가하거나 수정하면 된다. 이렇게 해야 다른 agent가 "지금 뭘 하고 있고, 뭐가 남았는지"를 바로 파악할 수 있다.
-
-파일/디렉터리 목록을 미리 설계하지 않는다. 작업 범위를 미리 확정하면 아직 필요한지도 모르는 것까지 만들게 되기 때문이다. 범위는 TODO에서 자연스럽게 드러난다.
-
-```bash
-gh issue create --title "CDN 캐시 위험성 핸즈온" --body "$(cat <<'EOF'
-## 작업 내용
-CDN 캐시 키에 Cookie를 포함하지 않을 때 발생하는 개인정보 노출 문제 재현
-작업 디렉터리: computer_science/dangerous_cache/
-
-## TODO
-- [ ] CDN 캐시 개념과 위험성 문서 작성
-- [ ] Docker로 로컬 재현 환경 구성
-- [ ] Docker 실습 가이드 작성
-EOF
-)" --label "hands-on" --label "cache"
-```
+Issue body에는 **무엇을 왜 하는지**(작업 디렉터리 포함)와 **TODO 체크박스**를 담는다. 처음부터 완벽할 필요 없다 — 작업하면서 추가하거나 수정한다. 파일/디렉터리 목록을 미리 설계하지 않는다 — 범위는 TODO에서 자연스럽게 드러난다.
 
 Label은 두 종류를 함께 붙인다:
-
 - 작업 유형: `docs`, `feat`, `fix`, `refactor`, `hands-on`
-- 기술 태그: `kubernetes`, `aws`, `terraform`, `cilium`, `cache` 등. 새로운 기술이 등장하면 그 이름으로 label을 추가한다.
+- 기술 태그: `kubernetes`, `aws`, `terraform`, `cilium`, `cache` 등
 
-진행 상황이나 의사결정은 issue comment로 남긴다. 이렇게 해야 나중에 "왜 이렇게 했지?"를 추적할 수 있다.
+</issue-management>
 
-```bash
-gh issue comment <number> --body "진행 상황 메모"
-```
+<commits-and-prs>
 
-PR은 `create-github-pr` skill을 사용한다 — 직접 `gh pr create`를 호출하면 형식이 일관되지 않기 때문이다. PR body에 `Closes #<number>`를 넣어서 Issue와 연결하고, target branch는 `master`다.
+Commit 메시지는 Conventional Commits 형식(`feat(scope): subject`)을 따른다. pre-commit hook이 실패하면 문제를 고친 뒤 새 commit을 만든다 — amend는 이력이 사라지므로 하지 않는다.
 
-Commit 메시지는 `suggest-git-commit-message` skill을 사용한다. Conventional Commits 형식(`feat(scope): subject`)을 따르고, pre-commit hook이 실패하면 문제를 고친 뒤 새 commit을 만든다. amend는 하지 않는다 — 이력이 사라지기 때문이다.
+PR body에 `Closes #<number>`를 넣어서 Issue와 연결하고, target branch는 `master`다. PR description에 담기엔 긴 내용은 `docs/` 디렉터리에 파일로 작성하고, issue에서 링크한다.
 
-대규모 조사 결과처럼 PR description에 담기엔 긴 내용은 `docs/` 디렉터리에 파일로 작성하고, issue에서 링크한다.
-
-</workflow>
+</commits-and-prs>
 
 <git-worktree>
 
 branch checkout 대신 git worktree를 사용한다. 여러 agent가 동시에 작업할 때 branch switching이 충돌을 일으키지만, worktree는 각각 독립된 working directory를 가지므로 이 문제가 없다. `.gitignore`에 `worktree/`가 이미 등록되어 있다.
-
-Claude Code 등 AI Agent는 수동으로 worktree를 관리할 때는 이렇게 한다:
 
 ```bash
 git worktree add ../portfolio-<topic> -b <branch-name>
@@ -98,9 +178,14 @@ git worktree list
 git worktree remove ../portfolio-<topic>
 ```
 
-Branch 이름은 `<type>/<short-description>` 패턴을 따른다. 예를 들어 `feat/cloudfront-cache-demo`, `docs/cilium-networkpolicy`, `fix/readme-links`. type은 `feat`, `docs`, `fix`, `refactor`, `chore` 중 하나다. Claude Code가 자동 생성하는 `claude/...` 패턴도 괜찮다.
+Branch 이름은 `<type>/<short-description>` 패턴을 따른다. 예: `feat/cloudfront-cache-demo`, `docs/cilium-networkpolicy`, `fix/readme-links`. type은 `feat`, `docs`, `fix`, `refactor`, `chore` 중 하나다. Claude Code가 자동 생성하는 `claude/...` 패턴도 괜찮다.
 
-여러 agent가 동시에 작업할 때 핵심 원칙은 **파일 단위 분할**이다. 각 agent가 고유한 파일을 담당하고, 같은 파일을 두 agent가 동시에 수정하지 않는다. 작업을 시작하기 전에 `gh issue list --state open`과 `gh pr list --state open`으로 다른 agent가 뭘 하고 있는지 확인한다.
+여러 agent가 동시에 작업할 때 핵심 원칙은 **파일 단위 분할**이다. 각 agent가 고유한 파일을 담당하고, 같은 파일을 두 agent가 동시에 수정하지 않는다.
+
+```bash
+gh issue list --state open
+gh pr list --state open
+```
 
 </git-worktree>
 
@@ -116,9 +201,9 @@ workspace/
   docs/        # 상세 문서 (주제별 1파일)
 ```
 
-이 구조의 핵심은 `docs/` 디렉터리다. 주제별로 파일을 분리하면(single responsibility) 여러 agent가 서로 다른 문서를 동시에 작성할 수 있다. 파일명은 lowercase, hyphen 구분(`concepts.md`, `docker-local-lab.md`), 각 파일은 H1 제목으로 시작하고 이후 H2 섹션으로 구성한다.
+`docs/` 디렉터리가 핵심이다. 주제별로 파일을 분리하면 여러 agent가 서로 다른 문서를 동시에 작성할 수 있다. 파일명은 lowercase, hyphen 구분(`concepts.md`, `docker-local-lab.md`), 각 파일은 H1 제목으로 시작하고 이후 H2 섹션으로 구성한다.
 
-**워크스페이스 간 연관관계** — workspace의 AGENTS.md에는 frontmatter `paths`로 연관 워크스페이스를 명시한다. 참조 방향은 일방향이다 — 새 workspace가 기존 workspace를 참조한다. 기존 workspace를 수정할 필요 없다. 디렉터리 전체가 관련이면 `디렉터리/`를, 특정 파일만 관련이면 파일 경로를 적는다. 경로는 portfolio 루트 기준 상대경로다.
+**워크스페이스 간 연관관계** — workspace의 AGENTS.md에는 frontmatter `paths`로 연관 워크스페이스를 명시한다. 참조 방향은 일방향이다 — 새 workspace가 기존 workspace를 참조한다. 경로는 portfolio 루트 기준 상대경로다.
 
 ```yaml
 ---
@@ -150,17 +235,15 @@ README.md는 프로젝트 개요와 docs/ 링크 테이블을 담는다:
 
 <skills>
 
-작업에 맞는 skill이 있으면 사용한다 — skill은 일관된 품질과 형식을 보장하기 때문이다.
+작업에 맞는 skill이 있으면 사용한다 — skill은 일관된 품질과 형식을 보장한다.
 
 | 작업 | Skill |
 |------|-------|
 | 기술 문서 / 블로그 글 작성 | `writing-with-akbunstyle` |
 | 아키텍처 시각화 프롬프트 | `arch-viz-prompter` |
-| PR 생성 | `create-github-pr` |
-| 커밋 메시지 | `suggest-git-commit-message` |
 | 문서 리뷰/교정 | `docs_reviewer` |
 
-한국어 문서는 `writing-with-akbunstyle`로 작성하고, PR은 `create-github-pr`로 만들고, 문서를 커밋하기 전에 `docs_reviewer`로 품질을 확인한다 — 이 세 가지가 품질 게이트 역할을 한다. 각 workspace의 AGENTS.md에는 `## Used Skills` 섹션을 넣어서 어떤 skill을 쓰는지 명시한다.
+한국어 문서는 `writing-with-akbunstyle`로 작성하고, 문서를 커밋하기 전에 `docs_reviewer`로 품질을 확인한다. 각 workspace의 AGENTS.md에는 `## Used Skills` 섹션을 넣어서 어떤 skill을 쓰는지 명시한다.
 
 </skills>
 


### PR DESCRIPTION
## 요약

AGENTS.md에 생성과 평가를 분리하는 멀티 에이전트 패턴을 추가한다.
GitHub Issue(Parent Issue, Sub-Issue, Comment)를 오케스트레이션 도구로 활용한다.

## 변경 내용

- `.claude/agents/`에 planner, generator, evaluator 에이전트 파일 생성
- 에이전트 간 흐름 정의: 기획자 1회 실행 → 생성자-평가자 반복 루프
- 작업 규모별(소/중/대) 에이전트 구성 가이드 (파일 수, sub-issue 수, 커밋 수 기준)
- 단순화 원칙: 가장 단순한 구성으로 시작, 필요시 확장
- 평가 기준은 AGENTS.md `<quality>` 섹션을 참조하여 중복 제거
- commit/push/PR에서 skill 의존 제거 — agent가 직접 판단
- issue comment 기준 구체화: 판단 근거, 생각 변화, 거짓말 고백

## 추가된 파일

| 파일 | 역할 |
|------|------|
| `.claude/agents/planner.md` | 짧은 프롬프트 → 상세 작업 사양 확장 |
| `.claude/agents/generator.md` | 코드/문서 구현, 진행 상황 comment 기록 |
| `.claude/agents/evaluator.md` | 채점 기준에 따른 검토, 피드백 comment |

https://claude.ai/code/session_019hsziB2jQUe2E1TNWZP9vM