### PR TITLE
[docs] Next.js EKS 환경변수/Secret 관리 핸즈온

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 80. client -> HAProxy or EnvoyProxy -> server pod구조에서 TCP통신 끊기는지 확인 (26.6.3) - [링크](./computer_science/k8s_haproxy_tcp/)
 81. ECR lifecycle을 설정할 때 운영환경에서 사용하는 이미지를 보호하는 방법 (26.6.21) - [링크](./aws/ecr/tag_vs_digest/)
 82. AWS CodeBuild에서 GitHub App connection으로 GitHub repository 연결 (26.6.21) - [링크](./aws/codebuild/github_connection/)
+83. Next.js EKS 환경변수와 Secret 관리 핸즈온 (26.6.24) - [링크](./aws/eks-nextjs-env-secret/)
 
 ## 직접 만든 제품
 

--- a/aws/eks-nextjs-env-secret/Makefile
+++ b/aws/eks-nextjs-env-secret/Makefile
@@ -1,0 +1,37 @@
+IMAGE_NAME ?= nextjs-env-secret-demo
+IMAGE_TAG ?= local
+KIND_CLUSTER ?= nextjs-env-secret
+NAMESPACE ?= nextjs-env-secret
+BUILD_ENV ?= local-build
+
+.PHONY: build-image create_kind delete_kind load-image deploy-local port-forward curl-local rollout-local-secret down
+
+build-image:
+	docker build --build-arg NEXT_PUBLIC_BUILD_ENV_NAME=$(BUILD_ENV) -t $(IMAGE_NAME):$(IMAGE_TAG) ./app
+
+create_kind:
+	kind create cluster --name $(KIND_CLUSTER) --config ./kind/kind-config.yaml
+
+delete_kind:
+	kind delete cluster --name $(KIND_CLUSTER)
+
+load-image:
+	kind load docker-image $(IMAGE_NAME):$(IMAGE_TAG) --name $(KIND_CLUSTER)
+
+deploy-local:
+	kubectl apply -f ./manifests/local
+	kubectl rollout status deployment/nextjs-env-secret-demo -n $(NAMESPACE)
+
+port-forward:
+	kubectl port-forward service/nextjs-env-secret-demo 3000:80 -n $(NAMESPACE)
+
+curl-local:
+	curl -s http://localhost:3000/api/env | jq .
+
+rollout-local-secret:
+	kubectl apply -f ./manifests/local-updates/secret-v2.yaml
+	kubectl rollout restart deployment/nextjs-env-secret-demo -n $(NAMESPACE)
+	kubectl rollout status deployment/nextjs-env-secret-demo -n $(NAMESPACE)
+
+down:
+	kubectl delete -f ./manifests/local --ignore-not-found

--- a/aws/eks-nextjs-env-secret/README.md
+++ b/aws/eks-nextjs-env-secret/README.md
@@ -1,0 +1,18 @@
+# EKS Next.js env Secret hands-on
+
+Next.js를 EKS에 배포할 때 build-time env, runtime env, Secret이 어디에서 고정되고 어디에서 바뀌는지 직접 확인합니다.
+
+## 문서
+
+- [문서 인덱스](./docs/README.md)
+- [1. local kind에서 env 경계 확인](./docs/1-local-kind-env.md)
+- [2. EKS에서 AWS Secrets Manager와 External Secrets 연결](./docs/2-eks-secrets-manager.md)
+- [3. GitHub Actions build/deploy 분리](./docs/3-github-actions.md)
+
+## 파일
+
+- [app](./app/)
+- [kind](./kind/)
+- [manifests](./manifests/)
+- [terraform](./terraform/)
+- [github-actions](./github-actions/)

--- a/aws/eks-nextjs-env-secret/app/.dockerignore
+++ b/aws/eks-nextjs-env-secret/app/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+npm-debug.log
+.env
+.env*

--- a/aws/eks-nextjs-env-secret/app/.gitignore
+++ b/aws/eks-nextjs-env-secret/app/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.next/
+.env
+.env*
+npm-debug.log

--- a/aws/eks-nextjs-env-secret/app/Dockerfile
+++ b/aws/eks-nextjs-env-secret/app/Dockerfile
@@ -1,0 +1,38 @@
+FROM node:22-alpine AS deps
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+ARG NEXT_PUBLIC_BUILD_ENV_NAME=local-build
+ENV NEXT_PUBLIC_BUILD_ENV_NAME=${NEXT_PUBLIC_BUILD_ENV_NAME}
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/aws/eks-nextjs-env-secret/app/app/api/env/route.ts
+++ b/aws/eks-nextjs-env-secret/app/app/api/env/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { fingerprintSecret } from "../../support/fingerprint-secret";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  const runtimeSecret = process.env.RUNTIME_SECRET_TOKEN ?? "";
+
+  return NextResponse.json({
+    nextPublicBuildEnvName: process.env.NEXT_PUBLIC_BUILD_ENV_NAME ?? "unset",
+    runtimeConfigName: process.env.RUNTIME_CONFIG_NAME ?? "unset",
+    runtimeSecretFingerprint: fingerprintSecret(runtimeSecret),
+  });
+}

--- a/aws/eks-nextjs-env-secret/app/app/components/client-env-card.tsx
+++ b/aws/eks-nextjs-env-secret/app/app/components/client-env-card.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+const publicBuildEnvName = process.env.NEXT_PUBLIC_BUILD_ENV_NAME ?? "unset";
+
+export function ClientEnvCard() {
+  return (
+    <dl>
+      <dt>NEXT_PUBLIC_BUILD_ENV_NAME</dt>
+      <dd>{publicBuildEnvName}</dd>
+    </dl>
+  );
+}

--- a/aws/eks-nextjs-env-secret/app/app/layout.tsx
+++ b/aws/eks-nextjs-env-secret/app/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "EKS Next.js env Secret demo",
+  description: "Build-time env, runtime env, and Secret boundary demo",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ko">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/aws/eks-nextjs-env-secret/app/app/page.tsx
+++ b/aws/eks-nextjs-env-secret/app/app/page.tsx
@@ -1,0 +1,34 @@
+import { connection } from "next/server";
+import { ClientEnvCard } from "./components/client-env-card";
+import { fingerprintSecret } from "./support/fingerprint-secret";
+
+export default async function Home() {
+  await connection();
+
+  const runtimeConfigName = process.env.RUNTIME_CONFIG_NAME ?? "unset";
+  const runtimeSecret = process.env.RUNTIME_SECRET_TOKEN ?? "";
+
+  return (
+    <main style={{ fontFamily: "system-ui, sans-serif", margin: "40px", lineHeight: 1.6 }}>
+      <h1>EKS Next.js env Secret demo</h1>
+      <p>
+        브라우저 bundle에 들어간 값과 서버 runtime에서 읽는 값을 같은 화면에서 비교합니다.
+      </p>
+
+      <section>
+        <h2>build-time public env</h2>
+        <ClientEnvCard />
+      </section>
+
+      <section>
+        <h2>runtime server env</h2>
+        <dl>
+          <dt>RUNTIME_CONFIG_NAME</dt>
+          <dd>{runtimeConfigName}</dd>
+          <dt>RUNTIME_SECRET_TOKEN fingerprint</dt>
+          <dd>{fingerprintSecret(runtimeSecret)}</dd>
+        </dl>
+      </section>
+    </main>
+  );
+}

--- a/aws/eks-nextjs-env-secret/app/app/support/fingerprint-secret.ts
+++ b/aws/eks-nextjs-env-secret/app/app/support/fingerprint-secret.ts
@@ -1,0 +1,9 @@
+import crypto from "node:crypto";
+
+export function fingerprintSecret(value: string) {
+  if (value.length === 0) {
+    return "unset";
+  }
+
+  return crypto.createHash("sha256").update(value).digest("hex").slice(0, 12);
+}

--- a/aws/eks-nextjs-env-secret/app/next-env.d.ts
+++ b/aws/eks-nextjs-env-secret/app/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/aws/eks-nextjs-env-secret/app/next.config.js
+++ b/aws/eks-nextjs-env-secret/app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+};
+
+module.exports = nextConfig;

--- a/aws/eks-nextjs-env-secret/app/package-lock.json
+++ b/aws/eks-nextjs-env-secret/app/package-lock.json
@@ -1,0 +1,974 @@
+{
+  "name": "eks-nextjs-env-secret-demo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eks-nextjs-env-secret-demo",
+      "dependencies": {
+        "next": "16.2.9",
+        "react": "19.2.0",
+        "react-dom": "19.2.0"
+      },
+      "devDependencies": {
+        "@types/node": "24.0.0",
+        "@types/react": "19.0.0",
+        "@types/react-dom": "19.0.0",
+        "typescript": "5.8.3"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.9",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.9",
+        "@next/swc-darwin-x64": "16.2.9",
+        "@next/swc-linux-arm64-gnu": "16.2.9",
+        "@next/swc-linux-arm64-musl": "16.2.9",
+        "@next/swc-linux-x64-gnu": "16.2.9",
+        "@next/swc-linux-x64-musl": "16.2.9",
+        "@next/swc-win32-arm64-msvc": "16.2.9",
+        "@next/swc-win32-x64-msvc": "16.2.9",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/aws/eks-nextjs-env-secret/app/package.json
+++ b/aws/eks-nextjs-env-secret/app/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "eks-nextjs-env-secret-demo",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "node .next/standalone/server.js",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "16.2.9",
+    "react": "19.2.0",
+    "react-dom": "19.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "24.0.0",
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "typescript": "5.8.3"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
+  }
+}

--- a/aws/eks-nextjs-env-secret/app/tsconfig.json
+++ b/aws/eks-nextjs-env-secret/app/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "es2022"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/aws/eks-nextjs-env-secret/docs/1-local-kind-env.md
+++ b/aws/eks-nextjs-env-secret/docs/1-local-kind-env.md
@@ -1,0 +1,117 @@
+# local kind에서는 왜 build-time env와 runtime env가 다르게 보일까
+
+Next.js 이미지를 한 번 빌드한 뒤 Kubernetes env만 바꿨는데, 브라우저 화면의 값은 그대로인 경우가 있습니다. 서버가 읽는 값은 바뀌는데 왜 브라우저 bundle의 값은 바뀌지 않을까요?
+
+## 실습에서 무엇을 확인하나
+
+이 실습은 세 값을 분리해서 봅니다.
+
+- `NEXT_PUBLIC_BUILD_ENV_NAME`: Docker image build 시점에 browser bundle로 들어가는 public env입니다.
+- `RUNTIME_CONFIG_NAME`: Kubernetes ConfigMap에서 Pod 시작 시점에 주입되는 non-secret runtime env입니다.
+- `RUNTIME_SECRET_TOKEN`: Kubernetes Secret에서 Pod 시작 시점에 주입되는 secret runtime env입니다.
+
+**핵심은 public env는 image build 결과에 가깝고, runtime env는 Pod가 시작될 때의 환경에 가깝다는 점입니다.**
+
+## 왜 local kind부터 확인할까
+
+EKS에서 바로 확인하면 ECR, IAM, External Secrets Operator, AWS Secrets Manager까지 한꺼번에 봐야 합니다. local kind는 같은 애플리케이션을 작은 Kubernetes cluster에 올려서 Next.js와 Kubernetes env 경계만 먼저 확인합니다.
+
+장점은 빠르고 비용이 없다는 점입니다. 단점은 AWS Secrets Manager와 External Secrets Operator의 실제 IAM 동작은 검증하지 못한다는 점입니다. 그래서 local kind는 경계 학습용이고, AWS 연동은 다음 문서에서 따로 봅니다.
+
+## 준비
+
+아래 도구가 필요합니다.
+
+- Docker
+- kind
+- kubectl
+- jq
+
+이미지를 빌드합니다. `BUILD_ENV` 값은 build-time public env로 고정됩니다.
+
+```bash
+cd aws/eks-nextjs-env-secret
+make build-image BUILD_ENV=local-build-v1
+```
+
+kind cluster를 만들고 이미지를 로드합니다.
+
+```bash
+make create_kind
+make load-image
+```
+
+## 처음 배포하면 어떤 값이 보일까
+
+local manifest를 배포합니다.
+
+```bash
+make deploy-local
+```
+
+다른 터미널에서 port-forward를 실행합니다.
+
+```bash
+cd aws/eks-nextjs-env-secret
+make port-forward
+```
+
+API 응답을 확인합니다. Secret 원문은 반환하지 않고 fingerprint만 반환합니다.
+
+```bash
+make curl-local
+```
+
+응답 예시는 아래 형태입니다.
+
+```json
+{
+  "nextPublicBuildEnvName": "local-build-v1",
+  "runtimeConfigName": "local-runtime-v1",
+  "runtimeSecretFingerprint": "..."
+}
+```
+
+## Secret을 바꾸면 기존 Pod는 왜 바로 바뀌지 않을까
+
+Kubernetes가 Secret을 env로 주입하면 컨테이너 프로세스의 환경변수로 들어갑니다. Secret object가 바뀌어도 이미 실행 중인 프로세스의 환경변수는 자동으로 다시 쓰이지 않습니다.
+
+Secret object만 v2 값으로 바꿉니다.
+
+```bash
+kubectl apply -f manifests/local-updates/secret-v2.yaml
+make curl-local
+```
+
+이 시점에는 기존 Pod가 계속 떠 있으므로 fingerprint가 그대로일 수 있습니다. 새 Secret 값을 보려면 Pod를 다시 시작해야 합니다.
+
+```bash
+kubectl rollout restart deployment/nextjs-env-secret-demo -n nextjs-env-secret
+kubectl rollout status deployment/nextjs-env-secret-demo -n nextjs-env-secret
+make curl-local
+```
+
+## build-time env를 바꾸려면 왜 이미지를 다시 빌드해야 할까
+
+`NEXT_PUBLIC_*` 값은 browser bundle에서 쓰이면 `next build` 시점의 값으로 들어갑니다. Kubernetes Deployment env만 바꿔서는 이미 만들어진 JavaScript bundle이 다시 만들어지지 않습니다.
+
+build-time 값을 바꾸려면 이미지를 다시 빌드하고 cluster에 다시 로드합니다.
+
+```bash
+make build-image BUILD_ENV=local-build-v2
+make load-image
+kubectl rollout restart deployment/nextjs-env-secret-demo -n nextjs-env-secret
+kubectl rollout status deployment/nextjs-env-secret-demo -n nextjs-env-secret
+make curl-local
+```
+
+같은 tag를 다시 쓰면 운영에서는 추적이 어려워집니다. 실무에서는 immutable image tag를 쓰는 편이 좋습니다. 장점은 어떤 build-time 값이 들어간 이미지인지 추적하기 쉽다는 점입니다. 단점은 image tag와 배포 manifest를 매번 갱신해야 한다는 점입니다.
+
+## 정리
+
+정리하면, 브라우저 bundle의 public env가 Kubernetes env 변경에 반응하지 않는 이유는 값이 `next build` 시점에 고정되기 때문입니다. 반대로 ConfigMap과 Secret을 env로 주입한 값은 Pod 시작 시점에 결정되므로, 값을 바꾼 뒤에는 rollout으로 새 Pod를 만들어야 합니다.
+
+## 참고자료
+
+- [Next.js Environment Variables](https://nextjs.org/docs/app/guides/environment-variables)
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)

--- a/aws/eks-nextjs-env-secret/docs/2-eks-secrets-manager.md
+++ b/aws/eks-nextjs-env-secret/docs/2-eks-secrets-manager.md
@@ -1,0 +1,109 @@
+# EKS에서는 왜 Secret 값을 GitHub Actions에 두지 않아도 될까
+
+EKS에 배포할 때 가장 쉬운 방법은 GitHub Actions secret에 애플리케이션 Secret 값을 넣고 manifest에 주입하는 것입니다. 그런데 이 방식은 CI/CD가 애플리케이션 Secret 원문을 알게 만듭니다. Secret 원문을 Actions 밖에 둘 수는 없을까요?
+
+## 어떤 구조를 사용할까
+
+이 예제는 AWS Secrets Manager를 Secret 원본으로 두고, External Secrets Operator가 EKS 안의 Kubernetes Secret으로 동기화하는 구조를 사용합니다.
+
+흐름은 아래와 같습니다.
+
+```text
+AWS Secrets Manager
+  -> External Secrets Operator
+  -> Kubernetes Secret
+  -> Deployment env
+  -> Next.js server runtime
+```
+
+장점은 GitHub Actions가 애플리케이션 Secret 원문을 몰라도 된다는 점입니다. 단점은 External Secrets Operator, IAM role, SecretStore 설정이 추가되어 운영 요소가 늘어난다는 점입니다.
+
+## Terraform은 무엇을 만들까
+
+Terraform 예제는 EKS cluster를 만들지 않습니다. 이미 있는 EKS cluster에서 아래 리소스만 만듭니다.
+
+- AWS Secrets Manager Secret
+- Secret을 읽을 수 있는 IAM policy
+- External Secrets Operator service account가 사용할 IAM role
+
+민감값은 예시 파일에 넣지 않습니다. `terraform.tfvars`는 로컬에서만 만들고 commit하지 않습니다.
+
+```bash
+cd aws/eks-nextjs-env-secret/terraform
+cp terraform.tfvars.example terraform.tfvars
+terraform init
+terraform plan
+terraform apply
+```
+
+`terraform apply` 후 출력되는 `external_secrets_role_arn`을 External Secrets Operator service account에 annotation으로 연결합니다. 실제 설치 방식은 Helm chart 설정에 따라 달라질 수 있어서 cluster 설치값은 확인 필요입니다.
+
+## ExternalSecret은 어떤 Secret version을 읽을까
+
+External Secrets Operator의 AWS Secrets Manager provider는 `remoteRef.version`으로 version stage 또는 version id를 지정할 수 있습니다. `AWSCURRENT`를 지정하면 현재 stage가 가리키는 Secret version을 읽습니다. `uuid/<version-id>` 형식이면 특정 VersionId를 읽습니다.
+
+이 예제 manifest는 `AWSCURRENT`를 사용합니다.
+
+```yaml
+remoteRef:
+  key: eks-nextjs-env-secret/demo
+  property: RUNTIME_SECRET_TOKEN
+  version: AWSCURRENT
+```
+
+장점은 Secret rotation 후 `AWSCURRENT` stage만 옮기면 External Secrets Operator가 새 값을 따라간다는 점입니다. 단점은 배포 단위가 특정 Secret version에 고정되지 않기 때문에, 값 변경과 애플리케이션 rollout 시점의 관계를 별도로 관리해야 한다는 점입니다.
+
+특정 배포 버전에 Secret 값을 고정하려면 `uuid/<version-id>`를 쓰는 방법이 있습니다. 장점은 release가 어떤 Secret version을 읽는지 명확하다는 점입니다. 단점은 매 release마다 manifest나 배포 파라미터를 갱신해야 한다는 점입니다.
+
+## Secret이 동기화되면 기존 Pod는 바로 바뀔까
+
+External Secrets Operator가 Kubernetes Secret을 새 값으로 갱신해도, env로 주입된 기존 Pod의 프로세스 환경변수는 바로 바뀌지 않습니다. 새 값을 애플리케이션에 반영하려면 Deployment rollout이 필요합니다.
+
+```bash
+kubectl rollout restart deployment/nextjs-env-secret-demo -n nextjs-env-secret
+kubectl rollout status deployment/nextjs-env-secret-demo -n nextjs-env-secret
+```
+
+이 방식의 장점은 Secret 변경만으로 예기치 않은 runtime 변경이 즉시 발생하지 않는다는 점입니다. 단점은 rotation 후 rollout을 놓치면 애플리케이션이 오래된 Secret을 계속 사용할 수 있다는 점입니다.
+
+## EKS manifest 적용 순서
+
+이미 ECR에 image가 있고 External Secrets Operator가 설치되어 있다고 가정합니다.
+
+먼저 namespace와 SecretStore, ExternalSecret을 적용합니다.
+
+```bash
+cd aws/eks-nextjs-env-secret
+kubectl apply -f manifests/eks/namespace.yaml
+kubectl apply -f manifests/eks/secret-store.yaml.template
+kubectl apply -f manifests/eks/external-secret.yaml.template
+```
+
+Secret 동기화 상태를 확인합니다.
+
+```bash
+kubectl get externalsecret -n nextjs-env-secret
+kubectl get secret nextjs-runtime-secret -n nextjs-env-secret
+```
+
+이미지 주소를 실제 ECR 주소로 바꿔 Deployment를 적용합니다.
+
+```bash
+sed "s#<aws-account-id>.dkr.ecr.ap-northeast-2.amazonaws.com/eks-nextjs-env-secret:<image-tag>#123456789012.dkr.ecr.ap-northeast-2.amazonaws.com/eks-nextjs-env-secret:demo#g" \
+  manifests/eks/deployment.yaml.template \
+  > /tmp/nextjs-env-secret-deployment.yaml
+
+kubectl apply -f manifests/eks/configmap.yaml.template
+kubectl apply -f /tmp/nextjs-env-secret-deployment.yaml
+kubectl apply -f manifests/eks/service.yaml
+kubectl rollout status deployment/nextjs-env-secret-demo -n nextjs-env-secret
+```
+
+## 정리
+
+정리하면, Secret 값을 GitHub Actions에 두지 않아도 되는 이유는 CI/CD가 Secret 원문을 전달하는 대신 EKS 안의 controller가 AWS Secrets Manager에서 값을 읽기 때문입니다. 대신 IAM, External Secrets Operator, rollout 정책을 함께 운영해야 하므로 단순한 manifest env보다 구성 요소가 많아집니다.
+
+## 참고자료
+
+- [External Secrets Operator AWS Secrets Manager provider](https://external-secrets.io/latest/provider/aws-secrets-manager/)
+- [AWS Secrets Manager version stages](https://docs.aws.amazon.com/secretsmanager/latest/userguide/getting-started.html)

--- a/aws/eks-nextjs-env-secret/docs/3-github-actions.md
+++ b/aws/eks-nextjs-env-secret/docs/3-github-actions.md
@@ -1,0 +1,55 @@
+# GitHub Actions는 왜 build와 deploy를 분리해야 할까
+
+Next.js image를 만들고 EKS에 배포하는 일을 한 job에 몰아넣을 수 있습니다. 그런데 build-time env와 runtime Secret의 책임이 다르다면, CI/CD도 그 경계를 나눠야 하지 않을까요?
+
+## build job은 무엇만 알아야 하나
+
+build job은 Docker image를 만들고 ECR에 push합니다. 이때 필요한 값은 image build에 들어갈 public build-time env와 ECR push 권한입니다.
+
+`NEXT_PUBLIC_BUILD_ENV_NAME` 같은 값은 browser bundle에 들어갈 수 있으므로 Secret으로 취급하면 안 됩니다. 장점은 사용자가 보는 build 식별자나 public API endpoint를 명확하게 고정할 수 있다는 점입니다. 단점은 build 후에는 Kubernetes env로 바꿀 수 없다는 점입니다.
+
+예제 workflow는 아래 위치에 있습니다.
+
+```text
+aws/eks-nextjs-env-secret/github-actions/eks-nextjs-env-secret.yml
+```
+
+## deploy job은 무엇만 알아야 하나
+
+deploy job은 EKS kubeconfig를 설정하고 manifest를 적용합니다. 애플리케이션 Secret value는 GitHub Actions secret에 넣지 않습니다. 대신 EKS 안의 External Secrets Operator가 AWS Secrets Manager에서 읽습니다.
+
+이 방식의 장점은 CI/CD log와 workflow input에 애플리케이션 Secret 원문이 지나가지 않는다는 점입니다. 단점은 EKS cluster 쪽에 External Secrets Operator와 IAM role이 미리 준비되어 있어야 한다는 점입니다.
+
+## OIDC 권한은 어떻게 나눌까
+
+예제 workflow는 `permissions`를 최소화합니다.
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+```
+
+`id-token: write`는 GitHub Actions OIDC로 AWS role을 assume하기 위해 필요합니다. build role은 ECR push 권한만 갖고, deploy role은 EKS 배포에 필요한 권한만 갖는 방향이 좋습니다.
+
+권한을 나누는 장점은 build job이 cluster-admin에 가까운 권한을 갖지 않아도 된다는 점입니다. 단점은 IAM role과 trust policy가 늘어나므로 처음 설정이 번거롭다는 점입니다.
+
+## Secret rotation은 workflow에서 무엇을 해야 하나
+
+Secret 원문을 바꾸는 일은 GitHub Actions workflow가 아니라 AWS Secrets Manager 쪽 작업입니다. workflow는 새 image를 배포하거나, Secret 변경 후 애플리케이션 Pod를 새로 띄우는 rollout을 수행합니다.
+
+```bash
+kubectl rollout restart deployment/nextjs-env-secret-demo -n nextjs-env-secret
+kubectl rollout status deployment/nextjs-env-secret-demo -n nextjs-env-secret
+```
+
+release마다 Secret version을 고정하려면 workflow input에 Secret version id를 받고 ExternalSecret manifest의 `remoteRef.version`을 `uuid/<version-id>`로 바꾸는 방식을 검토할 수 있습니다. 이 방식은 재현성이 좋아지는 장점이 있지만, 운영자가 version id를 관리해야 하는 단점이 있습니다.
+
+## 정리
+
+정리하면, build와 deploy를 분리하는 이유는 Next.js build-time env와 EKS runtime Secret의 책임이 다르기 때문입니다. build job은 public build 값을 image에 고정하고, deploy job은 EKS에 그 image를 배포하며, Secret 원문은 AWS Secrets Manager와 External Secrets Operator 경로에 남겨두는 구조가 안전합니다.
+
+## 참고자료
+
+- [GitHub Actions OIDC in AWS](https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-aws)
+- [AWS ECR GitHub Actions login action](https://github.com/aws-actions/amazon-ecr-login)

--- a/aws/eks-nextjs-env-secret/docs/README.md
+++ b/aws/eks-nextjs-env-secret/docs/README.md
@@ -1,0 +1,7 @@
+# EKS Next.js env Secret 문서
+
+| 순서 | 문서 | 설명 |
+|---|---|---|
+| 1 | [local kind에서 env 경계 확인](./1-local-kind-env.md) | build-time env와 runtime env/Secret 차이를 로컬에서 확인 |
+| 2 | [EKS에서 AWS Secrets Manager와 External Secrets 연결](./2-eks-secrets-manager.md) | External Secrets Operator로 AWS Secrets Manager 값을 Kubernetes Secret으로 동기화 |
+| 3 | [GitHub Actions build/deploy 분리](./3-github-actions.md) | image build와 EKS deploy job을 분리하고 Secret value를 Actions에 두지 않는 흐름 |

--- a/aws/eks-nextjs-env-secret/github-actions/eks-nextjs-env-secret.yml
+++ b/aws/eks-nextjs-env-secret/github-actions/eks-nextjs-env-secret.yml
@@ -1,0 +1,70 @@
+name: eks-nextjs-env-secret
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to build and deploy"
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: eks-nextjs-env-secret
+  EKS_CLUSTER_NAME: replace-with-cluster-name
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/github-actions-ecr-push
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - id: image
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          IMAGE="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY}:${{ inputs.image_tag }}"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - run: |
+          docker build \
+            --build-arg NEXT_PUBLIC_BUILD_ENV_NAME="build-${{ inputs.image_tag }}" \
+            -t "${{ steps.image.outputs.image }}" \
+            ./aws/eks-nextjs-env-secret/app
+          docker push "${{ steps.image.outputs.image }}"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::123456789012:role/github-actions-eks-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - run: aws eks update-kubeconfig --name "${EKS_CLUSTER_NAME}" --region "${AWS_REGION}"
+
+      - run: |
+          sed "s#<aws-account-id>.dkr.ecr.ap-northeast-2.amazonaws.com/eks-nextjs-env-secret:<image-tag>#${{ needs.build.outputs.image }}#g" \
+            ./aws/eks-nextjs-env-secret/manifests/eks/deployment.yaml.template \
+            > /tmp/deployment.yaml
+          kubectl apply -f ./aws/eks-nextjs-env-secret/manifests/eks/namespace.yaml
+          kubectl apply -f ./aws/eks-nextjs-env-secret/manifests/eks/configmap.yaml.template
+          kubectl apply -f ./aws/eks-nextjs-env-secret/manifests/eks/secret-store.yaml.template
+          kubectl apply -f ./aws/eks-nextjs-env-secret/manifests/eks/external-secret.yaml.template
+          kubectl apply -f /tmp/deployment.yaml
+          kubectl apply -f ./aws/eks-nextjs-env-secret/manifests/eks/service.yaml
+          kubectl rollout status deployment/nextjs-env-secret-demo -n nextjs-env-secret

--- a/aws/eks-nextjs-env-secret/kind/kind-config.yaml
+++ b/aws/eks-nextjs-env-secret/kind/kind-config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/aws/eks-nextjs-env-secret/manifests/README.md
+++ b/aws/eks-nextjs-env-secret/manifests/README.md
@@ -1,0 +1,7 @@
+# manifests
+
+| 디렉터리/파일 | 설명 |
+|---|---|
+| `local/` | kind에서 build-time env, runtime env, Secret rollout 차이를 확인하는 예제 |
+| `local-updates/` | local Secret 변경 후 rollout을 확인하는 업데이트 예제 |
+| `eks/` | EKS에서 AWS Secrets Manager와 External Secrets Operator를 연결하는 예제 |

--- a/aws/eks-nextjs-env-secret/manifests/eks/configmap.yaml.template
+++ b/aws/eks-nextjs-env-secret/manifests/eks/configmap.yaml.template
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nextjs-env-config
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+data:
+  RUNTIME_CONFIG_NAME: "eks-runtime-v1"

--- a/aws/eks-nextjs-env-secret/manifests/eks/deployment.yaml.template
+++ b/aws/eks-nextjs-env-secret/manifests/eks/deployment.yaml.template
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nextjs-env-secret-demo
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextjs-env-secret-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nextjs-env-secret-demo
+    spec:
+      containers:
+        - name: nextjs
+          image: <aws-account-id>.dkr.ecr.ap-northeast-2.amazonaws.com/eks-nextjs-env-secret:<image-tag>
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: RUNTIME_CONFIG_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: nextjs-env-config
+                  key: RUNTIME_CONFIG_NAME
+            - name: RUNTIME_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nextjs-runtime-secret
+                  key: RUNTIME_SECRET_TOKEN
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/aws/eks-nextjs-env-secret/manifests/eks/external-secret.yaml.template
+++ b/aws/eks-nextjs-env-secret/manifests/eks/external-secret.yaml.template
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nextjs-runtime-secret
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: SecretStore
+  target:
+    name: nextjs-runtime-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: RUNTIME_SECRET_TOKEN
+      remoteRef:
+        key: eks-nextjs-env-secret/demo
+        property: RUNTIME_SECRET_TOKEN
+        version: AWSCURRENT

--- a/aws/eks-nextjs-env-secret/manifests/eks/namespace.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/eks/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo

--- a/aws/eks-nextjs-env-secret/manifests/eks/secret-store.yaml.template
+++ b/aws/eks-nextjs-env-secret/manifests/eks/secret-store.yaml.template
@@ -1,0 +1,12 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: aws-secretsmanager
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: ap-northeast-2

--- a/aws/eks-nextjs-env-secret/manifests/eks/service.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/eks/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-env-secret-demo
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/aws/eks-nextjs-env-secret/manifests/local-updates/secret-v2.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/local-updates/secret-v2.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nextjs-runtime-secret
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+type: Opaque
+stringData:
+  RUNTIME_SECRET_TOKEN: "local-demo-secret-v2"

--- a/aws/eks-nextjs-env-secret/manifests/local/configmap.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/local/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nextjs-env-config
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+data:
+  RUNTIME_CONFIG_NAME: "local-runtime-v1"

--- a/aws/eks-nextjs-env-secret/manifests/local/deployment.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/local/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nextjs-env-secret-demo
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextjs-env-secret-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nextjs-env-secret-demo
+    spec:
+      containers:
+        - name: nextjs
+          image: nextjs-env-secret-demo:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: RUNTIME_CONFIG_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: nextjs-env-config
+                  key: RUNTIME_CONFIG_NAME
+            - name: RUNTIME_SECRET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: nextjs-runtime-secret
+                  key: RUNTIME_SECRET_TOKEN
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/aws/eks-nextjs-env-secret/manifests/local/namespace.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/local/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo

--- a/aws/eks-nextjs-env-secret/manifests/local/secret-v1.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/local/secret-v1.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nextjs-runtime-secret
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+type: Opaque
+stringData:
+  RUNTIME_SECRET_TOKEN: "local-demo-secret-v1"

--- a/aws/eks-nextjs-env-secret/manifests/local/service.yaml
+++ b/aws/eks-nextjs-env-secret/manifests/local/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextjs-env-secret-demo
+  namespace: nextjs-env-secret
+  labels:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: nextjs-env-secret-demo
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/aws/eks-nextjs-env-secret/terraform/.gitignore
+++ b/aws/eks-nextjs-env-secret/terraform/.gitignore
@@ -1,0 +1,6 @@
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+*.tfvars
+!terraform.tfvars.example

--- a/aws/eks-nextjs-env-secret/terraform/README.md
+++ b/aws/eks-nextjs-env-secret/terraform/README.md
@@ -1,0 +1,18 @@
+# Terraform
+
+AWS Secrets Manager Secret과 External Secrets Operator가 읽을 IAM role을 만듭니다.
+
+이 예제는 EKS 클러스터 자체를 만들지 않습니다. 이미 존재하는 EKS 클러스터의 OIDC provider ARN과 issuer URL을 입력받아 External Secrets Operator service account에 연결할 IAM role만 만듭니다.
+
+## 사용 순서
+
+민감값은 `terraform.tfvars`에 직접 커밋하지 않습니다. 아래 파일은 예시입니다.
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+terraform init
+terraform plan
+terraform apply
+```
+
+`terraform apply` 후 `external_secrets_role_arn` 값을 External Secrets Operator service account annotation에 사용합니다.

--- a/aws/eks-nextjs-env-secret/terraform/iam.tf
+++ b/aws/eks-nextjs-env-secret/terraform/iam.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "external_secrets_assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.eks_oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.eks_oidc_provider_url_without_https}:sub"
+      values = [
+        "system:serviceaccount:${var.external_secrets_namespace}:${var.external_secrets_service_account_name}",
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.eks_oidc_provider_url_without_https}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "external_secrets" {
+  name               = "${var.project_name}-external-secrets"
+  assume_role_policy = data.aws_iam_policy_document.external_secrets_assume_role.json
+
+  tags = {
+    Name = "${var.project_name}-external-secrets"
+  }
+}
+
+data "aws_iam_policy_document" "external_secrets_read_secret" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:ListSecretVersionIds",
+    ]
+
+    resources = [aws_secretsmanager_secret.demo.arn]
+  }
+}
+
+resource "aws_iam_policy" "external_secrets_read_secret" {
+  name   = "${var.project_name}-read-secret"
+  policy = data.aws_iam_policy_document.external_secrets_read_secret.json
+}
+
+resource "aws_iam_role_policy_attachment" "external_secrets_read_secret" {
+  role       = aws_iam_role.external_secrets.name
+  policy_arn = aws_iam_policy.external_secrets_read_secret.arn
+}

--- a/aws/eks-nextjs-env-secret/terraform/outputs.tf
+++ b/aws/eks-nextjs-env-secret/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "secret_name" {
+  description = "AWS Secrets Manager secret name used by the ExternalSecret manifest."
+  value       = aws_secretsmanager_secret.demo.name
+}
+
+output "external_secrets_role_arn" {
+  description = "IAM role ARN to annotate on the External Secrets Operator service account."
+  value       = aws_iam_role.external_secrets.arn
+}

--- a/aws/eks-nextjs-env-secret/terraform/providers.tf
+++ b/aws/eks-nextjs-env-secret/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/aws/eks-nextjs-env-secret/terraform/secrets-manager.tf
+++ b/aws/eks-nextjs-env-secret/terraform/secrets-manager.tf
@@ -1,0 +1,15 @@
+resource "aws_secretsmanager_secret" "demo" {
+  name                    = "${var.project_name}/demo"
+  recovery_window_in_days = 0
+
+  tags = {
+    Name = "${var.project_name}-demo"
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "demo" {
+  secret_id = aws_secretsmanager_secret.demo.id
+  secret_string = jsonencode({
+    RUNTIME_SECRET_TOKEN = var.demo_secret_value
+  })
+}

--- a/aws/eks-nextjs-env-secret/terraform/terraform.tf
+++ b/aws/eks-nextjs-env-secret/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/aws/eks-nextjs-env-secret/terraform/terraform.tfvars.example
+++ b/aws/eks-nextjs-env-secret/terraform/terraform.tfvars.example
@@ -1,0 +1,4 @@
+demo_secret_value = "replace-with-demo-value"
+
+eks_oidc_provider_arn               = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.ap-northeast-2.amazonaws.com/id/EXAMPLE"
+eks_oidc_provider_url_without_https = "oidc.eks.ap-northeast-2.amazonaws.com/id/EXAMPLE"

--- a/aws/eks-nextjs-env-secret/terraform/variables.tf
+++ b/aws/eks-nextjs-env-secret/terraform/variables.tf
@@ -1,0 +1,39 @@
+variable "aws_region" {
+  description = "AWS region for the hands-on resources."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "Project name used for tags and resource names."
+  type        = string
+  default     = "eks-nextjs-env-secret"
+}
+
+variable "demo_secret_value" {
+  description = "Demo Secret value stored in AWS Secrets Manager. Do not put a real password here."
+  type        = string
+  sensitive   = true
+}
+
+variable "eks_oidc_provider_arn" {
+  description = "EKS cluster OIDC provider ARN used by the External Secrets controller service account."
+  type        = string
+}
+
+variable "eks_oidc_provider_url_without_https" {
+  description = "EKS OIDC issuer URL without https://. Example: oidc.eks.ap-northeast-2.amazonaws.com/id/EXAMPLE"
+  type        = string
+}
+
+variable "external_secrets_namespace" {
+  description = "Namespace where External Secrets Operator runs."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "external_secrets_service_account_name" {
+  description = "ServiceAccount name used by External Secrets Operator."
+  type        = string
+  default     = "external-secrets"
+}


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

Next.js 애플리케이션을 EKS에 배포할 때 build-time env, runtime env, Secret이 언제 고정되고 어떻게 바뀌는지 확인하는 핸즈온을 추가했습니다.

## 문제를 어떻게 해결 또는 공부했는가

`aws/eks-nextjs-env-secret` 아래에 최소 Next.js 앱, local kind manifest, EKS External Secrets manifest, AWS Secrets Manager/IAM Terraform 예제, GitHub Actions 예시를 나눠 작성했습니다. 문서는 질문식 흐름으로 local kind 확인, EKS Secrets Manager 연동, GitHub Actions build/deploy 분리 순서로 구성했습니다.

## GitHub Issue (선택)

Issue #426

## 파일 디렉터리 구조

```text
README.md
  - 루트 목차에 새 핸즈온 링크 추가
aws/eks-nextjs-env-secret/
  - README.md: 링크 허브
  - Makefile: local kind 실습 명령
  - app/: Next.js demo app과 Dockerfile
  - docs/: 주제별 핸즈온 문서
  - github-actions/: 활성화되지 않는 GitHub Actions workflow 예시
  - kind/: kind cluster 설정
  - manifests/: local/EKS Kubernetes manifest 예시
  - terraform/: AWS Secrets Manager와 External Secrets IAM role 예시
```
