### PR TITLE
[codex] Sanitize Tistory markdown copy output

### DIFF
--- a/product/tistory-skin/akbun/docs/validation.md
+++ b/product/tistory-skin/akbun/docs/validation.md
@@ -84,6 +84,10 @@
 - 버튼 클릭 시 클립보드에 글 제목, 본문 Markdown, 출처 URL이 복사되는지
 - 복사 결과에서 본문 헤딩 depth가 원본 그대로 유지되는지. 티스토리 본문 `h1`은 `#`, `h2`는 `##`로 변환하며 강등하지 않는다
 - 표, 코드블록, 리스트, blockquote가 Markdown으로 보존되는지. 리스트 marker 뒤 공백은 1개만 둔다. 예: `- 목록`
+- 복사 결과의 끝부분에서 티스토리 footer와 그 직전 광고 부산물이 제거되는지. 예: `adsbygoogle`, `반응형`, `ReactionButtonType`
+- 복사 결과에서 제어문자가 제거되는지. 예: 한영 전환 중 들어간 U+0008 backspace
+- 복사 결과에서 티스토리 자동 푸터가 제거되는지. 예: `좋아요공감`, `공유하기`, `통계`, `게시글 관리`, CCL 링크, "카테고리의 다른 글" 표
+- 본문 중간에 `통계`, `게시글 관리`, `공유하기` 같은 단어가 있어도 그 지점에서 Markdown이 잘리지 않는지
 - 데스크톱 폭(1400px 이상)에서 floating ToC가 보이는지
 - ToC가 본문 `h1`, `h2`를 수집하는지
 
@@ -110,7 +114,10 @@ service.use(window.turndownPluginGfm.gfm);
 service.addRule("compactListItem", {
   filter: "li",
   replacement: function (content, node, options) {
-    var item = content.replace(/^\n+/, "").replace(/\n+$/, "\n");
+    var item = content
+      .replace(/^\n+/, "")
+      .replace(/\n+$/, "\n")
+      .replace(/\n/gm, "\n    ");
     var prefix = options.bulletListMarker + " ";
     var parent = node.parentNode;
 
@@ -120,9 +127,26 @@ service.addRule("compactListItem", {
       prefix = (start ? Number(start) + index : index + 1) + ". ";
     }
 
-    return prefix + item;
+    return prefix + item + (node.nextSibling && !/\n$/.test(item) ? "\n" : "");
   }
 });
+```
+
+**JS** — 복사 전후로 티스토리가 생성한 광고/푸터와 제어문자를 제거해야 한다.
+
+```js
+var body = cleanMarkdown(service.turndown(createCleanPostBody().innerHTML));
+
+function removeControlCharactersFromText(text) {
+  return text.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
+}
+```
+
+**JS** — footer 절단은 문서 끝 근처의 티스토리 footer 신호 묶음에만 적용한다.
+
+```js
+var searchStart = Math.max(0, markdown.length - 6000);
+var relativeIndex = findTistoryFooterStartIndex(markdown.slice(searchStart));
 ```
 
 **JS** — ToC 생성 셀렉터를 변경하면 목차가 비게 된다.

--- a/product/tistory-skin/akbun/src/index.xml
+++ b/product/tistory-skin/akbun/src/index.xml
@@ -2,7 +2,7 @@
 <skin>
   <information>
     <name><![CDATA[akbun]]></name>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <description><![CDATA[악분 스킨]]></description>
     <license><![CDATA[MIT License]]></license>
   </information>

--- a/product/tistory-skin/akbun/src/preview-post.html
+++ b/product/tistory-skin/akbun/src/preview-post.html
@@ -403,13 +403,147 @@ redis-pod   1/1     Running   0          12m</code></pre>
       });
     }
 
+    function createCleanPostBody() {
+      var clone = postBody.cloneNode(true);
+      removeGeneratedElements(clone);
+      removeControlCharacters(clone);
+      return clone;
+    }
+
+    function removeGeneratedElements(root) {
+      [
+        "script",
+        "style",
+        "noscript",
+        ".adsbygoogle",
+        ".revenue_unit_wrap",
+        ".revenue_unit_item",
+        ".container_postbtn",
+        ".postbtn_like",
+        ".postbtn_ccl",
+        ".another_category",
+        ".wrap_btn_share",
+        ".wrap_btn_etc",
+        ".btn_menu_toolbar",
+        "#tistoryEtcLayer",
+        "[data-ad-client]",
+        "[data-ad-host]",
+        "[data-ad-slot]",
+        "[data-tistory-react-app='NaverAd']",
+        "[data-tistory-react-app='Reaction']",
+        "iframe[src*='googlesyndication']",
+        "iframe[src*='doubleclick']",
+        "iframe[src*='googleads']"
+      ].forEach(function (selector) {
+        root.querySelectorAll(selector).forEach(function (node) {
+          node.parentNode.removeChild(node);
+        });
+      });
+    }
+
+    function removeControlCharacters(root) {
+      var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      var node = walker.nextNode();
+
+      while (node) {
+        node.nodeValue = removeControlCharactersFromText(node.nodeValue);
+        node = walker.nextNode();
+      }
+    }
+
+    function removeControlCharactersFromText(text) {
+      return text.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
+    }
+
+    function cleanMarkdown(markdown) {
+      return truncateTistoryFooter(removeControlCharactersFromText(markdown))
+        .replace(/\n{3,}/g, "\n\n")
+        .trim();
+    }
+
+    function truncateTistoryFooter(markdown) {
+      var searchStart = Math.max(0, markdown.length - 6000);
+      var searchArea = markdown.slice(searchStart);
+      var relativeIndex = findTistoryFooterStartIndex(searchArea);
+
+      if (relativeIndex === -1) return markdown;
+
+      var cutIndex = searchStart + relativeIndex;
+      return trimTrailingGeneratedFooterLines(markdown.slice(0, cutIndex));
+    }
+
+    function findTistoryFooterStartIndex(markdown) {
+      var markers = [
+        /^window\.ReactionButtonType/m,
+        /^좋아요\s*공감$/m,
+        /^\[저작자표시.*creativecommons\.org/m,
+        /^#### .*카테고리의 다른 글/m,
+        /^<table\b[^>]*>\s*<tbody\b[^>]*>\s*<tr\b[^>]*>\s*<th\b[^>]*>\s*<a\b[^>]*href="\/\d+"/m
+      ];
+      var startIndex = -1;
+
+      markers.forEach(function (marker) {
+        var match = marker.exec(markdown);
+        if (match && isTistoryFooterTail(markdown.slice(match.index)) && (startIndex === -1 || match.index < startIndex)) {
+          startIndex = match.index;
+        }
+      });
+
+      return startIndex;
+    }
+
+    function isTistoryFooterTail(markdown) {
+      var sample = markdown.slice(0, 2500);
+      var signals = [
+        /ReactionButtonType|ReactionApiUrl|ReactionReqBody/,
+        /^좋아요\s*공감$/m,
+        /^공유하기$/m,
+        /^URL 복사.*공유$/m,
+        /^통계$/m,
+        /^게시글 관리$/m,
+        /creativecommons\.org/,
+        /카테고리의 다른 글/,
+        /<table\b[^>]*>\s*<tbody\b[^>]*>/m
+      ];
+      var count = 0;
+
+      signals.forEach(function (signal) {
+        if (signal.test(sample)) count += 1;
+      });
+
+      return count >= 2;
+    }
+
+    function trimTrailingGeneratedFooterLines(markdown) {
+      var lines = markdown.split("\n");
+
+      while (lines.length && lines[lines.length - 1].trim() === "") {
+        lines.pop();
+      }
+
+      while (lines.length && isGeneratedFooterLine(lines[lines.length - 1])) {
+        lines.pop();
+        while (lines.length && lines[lines.length - 1].trim() === "") {
+          lines.pop();
+        }
+      }
+
+      return lines.join("\n");
+    }
+
+    function isGeneratedFooterLine(line) {
+      var text = line.trim();
+      if (text === "반응형") return true;
+      return /adsbygoogle|observeAdsenseUnfilledState|ReactionButtonType|ReactionApiUrl|ReactionReqBody/.test(text);
+    }
+
     function buildMarkdown() {
       var service = createMarkdownService();
       if (!service) throw new Error("TurndownService is unavailable");
 
       var titleEl = document.querySelector(".post-title");
       var title = titleEl ? titleEl.textContent.trim() : document.title;
-      var body = service.turndown(postBody.innerHTML);
+      var body = cleanMarkdown(service.turndown(createCleanPostBody().innerHTML));
       return "# " + title + "\n\n" + body + "\n\n---\n출처: " + location.href + "\n";
     }
 

--- a/product/tistory-skin/akbun/src/skin.html
+++ b/product/tistory-skin/akbun/src/skin.html
@@ -526,13 +526,147 @@
         });
       }
 
+      function createCleanPostBody() {
+        var clone = postBody.cloneNode(true);
+        removeGeneratedElements(clone);
+        removeControlCharacters(clone);
+        return clone;
+      }
+
+      function removeGeneratedElements(root) {
+        [
+          "script",
+          "style",
+          "noscript",
+          ".adsbygoogle",
+          ".revenue_unit_wrap",
+          ".revenue_unit_item",
+          ".container_postbtn",
+          ".postbtn_like",
+          ".postbtn_ccl",
+          ".another_category",
+          ".wrap_btn_share",
+          ".wrap_btn_etc",
+          ".btn_menu_toolbar",
+          "#tistoryEtcLayer",
+          "[data-ad-client]",
+          "[data-ad-host]",
+          "[data-ad-slot]",
+          "[data-tistory-react-app='NaverAd']",
+          "[data-tistory-react-app='Reaction']",
+          "iframe[src*='googlesyndication']",
+          "iframe[src*='doubleclick']",
+          "iframe[src*='googleads']"
+        ].forEach(function (selector) {
+          root.querySelectorAll(selector).forEach(function (node) {
+            node.parentNode.removeChild(node);
+          });
+        });
+      }
+
+      function removeControlCharacters(root) {
+        var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        var node = walker.nextNode();
+
+        while (node) {
+          node.nodeValue = removeControlCharactersFromText(node.nodeValue);
+          node = walker.nextNode();
+        }
+      }
+
+      function removeControlCharactersFromText(text) {
+        return text.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "");
+      }
+
+      function cleanMarkdown(markdown) {
+        return truncateTistoryFooter(removeControlCharactersFromText(markdown))
+          .replace(/\n{3,}/g, "\n\n")
+          .trim();
+      }
+
+      function truncateTistoryFooter(markdown) {
+        var searchStart = Math.max(0, markdown.length - 6000);
+        var searchArea = markdown.slice(searchStart);
+        var relativeIndex = findTistoryFooterStartIndex(searchArea);
+
+        if (relativeIndex === -1) return markdown;
+
+        var cutIndex = searchStart + relativeIndex;
+        return trimTrailingGeneratedFooterLines(markdown.slice(0, cutIndex));
+      }
+
+      function findTistoryFooterStartIndex(markdown) {
+        var markers = [
+          /^window\.ReactionButtonType/m,
+          /^좋아요\s*공감$/m,
+          /^\[저작자표시.*creativecommons\.org/m,
+          /^#### .*카테고리의 다른 글/m,
+          /^<table\b[^>]*>\s*<tbody\b[^>]*>\s*<tr\b[^>]*>\s*<th\b[^>]*>\s*<a\b[^>]*href="\/\d+"/m
+        ];
+        var startIndex = -1;
+
+        markers.forEach(function (marker) {
+          var match = marker.exec(markdown);
+          if (match && isTistoryFooterTail(markdown.slice(match.index)) && (startIndex === -1 || match.index < startIndex)) {
+            startIndex = match.index;
+          }
+        });
+
+        return startIndex;
+      }
+
+      function isTistoryFooterTail(markdown) {
+        var sample = markdown.slice(0, 2500);
+        var signals = [
+          /ReactionButtonType|ReactionApiUrl|ReactionReqBody/,
+          /^좋아요\s*공감$/m,
+          /^공유하기$/m,
+          /^URL 복사.*공유$/m,
+          /^통계$/m,
+          /^게시글 관리$/m,
+          /creativecommons\.org/,
+          /카테고리의 다른 글/,
+          /<table\b[^>]*>\s*<tbody\b[^>]*>/m
+        ];
+        var count = 0;
+
+        signals.forEach(function (signal) {
+          if (signal.test(sample)) count += 1;
+        });
+
+        return count >= 2;
+      }
+
+      function trimTrailingGeneratedFooterLines(markdown) {
+        var lines = markdown.split("\n");
+
+        while (lines.length && lines[lines.length - 1].trim() === "") {
+          lines.pop();
+        }
+
+        while (lines.length && isGeneratedFooterLine(lines[lines.length - 1])) {
+          lines.pop();
+          while (lines.length && lines[lines.length - 1].trim() === "") {
+            lines.pop();
+          }
+        }
+
+        return lines.join("\n");
+      }
+
+      function isGeneratedFooterLine(line) {
+        var text = line.trim();
+        if (text === "반응형") return true;
+        return /adsbygoogle|observeAdsenseUnfilledState|ReactionButtonType|ReactionApiUrl|ReactionReqBody/.test(text);
+      }
+
       function buildMarkdown() {
         var service = createMarkdownService();
         if (!service) throw new Error("TurndownService is unavailable");
 
         var titleEl = document.querySelector(".post-title");
         var title = titleEl ? titleEl.textContent.trim() : document.title;
-        var body = service.turndown(postBody.innerHTML);
+        var body = cleanMarkdown(service.turndown(createCleanPostBody().innerHTML));
         return "# " + title + "\n\n" + body + "\n\n---\n출처: " + location.href + "\n";
       }
 


### PR DESCRIPTION
## Summary

Sanitize the Tistory markdown copy output so it no longer includes generated advertising text, broken control characters, or Tistory's automatic post footer.

## Why

Actual copied markdown still included AdSense remnants such as `adsbygoogle`, corrupted control characters from Korean/English input switching, and Tistory-generated footer content such as reaction/share/statistics controls, CCL links, and the "other posts in this category" table.

## Changes

- Clone and clean the post body before converting it with Turndown.
- Remove generated ad, script, reaction, share, CCL, and related-category elements from the copied DOM.
- Strip ASCII control characters, including U+0008 backspace, from copied text.
- Truncate generated Tistory footer content that remains after markdown conversion.
- Update the akbun skin version to `1.1.2`.
- Update the validation checklist with the new markdown copy cleanup criteria.

## Validation

- `git diff --check`
- `ruby -r rexml/document -e 'REXML::Document.new(File.read(ARGV[0])); puts "xml ok"' product/tistory-skin/akbun/src/index.xml`
- Inline JavaScript parse check for `skin.html` and `preview-post.html`
- `make zip`
- Sanitizer sample test using the actual pasted markdown output from the issue

## Notes

In-app browser click and clipboard verification was not completed because the in-app browser backend was unavailable in this session.
