### PR TITLE
Add hermes agent Docker image with Graphify and NotesMD CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@
 - [AI agent용 슬라이드 레이아웃 레퍼런스 시스템](./product/slide-reference/) (26.3.28)
 - [티스토리 스킨](./product/tistory-skin/akbun/) (26.4.4)
 
+## Dockerfile
+
+- [hermes agent dockerfile](./dockerfiles/nikolaik-harmes/)
+
 ## 다른 저장소 링크
 
 - [Akbun Claude plugins (akbun-aitools)](https://github.com/choisungwook/akbun-aitools.git) (26.4.4)

--- a/dockerfiles/nikolaik-harmes/AGENTS.md
+++ b/dockerfiles/nikolaik-harmes/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent Guide
+
+## 목적
+
+- 이 이미지는 Hermes 또는 Codex 계열 작업 환경에서 Graphify CLI와 vault 조회용 NotesMD CLI를 바로 쓰기 위한 custom 컨테이너 이미지다.
+- base image는 태그만 쓰지 말고 반드시 digest를 유지한다.
+- `7cb03...`은 `linux/amd64`, `8e496...`은 `linux/arm64` digest다.
+- 이미지 tag는 빌드 날짜와 revision으로 관리한다. 예: `20260614-v1`, `20260614-v2`.
+
+## 파일 역할
+
+- `Dockerfile`: base image digest, 설치할 CLI, 최소 검증 명령을 관리한다.
+- `Makefile`: 로컬 build, multi-arch buildx push, 이미지 검증 명령을 제공한다.
+- `AGENTS.md`: 다음 agent가 이 디렉터리의 의도와 수정 범위를 빠르게 파악하기 위한 문서다.
+
+## 수정 원칙
+
+- version pin을 사용
+- Graphify 패키지명은 `graphifyy`이고 실행 파일은 `graphify`
+- NotesMD CLI는 `notesmd-cli`이고 `/usr/local/bin/obsidian` wrapper로 조회용 subset을 제공
+- pip/npm 설치 cache는 최종 layer에서 제거한다.
+- Obsidian 공식 CLI는 공식 문서 기준 데스크톱 앱 1.12+에서 Settings -> General -> Command line interface를 켜야 등록된다. 이 이미지는 공식 CLI 대신 NotesMD CLI wrapper를 사용한다.
+
+## 빌드 테스트
+
+- 로컬 테스트는 `make build` 후 `make verify`로 확인

--- a/dockerfiles/nikolaik-harmes/Dockerfile
+++ b/dockerfiles/nikolaik-harmes/Dockerfile
@@ -1,0 +1,40 @@
+ARG NOTESMD_CLI_VERSION=0.3.6
+
+FROM --platform=linux/amd64 nikolaik/python-nodejs:python3.14-nodejs24@sha256:7cb039cee978768dc35930cfce14156ff5b4f829661ca575c5677f085e400c60 AS base-amd64
+FROM base-amd64 AS runtime-amd64
+ARG NOTESMD_CLI_VERSION
+ADD --checksum=sha256:e9c484adca59d46365d27a52a6a2e82f2c50b932457bef86e4972c73ccc209c2 https://github.com/Yakitrak/notesmd-cli/releases/download/v${NOTESMD_CLI_VERSION}/notesmd-cli_${NOTESMD_CLI_VERSION}_linux_amd64.tar.gz /tmp/notesmd-cli.tar.gz
+RUN tar -xzf /tmp/notesmd-cli.tar.gz -C /usr/local/bin notesmd-cli \
+  && chmod +x /usr/local/bin/notesmd-cli \
+  && rm -f /tmp/notesmd-cli.tar.gz
+
+FROM --platform=linux/arm64 nikolaik/python-nodejs:python3.14-nodejs24@sha256:8e496af1e388bddb5d3c05bdec2ba84f6b0e38a7bfc9dbaa6517bfe276469bc2 AS base-arm64
+FROM base-arm64 AS runtime-arm64
+ARG NOTESMD_CLI_VERSION
+ADD --checksum=sha256:2a7d662816859a1b8f0ad25ebaadeafd7e284b0173b85ec547cb6c7b18603366 https://github.com/Yakitrak/notesmd-cli/releases/download/v${NOTESMD_CLI_VERSION}/notesmd-cli_${NOTESMD_CLI_VERSION}_linux_arm64.tar.gz /tmp/notesmd-cli.tar.gz
+RUN tar -xzf /tmp/notesmd-cli.tar.gz -C /usr/local/bin notesmd-cli \
+  && chmod +x /usr/local/bin/notesmd-cli \
+  && rm -f /tmp/notesmd-cli.tar.gz
+
+ARG TARGETARCH
+FROM runtime-${TARGETARCH}
+
+ARG GRAPHIFYY_VERSION=0.8.39
+
+ENV PIP_NO_CACHE_DIR=1
+ENV PYTHONDONTWRITEBYTECODE=1
+
+LABEL org.opencontainers.image.base.name="nikolaik/python-nodejs:python3.14-nodejs24"
+LABEL org.opencontainers.image.base.digest.linux-amd64="sha256:7cb039cee978768dc35930cfce14156ff5b4f829661ca575c5677f085e400c60"
+LABEL org.opencontainers.image.base.digest.linux-arm64="sha256:8e496af1e388bddb5d3c05bdec2ba84f6b0e38a7bfc9dbaa6517bfe276469bc2"
+LABEL org.opencontainers.image.description="nikolaik/python-nodejs base with graphify and notesmd-cli"
+
+COPY obsidian /usr/local/bin/obsidian
+
+RUN python -m pip install --root-user-action=ignore --no-cache-dir --no-compile "graphifyy==${GRAPHIFYY_VERSION}" \
+  && npm cache clean --force \
+  && rm -rf /root/.cache /root/.npm /tmp/* \
+  && chmod +x /usr/local/bin/obsidian \
+  && command -v notesmd-cli \
+  && command -v obsidian \
+  && command -v graphify

--- a/dockerfiles/nikolaik-harmes/Makefile
+++ b/dockerfiles/nikolaik-harmes/Makefile
@@ -1,0 +1,18 @@
+IMAGE_NAME=choisunguk/nikolaik-harmes
+BUILD_DATE=20260614
+IMAGE_VERSION=v2
+IMAGE_TAG=$(BUILD_DATE)-$(IMAGE_VERSION)
+BUILDER_NAME=mybuilder
+PLATFORMS=linux/amd64,linux/arm64
+
+create-builder:
+	docker buildx create --name $(BUILDER_NAME) --driver docker-container --use --bootstrap
+
+build:
+	docker build -t $(IMAGE_NAME):${IMAGE_TAG} .
+
+build-push:
+	docker buildx build --platform $(PLATFORMS) -t $(IMAGE_NAME):${IMAGE_TAG} --push .
+
+verify:
+	docker run --rm $(IMAGE_NAME):${IMAGE_TAG} sh -lc 'python --version && node --version && npm --version && command -v graphify && command -v notesmd-cli && command -v obsidian && obsidian --version && test ! -d /root/.cache/pip && test ! -d /root/.npm'

--- a/dockerfiles/nikolaik-harmes/obsidian
+++ b/dockerfiles/nikolaik-harmes/obsidian
@@ -1,0 +1,104 @@
+#!/bin/sh
+set -eu
+
+default_vault_path="${OBSIDIAN_VAULT_PATH:-/obsidian}"
+
+if [ -d "$default_vault_path" ]; then
+  notesmd-cli add-vault "$default_vault_path" --set-default >/dev/null 2>&1 || true
+fi
+
+get_param() {
+  key="$1"
+  shift
+
+  for arg in "$@"; do
+    case "$arg" in
+      "$key="*)
+        printf '%s\n' "${arg#*=}"
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+run_notesmd() {
+  if [ -n "${vault_name:-}" ]; then
+    exec notesmd-cli "$@" --vault "$vault_name"
+  fi
+
+  exec notesmd-cli "$@"
+}
+
+unsupported() {
+  echo "obsidian wrapper: official Obsidian CLI is unavailable in this image." >&2
+  echo "obsidian wrapper: notesmd-cli is used for read-only commands: help, version, read, search, files, vaults." >&2
+  exit 64
+}
+
+vault_name=""
+if [ "${1:-}" != "" ]; then
+  case "$1" in
+    vault=*)
+      vault_name="${1#vault=}"
+      shift
+      ;;
+  esac
+fi
+
+cmd="${1:-help}"
+if [ "$#" -gt 0 ]; then
+  shift
+fi
+
+case "$cmd" in
+  help|--help|-h)
+    exec notesmd-cli --help
+    ;;
+  version|--version)
+    exec notesmd-cli --version
+    ;;
+  read)
+    target="$(get_param path "$@" || true)"
+    if [ -z "$target" ]; then
+      target="$(get_param file "$@" || true)"
+    fi
+    if [ -z "$target" ]; then
+      echo "obsidian wrapper: read requires path= or file=." >&2
+      exit 64
+    fi
+    run_notesmd print "$target"
+    ;;
+  search)
+    query="$(get_param query "$@" || true)"
+    if [ -z "$query" ]; then
+      echo "obsidian wrapper: search requires query=." >&2
+      exit 64
+    fi
+    format="$(get_param format "$@" || true)"
+    if [ "$format" = "json" ]; then
+      run_notesmd search-content "$query" --format json
+    fi
+    run_notesmd search-content "$query" --no-interactive
+    ;;
+  files)
+    folder="$(get_param folder "$@" || true)"
+    if [ -n "$folder" ]; then
+      run_notesmd list "$folder"
+    fi
+    run_notesmd list
+    ;;
+  vault|vaults)
+    exec notesmd-cli list-vaults
+    ;;
+  print|list|search-content)
+    run_notesmd "$cmd" "$@"
+    ;;
+  list-vaults|add-vault|remove-vault|set-default-vault)
+    exec notesmd-cli "$cmd" "$@"
+    ;;
+  *)
+    unsupported
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add a new `dockerfiles/nikolaik-harmes/` Docker image for Hermes/Codex-style workspaces.
- Pin the base image by digest for both `linux/amd64` and `linux/arm64` and install `graphifyy` plus `notesmd-cli`.
- Add an `obsidian` wrapper that exposes a read-only NotesMD-backed subset for vault lookup.
- Document the image in the top-level `README.md`.

## Testing
- Not run (not requested)