### PR TITLE
Add Kafka pub/sub kind hands-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 80. client -> HAProxy or EnvoyProxy -> server pod구조에서 TCP통신 끊기는지 확인 (26.6.3) - [링크](./computer_science/k8s_haproxy_tcp/)
 81. ECR lifecycle을 설정할 때 운영환경에서 사용하는 이미지를 보호하는 방법 (26.6.21) - [링크](./aws/ecr/tag_vs_digest/)
 82. AWS CodeBuild에서 GitHub App connection으로 GitHub repository 연결 (26.6.21) - [링크](./aws/codebuild/github_connection/)
+83. Kafka pub/sub 로컬 Kubernetes 핸즈온 (26.6.25) - [링크](./backend/kafka-pubsub-kind/)
 
 ## 직접 만든 제품
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,3 +2,4 @@
 * [Lettuce 라이브러리에서 Redis Failover connection 테스트](./springboot_lettuce_connection/README.md)
 * [firebase FCM 부하 테스트](./firebase-fcm/)
 * [springboot Readiness](./readiness/)
+* [Kafka pub/sub 로컬 Kubernetes 핸즈온](./kafka-pubsub-kind/)

--- a/backend/kafka-pubsub-kind/.dockerignore
+++ b/backend/kafka-pubsub-kind/.dockerignore
@@ -1,0 +1,2 @@
+.gradle
+build

--- a/backend/kafka-pubsub-kind/Dockerfile
+++ b/backend/kafka-pubsub-kind/Dockerfile
@@ -1,0 +1,14 @@
+FROM gradle:8.8-jdk21 AS build
+
+WORKDIR /workspace
+COPY settings.gradle build.gradle ./
+COPY src ./src
+RUN gradle bootJar --no-daemon
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+COPY --from=build /workspace/build/libs/kafka-pubsub-kind-0.0.1-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/backend/kafka-pubsub-kind/Makefile
+++ b/backend/kafka-pubsub-kind/Makefile
@@ -1,0 +1,38 @@
+CLUSTER_NAME ?= kafka-pubsub
+IMAGE ?= kafka-pubsub-app:local
+NAMESPACE ?= kafka
+
+create_kind:
+	kind create cluster --name $(CLUSTER_NAME) --config kind/kind-config.yaml
+
+delete_kind:
+	kind delete cluster --name $(CLUSTER_NAME)
+
+build:
+	docker build -t $(IMAGE) .
+
+load:
+	kind load docker-image $(IMAGE) --name $(CLUSTER_NAME)
+
+deploy:
+	kubectl apply -f manifests
+
+wait:
+	kubectl -n $(NAMESPACE) wait --for=condition=available deployment/kafka --timeout=180s
+	kubectl -n $(NAMESPACE) wait --for=condition=available deployment/kafka-pubsub-app --timeout=180s
+	kubectl -n $(NAMESPACE) wait --for=condition=available deployment/prometheus --timeout=180s
+	kubectl -n $(NAMESPACE) wait --for=condition=available deployment/grafana --timeout=180s
+
+up: create_kind build load deploy wait
+
+down:
+	kubectl delete -f manifests --ignore-not-found=true
+
+port-forward-app:
+	kubectl -n $(NAMESPACE) port-forward svc/kafka-pubsub-app 8080:8080
+
+port-forward-prometheus:
+	kubectl -n $(NAMESPACE) port-forward svc/prometheus 9090:9090
+
+port-forward-grafana:
+	kubectl -n $(NAMESPACE) port-forward svc/grafana 3000:3000

--- a/backend/kafka-pubsub-kind/README.md
+++ b/backend/kafka-pubsub-kind/README.md
@@ -1,0 +1,16 @@
+# Kafka pub/sub 로컬 Kubernetes 핸즈온
+
+Kafka를 왜 쓰는지 말로만 이해하지 않고, kind cluster에서 메시지를 발행하고 소비하는 흐름을 직접 확인하기 위한 핸즈온입니다.
+
+## 문서
+
+1. [kind에서 Kafka를 먼저 띄우는 이유](./docs/1-kind-kafka.md)
+2. [Spring Boot producer/consumer는 어떻게 메시지를 주고받을까](./docs/2-spring-producer-consumer.md)
+3. [Prometheus와 Grafana로 무엇을 확인할까](./docs/3-prometheus-grafana.md)
+
+## 구성
+
+- `src/`: Spring Boot producer/consumer 예제
+- `kind/`: kind cluster 설정
+- `manifests/`: Kafka, 애플리케이션, Prometheus, Grafana manifest
+- `Makefile`: 로컬 실습 명령

--- a/backend/kafka-pubsub-kind/build.gradle
+++ b/backend/kafka-pubsub-kind/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+  id 'java'
+  id 'org.springframework.boot' version '3.3.1'
+  id 'io.spring.dependency-management' version '1.1.5'
+}
+
+group = 'com.akbun'
+version = '0.0.1-SNAPSHOT'
+
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(21)
+  }
+}
+
+dependencies {
+  implementation 'org.springframework.boot:spring-boot-starter-actuator'
+  implementation 'org.springframework.boot:spring-boot-starter-web'
+  implementation 'org.springframework.kafka:spring-kafka'
+  runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+  testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') {
+  useJUnitPlatform()
+}

--- a/backend/kafka-pubsub-kind/docs/1-kind-kafka.md
+++ b/backend/kafka-pubsub-kind/docs/1-kind-kafka.md
@@ -1,0 +1,66 @@
+# kind에서 Kafka를 먼저 띄우는 이유
+
+Kafka를 공부할 때 가장 먼저 막히는 지점은 broker 자체보다 실행 환경입니다. 로컬에서 Docker Compose로 바로 띄우면 빠르지만, Kubernetes에서 서비스 이름과 Pod 생명주기가 메시징 시스템에 어떤 영향을 주는지 보기 어렵습니다. 그래서 이 핸즈온은 왜 kind cluster에서 Kafka를 먼저 띄울까요?
+
+## 왜 Docker Compose가 아니라 kind로 시작할까요?
+
+Docker Compose는 빠르게 Kafka를 실행할 수 있다는 장점이 있습니다. 단점은 Kubernetes Service, Deployment, readiness probe, NodePort 같은 운영 환경의 기본 단서를 함께 보지 못한다는 점입니다.
+
+kind는 로컬 Docker 위에 Kubernetes cluster를 만들기 때문에 실제 운영 cluster와 완전히 같지는 않습니다. 하지만 학습 목적에서는 Service DNS, Pod 재시작, manifest 적용 흐름을 같이 볼 수 있습니다. **Kafka를 Kubernetes에서 사용할 때 헷갈리는 부분은 broker보다 네트워크 이름과 실행 순서에서 자주 드러납니다.**
+
+## 어떤 구조로 실행될까요?
+
+이 예제는 단일 namespace 안에 Kafka, Spring Boot 애플리케이션, Prometheus, Grafana를 둡니다. 학습 목적이므로 Kafka는 단일 broker로 실행하고, 데이터는 `emptyDir`에 저장합니다.
+
+장점은 구조가 단순해서 pub/sub 흐름에 집중할 수 있다는 점입니다. 단점은 broker 장애, 데이터 보존, multi broker replication 같은 운영 주제를 다루지 못한다는 점입니다. 운영 Kafka를 구성하려면 Strimzi 또는 Confluent Operator 같은 선택지도 검토해야 합니다. 이 문서에서는 로컬 학습 범위를 넘기 때문에 다루지 않습니다.
+
+## kind cluster는 어떻게 만들까요?
+
+다음 명령은 kind cluster를 만들고 애플리케이션 이미지를 빌드한 뒤 cluster에 로드하고 manifest를 적용합니다.
+
+```sh
+make up
+```
+
+명령이 성공하면 다음 리소스를 확인합니다.
+
+```sh
+kubectl -n kafka get pods
+kubectl -n kafka get svc
+```
+
+`kafka` Deployment가 먼저 준비되고, 그 다음 `kafka-pubsub-app`이 Kafka bootstrap server인 `kafka:9092`로 연결합니다.
+
+## Kafka manifest에서 무엇을 봐야 할까요?
+
+Kafka는 `manifests/10-kafka.yaml`에 있습니다. 이 예제는 Confluent Kafka image를 KRaft mode로 실행합니다. ZooKeeper를 따로 두지 않는 대신, broker와 controller 역할을 한 Pod가 같이 수행합니다.
+
+확인해야 할 값은 세 가지입니다.
+
+1. `KAFKA_LISTENERS`: Kafka container가 어떤 주소와 port에서 listen하는지 정합니다.
+2. `KAFKA_ADVERTISED_LISTENERS`: client에게 어떤 주소로 접속하라고 알려줄지 정합니다.
+3. `KAFKA_AUTO_CREATE_TOPICS_ENABLE`: 실습을 단순하게 하기 위해 topic 자동 생성을 켭니다.
+
+topic 자동 생성은 실습에서는 편합니다. 장점은 별도 topic 생성 Job 없이 바로 메시지를 보낼 수 있다는 점입니다. 단점은 운영에서 오타 topic이 자동 생성될 수 있다는 점입니다. 운영에서는 topic을 명시적으로 만들고 replication factor, partition 수, retention을 관리하는 편이 안전합니다.
+
+## 정리는 어떻게 할까요?
+
+실습 리소스만 지우려면 다음 명령을 사용합니다.
+
+```sh
+make down
+```
+
+kind cluster까지 지우려면 다음 명령을 사용합니다.
+
+```sh
+make delete_kind
+```
+
+정리하면, 이 핸즈온이 kind에서 Kafka를 먼저 띄우는 이유는 broker 실행보다 Kubernetes 안에서 client가 Kafka를 어떻게 찾는지 보기 위해서입니다. Docker Compose보다 느릴 수 있지만, Service DNS와 probe까지 함께 볼 수 있다는 점이 이 실습의 핵심입니다.
+
+## 참고자료
+
+- Apache Kafka Documentation: <https://kafka.apache.org/documentation/>
+- Confluent Docker Configuration Reference: <https://docs.confluent.io/platform/current/installation/docker/config-reference.html>
+- kind Documentation: <https://kind.sigs.k8s.io/>

--- a/backend/kafka-pubsub-kind/docs/2-spring-producer-consumer.md
+++ b/backend/kafka-pubsub-kind/docs/2-spring-producer-consumer.md
@@ -1,0 +1,87 @@
+# Spring Boot producer/consumer는 어떻게 메시지를 주고받을까
+
+Kafka는 producer가 topic에 record를 쓰고 consumer가 topic을 읽는 구조입니다. 그런데 처음 실습할 때는 producer와 consumer를 따로 설명하면 흐름이 끊겨 보이기 쉽습니다. 같은 Spring Boot 앱 안에서 메시지를 보내고 다시 읽게 만들면 무엇이 더 잘 보일까요?
+
+## 왜 producer와 consumer를 한 앱에 같이 둘까요?
+
+producer와 consumer를 한 앱에 같이 두면 메시지 발행 요청부터 consumer listener 동작까지 한 번에 확인할 수 있습니다. 장점은 실습자가 API 하나로 전체 흐름을 검증할 수 있다는 점입니다. 단점은 실제 서비스처럼 producer 서비스와 consumer 서비스를 분리한 구조는 아니라는 점입니다.
+
+이 예제의 목적은 Kafka를 처음 접하는 엔지니어가 pub/sub 흐름을 빠르게 확인하는 것입니다. 그래서 구조를 나누기보다 producer class와 consumer class를 분리하고, 애플리케이션 배포는 하나로 유지했습니다.
+
+## 메시지는 어떻게 발행할까요?
+
+애플리케이션은 `POST /messages` API를 제공합니다. 먼저 애플리케이션 Service를 로컬로 연결합니다.
+
+```sh
+make port-forward-app
+```
+
+다른 터미널에서 메시지를 발행합니다.
+
+```sh
+curl -X POST http://localhost:8080/messages \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"hello kafka from kind"}'
+```
+
+응답에는 Kafka가 기록한 topic, partition, offset이 들어옵니다.
+
+```json
+{
+  "value": "hello kafka from kind",
+  "topic": "study-events",
+  "partition": 0,
+  "offset": 0
+}
+```
+
+## consumer는 언제 메시지를 읽을까요?
+
+Spring Kafka의 `@KafkaListener`는 topic을 구독하고 record가 들어오면 listener method를 실행합니다. 이 예제는 최근에 소비한 메시지 20개만 메모리에 보관합니다. 그래서 발행 후 다음 API로 consumer가 읽은 메시지를 확인할 수 있습니다.
+
+```sh
+curl http://localhost:8080/messages
+```
+
+응답 예시는 다음과 같습니다.
+
+```json
+[
+  {
+    "value": "hello kafka from kind",
+    "topic": "study-events",
+    "partition": 0,
+    "offset": 0,
+    "consumedAt": "2026-06-25T00:00:00Z"
+  }
+]
+```
+
+`consumedAt`은 예시 값입니다. 실제 값은 실행한 시간으로 달라집니다.
+
+## Kafka consumer group은 왜 중요할까요?
+
+consumer group은 같은 topic을 읽는 consumer들을 하나의 소비 단위로 묶습니다. 같은 group 안에서는 partition이 consumer들에게 나뉘어 배정됩니다. 이 예제는 단일 Pod와 단일 topic으로 시작하기 때문에 group 동작이 크게 드러나지 않습니다.
+
+Pod replica를 늘리면 group 개념이 더 중요해집니다. 장점은 메시지 처리량을 늘릴 수 있다는 점입니다. 단점은 partition 수보다 consumer 수가 많으면 놀고 있는 consumer가 생길 수 있다는 점입니다. 그래서 Kafka를 설계할 때는 topic partition 수와 consumer replica 수를 함께 봐야 합니다.
+
+## 애플리케이션 설정은 어디에서 바꿀까요?
+
+Kubernetes에서는 `manifests/20-app.yaml`의 ConfigMap이 Spring Boot 환경 변수를 주입합니다.
+
+```yaml
+data:
+  KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+  KAFKA_TOPIC: study-events
+  KAFKA_CONSUMER_GROUP: kafka-pubsub-kind
+```
+
+로컬에서 직접 Spring Boot를 실행하려면 `KAFKA_BOOTSTRAP_SERVERS`를 접근 가능한 Kafka 주소로 바꿔야 합니다. 이 저장소는 kind 실습을 기준으로 구성했기 때문에 로컬 JVM 직접 실행은 별도 검증이 필요합니다. 확인 필요.
+
+정리하면, producer와 consumer를 한 앱에 둔 이유는 Kafka record가 topic에 쓰이고 다시 소비되는 흐름을 짧게 보기 위해서입니다. 실제 서비스 설계에서는 producer와 consumer를 분리할 수 있지만, 첫 학습에서는 offset과 consumer group을 눈으로 확인하는 것이 더 중요합니다.
+
+## 참고자료
+
+- Spring for Apache Kafka Reference: <https://docs.spring.io/spring-kafka/reference/>
+- Spring Boot Actuator Reference: <https://docs.spring.io/spring-boot/reference/actuator/>
+- Apache Kafka Consumer Design: <https://kafka.apache.org/documentation/#consumerconfigs>

--- a/backend/kafka-pubsub-kind/docs/3-prometheus-grafana.md
+++ b/backend/kafka-pubsub-kind/docs/3-prometheus-grafana.md
@@ -1,0 +1,82 @@
+# Prometheus와 Grafana로 무엇을 확인할까
+
+Kafka pub/sub가 동작한다고 해도 운영에서는 "메시지가 잘 갔다"만으로 충분하지 않습니다. 애플리케이션이 살아 있는지, HTTP 요청이 들어오는지, JVM이 어떤 상태인지도 같이 봐야 합니다. 이 핸즈온에서는 Prometheus와 Grafana로 무엇을 확인할까요?
+
+## 왜 Kafka broker metric 대신 애플리케이션 metric부터 볼까요?
+
+Kafka broker metric을 보려면 JMX exporter나 broker metric 설정이 추가로 필요합니다. 장점은 broker 내부 상태를 볼 수 있다는 점입니다. 단점은 첫 실습에서 Kafka, JMX, Prometheus 설정을 동시에 이해해야 해서 pub/sub 흐름이 흐려질 수 있다는 점입니다.
+
+이 예제는 Spring Boot Actuator의 `/actuator/prometheus`를 먼저 수집합니다. 애플리케이션 관점에서 요청 수, 응답 시간, JVM 상태를 확인하고, broker metric은 다음 단계로 남깁니다. **처음에는 producer/consumer 앱이 정상인지 보는 것이 Kafka 자체를 깊게 보는 것보다 학습 비용이 낮습니다.**
+
+## Prometheus target은 어떻게 확인할까요?
+
+Prometheus를 로컬로 연결합니다.
+
+```sh
+make port-forward-prometheus
+```
+
+브라우저에서 다음 주소를 엽니다.
+
+```text
+http://localhost:9090/targets
+```
+
+`kafka-pubsub-app` target이 `UP`이면 Prometheus가 Spring Boot metric을 수집하고 있습니다. `DOWN`이면 먼저 Pod 상태와 Service 이름을 확인합니다.
+
+```sh
+kubectl -n kafka get pods
+kubectl -n kafka get svc kafka-pubsub-app
+```
+
+## 어떤 PromQL을 먼저 보면 좋을까요?
+
+HTTP 요청이 들어오는지 보려면 다음 query를 사용합니다.
+
+```promql
+http_server_requests_seconds_count
+```
+
+JVM memory 사용량은 다음 query로 확인합니다.
+
+```promql
+jvm_memory_used_bytes
+```
+
+consumer lag 같은 Kafka 중심 metric은 이 예제에 포함하지 않았습니다. 확인 필요: broker JMX exporter를 추가하면 `kafka.consumer` 또는 broker 관련 metric까지 확장할 수 있습니다.
+
+## Grafana는 어떻게 열까요?
+
+Grafana를 로컬로 연결합니다.
+
+```sh
+make port-forward-grafana
+```
+
+브라우저에서 다음 주소를 엽니다.
+
+```text
+http://localhost:3000
+```
+
+이 예제는 실습 편의를 위해 anonymous access를 켰습니다. 장점은 비밀번호를 문서와 manifest에 넣지 않아도 된다는 점입니다. 단점은 운영 환경에는 절대 맞지 않는 설정이라는 점입니다. 운영에서는 인증과 권한을 반드시 따로 구성해야 합니다.
+
+Grafana Explore에서 datasource로 `Prometheus`를 선택하고, Prometheus에서 사용한 query를 그대로 실행합니다.
+
+## 장애를 일부러 만들면 무엇을 볼 수 있을까요?
+
+애플리케이션 Pod를 재시작하면 readiness와 HTTP metric 변화를 볼 수 있습니다.
+
+```sh
+kubectl -n kafka rollout restart deployment/kafka-pubsub-app
+```
+
+재시작 후 다시 메시지를 보내고 `http_server_requests_seconds_count`가 증가하는지 확인합니다. 이 과정에서 Kafka topic의 기존 메시지가 다시 보일 수 있습니다. consumer group offset과 topic retention 정책에 따라 보이는 결과가 달라질 수 있습니다.
+
+정리하면, 이 핸즈온에서 Prometheus와 Grafana를 붙인 이유는 Kafka 자체를 모두 관측하려는 것이 아니라 pub/sub 애플리케이션이 요청을 받고 metric을 내보내는 첫 경로를 보기 위해서입니다. broker metric까지 보려면 JMX exporter를 추가하는 다음 실습이 필요합니다.
+
+## 참고자료
+
+- Prometheus Documentation: <https://prometheus.io/docs/introduction/overview/>
+- Grafana Documentation: <https://grafana.com/docs/grafana/latest/>
+- Micrometer Prometheus Registry: <https://micrometer.io/docs/registry/prometheus>

--- a/backend/kafka-pubsub-kind/kind/kind-config.yaml
+++ b/backend/kafka-pubsub-kind/kind/kind-config.yaml
@@ -1,0 +1,14 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30080
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: 30090
+        hostPort: 9090
+        protocol: TCP
+      - containerPort: 30300
+        hostPort: 3000
+        protocol: TCP

--- a/backend/kafka-pubsub-kind/manifests/00-namespace.yaml
+++ b/backend/kafka-pubsub-kind/manifests/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka

--- a/backend/kafka-pubsub-kind/manifests/10-kafka.yaml
+++ b/backend/kafka-pubsub-kind/manifests/10-kafka.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  selector:
+    app: kafka
+  ports:
+    - name: plaintext
+      port: 9092
+      targetPort: 9092
+    - name: controller
+      port: 29093
+      targetPort: 29093
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.6.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9092
+              name: plaintext
+            - containerPort: 29093
+              name: controller
+          env:
+            - name: CLUSTER_ID
+              value: MkU3OEVBNTcwNTJENDM2Qk
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: broker,controller
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: 1@kafka:29093
+            - name: KAFKA_LISTENERS
+              value: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://kafka:9092
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: CONTROLLER
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: PLAINTEXT
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: "0"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+          readinessProbe:
+            tcpSocket:
+              port: 9092
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          volumeMounts:
+            - name: kafka-data
+              mountPath: /var/lib/kafka/data
+      volumes:
+        - name: kafka-data
+          emptyDir: {}

--- a/backend/kafka-pubsub-kind/manifests/20-app.yaml
+++ b/backend/kafka-pubsub-kind/manifests/20-app.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-pubsub-app-config
+  namespace: kafka
+data:
+  KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+  KAFKA_TOPIC: study-events
+  KAFKA_CONSUMER_GROUP: kafka-pubsub-kind
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-pubsub-app
+  namespace: kafka
+spec:
+  type: NodePort
+  selector:
+    app: kafka-pubsub-app
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      nodePort: 30080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-pubsub-app
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-pubsub-app
+  template:
+    metadata:
+      labels:
+        app: kafka-pubsub-app
+    spec:
+      containers:
+        - name: app
+          image: kafka-pubsub-app:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          envFrom:
+            - configMapRef:
+                name: kafka-pubsub-app-config
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 20

--- a/backend/kafka-pubsub-kind/manifests/30-observability.yaml
+++ b/backend/kafka-pubsub-kind/manifests/30-observability.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: kafka
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+
+    scrape_configs:
+      - job_name: kafka-pubsub-app
+        metrics_path: /actuator/prometheus
+        static_configs:
+          - targets:
+              - kafka-pubsub-app:8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: kafka
+spec:
+  type: NodePort
+  selector:
+    app: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      nodePort: 30090
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.52.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+          ports:
+            - containerPort: 9090
+              name: http
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource
+  namespace: kafka
+data:
+  prometheus.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus:9090
+        isDefault: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: kafka
+spec:
+  type: NodePort
+  selector:
+    app: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+      nodePort: 30300
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              name: http
+          env:
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Admin
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "true"
+          volumeMounts:
+            - name: grafana-datasource
+              mountPath: /etc/grafana/provisioning/datasources
+      volumes:
+        - name: grafana-datasource
+          configMap:
+            name: grafana-datasource

--- a/backend/kafka-pubsub-kind/settings.gradle
+++ b/backend/kafka-pubsub-kind/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    mavenCentral()
+  }
+}
+
+rootProject.name = 'kafka-pubsub-kind'

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/KafkaPubsubApplication.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/KafkaPubsubApplication.java
@@ -1,0 +1,11 @@
+package com.akbun.kafka;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class KafkaPubsubApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(KafkaPubsubApplication.class, args);
+  }
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/ConsumedMessage.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/ConsumedMessage.java
@@ -1,0 +1,12 @@
+package com.akbun.kafka.message;
+
+import java.time.Instant;
+
+public record ConsumedMessage(
+    String value,
+    String topic,
+    int partition,
+    long offset,
+    Instant consumedAt
+) {
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessageConsumer.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessageConsumer.java
@@ -1,0 +1,35 @@
+package com.akbun.kafka.message;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MessageConsumer {
+  private static final int MAX_RECENT_MESSAGES = 20;
+
+  private final ConcurrentLinkedDeque<ConsumedMessage> recentMessages = new ConcurrentLinkedDeque<>();
+
+  @KafkaListener(topics = "${app.kafka.topic}", groupId = "${spring.kafka.consumer.group-id}")
+  public void consume(ConsumerRecord<String, String> record) {
+    recentMessages.addFirst(new ConsumedMessage(
+        record.value(),
+        record.topic(),
+        record.partition(),
+        record.offset(),
+        Instant.now()
+    ));
+
+    while (recentMessages.size() > MAX_RECENT_MESSAGES) {
+      recentMessages.pollLast();
+    }
+  }
+
+  public List<ConsumedMessage> recentMessages() {
+    return new ArrayList<>(recentMessages);
+  }
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessageController.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessageController.java
@@ -1,0 +1,31 @@
+package com.akbun.kafka.message;
+
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MessageController {
+  private final MessageProducer producer;
+  private final MessageConsumer consumer;
+
+  public MessageController(MessageProducer producer, MessageConsumer consumer) {
+    this.producer = producer;
+    this.consumer = consumer;
+  }
+
+  @PostMapping("/messages")
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  public PublishedMessage publish(@RequestBody PublishMessageRequest request) {
+    return producer.publish(request.message());
+  }
+
+  @GetMapping("/messages")
+  public List<ConsumedMessage> recentMessages() {
+    return consumer.recentMessages();
+  }
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessageProducer.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessageProducer.java
@@ -1,0 +1,36 @@
+package com.akbun.kafka.message;
+
+import java.util.concurrent.ExecutionException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MessageProducer {
+  private final KafkaTemplate<String, String> kafkaTemplate;
+  private final String topic;
+
+  public MessageProducer(KafkaTemplate<String, String> kafkaTemplate, @Value("${app.kafka.topic}") String topic) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.topic = topic;
+  }
+
+  public PublishedMessage publish(String message) {
+    try {
+      var result = kafkaTemplate.send(topic, message).get();
+      var metadata = result.getRecordMetadata();
+
+      return new PublishedMessage(
+          message,
+          metadata.topic(),
+          metadata.partition(),
+          metadata.offset()
+      );
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new MessagePublishException("Kafka publish was interrupted", exception);
+    } catch (ExecutionException exception) {
+      throw new MessagePublishException("Kafka publish failed", exception);
+    }
+  }
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessagePublishException.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/MessagePublishException.java
@@ -1,0 +1,7 @@
+package com.akbun.kafka.message;
+
+public class MessagePublishException extends RuntimeException {
+  public MessagePublishException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/PublishMessageRequest.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/PublishMessageRequest.java
@@ -1,0 +1,4 @@
+package com.akbun.kafka.message;
+
+public record PublishMessageRequest(String message) {
+}

--- a/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/PublishedMessage.java
+++ b/backend/kafka-pubsub-kind/src/main/java/com/akbun/kafka/message/PublishedMessage.java
@@ -1,0 +1,9 @@
+package com.akbun.kafka.message;
+
+public record PublishedMessage(
+    String value,
+    String topic,
+    int partition,
+    long offset
+) {
+}

--- a/backend/kafka-pubsub-kind/src/main/resources/application.yaml
+++ b/backend/kafka-pubsub-kind/src/main/resources/application.yaml
@@ -1,0 +1,30 @@
+server:
+  port: 8080
+
+spring:
+  application:
+    name: kafka-pubsub-kind
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      group-id: ${KAFKA_CONSUMER_GROUP:kafka-pubsub-kind}
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+app:
+  kafka:
+    topic: ${KAFKA_TOPIC:study-events}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

Kafka를 처음 접하는 엔지니어가 로컬 kind cluster에서 pub/sub 흐름을 직접 확인할 수 있는 핸즈온을 추가했습니다. Issue #430의 create-code 작업입니다.

## 문제를 어떻게 해결 또는 공부했는가

Spring Boot 앱에 메시지 발행 API와 Kafka consumer listener를 추가했습니다. kind cluster에서 Confluent Kafka 단일 broker, 애플리케이션, Prometheus, Grafana를 실행하는 manifest와 Makefile을 함께 구성했습니다. 문서는 질문식 흐름으로 kind/Kafka 실행, producer/consumer 확인, Prometheus/Grafana 관측을 주제별로 분리했습니다.

## GitHub Issue (선택)

Issue #430

## 파일 디렉터리 구조

```text
backend/kafka-pubsub-kind/
├── README.md                     # 핸즈온 목적과 docs 링크 허브
├── Dockerfile                    # Spring Boot 앱 이미지 빌드
├── Makefile                      # kind 생성, 이미지 빌드/로드, 배포, 포트포워딩
├── build.gradle                  # Spring Boot, Spring Kafka, Actuator 의존성
├── docs/                         # 주제별 질문식 핸즈온 문서
├── kind/kind-config.yaml         # kind host port mapping
├── manifests/                    # Kafka, 앱, Prometheus, Grafana manifest
└── src/                          # producer API와 consumer listener 코드
```

루트 README와 backend README에는 새 핸즈온 링크를 추가했습니다.
