### PR TITLE
[codex] Tighten Tistory markdown copy output

### DIFF
--- a/product/tistory-skin/akbun/docs/validation.md
+++ b/product/tistory-skin/akbun/docs/validation.md
@@ -83,7 +83,7 @@
 - "markdown으로 복사하기" 버튼이 링크 오른쪽에 존재하는지
 - 버튼 클릭 시 클립보드에 글 제목, 본문 Markdown, 출처 URL이 복사되는지
 - 복사 결과에서 본문 헤딩 depth가 원본 그대로 유지되는지. 티스토리 본문 `h1`은 `#`, `h2`는 `##`로 변환하며 강등하지 않는다
-- 표, 코드블록, 리스트, blockquote가 Markdown으로 보존되는지
+- 표, 코드블록, 리스트, blockquote가 Markdown으로 보존되는지. 리스트 marker 뒤 공백은 1개만 둔다. 예: `- 목록`
 - 데스크톱 폭(1400px 이상)에서 floating ToC가 보이는지
 - ToC가 본문 `h1`, `h2`를 수집하는지
 
@@ -101,12 +101,28 @@
 **JS** — Markdown 변환은 본문 헤딩을 강등하지 않아야 한다.
 
 ```js
-new TurndownService({
+var service = new TurndownService({
   headingStyle: "atx",
   codeBlockStyle: "fenced",
   bulletListMarker: "-"
 });
 service.use(window.turndownPluginGfm.gfm);
+service.addRule("compactListItem", {
+  filter: "li",
+  replacement: function (content, node, options) {
+    var item = content.replace(/^\n+/, "").replace(/\n+$/, "\n");
+    var prefix = options.bulletListMarker + " ";
+    var parent = node.parentNode;
+
+    if (parent && parent.nodeName === "OL") {
+      var start = parent.getAttribute("start");
+      var index = Array.prototype.indexOf.call(parent.children, node);
+      prefix = (start ? Number(start) + index : index + 1) + ". ";
+    }
+
+    return prefix + item;
+  }
+});
 ```
 
 **JS** — ToC 생성 셀렉터를 변경하면 목차가 비게 된다.
@@ -121,7 +137,7 @@ document.querySelectorAll(".post-body h1, .post-body h2")
 #tt-body-page .page-home-link {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.75rem;
   flex-wrap: wrap;
 }

--- a/product/tistory-skin/akbun/src/index.xml
+++ b/product/tistory-skin/akbun/src/index.xml
@@ -2,7 +2,7 @@
 <skin>
   <information>
     <name><![CDATA[akbun]]></name>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <description><![CDATA[악분 스킨]]></description>
     <license><![CDATA[MIT License]]></license>
   </information>

--- a/product/tistory-skin/akbun/src/preview-post.html
+++ b/product/tistory-skin/akbun/src/preview-post.html
@@ -377,7 +377,30 @@ redis-pod   1/1     Running   0          12m</code></pre>
       if (window.turndownPluginGfm) {
         service.use(window.turndownPluginGfm.gfm);
       }
+      addCompactListItemRule(service);
       return service;
+    }
+
+    function addCompactListItemRule(service) {
+      service.addRule("compactListItem", {
+        filter: "li",
+        replacement: function (content, node, options) {
+          var item = content
+            .replace(/^\n+/, "")
+            .replace(/\n+$/, "\n")
+            .replace(/\n/gm, "\n    ");
+          var prefix = options.bulletListMarker + " ";
+          var parent = node.parentNode;
+
+          if (parent && parent.nodeName === "OL") {
+            var start = parent.getAttribute("start");
+            var index = Array.prototype.indexOf.call(parent.children, node);
+            prefix = (start ? Number(start) + index : index + 1) + ". ";
+          }
+
+          return prefix + item + (node.nextSibling && !/\n$/.test(item) ? "\n" : "");
+        }
+      });
     }
 
     function buildMarkdown() {

--- a/product/tistory-skin/akbun/src/skin.html
+++ b/product/tistory-skin/akbun/src/skin.html
@@ -500,7 +500,30 @@
         if (window.turndownPluginGfm) {
           service.use(window.turndownPluginGfm.gfm);
         }
+        addCompactListItemRule(service);
         return service;
+      }
+
+      function addCompactListItemRule(service) {
+        service.addRule("compactListItem", {
+          filter: "li",
+          replacement: function (content, node, options) {
+            var item = content
+              .replace(/^\n+/, "")
+              .replace(/\n+$/, "\n")
+              .replace(/\n/gm, "\n    ");
+            var prefix = options.bulletListMarker + " ";
+            var parent = node.parentNode;
+
+            if (parent && parent.nodeName === "OL") {
+              var start = parent.getAttribute("start");
+              var index = Array.prototype.indexOf.call(parent.children, node);
+              prefix = (start ? Number(start) + index : index + 1) + ". ";
+            }
+
+            return prefix + item + (node.nextSibling && !/\n$/.test(item) ? "\n" : "");
+          }
+        });
       }
 
       function buildMarkdown() {

--- a/product/tistory-skin/akbun/src/style.css
+++ b/product/tistory-skin/akbun/src/style.css
@@ -1235,7 +1235,7 @@ img {
 #tt-body-page .page-home-link {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 0.75rem;
   flex-wrap: wrap;
   margin-top: 0;


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

티스토리 스킨의 `markdown으로 복사하기` 결과에서 리스트 marker 뒤 공백이 3개로 들어가는 문제를 수정한다. 또한 글 상세 상단의 복사 버튼이 "글 목록으로 돌아가기" 버튼에서 너무 멀리 떨어져 보이는 UI 문제를 함께 다룬다.

## 문제를 어떻게 해결 또는 공부했는가

Turndown의 `li` 변환 rule을 명시적으로 추가해 unordered list는 `- 항목`, ordered list는 `1. 항목`처럼 marker 뒤 공백을 1개만 사용하도록 했다. 포스트 상단 액션 영역은 `justify-content: flex-start`로 바꿔 두 버튼이 왼쪽에서 자연스럽게 나란히 배치되도록 했다. 실제 스킨 파일이 바뀌었으므로 `index.xml` patch version도 `1.1.1`로 올렸다.

검증은 `git diff --check`, `index.xml` XML 파싱, `make zip`, list replacement 함수 mock 검증으로 진행했다.

## GitHub Issue (선택)

없음.

## 파일 디렉터리 구조

```text
product/tistory-skin/akbun/
├── docs/
│   └── validation.md      # Markdown 복사 결과와 버튼 배치 검증 기준 갱신
└── src/
    ├── index.xml          # patch version 1.1.1
    ├── preview-post.html  # preview 복사 로직 list spacing 보정
    ├── skin.html          # 실제 스킨 복사 로직 list spacing 보정
    └── style.css          # 포스트 상단 버튼 간격 조정
```
