### PR TITLE
Add markdown copy button and versioned release workflow for akbun skin

### DIFF
--- a/.github/workflows/release-tistory-skin.yml
+++ b/.github/workflows/release-tistory-skin.yml
@@ -23,11 +23,17 @@ jobs:
         id: version
         run: |
           cd product/tistory-skin/akbun/src
-          VERSION=$(grep -oP '(?<=<version>)[^<]+' index.xml | head -n1)
-          if [ -z "$VERSION" ]; then
-            echo "index.xml version not found" >&2
-            exit 1
-          fi
+          VERSION=$(python3 - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("index.xml").getroot()
+          version = root.findtext("./information/version")
+          if not version or not version.strip():
+            sys.exit("index.xml version not found")
+          print(version.strip())
+          PY
+          )
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=tistory-$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release-tistory-skin.yml
+++ b/.github/workflows/release-tistory-skin.yml
@@ -1,0 +1,62 @@
+name: release-tistory-skin
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'product/tistory-skin/akbun/src/skin.html'
+      - 'product/tistory-skin/akbun/src/style.css'
+      - 'product/tistory-skin/akbun/src/index.xml'
+      - 'product/tistory-skin/akbun/src/images/**'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Read skin version
+        id: version
+        run: |
+          cd product/tistory-skin/akbun/src
+          VERSION=$(grep -oP '(?<=<version>)[^<]+' index.xml | head -n1)
+          if [ -z "$VERSION" ]; then
+            echo "index.xml version not found" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=tistory-$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check existing release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build zip
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          cd product/tistory-skin/akbun/src
+          files="skin.html style.css index.xml"
+          [ -d images ] && files="$files images"
+          zip -r ../akbun-skin.zip $files
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd product/tistory-skin/akbun
+          gh release create "${{ steps.version.outputs.tag }}" akbun-skin.zip \
+            --target "${{ github.sha }}" \
+            --title "tistory-${{ steps.version.outputs.version }}" \
+            --notes "티스토리 스킨 tistory-${{ steps.version.outputs.version }} 배포 아티팩트. skin.html, style.css, index.xml 포함."

--- a/product/tistory-skin/akbun/AGENTS.md
+++ b/product/tistory-skin/akbun/AGENTS.md
@@ -1,0 +1,25 @@
+# akbun tistory skin
+
+이 프로젝트는 티스토리 블로그용 커스텀 스킨이다. 스킨 파일(`skin.html`, `style.css`, `index.xml`)을 수정하고, 로컬 preview 파일로 확인한 뒤, 티스토리 관리자에 업로드하는 흐름으로 작업한다.
+
+## 문서 구조
+
+| 문서 | 역할 |
+| --- | --- |
+| [`docs/tistory-rules.md`](./docs/tistory-rules.md) | 티스토리 파서의 블록 태그, 치환자, 페이지 유형 규칙 |
+| [`docs/design.md`](./docs/design.md) | 레이아웃 비율, 색상, 타이포그래피 등 디자인 명세 |
+| [`docs/validation.md`](./docs/validation.md) | 작업 후 검증 체크리스트 (HTML/CSS/JS 스냅샷 포함) |
+| [`docs/deploy.md`](./docs/deploy.md) | 티스토리 관리자 업로드 절차 |
+
+스킨 수정 전에 `docs/tistory-rules.md`와 `docs/design.md`를 먼저 읽어라 -- 티스토리 파서는 오류 메시지 없이 실패하므로 규칙을 모르면 디버깅이 불가능하다.
+
+## 작업 완료 전 검증
+
+작업을 마치면 종료 전에 [`docs/validation.md`](./docs/validation.md)를 기준으로 검증한다. preview 파일을 읽어서 확인할 수 있는 항목은 소스를 직접 확인하고, 브라우저에서만 확인 가능한 항목은 "수동 확인 필요"로 표시한다.
+
+- UI나 구조가 바뀌었으면 `docs/validation.md`도 함께 갱신할지 사용자에게 확인한다 -- 검증 문서가 실제 스킨과 어긋나면 이후 작업에서 잘못된 기준으로 검증하게 된다.
+- 검증 결과는 표 형식으로 정리해서 보여준다.
+
+## 참고
+
+- 티스토리 스킨 공식 문서: <https://tistory.github.io/document-tistory-skin/common/basic.html>

--- a/product/tistory-skin/akbun/CLAUDE.md
+++ b/product/tistory-skin/akbun/CLAUDE.md
@@ -1,3 +1,3 @@
 # akbun tistory skin
 
-Follow a @AGENTS.md
+이 프로젝트의 작업 지침은 [AGENTS.md](./AGENTS.md)를 따른다.

--- a/product/tistory-skin/akbun/CLAUDE.md
+++ b/product/tistory-skin/akbun/CLAUDE.md
@@ -1,25 +1,3 @@
 # akbun tistory skin
 
-이 프로젝트는 티스토리 블로그용 커스텀 스킨이다. 스킨 파일(`skin.html`, `style.css`, `index.xml`)을 수정하고, 로컬 preview 파일로 확인한 뒤, 티스토리 관리자에 업로드하는 흐름으로 작업한다.
-
-## 문서 구조
-
-| 문서 | 역할 |
-| --- | --- |
-| [`docs/tistory-rules.md`](./docs/tistory-rules.md) | 티스토리 파서의 블록 태그, 치환자, 페이지 유형 규칙 |
-| [`docs/design.md`](./docs/design.md) | 레이아웃 비율, 색상, 타이포그래피 등 디자인 명세 |
-| [`docs/validation.md`](./docs/validation.md) | 작업 후 검증 체크리스트 (HTML/CSS/JS 스냅샷 포함) |
-| [`docs/deploy.md`](./docs/deploy.md) | 티스토리 관리자 업로드 절차 |
-
-스킨 수정 전에 `docs/tistory-rules.md`와 `docs/design.md`를 먼저 읽어라 -- 티스토리 파서는 오류 메시지 없이 실패하므로 규칙을 모르면 디버깅이 불가능하다.
-
-## 작업 완료 전 검증
-
-작업을 마치면 종료 전에 [`docs/validation.md`](./docs/validation.md)를 기준으로 검증한다. preview 파일을 읽어서 확인할 수 있는 항목은 소스를 직접 확인하고, 브라우저에서만 확인 가능한 항목은 "수동 확인 필요"로 표시한다.
-
-- UI나 구조가 바뀌었으면 `docs/validation.md`도 함께 갱신할지 사용자에게 확인한다 -- 검증 문서가 실제 스킨과 어긋나면 이후 작업에서 잘못된 기준으로 검증하게 된다.
-- 검증 결과는 표 형식으로 정리해서 보여준다.
-
-## 참고
-
-- 티스토리 스킨 공식 문서: <https://tistory.github.io/document-tistory-skin/common/basic.html>
+Follow a @AGENTS.md

--- a/product/tistory-skin/akbun/Makefile
+++ b/product/tistory-skin/akbun/Makefile
@@ -1,4 +1,7 @@
-.PHONY: preview
+.PHONY: preview zip
 
 preview:
 	cd src && python3 -m http.server 3000
+
+zip:
+	cd src && zip -r ../akbun-skin.zip skin.html style.css index.xml $$([ -d images ] && echo images)

--- a/product/tistory-skin/akbun/docs/deploy.md
+++ b/product/tistory-skin/akbun/docs/deploy.md
@@ -14,6 +14,24 @@
    - `images/` 폴더 안의 파일도 전부 업로드
 5. 저장 → 스킨이름 지정 → 적용
 
+## Release zip
+
+`master`에 스킨 소스 변경이 push되면 GitHub Actions가 `src/index.xml`의 `<version>`을 읽어 Release를 만든다. tag와 Release title은 `tistory-<version>` 형식이며, 같은 tag Release가 이미 있으면 새 Release를 만들지 않는다. Release tag는 workflow가 실행된 commit SHA(`${{ github.sha }}`)를 `gh release create --target`에 넘겨 만든다.
+
+agent가 `skin.html`, `style.css`, `index.xml`, `images/`처럼 실제 업로드되는 스킨 파일을 수정하면 `src/index.xml`의 `<version>`도 함께 올린다. 버전을 올리지 않으면 workflow는 실행될 수 있지만, 기존 tag가 이미 있어서 새 Release zip이 만들어지지 않는다.
+
+- 기능 추가나 UI 변경은 minor version을 올린다. 예: `1.1.0` → `1.2.0`
+- 작은 버그 수정은 patch version을 올린다. 예: `1.1.0` → `1.1.1`
+- preview 파일이나 문서만 수정한 경우에는 version을 올리지 않는다.
+
+로컬에서 동일한 업로드 zip을 만들 때는 아래 명령을 사용한다.
+
+```bash
+make zip
+```
+
+생성되는 `akbun-skin.zip`에는 `skin.html`, `style.css`, `index.xml`, `images/`가 있으면 `images/`가 포함된다. preview 파일은 배포 zip에 포함하지 않는다.
+
 ### 구글 서치콘솔 (옵션)
 
 검색 노출에 필요하다. 스킨 저장소에는 넣지 않고, 업로드 후 각자 본인 코드로 추가한다.

--- a/product/tistory-skin/akbun/docs/validation.md
+++ b/product/tistory-skin/akbun/docs/validation.md
@@ -80,14 +80,33 @@
 `/preview-post.html`에서 다음을 확인한다.
 
 - "글 목록으로 돌아가기" 링크가 존재하는지
+- "markdown으로 복사하기" 버튼이 링크 오른쪽에 존재하는지
+- 버튼 클릭 시 클립보드에 글 제목, 본문 Markdown, 출처 URL이 복사되는지
+- 복사 결과에서 본문 헤딩 depth가 원본 그대로 유지되는지. 티스토리 본문 `h1`은 `#`, `h2`는 `##`로 변환하며 강등하지 않는다
+- 표, 코드블록, 리스트, blockquote가 Markdown으로 보존되는지
 - 데스크톱 폭(1400px 이상)에서 floating ToC가 보이는지
 - ToC가 본문 `h1`, `h2`를 수집하는지
 
 **HTML 구조**
 
 ```html
+<div class="page-home-link">
+  <a href="preview.html" class="page-home-link-anchor">글 목록으로 돌아가기</a>
+  <button type="button" class="copy-markdown-btn" id="copy-markdown-btn">markdown으로 복사하기</button>
+</div>
 <div id="floating-toc" class="floating-toc">
 <nav id="toc-nav"></nav>
+```
+
+**JS** — Markdown 변환은 본문 헤딩을 강등하지 않아야 한다.
+
+```js
+new TurndownService({
+  headingStyle: "atx",
+  codeBlockStyle: "fenced",
+  bulletListMarker: "-"
+});
+service.use(window.turndownPluginGfm.gfm);
 ```
 
 **JS** — ToC 생성 셀렉터를 변경하면 목차가 비게 된다.
@@ -99,6 +118,19 @@ document.querySelectorAll(".post-body h1, .post-body h2")
 **CSS** — ToC 폰트 크기와 반응형 숨김 처리를 유지한다.
 
 ```css
+#tt-body-page .page-home-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.copy-markdown-btn.is-copied {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
 .floating-toc-header {
   font-size: 0.9375rem;
 }

--- a/product/tistory-skin/akbun/src/index.xml
+++ b/product/tistory-skin/akbun/src/index.xml
@@ -2,7 +2,7 @@
 <skin>
   <information>
     <name><![CDATA[akbun]]></name>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <description><![CDATA[악분 스킨]]></description>
     <license><![CDATA[MIT License]]></license>
   </information>

--- a/product/tistory-skin/akbun/src/preview-post.html
+++ b/product/tistory-skin/akbun/src/preview-post.html
@@ -34,6 +34,7 @@
 
       <div class="page-home-link">
         <a href="preview.html" class="page-home-link-anchor">글 목록으로 돌아가기</a>
+        <button type="button" class="copy-markdown-btn" id="copy-markdown-btn">markdown으로 복사하기</button>
       </div>
 
       <article class="post-full">
@@ -349,6 +350,93 @@ redis-pod   1/1     Running   0          12m</code></pre>
       }
     });
     Prism.highlightAll();
+  });
+</script>
+<script src="https://cdn.jsdelivr.net/npm/turndown@7.2.0/dist/turndown.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/turndown-plugin-gfm@1.0.2/dist/turndown-plugin-gfm.js"></script>
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var btn = document.getElementById("copy-markdown-btn");
+    var postBody = document.querySelector(".post-body");
+    if (!btn || !postBody) {
+      if (btn) btn.style.display = "none";
+      return;
+    }
+
+    var label = "markdown으로 복사하기";
+
+    function createMarkdownService() {
+      if (typeof TurndownService === "undefined") return null;
+
+      var service = new TurndownService({
+        headingStyle: "atx",
+        codeBlockStyle: "fenced",
+        bulletListMarker: "-"
+      });
+      if (window.turndownPluginGfm) {
+        service.use(window.turndownPluginGfm.gfm);
+      }
+      return service;
+    }
+
+    function buildMarkdown() {
+      var service = createMarkdownService();
+      if (!service) throw new Error("TurndownService is unavailable");
+
+      var titleEl = document.querySelector(".post-title");
+      var title = titleEl ? titleEl.textContent.trim() : document.title;
+      var body = service.turndown(postBody.innerHTML);
+      return "# " + title + "\n\n" + body + "\n\n---\n출처: " + location.href + "\n";
+    }
+
+    function flash(text) {
+      btn.textContent = text;
+      btn.classList.add("is-copied");
+      setTimeout(function () {
+        btn.textContent = label;
+        btn.classList.remove("is-copied");
+      }, 2000);
+    }
+
+    function fallbackCopy(text) {
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+
+      var copied = false;
+      try {
+        copied = document.execCommand("copy");
+      } catch (e) {
+        copied = false;
+      }
+
+      document.body.removeChild(ta);
+      flash(copied ? "복사됨!" : "복사 실패");
+    }
+
+    btn.addEventListener("click", function () {
+      var md;
+      try {
+        md = buildMarkdown();
+      } catch (e) {
+        flash("복사 실패");
+        return;
+      }
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(md).then(function () {
+          flash("복사됨!");
+        }).catch(function () {
+          fallbackCopy(md);
+        });
+        return;
+      }
+
+      fallbackCopy(md);
+    });
   });
 </script>
 <script>

--- a/product/tistory-skin/akbun/src/preview-post.html
+++ b/product/tistory-skin/akbun/src/preview-post.html
@@ -364,6 +364,7 @@ redis-pod   1/1     Running   0          12m</code></pre>
     }
 
     var label = "markdown으로 복사하기";
+    var flashTimer = null;
 
     function createMarkdownService() {
       if (typeof TurndownService === "undefined") return null;
@@ -390,11 +391,13 @@ redis-pod   1/1     Running   0          12m</code></pre>
     }
 
     function flash(text) {
+      if (flashTimer) clearTimeout(flashTimer);
       btn.textContent = text;
       btn.classList.add("is-copied");
-      setTimeout(function () {
+      flashTimer = setTimeout(function () {
         btn.textContent = label;
         btn.classList.remove("is-copied");
+        flashTimer = null;
       }, 2000);
     }
 

--- a/product/tistory-skin/akbun/src/skin.html
+++ b/product/tistory-skin/akbun/src/skin.html
@@ -487,6 +487,7 @@
       }
 
       var label = "markdown으로 복사하기";
+      var flashTimer = null;
 
       function createMarkdownService() {
         if (typeof TurndownService === "undefined") return null;
@@ -513,11 +514,13 @@
       }
 
       function flash(text) {
+        if (flashTimer) clearTimeout(flashTimer);
         btn.textContent = text;
         btn.classList.add("is-copied");
-        setTimeout(function () {
+        flashTimer = setTimeout(function () {
           btn.textContent = label;
           btn.classList.remove("is-copied");
+          flashTimer = null;
         }, 2000);
       }
 

--- a/product/tistory-skin/akbun/src/skin.html
+++ b/product/tistory-skin/akbun/src/skin.html
@@ -68,6 +68,7 @@
       <!-- ===== Top Actions ===== -->
       <div class="page-home-link">
         <a href="[##_blog_link_##]" class="page-home-link-anchor">글 목록으로 돌아가기</a>
+        <button type="button" class="copy-markdown-btn" id="copy-markdown-btn">markdown으로 복사하기</button>
       </div>
 
       <!-- ===== Ad: List Upper ===== -->
@@ -470,6 +471,95 @@
         }
       });
       Prism.highlightAll();
+    });
+  </script>
+
+  <!-- HTML to Markdown -->
+  <script src="https://cdn.jsdelivr.net/npm/turndown@7.2.0/dist/turndown.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/turndown-plugin-gfm@1.0.2/dist/turndown-plugin-gfm.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var btn = document.getElementById("copy-markdown-btn");
+      var postBody = document.querySelector(".post-body");
+      if (!btn || !postBody) {
+        if (btn) btn.style.display = "none";
+        return;
+      }
+
+      var label = "markdown으로 복사하기";
+
+      function createMarkdownService() {
+        if (typeof TurndownService === "undefined") return null;
+
+        var service = new TurndownService({
+          headingStyle: "atx",
+          codeBlockStyle: "fenced",
+          bulletListMarker: "-"
+        });
+        if (window.turndownPluginGfm) {
+          service.use(window.turndownPluginGfm.gfm);
+        }
+        return service;
+      }
+
+      function buildMarkdown() {
+        var service = createMarkdownService();
+        if (!service) throw new Error("TurndownService is unavailable");
+
+        var titleEl = document.querySelector(".post-title");
+        var title = titleEl ? titleEl.textContent.trim() : document.title;
+        var body = service.turndown(postBody.innerHTML);
+        return "# " + title + "\n\n" + body + "\n\n---\n출처: " + location.href + "\n";
+      }
+
+      function flash(text) {
+        btn.textContent = text;
+        btn.classList.add("is-copied");
+        setTimeout(function () {
+          btn.textContent = label;
+          btn.classList.remove("is-copied");
+        }, 2000);
+      }
+
+      function fallbackCopy(text) {
+        var ta = document.createElement("textarea");
+        ta.value = text;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+
+        var copied = false;
+        try {
+          copied = document.execCommand("copy");
+        } catch (e) {
+          copied = false;
+        }
+
+        document.body.removeChild(ta);
+        flash(copied ? "복사됨!" : "복사 실패");
+      }
+
+      btn.addEventListener("click", function () {
+        var md;
+        try {
+          md = buildMarkdown();
+        } catch (e) {
+          flash("복사 실패");
+          return;
+        }
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(md).then(function () {
+            flash("복사됨!");
+          }).catch(function () {
+            fallbackCopy(md);
+          });
+          return;
+        }
+
+        fallbackCopy(md);
+      });
     });
   </script>
 

--- a/product/tistory-skin/akbun/src/style.css
+++ b/product/tistory-skin/akbun/src/style.css
@@ -127,6 +127,10 @@ img {
   gap: var(--layout-gap);
 }
 
+.content {
+  min-width: 0;
+}
+
 /* ===================================================================
    Sidebar
    =================================================================== */
@@ -282,7 +286,8 @@ img {
   margin-bottom: 2rem;
 }
 
-.page-home-link-anchor {
+.page-home-link-anchor,
+.copy-markdown-btn {
   display: inline-flex;
   align-items: center;
   padding: 0.625rem 0.875rem;
@@ -296,7 +301,13 @@ img {
   transition: color var(--transition), border-color var(--transition);
 }
 
-.page-home-link-anchor:hover {
+.copy-markdown-btn {
+  cursor: pointer;
+}
+
+.page-home-link-anchor:hover,
+.copy-markdown-btn:hover,
+.copy-markdown-btn.is-copied {
   color: var(--color-accent);
   border-color: var(--color-accent);
 }
@@ -390,6 +401,7 @@ img {
   letter-spacing: -0.02em;
   margin-top: 0;
   margin-bottom: 1rem;
+  overflow-wrap: anywhere;
 }
 
 .post-meta {
@@ -1221,7 +1233,11 @@ img {
 }
 
 #tt-body-page .page-home-link {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Summary
- Add a `markdown으로 복사하기` button to post pages and preview pages, with HTML-to-Markdown conversion, clipboard copy fallback, and visual copy feedback.
- Keep post layout responsive by making the post action row flex on permalink pages and adding mobile overflow fixes for the post content area.
- Add a GitHub Actions release workflow that builds `akbun-skin.zip` only from the skin assets, gates releases by `src/index.xml` version, and publishes the release against the current commit SHA.
- Update deployment and validation docs to reflect the new release/versioning flow and the new copy button behavior.

## Testing
- Ran `git diff --check` with no errors.
- Validated `src/index.xml` as XML and the release workflow as YAML.
- Verified the generated `akbun-skin.zip` contains only `skin.html`, `style.css`, and `index.xml`.
- Performed local browser testing on `preview-post.html` to confirm button placement, responsive wrapping, and copied Markdown structure, including preserved headings, tables, fenced code, and source URL.