### PR TITLE
Add aws login documentation and Terraform setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 63. Argo CD preview github action added 26.3.8 - [링크](https://github.com/choisungwook/argocd-practice/tree/main/argocd-diff-preview)
 64. CDN cache를 잘못설정하면 위험한 케이스 26.3.22 - [링크](./computer_science/dangerous_cache/)
 65. Cache-Control 의미 26.3.22 - [링크](./computer_science/cache_control/)
+66. AWS `aws login` — Access Key 없이 CLI 인증하기 26.3.27 - [링크](./aws/aws-login/)
 
 ## 다른 정리된 문서 링크
 

--- a/aws/aws-login/AGENTS.md
+++ b/aws/aws-login/AGENTS.md
@@ -1,0 +1,15 @@
+# aws login 핸즈온
+
+2025년 11월에 공개된 `aws login` 명령어로 Access Key 없이 AWS CLI를 인증하는 핸즈온 프로젝트.
+
+## 핵심 개념
+
+- `aws login`은 OAuth2 Authorization Code Flow + PKCE로 동작한다
+- IAM User에 `signin:AuthorizeOAuth2Access`, `signin:CreateOAuth2Token` 권한이 필수다
+- AWS CLI v2.32.0 이상 필요
+- IAM Identity Center(SSO)와는 다른 별개 기능이다
+
+## Used Skills
+
+- `writing-with-akbunstyle`: 한국어 문서 작성
+- `docs_reviewer`: 커밋 전 문서 품질 확인

--- a/aws/aws-login/CLAUDE.md
+++ b/aws/aws-login/CLAUDE.md
@@ -1,0 +1,1 @@
+Read AGENTS.md for project context.

--- a/aws/aws-login/README.md
+++ b/aws/aws-login/README.md
@@ -1,0 +1,30 @@
+# aws login — Access Key 없이 AWS CLI 인증하기
+
+## 개요
+
+2025년 11월에 공개된 `aws login` 명령어를 사용하여 Access Key 없이 브라우저 기반 OAuth2 인증으로 AWS CLI를 사용하는 핸즈온입니다.
+
+지금까지 IAM User가 CLI를 사용하려면 Access Key(장기 자격증명)를 발급받아야 했습니다. `aws login`은 브라우저 로그인으로 임시 자격증명을 자동 발급받아 이 문제를 해결합니다.
+
+## 문서 목차
+
+| 문서 | 설명 |
+|------|------|
+| [concepts.md](./docs/concepts.md) | aws login 개념, 원리, 필수 조건, 기존 방식 비교 |
+| [hands-on.md](./docs/hands-on.md) | Terraform으로 IAM User 생성부터 aws login 실행까지 실습 가이드 |
+
+## 디렉터리 구조
+
+```
+aws/aws-login/
+├── docs/
+│   ├── concepts.md      # 개념 문서
+│   └── hands-on.md      # 핸즈온 가이드
+└── terraform/            # IAM User + aws login 권한 구성
+    ├── terraform.tf
+    ├── providers.tf
+    ├── variables.tf
+    ├── iam.tf
+    ├── outputs.tf
+    └── terraform.tfvars.example
+```

--- a/aws/aws-login/docs/concepts.md
+++ b/aws/aws-login/docs/concepts.md
@@ -130,7 +130,15 @@ sudo ./aws/install --update
 
 **IAM User에 `signin:AuthorizeOAuth2Access`와 `signin:CreateOAuth2Token` 권한이 있어야 합니다.** 이 두 권한이 없으면 `aws login`은 동작하지 않습니다.
 
-IAM Policy JSON 예시입니다.
+가장 간단한 방법은 AWS 관리형 정책 `SignInLocalDevelopmentAccess`를 붙이는 것입니다.
+
+```bash
+aws iam attach-user-policy \
+  --user-name test-developer \
+  --policy-arn arn:aws:iam::aws:policy/SignInLocalDevelopmentAccess
+```
+
+이 관리형 정책의 내용은 다음과 같습니다.
 
 ```json
 {
@@ -142,13 +150,23 @@ IAM Policy JSON 예시입니다.
         "signin:AuthorizeOAuth2Access",
         "signin:CreateOAuth2Token"
       ],
-      "Resource": "*"
+      "Resource": "arn:aws:signin:*:*:oauth2/public-client/*"
     }
   ]
 }
 ```
 
-이 권한은 AWS 콘솔 로그인 서비스(`signin`)에 대한 것입니다. IAM User에 직접 붙이거나, IAM Group을 통해 부여할 수 있습니다.
+각 액션의 역할입니다.
+
+- `signin:AuthorizeOAuth2Access`: 브라우저 인증 후 OAuth2 Authorization Code를 받을 수 있는 권한
+- `signin:CreateOAuth2Token`: Authorization Code를 Access Token과 Refresh Token으로 교환하는 권한
+
+Resource ARN에서 같은 기기 인증(`localhost`)과 원격 인증(`remote`)을 별도로 제어할 수도 있습니다.
+
+| Resource ARN | 용도 |
+|---|---|
+| `arn:aws:signin:*:*:oauth2/public-client/localhost` | `aws login` (같은 기기) |
+| `arn:aws:signin:*:*:oauth2/public-client/remote` | `aws login --remote` (원격) |
 
 ## 기존 방식과 비교
 
@@ -193,6 +211,29 @@ aws login --remote
 ```
 
 화면에 URL과 코드가 표시되면, 브라우저가 있는 로컬 PC에서 해당 URL에 접속하여 인증합니다. 이 방식은 OAuth2 Device Authorization Grant를 사용합니다.
+
+### Terraform에서 aws login 자격증명 사용하기
+
+Terraform AWS Provider는 `login_session` 자격증명을 아직 네이티브로 지원하지 않습니다. `credential_process`를 사용하여 우회할 수 있습니다.
+
+`~/.aws/config`에 다음과 같이 설정합니다.
+
+```ini
+[profile signin]
+login_session = arn:aws:iam::123456789012:user/username
+region = ap-northeast-2
+
+[profile terraform]
+credential_process = aws configure export-credentials --profile signin --format process
+region = ap-northeast-2
+```
+
+Terraform에서는 `terraform` 프로필을 사용합니다.
+
+```bash
+export AWS_PROFILE=terraform
+terraform plan
+```
 
 ## 실습
 

--- a/aws/aws-login/docs/concepts.md
+++ b/aws/aws-login/docs/concepts.md
@@ -1,0 +1,212 @@
+# aws login — Access Key 없이 AWS CLI 인증하기
+
+## 목차
+
+- [공부 배경](#공부-배경)
+- [이 글을 읽고 답할 수 있는 질문](#이-글을-읽고-답할-수-있는-질문)
+- [Access Key의 문제](#access-key의-문제)
+- [aws login이란](#aws-login이란)
+- [동작 원리 — OAuth2 Authorization Code Flow](#동작-원리--oauth2-authorization-code-flow)
+- [필수 조건](#필수-조건)
+- [기존 방식과 비교](#기존-방식과-비교)
+- [헷갈리면 안되는 점](#헷갈리면-안되는-점)
+- [실습](#실습)
+- [결론](#결론)
+- [참고자료](#참고자료)
+
+## 공부 배경
+
+지금까지 IAM User가 AWS CLI를 사용하려면 Access Key를 발급받아야 했습니다. 다른 방법이 없었습니다.
+
+Access Key는 한번 발급하면 삭제하기 전까지 영구적으로 유효한 장기 자격증명(Long-term Credential)입니다. 키가 유출되면 바로 보안 사고로 이어집니다.
+
+그래서 AWS는 항상 "Access Key 대신 IAM Role이나 Identity Center를 쓰세요"라고 권장해왔습니다. 하지만 개인 계정이나 소규모 팀에서 Identity Center를 구성하는 건 과한 경우가 많았습니다.
+
+2025년 11월, AWS가 이 문제를 해결하는 `aws login` 명령어를 공개했습니다. **Access Key 없이도 브라우저 로그인만으로 CLI 임시 자격증명을 받을 수 있게 된 것입니다.**
+
+## 이 글을 읽고 답할 수 있는 질문
+
+1. Access Key의 보안 문제가 정확히 무엇인가?
+2. `aws login`은 어떤 원리로 동작하는가?
+3. `aws login`을 사용하려면 어떤 IAM 권한이 필요한가?
+4. Access Key, `aws login`, `aws sso login`의 차이는 무엇인가?
+5. `aws login`과 IAM Identity Center(SSO)는 같은 것인가?
+
+## Access Key의 문제
+
+IAM User의 CLI 인증 흐름은 지금까지 이랬습니다.
+
+1. AWS 콘솔에서 IAM User 생성
+2. Access Key(Access Key ID + Secret Access Key) 발급
+3. 개발자 PC의 `~/.aws/credentials` 파일에 키 저장
+4. CLI 명령 실행 시 이 키를 사용하여 인증
+
+문제는 3번입니다. **`~/.aws/credentials`에 저장된 Access Key는 만료되지 않는 평문 자격증명입니다.**
+
+이게 왜 위험하냐면:
+
+- 노트북을 분실하면 키가 그대로 유출됩니다
+- `.env` 파일이나 git commit에 실수로 키가 포함되면 즉시 악용 가능합니다
+- 퇴사자의 키를 회수하지 못하면 외부에서 계속 접근할 수 있습니다
+- 키 로테이션을 주기적으로 해야 하지만, 수동 관리라 잊기 쉽습니다
+
+AWS도 이 문제를 알고 있습니다. CloudTrail에서 오래된 Access Key 사용을 경고하고, IAM Access Analyzer로 미사용 키를 탐지하는 등 여러 장치를 만들었습니다. 하지만 근본적인 해결은 아니었습니다.
+
+`aws login`은 이 근본 문제를 해결합니다. **장기 자격증명 자체를 없앤 것입니다.**
+
+## aws login이란
+
+`aws login`은 AWS CLI v2.32.0에서 추가된 명령어입니다.
+
+**브라우저에서 AWS 콘솔에 로그인하면, CLI가 임시 자격증명을 자동으로 받아오는 기능입니다.** 콘솔 로그인 방식(Root User, IAM User, 페더레이션)을 그대로 사용합니다.
+
+핵심을 정리하면:
+
+- Access Key를 발급할 필요가 없습니다
+- 임시 자격증명이 자동으로 발급되고, 15분마다 자동 갱신됩니다
+- 최대 12시간 유효하며, 만료되면 다시 `aws login`을 실행합니다
+- 자격증명은 `~/.aws/login/cache`에 저장됩니다
+
+## 동작 원리 — OAuth2 Authorization Code Flow
+
+`aws login`은 내부적으로 OAuth2 Authorization Code Flow + PKCE를 사용합니다.
+
+그런데, OAuth2가 뭔지 몰라도 사용하는 데는 문제없습니다. 중요한 건 "브라우저에서 로그인하면 CLI가 알아서 임시 키를 받아온다"는 것입니다. 원리가 궁금한 분을 위해 설명합니다.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User as 개발자
+    participant CLI as AWS CLI
+    participant Browser as 브라우저
+    participant AWS as AWS Sign-in 서비스
+
+    User->>CLI: aws login 실행
+    CLI->>CLI: OAuth2 코드 챌린지 생성 (PKCE)
+    CLI->>Browser: 브라우저 열기 (인증 URL)
+    Browser->>AWS: 콘솔 로그인 페이지 표시
+    User->>AWS: ID/PW 입력 (또는 기존 세션 사용)
+    AWS->>CLI: Authorization Code 전달 (localhost 리다이렉트)
+    CLI->>AWS: Authorization Code + PKCE 검증값 전송
+    AWS->>CLI: 임시 자격증명 발급
+    CLI->>CLI: ~/.aws/login/cache에 저장
+    Note over CLI,AWS: 이후 15분마다 자동 갱신, 최대 12시간
+```
+
+단계별로 보면:
+
+1. `aws login`을 실행하면 CLI가 내부적으로 OAuth2 코드 챌린지(PKCE)를 생성합니다
+2. CLI가 브라우저를 열어 AWS 로그인 페이지로 이동시킵니다
+3. 이미 콘솔에 로그인되어 있으면 "Continue with an active session" 화면이 보입니다
+4. 로그인하면 AWS가 Authorization Code를 CLI에 전달합니다 (localhost로 리다이렉트)
+5. CLI가 이 코드와 PKCE 검증값을 AWS에 보내서 임시 자격증명을 받습니다
+6. 자격증명은 `~/.aws/login/cache`에 저장되고, 15분마다 자동 갱신됩니다
+
+CloudTrail에는 `AuthorizeOAuth2Access` 이벤트가 기록됩니다. OAuth2 리소스 ARN은 `arn:aws:signin:<region>:<account-id>:oauth2/public-client/localhost`입니다.
+
+## 필수 조건
+
+`aws login`을 사용하려면 두 가지가 필요합니다.
+
+### 1. AWS CLI v2.32.0 이상
+
+AWS CLI 버전을 확인합니다.
+
+```bash
+aws --version
+# aws-cli/2.32.0 이상이어야 합니다
+```
+
+버전이 낮으면 업데이트합니다.
+
+```bash
+# Linux
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install --update
+```
+
+### 2. IAM 권한: signin 서비스 액션 2개
+
+**IAM User에 `signin:AuthorizeOAuth2Access`와 `signin:CreateOAuth2Token` 권한이 있어야 합니다.** 이 두 권한이 없으면 `aws login`은 동작하지 않습니다.
+
+IAM Policy JSON 예시입니다.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "signin:AuthorizeOAuth2Access",
+        "signin:CreateOAuth2Token"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+이 권한은 AWS 콘솔 로그인 서비스(`signin`)에 대한 것입니다. IAM User에 직접 붙이거나, IAM Group을 통해 부여할 수 있습니다.
+
+## 기존 방식과 비교
+
+CLI 인증 방식 3가지를 비교합니다.
+
+| 항목 | Access Key | `aws login` | `aws sso login` |
+|------|-----------|-------------|-----------------|
+| 자격증명 유형 | 장기 (영구) | 임시 (최대 12시간) | 임시 |
+| 인증 방식 | Access Key ID + Secret | 브라우저 로그인 | 브라우저 로그인 |
+| 저장 위치 | `~/.aws/credentials` | `~/.aws/login/cache` | `~/.aws/sso/cache` |
+| 자동 갱신 | 없음 (영구) | 15분마다 자동 갱신 | 자동 갱신 |
+| 필요 인프라 | IAM User만 있으면 됨 | IAM User + signin 권한 | IAM Identity Center 구성 필요 |
+| 대상 | IAM User | Root User, IAM User, 페더레이션 | Identity Center 사용자 |
+| CLI 버전 | 모든 버전 | v2.32.0 이상 | v2 이상 |
+
+**개인 계정이나 소규모 팀에서 Identity Center 없이 보안을 강화하려면 `aws login`이 가장 적합합니다.**
+
+## 헷갈리면 안되는 점
+
+### aws login ≠ aws sso login
+
+이 두 명령어는 완전히 다릅니다.
+
+- `aws login`: IAM User, Root User, 페더레이션 사용자를 위한 기능입니다. IAM Identity Center가 필요 없습니다.
+- `aws sso login`: IAM Identity Center(구 AWS SSO)를 통해 인증하는 기능입니다. Identity Center 구성이 선행되어야 합니다.
+
+### 프로필 지원
+
+여러 AWS 계정을 사용한다면 프로필을 지정할 수 있습니다.
+
+```bash
+aws login --profile staging
+aws sts get-caller-identity --profile staging
+```
+
+### 원격 서버에서 사용하기
+
+브라우저가 없는 원격 서버(EC2, SSH 접속 환경)에서는 `--remote` 옵션을 사용합니다.
+
+```bash
+aws login --remote
+```
+
+화면에 URL과 코드가 표시되면, 브라우저가 있는 로컬 PC에서 해당 URL에 접속하여 인증합니다. 이 방식은 OAuth2 Device Authorization Grant를 사용합니다.
+
+## 실습
+
+실습자료는 저의 GitHub에 있습니다.
+
+- Terraform 코드: [terraform/](../terraform/)
+- 핸즈온 가이드: [hands-on.md](./hands-on.md)
+
+## 결론
+
+`aws login`은 "IAM User는 Access Key가 필수"라는 오래된 전제를 깨뜨린 기능입니다. 장기 자격증명을 발급하지 않고도 CLI를 사용할 수 있게 되면서, 개인 계정과 소규모 팀의 보안 수준을 한 단계 올릴 수 있게 되었습니다.
+
+## 참고자료
+
+- https://aws.amazon.com/blogs/security/simplified-developer-access-to-aws-with-aws-login/
+- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html
+- https://docs.aws.amazon.com/signin/latest/userguide/command-line-sign-in.html

--- a/aws/aws-login/docs/hands-on.md
+++ b/aws/aws-login/docs/hands-on.md
@@ -1,0 +1,189 @@
+# aws login 핸즈온
+
+## 목차
+
+- [사전 준비](#사전-준비)
+- [Step 1: Terraform으로 IAM User 생성](#step-1-terraform으로-iam-user-생성)
+- [Step 2: 콘솔 로그인 비밀번호 설정](#step-2-콘솔-로그인-비밀번호-설정)
+- [Step 3: aws login 실행](#step-3-aws-login-실행)
+- [Step 4: 임시 자격증명 확인](#step-4-임시-자격증명-확인)
+- [Step 5: 정리](#step-5-정리)
+- [참고자료](#참고자료)
+
+## 사전 준비
+
+- AWS 계정 (Root User 또는 AdministratorAccess 권한이 있는 IAM User)
+- Terraform >= 1.11
+- AWS CLI >= 2.32.0
+
+AWS CLI 버전을 확인합니다.
+
+```bash
+aws --version
+```
+
+2.32.0 미만이면 업데이트가 필요합니다.
+
+```bash
+# Linux (x86_64)
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install --update
+
+# macOS
+curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+sudo installer -pkg AWSCLIV2.pkg -target /
+```
+
+## Step 1: Terraform으로 IAM User 생성
+
+Terraform으로 `aws login`에 필요한 IAM User와 권한을 생성합니다.
+
+`terraform/` 디렉터리로 이동합니다.
+
+```bash
+cd terraform
+```
+
+`terraform.tfvars` 파일을 생성합니다. `terraform.tfvars.example`을 참고하세요.
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars`를 수정합니다.
+
+```hcl
+project_name = "aws-login-handson"
+aws_region   = "ap-northeast-2"
+iam_username = "test-developer"
+```
+
+Terraform을 실행합니다.
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+apply가 완료되면 output을 확인합니다.
+
+```bash
+terraform output
+```
+
+출력 예시입니다.
+
+```
+iam_user_name = "test-developer"
+iam_user_arn  = "arn:aws:iam::123456789012:user/test-developer"
+console_login_url = "https://123456789012.signin.aws.amazon.com/console"
+```
+
+## Step 2: 콘솔 로그인 비밀번호 설정
+
+`aws login`은 콘솔 로그인을 사용하기 때문에, IAM User에 콘솔 비밀번호가 설정되어 있어야 합니다.
+
+AWS 콘솔 > IAM > Users > `test-developer` > Security credentials > Console sign-in에서 비밀번호를 설정합니다.
+
+또는 CLI로 설정합니다.
+
+```bash
+aws iam create-login-profile \
+  --user-name test-developer \
+  --password 'YourSecurePassword123!' \
+  --password-reset-required
+```
+
+## Step 3: aws login 실행
+
+이제 Access Key 없이 CLI 인증을 해봅니다.
+
+기존 credentials 파일에 해당 프로필의 Access Key가 없는 상태여야 합니다. 깨끗한 프로필을 사용합니다.
+
+```bash
+aws login --profile test-developer
+```
+
+실행하면:
+
+1. 리전을 묻는 프롬프트가 나옵니다 (기본 리전이 설정되지 않은 경우)
+
+```
+AWS Region [ap-northeast-2]:
+```
+
+2. 브라우저가 열리면서 AWS 콘솔 로그인 페이지가 표시됩니다
+
+3. Account ID, IAM User 이름, 비밀번호를 입력하여 로그인합니다
+
+4. 로그인이 완료되면 CLI에 성공 메시지가 표시됩니다
+
+```
+Successfully logged in.
+```
+
+## Step 4: 임시 자격증명 확인
+
+`aws login`이 성공하면 임시 자격증명이 자동으로 캐시됩니다.
+
+캐시 파일을 확인합니다.
+
+```bash
+ls ~/.aws/login/cache/
+```
+
+현재 인증 정보를 확인합니다.
+
+```bash
+aws sts get-caller-identity --profile test-developer
+```
+
+출력 예시입니다.
+
+```json
+{
+    "UserId": "AIDAEXAMPLE",
+    "Account": "123456789012",
+    "Arn": "arn:aws:iam::123456789012:user/test-developer"
+}
+```
+
+S3 버킷 목록을 조회하여 실제로 CLI가 동작하는지 확인합니다.
+
+```bash
+aws s3 ls --profile test-developer
+```
+
+**Access Key를 발급하지 않았는데도 CLI가 정상 동작합니다.** 이것이 `aws login`의 핵심입니다.
+
+### 임시 자격증명의 수명
+
+- AWS CLI가 15분마다 자격증명을 자동 갱신합니다
+- 전체 세션은 최대 12시간 유효합니다
+- 12시간이 지나면 `aws login`을 다시 실행해야 합니다
+
+### 로그아웃
+
+작업이 끝나면 로그아웃합니다.
+
+```bash
+aws logout --profile test-developer
+```
+
+캐시된 자격증명이 삭제됩니다.
+
+## Step 5: 정리
+
+실습이 끝나면 Terraform 리소스를 삭제합니다.
+
+```bash
+cd terraform
+terraform destroy
+```
+
+## 참고자료
+
+- https://aws.amazon.com/blogs/security/simplified-developer-access-to-aws-with-aws-login/
+- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sign-in.html

--- a/aws/aws-login/terraform/iam.tf
+++ b/aws/aws-login/terraform/iam.tf
@@ -6,24 +6,9 @@ resource "aws_iam_user" "this" {
   }
 }
 
-resource "aws_iam_user_policy" "aws_login" {
-  name = "${var.project_name}-aws-login"
-  user = aws_iam_user.this.name
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowAWSLogin"
-        Effect = "Allow"
-        Action = [
-          "signin:AuthorizeOAuth2Access",
-          "signin:CreateOAuth2Token"
-        ]
-        Resource = "*"
-      }
-    ]
-  })
+resource "aws_iam_user_policy_attachment" "aws_login" {
+  user       = aws_iam_user.this.name
+  policy_arn = "arn:aws:iam::aws:policy/SignInLocalDevelopmentAccess"
 }
 
 resource "aws_iam_user_policy_attachment" "read_only" {

--- a/aws/aws-login/terraform/iam.tf
+++ b/aws/aws-login/terraform/iam.tf
@@ -1,0 +1,32 @@
+resource "aws_iam_user" "this" {
+  name = var.iam_username
+
+  tags = {
+    Name = var.iam_username
+  }
+}
+
+resource "aws_iam_user_policy" "aws_login" {
+  name = "${var.project_name}-aws-login"
+  user = aws_iam_user.this.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAWSLogin"
+        Effect = "Allow"
+        Action = [
+          "signin:AuthorizeOAuth2Access",
+          "signin:CreateOAuth2Token"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "read_only" {
+  user       = aws_iam_user.this.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}

--- a/aws/aws-login/terraform/outputs.tf
+++ b/aws/aws-login/terraform/outputs.tf
@@ -1,0 +1,21 @@
+data "aws_caller_identity" "current" {}
+
+output "iam_user_name" {
+  description = "IAM user name"
+  value       = aws_iam_user.this.name
+}
+
+output "iam_user_arn" {
+  description = "IAM user ARN"
+  value       = aws_iam_user.this.arn
+}
+
+output "console_login_url" {
+  description = "AWS console login URL"
+  value       = "https://${data.aws_caller_identity.current.account_id}.signin.aws.amazon.com/console"
+}
+
+output "aws_login_command" {
+  description = "Command to run aws login"
+  value       = "aws login --profile ${var.iam_username}"
+}

--- a/aws/aws-login/terraform/providers.tf
+++ b/aws/aws-login/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/aws/aws-login/terraform/terraform.tf
+++ b/aws/aws-login/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/aws/aws-login/terraform/terraform.tfvars.example
+++ b/aws/aws-login/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+project_name = "aws-login-handson"
+aws_region   = "ap-northeast-2"
+iam_username = "test-developer"

--- a/aws/aws-login/terraform/variables.tf
+++ b/aws/aws-login/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "project_name" {
+  description = "Project name for tagging"
+  type        = string
+  default     = "aws-login-handson"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "iam_username" {
+  description = "IAM user name for aws login handson"
+  type        = string
+  default     = "test-developer"
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and hands-on materials for AWS's new `aws login` feature, which enables Access Key-free CLI authentication using OAuth2-based browser login.

## Key Changes

- **Concept Documentation** (`docs/concepts.md`): Detailed explanation of the `aws login` feature including:
  - Security problems with traditional Access Keys
  - How `aws login` works using OAuth2 Authorization Code Flow + PKCE
  - Required IAM permissions (`signin:AuthorizeOAuth2Access`, `signin:CreateOAuth2Token`)
  - Comparison with existing authentication methods (Access Keys, `aws sso login`)
  - Clarification of common misconceptions

- **Hands-on Guide** (`docs/hands-on.md`): Step-by-step practical tutorial covering:
  - Prerequisites and AWS CLI version requirements
  - IAM User creation via Terraform
  - Console password setup
  - Running `aws login` command
  - Verifying temporary credentials
  - Cleanup procedures

- **Terraform Infrastructure Code** (`terraform/`): Complete IaC setup for the hands-on lab:
  - `terraform.tf`: Terraform version and provider requirements
  - `providers.tf`: AWS provider configuration with default tags
  - `variables.tf`: Input variables for project customization
  - `iam.tf`: IAM User creation with `SignInLocalDevelopmentAccess` policy attachment
  - `outputs.tf`: Useful outputs including console login URL and aws login command
  - `terraform.tfvars.example`: Example configuration template

- **Project Documentation**:
  - `README.md`: Overview and directory structure
  - `AGENTS.md`: Project context and key concepts for AI agents
  - `CLAUDE.md`: Reference to AGENTS.md

## Notable Implementation Details

- The documentation emphasizes that `aws login` is distinct from `aws sso login` and doesn't require IAM Identity Center
- Temporary credentials are automatically refreshed every 15 minutes with a maximum 12-hour session lifetime
- The Terraform code includes both the required `SignInLocalDevelopmentAccess` policy and `ReadOnlyAccess` for practical testing
- Comprehensive mermaid diagram illustrates the OAuth2 flow with PKCE

https://claude.ai/code/session_01EUxh1fNJpR7WpWzK2n1by2