### PR TITLE
docs(computer_science): AWS SQS/SNS 메시징 예제 추가

### DIFF
--- a/computer_science/README.md
+++ b/computer_science/README.md
@@ -9,3 +9,5 @@
 | 3 | 컨테이너 원리 - chroot | [링크](./linux_namespace/chroot/) |
 | 4 | 컨테이너 원리 - mount namespace | [링크](./linux_namespace/mount_namespace/) |
 | 5 | pivot_root | [링크](./linux_namespace/pivot_root/) |
+| 6 | AWS SQS 메시지 큐 예제 | [링크](./aws-sqs/) |
+| 7 | AWS SNS Pub/Sub 예제 | [링크](./aws-sns/) |

--- a/computer_science/aws-sns/README.md
+++ b/computer_science/aws-sns/README.md
@@ -1,0 +1,83 @@
+# AWS SNS Pub/Sub 예제
+
+## 왜 SNS인가
+
+SQS가 1:1 메시지 큐라면, SNS는 1:N 메시지 브로드캐스트다. 하나의 이벤트를 여러 구독자에게 동시에 알려야 할 때 사용한다. 예를 들어 "주문 완료" 이벤트가 발생하면 이메일 알림, 재고 처리, 로그 저장을 동시에 트리거할 수 있다.
+
+## SQS vs SNS 비교
+
+| 구분 | SQS | SNS |
+|------|-----|-----|
+| 패턴 | 1:1 (Producer → Consumer) | 1:N (Publisher → Subscribers) |
+| 메시지 보관 | 큐에 보관, consumer가 꺼내야 함 | 보관 안 함, 즉시 push |
+| 수신 방식 | consumer가 pull | SNS가 구독자에게 push |
+| 주요 용도 | 작업 분산, 비동기 처리 | 이벤트 알림, 팬아웃 |
+
+## 핵심 개념
+
+- **Topic**: 메시지를 발행하는 채널. publisher는 토픽에 메시지를 보낸다.
+- **Subscription**: 토픽을 구독하는 엔드포인트. SQS, Lambda, HTTP, Email 등 다양한 프로토콜을 지원한다.
+- **Fanout**: 하나의 메시지가 모든 구독자에게 동시에 전달되는 패턴. SNS + SQS 조합이 대표적이다.
+
+## 구조
+
+```
+aws-sns/
+├── README.md
+├── terraform/          # SNS 토픽 + SQS 구독자 인프라
+│   ├── terraform.tf
+│   ├── providers.tf
+│   ├── variables.tf
+│   ├── sns.tf
+│   └── outputs.tf
+└── examples/           # Python 예제
+    ├── publisher.py    # 토픽에 메시지 발행
+    └── subscriber.py   # SQS 경유로 메시지 수신
+```
+
+## 실습 순서
+
+### 1. 인프라 생성
+
+```bash
+cd terraform
+terraform init
+terraform apply -var="email_address=your@email.com"
+```
+
+이메일 구독은 확인 메일의 링크를 클릭해야 활성화된다.
+
+`terraform output`으로 `topic_arn`과 `subscriber_queue_url`을 확인한다.
+
+### 2. Python 예제 실행
+
+예제 파일에서 `TOPIC_ARN`과 `QUEUE_URL` 값을 교체한다.
+
+터미널 2개를 열어서 subscriber를 먼저 실행하고, 다른 터미널에서 publisher를 실행한다.
+
+subscriber를 실행한다.
+
+```bash
+pip install boto3
+python examples/subscriber.py
+```
+
+publisher로 메시지를 발행한다.
+
+```bash
+python examples/publisher.py
+```
+
+subscriber 터미널에서 메시지가 수신되는 것을 확인한다. 동시에 이메일로도 알림이 온다.
+
+### 3. 정리
+
+```bash
+cd terraform
+terraform destroy -var="email_address=your@email.com"
+```
+
+## 참고자료
+
+- https://docs.aws.amazon.com/sns/latest/dg/welcome.html
+- https://docs.aws.amazon.com/sns/latest/dg/sns-sqs-as-subscriber.html

--- a/computer_science/aws-sns/examples/publisher.py
+++ b/computer_science/aws-sns/examples/publisher.py
@@ -1,0 +1,26 @@
+"""SNS Publisher — 토픽에 메시지를 발행하는 예제"""
+
+import json
+import boto3
+
+TOPIC_ARN = "YOUR_TOPIC_ARN"  # terraform output topic_arn 값으로 교체
+
+sns = boto3.client("sns", region_name="ap-northeast-2")
+
+
+def publish_message(subject: str, body: dict) -> dict:
+    """SNS 토픽에 메시지를 발행한다. 모든 구독자에게 동시에 전달된다."""
+    response = sns.publish(
+        TopicArn=TOPIC_ARN,
+        Subject=subject,
+        Message=json.dumps(body),
+    )
+    print(f"[발행] MessageId: {response['MessageId']}")
+    return response
+
+
+if __name__ == "__main__":
+    publish_message(
+        subject="주문 완료 알림",
+        body={"order_id": 1, "status": "completed", "item": "product-1"},
+    )

--- a/computer_science/aws-sns/examples/subscriber.py
+++ b/computer_science/aws-sns/examples/subscriber.py
@@ -1,0 +1,44 @@
+"""SNS Subscriber (SQS 경유) — SNS 메시지를 SQS 큐에서 수신하는 예제
+
+SNS는 push 방식이라 직접 poll할 수 없다.
+그래서 SQS 큐를 구독자로 등록하고, SQS에서 메시지를 꺼내는 방식으로 수신한다.
+"""
+
+import json
+import boto3
+
+QUEUE_URL = "YOUR_QUEUE_URL"  # terraform output subscriber_queue_url 값으로 교체
+
+sqs = boto3.client("sqs", region_name="ap-northeast-2")
+
+
+def poll_messages() -> None:
+    """SQS 큐에서 SNS가 전달한 메시지를 수신한다."""
+    response = sqs.receive_message(
+        QueueUrl=QUEUE_URL,
+        MaxNumberOfMessages=5,
+        WaitTimeSeconds=10,
+    )
+
+    messages = response.get("Messages", [])
+    if not messages:
+        print("[대기] 메시지 없음")
+        return
+
+    for msg in messages:
+        # SNS가 SQS에 보내는 메시지는 한 번 더 감싸져 있다
+        sns_envelope = json.loads(msg["Body"])
+        subject = sns_envelope.get("Subject", "(제목 없음)")
+        body = json.loads(sns_envelope["Message"])
+        print(f"[수신] Subject: {subject}, Body: {body}")
+
+        sqs.delete_message(
+            QueueUrl=QUEUE_URL,
+            ReceiptHandle=msg["ReceiptHandle"],
+        )
+
+
+if __name__ == "__main__":
+    print("SNS 메시지 수신 대기 중... (Ctrl+C로 종료)")
+    while True:
+        poll_messages()

--- a/computer_science/aws-sns/terraform/outputs.tf
+++ b/computer_science/aws-sns/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "topic_arn" {
+  description = "SNS 토픽 ARN"
+  value       = aws_sns_topic.example.arn
+}
+
+output "subscriber_queue_url" {
+  description = "구독용 SQS 큐 URL"
+  value       = aws_sqs_queue.subscriber.url
+}

--- a/computer_science/aws-sns/terraform/providers.tf
+++ b/computer_science/aws-sns/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/computer_science/aws-sns/terraform/sns.tf
+++ b/computer_science/aws-sns/terraform/sns.tf
@@ -1,0 +1,51 @@
+resource "aws_sns_topic" "example" {
+  name = "${var.project_name}-topic"
+
+  tags = {
+    Name = "${var.project_name}-topic"
+  }
+}
+
+resource "aws_sqs_queue" "subscriber" {
+  name                       = "${var.project_name}-subscriber-queue"
+  message_retention_seconds  = 86400
+  visibility_timeout_seconds = 30
+
+  tags = {
+    Name = "${var.project_name}-subscriber-queue"
+  }
+}
+
+resource "aws_sqs_queue_policy" "allow_sns" {
+  queue_url = aws_sqs_queue.subscriber.url
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowSNSPublish"
+        Effect    = "Allow"
+        Principal = { Service = "sns.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = aws_sqs_queue.subscriber.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_sns_topic.example.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "sqs" {
+  topic_arn = aws_sns_topic.example.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.subscriber.arn
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  topic_arn = aws_sns_topic.example.arn
+  protocol  = "email"
+  endpoint  = var.email_address
+}

--- a/computer_science/aws-sns/terraform/terraform.tf
+++ b/computer_science/aws-sns/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/computer_science/aws-sns/terraform/variables.tf
+++ b/computer_science/aws-sns/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "프로젝트 이름"
+  type        = string
+  default     = "sns-example"
+}
+
+variable "email_address" {
+  description = "SNS 구독에 사용할 이메일 주소"
+  type        = string
+}

--- a/computer_science/aws-sqs/README.md
+++ b/computer_science/aws-sqs/README.md
@@ -1,0 +1,68 @@
+# AWS SQS 메시지 큐 예제
+
+## 왜 SQS인가
+
+서비스 간에 직접 API를 호출하면 한쪽이 죽었을 때 메시지가 유실된다. SQS를 중간에 두면 producer가 보낸 메시지를 큐가 보관하고, consumer가 자기 속도로 꺼내서 처리할 수 있다. 즉, 두 서비스의 속도와 가용성을 분리(decoupling)하는 게 핵심이다.
+
+## 핵심 개념
+
+- **Producer**: 메시지를 큐에 넣는 쪽. `send_message` API를 호출한다.
+- **Consumer**: 메시지를 큐에서 꺼내는 쪽. `receive_message`로 가져오고, 처리 완료 후 `delete_message`로 지운다.
+- **Visibility Timeout**: consumer가 메시지를 받으면 다른 consumer에게 안 보이는 시간. 이 시간 안에 처리+삭제를 못 하면 메시지가 다시 큐에 나타난다.
+- **Long Polling**: `WaitTimeSeconds > 0`으로 설정하면 메시지가 올 때까지 대기한다. 빈 응답을 줄여서 비용을 아낀다.
+
+## 구조
+
+```
+aws-sqs/
+├── README.md
+├── terraform/          # SQS 큐 인프라
+│   ├── terraform.tf
+│   ├── providers.tf
+│   ├── variables.tf
+│   ├── sqs.tf
+│   └── outputs.tf
+└── examples/           # Python 예제
+    ├── producer.py     # 메시지 보내기
+    └── consumer.py     # 메시지 받기 + 삭제
+```
+
+## 실습 순서
+
+### 1. 인프라 생성
+
+```bash
+cd terraform
+terraform init
+terraform apply
+```
+
+`terraform output queue_url`로 출력된 URL을 복사한다.
+
+### 2. Python 예제 실행
+
+예제 파일에서 `QUEUE_URL` 값을 위에서 복사한 URL로 교체한다.
+
+producer로 메시지 3건을 보낸다.
+
+```bash
+pip install boto3
+python examples/producer.py
+```
+
+consumer로 메시지를 꺼낸다.
+
+```bash
+python examples/consumer.py
+```
+
+### 3. 정리
+
+```bash
+cd terraform
+terraform destroy
+```
+
+## 참고자료
+
+- https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/welcome.html

--- a/computer_science/aws-sqs/examples/consumer.py
+++ b/computer_science/aws-sqs/examples/consumer.py
@@ -1,0 +1,39 @@
+"""SQS Consumer — 큐에서 메시지를 꺼내는 예제"""
+
+import json
+import boto3
+
+QUEUE_URL = "YOUR_QUEUE_URL"  # terraform output queue_url 값으로 교체
+
+sqs = boto3.client("sqs", region_name="ap-northeast-2")
+
+
+def receive_and_delete() -> None:
+    """큐에서 메시지를 받고, 처리 후 삭제한다."""
+    response = sqs.receive_message(
+        QueueUrl=QUEUE_URL,
+        MaxNumberOfMessages=5,
+        WaitTimeSeconds=10,
+    )
+
+    messages = response.get("Messages", [])
+    if not messages:
+        print("[대기] 메시지 없음")
+        return
+
+    for msg in messages:
+        body = json.loads(msg["Body"])
+        print(f"[받음] {body}")
+
+        # 처리 완료 후 삭제 — 삭제하지 않으면 visibility timeout 후 다시 나타남
+        sqs.delete_message(
+            QueueUrl=QUEUE_URL,
+            ReceiptHandle=msg["ReceiptHandle"],
+        )
+        print(f"[삭제] MessageId: {msg['MessageId']}")
+
+
+if __name__ == "__main__":
+    print("메시지 수신 대기 중... (Ctrl+C로 종료)")
+    while True:
+        receive_and_delete()

--- a/computer_science/aws-sqs/examples/producer.py
+++ b/computer_science/aws-sqs/examples/producer.py
@@ -1,0 +1,23 @@
+"""SQS Producer — 메시지를 큐에 보내는 예제"""
+
+import json
+import boto3
+
+QUEUE_URL = "YOUR_QUEUE_URL"  # terraform output queue_url 값으로 교체
+
+sqs = boto3.client("sqs", region_name="ap-northeast-2")
+
+
+def send_message(body: dict) -> dict:
+    """SQS 큐에 메시지 1건을 전송한다."""
+    response = sqs.send_message(
+        QueueUrl=QUEUE_URL,
+        MessageBody=json.dumps(body),
+    )
+    print(f"[보냄] MessageId: {response['MessageId']}")
+    return response
+
+
+if __name__ == "__main__":
+    for i in range(3):
+        send_message({"order_id": i + 1, "item": f"product-{i + 1}"})

--- a/computer_science/aws-sqs/terraform/outputs.tf
+++ b/computer_science/aws-sqs/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "queue_url" {
+  description = "SQS 큐 URL"
+  value       = aws_sqs_queue.example.url
+}
+
+output "queue_arn" {
+  description = "SQS 큐 ARN"
+  value       = aws_sqs_queue.example.arn
+}

--- a/computer_science/aws-sqs/terraform/providers.tf
+++ b/computer_science/aws-sqs/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/computer_science/aws-sqs/terraform/sqs.tf
+++ b/computer_science/aws-sqs/terraform/sqs.tf
@@ -1,0 +1,10 @@
+resource "aws_sqs_queue" "example" {
+  name                       = "${var.project_name}-queue"
+  message_retention_seconds  = 86400
+  visibility_timeout_seconds = 30
+  receive_wait_time_seconds  = 10
+
+  tags = {
+    Name = "${var.project_name}-queue"
+  }
+}

--- a/computer_science/aws-sqs/terraform/terraform.tf
+++ b/computer_science/aws-sqs/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/computer_science/aws-sqs/terraform/variables.tf
+++ b/computer_science/aws-sqs/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS 리전"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "프로젝트 이름"
+  type        = string
+  default     = "sqs-example"
+}


### PR DESCRIPTION
SQS producer/consumer 패턴과 SNS pub/sub 패턴을 각각 Terraform + Python 예제로 정리한다.
issue #379
