### PR TITLE
docs: add LiteLLM proxy hands-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 80. client -> HAProxy or EnvoyProxy -> server pod구조에서 TCP통신 끊기는지 확인 (26.6.3) - [링크](./computer_science/k8s_haproxy_tcp/)
 81. ECR lifecycle을 설정할 때 운영환경에서 사용하는 이미지를 보호하는 방법 (26.6.21) - [링크](./aws/ecr/tag_vs_digest/)
 82. AWS CodeBuild에서 GitHub App connection으로 GitHub repository 연결 (26.6.21) - [링크](./aws/codebuild/github_connection/)
+83. LiteLLM Proxy Docker Compose와 ECS 핸즈온 (26.6.27) - [링크](./mlops/litellm-proxy/)
 
 ## 직접 만든 제품
 

--- a/mlops/litellm-proxy/.env.example
+++ b/mlops/litellm-proxy/.env.example
@@ -1,0 +1,6 @@
+LITELLM_MASTER_KEY=sk-local-change-me
+LITELLM_SALT_KEY=sk-local-salt-change-me
+MOCK_API_KEY=mock-key
+POSTGRES_USER=litellm
+POSTGRES_PASSWORD=litellm-local-password
+POSTGRES_DB=litellm

--- a/mlops/litellm-proxy/.gitignore
+++ b/mlops/litellm-proxy/.gitignore
@@ -1,0 +1,2 @@
+.env
+*.tfplan

--- a/mlops/litellm-proxy/Makefile
+++ b/mlops/litellm-proxy/Makefile
@@ -1,0 +1,22 @@
+COMPOSE=docker compose
+
+.PHONY: up down logs ps request
+
+up:
+	$(COMPOSE) up -d --build
+
+down:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f litellm
+
+ps:
+	$(COMPOSE) ps
+
+request:
+	curl -sS http://localhost:4000/v1/chat/completions \
+		-H 'Content-Type: application/json' \
+		-H 'Authorization: Bearer sk-local-change-me' \
+		-d '{"model":"local-mock","messages":[{"role":"user","content":"hello"}]}' \
+		| jq .

--- a/mlops/litellm-proxy/README.md
+++ b/mlops/litellm-proxy/README.md
@@ -1,0 +1,18 @@
+# LiteLLM Proxy hands-on
+
+LiteLLM Proxy를 로컬 Docker Compose로 실행하고, 같은 설정 흐름을 AWS ECS로 옮길 때 무엇을 확인해야 하는지 실습합니다.
+
+## 문서
+
+- [1. 로컬 Docker Compose 실습](./docs/1-local-docker-compose.md)
+- [2. Bedrock 연동 설정](./docs/2-bedrock-config.md)
+- [3. ECS Terraform 예시](./docs/3-ecs-terraform.md)
+- [4. 운영 확인 항목](./docs/4-monitoring.md)
+
+## 파일
+
+- [docker-compose.yml](./docker-compose.yml)
+- [litellm_config.yaml](./litellm_config.yaml)
+- [mock-openai](./mock-openai/)
+- [ecs-image](./ecs-image/)
+- [terraform](./terraform/)

--- a/mlops/litellm-proxy/docker-compose.yml
+++ b/mlops/litellm-proxy/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  litellm:
+    image: ghcr.io/berriai/litellm-database:main-latest
+    command:
+      - --config=/app/config.yaml
+      - --port=4000
+      - --num_workers=1
+    environment:
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-local-change-me}
+      LITELLM_SALT_KEY: ${LITELLM_SALT_KEY:-sk-local-salt-change-me}
+      MOCK_API_KEY: ${MOCK_API_KEY:-mock-key}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-litellm}:${POSTGRES_PASSWORD:-litellm-local-password}@postgres:5432/${POSTGRES_DB:-litellm}
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./litellm_config.yaml:/app/config.yaml:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      mock-openai:
+        condition: service_started
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-litellm}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-litellm-local-password}
+      POSTGRES_DB: ${POSTGRES_DB:-litellm}
+    volumes:
+      - litellm-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  mock-openai:
+    build:
+      context: ./mock-openai
+    environment:
+      MOCK_API_KEY: ${MOCK_API_KEY:-mock-key}
+
+volumes:
+  litellm-postgres:

--- a/mlops/litellm-proxy/docs/1-local-docker-compose.md
+++ b/mlops/litellm-proxy/docs/1-local-docker-compose.md
@@ -1,0 +1,100 @@
+# 로컬 Docker Compose 실습
+
+## TL;DR
+
+- Docker Compose로 LiteLLM Proxy, PostgreSQL, mock OpenAI API를 같이 실행합니다.
+- mock API를 둔 이유는 실제 LLM API key 없이도 "client -> LiteLLM -> provider" 경로를 확인하기 위해서입니다.
+- 실제 Bedrock 연동은 다음 문서에서 `model_list`만 바꿔 확인합니다.
+- 로컬 기본 master key는 예시값입니다. 실제 환경에서는 새 값으로 바꿔야 합니다.
+
+## 왜 mock API를 먼저 쓰는가
+
+LiteLLM Proxy 실습에서 처음 확인할 것은 모델 품질이 아니라 요청 흐름입니다. 먼저 로컬에서 프록시가 config를 읽고, 인증을 확인하고, provider API로 요청을 넘기는지 확인합니다.
+
+장점은 AWS 권한이나 외부 API key 없이도 프록시 구조를 볼 수 있다는 점입니다.
+
+단점은 Bedrock의 실제 모델 권한, 리전, quota 문제는 이 단계에서 검증되지 않는다는 점입니다.
+
+## 준비
+
+예제 디렉터리로 이동합니다.
+
+```shell
+cd mlops/litellm-proxy
+```
+
+환경 변수 파일을 만듭니다.
+
+```shell
+cp .env.example .env
+```
+
+`.env`의 값은 실습용 예시입니다. 실제로 외부에 노출되는 환경에서는 `LITELLM_MASTER_KEY`, `LITELLM_SALT_KEY`, `POSTGRES_PASSWORD`를 새 값으로 바꿉니다.
+
+## 실행
+
+Compose를 실행합니다.
+
+```shell
+make up
+```
+
+컨테이너 상태를 확인합니다.
+
+```shell
+make ps
+```
+
+LiteLLM 로그를 확인합니다.
+
+```shell
+make logs
+```
+
+## 요청 보내기
+
+LiteLLM Proxy를 통해 mock provider로 요청을 보냅니다.
+
+```shell
+make request
+```
+
+`jq`가 없다면 아래처럼 `curl`만 사용합니다.
+
+```shell
+curl -sS http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer sk-local-change-me' \
+  -d '{"model":"local-mock","messages":[{"role":"user","content":"hello"}]}'
+```
+
+응답에 `mock response through LiteLLM` 문장이 들어 있으면 요청이 LiteLLM Proxy를 통과한 것입니다.
+
+## 설정 파일에서 볼 것
+
+로컬 설정은 [litellm_config.yaml](../litellm_config.yaml)에 있습니다.
+
+```yaml
+model_list:
+  - model_name: local-mock
+    litellm_params:
+      model: openai/local-mock
+      api_base: http://mock-openai:8080/v1
+      api_key: os.environ/MOCK_API_KEY
+```
+
+client는 `local-mock`이라는 이름만 알고 있습니다. LiteLLM은 이 이름을 보고 `litellm_params`의 provider endpoint로 요청을 보냅니다.
+
+## 정리
+
+컨테이너를 내립니다.
+
+```shell
+make down
+```
+
+PostgreSQL volume까지 지우려면 직접 volume을 삭제합니다.
+
+```shell
+docker volume rm litellm-proxy_litellm-postgres
+```

--- a/mlops/litellm-proxy/docs/2-bedrock-config.md
+++ b/mlops/litellm-proxy/docs/2-bedrock-config.md
@@ -1,0 +1,67 @@
+# Bedrock 연동 설정
+
+## TL;DR
+
+- LiteLLM의 Bedrock provider route는 `bedrock/` prefix를 사용합니다.
+- ECS에서는 access key를 넣기보다 task role로 Bedrock 호출 권한을 주는 흐름을 우선합니다.
+- 모델 ID, 지원 리전, IAM 세부 권한은 계정과 Bedrock model access 설정에 따라 달라서 확인 필요입니다.
+- 이 문서는 설정 예시를 제공하고, 실제 호출 검증은 AWS 계정에서 수행해야 합니다.
+
+## 로컬 설정을 Bedrock으로 바꾸기
+
+로컬 mock 대신 Bedrock을 호출하려면 `model_list`를 다음처럼 바꿉니다.
+
+```yaml
+model_list:
+  - model_name: bedrock-claude
+    litellm_params:
+      model: bedrock/anthropic.claude-3-sonnet-20240229-v1:0
+      aws_region_name: os.environ/AWS_REGION_NAME
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+```
+
+로컬에서 AWS profile을 사용한다면 컨테이너에 credential을 전달해야 합니다. 이 방식은 실습 편의성은 있지만, 장기적으로는 권한이 넓어지기 쉽습니다.
+
+장점: 로컬에서 빠르게 Bedrock 연결을 확인할 수 있습니다.
+
+단점: AWS credential mount와 profile 이름이 개인 환경에 의존합니다. 이 저장소에는 개인 profile 이름을 넣지 않습니다.
+
+## ECS에서는 task role을 우선 사용
+
+ECS에서는 task role에 Bedrock 호출 권한을 붙입니다. 예제 Terraform은 다음 action을 task role에 부여합니다.
+
+```text
+bedrock:InvokeModel
+bedrock:InvokeModelWithResponseStream
+```
+
+리소스는 예제에서 `*`로 열어 두었습니다. 실제 환경에서는 사용할 foundation model ARN으로 좁히는 편이 좋습니다.
+
+장점: access key를 컨테이너 환경 변수로 넣지 않아도 됩니다.
+
+단점: 모델별 ARN, 리전, cross-region inference profile 사용 여부를 실제 계정에서 확인해야 합니다.
+
+## 요청 예시
+
+Bedrock 설정으로 프록시가 떠 있으면 다음 요청으로 확인합니다.
+
+```shell
+curl -sS http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer sk-local-change-me' \
+  -d '{
+    "model": "bedrock-claude",
+    "messages": [
+      {"role": "user", "content": "LiteLLM proxy가 Bedrock 앞에서 하는 역할을 한 문장으로 설명해줘"}
+    ]
+  }'
+```
+
+## 확인 필요
+
+- 사용할 Bedrock 모델이 선택한 리전에서 활성화되어 있는지 확인 필요.
+- 계정에서 해당 model access가 승인되어 있는지 확인 필요.
+- `bedrock:InvokeModelWithResponseStream`이 필요한지, non-stream 호출만 쓰는지 확인 필요.
+- cross-region inference profile을 쓰는 경우 모델 ID와 IAM resource 범위를 별도로 확인 필요.

--- a/mlops/litellm-proxy/docs/3-ecs-terraform.md
+++ b/mlops/litellm-proxy/docs/3-ecs-terraform.md
@@ -1,0 +1,119 @@
+# ECS Terraform 예시
+
+## TL;DR
+
+- Terraform은 ECS Fargate service, ALB, security group, CloudWatch Logs, task role을 만듭니다.
+- LiteLLM 설정 파일은 [ecs-image](../ecs-image/) 이미지에 포함합니다.
+- master key는 Secrets Manager secret ARN으로 전달합니다.
+- 이 예제는 RDS를 만들지 않습니다. 운영용 DB 연결은 별도 설계가 필요하고 확인 필요입니다.
+
+## ECS 이미지 만들기
+
+예제 이미지는 LiteLLM 공식 이미지를 기반으로 config만 포함합니다.
+
+```shell
+cd mlops/litellm-proxy
+docker build -t litellm-proxy-hands-on:latest ./ecs-image
+```
+
+ECR repository를 준비한 뒤 push합니다. 아래 값은 예시입니다.
+
+```shell
+AWS_REGION=ap-northeast-2
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REPO_NAME=litellm-proxy-hands-on
+IMAGE="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${REPO_NAME}:latest"
+
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+docker tag litellm-proxy-hands-on:latest "$IMAGE"
+docker push "$IMAGE"
+```
+
+## master key secret 만들기
+
+LiteLLM master key는 Terraform 변수에 평문으로 넣지 않습니다. Secrets Manager에 값을 만들고 ARN만 Terraform에 전달합니다.
+
+```shell
+aws secretsmanager create-secret \
+  --name litellm-master-key-example \
+  --secret-string 'sk-replace-with-strong-random-value'
+```
+
+출력된 ARN을 `litellm_master_key_secret_arn` 변수에 넣습니다.
+
+## Terraform 변수
+
+예제 변수 파일을 복사합니다.
+
+```shell
+cd terraform
+cp terraform.tfvars.example terraform.tfvars
+```
+
+`terraform.tfvars`에서 다음 값을 실제 환경에 맞게 바꿉니다.
+
+```hcl
+vpc_id                        = "vpc-..."
+public_subnet_ids             = ["subnet-...", "subnet-..."]
+allowed_cidr                  = "x.x.x.x/32"
+container_image               = "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com/litellm-proxy-hands-on:latest"
+litellm_master_key_secret_arn = "arn:aws:secretsmanager:ap-northeast-2:123456789012:secret:..."
+```
+
+`allowed_cidr = "0.0.0.0/0"`은 실습 편의 기본값입니다.
+
+장점: 접속 테스트가 쉽습니다.
+
+단점: 인터넷 전체에서 ALB에 접근할 수 있습니다. 실제 환경에서는 본인 IP나 VPN CIDR로 좁혀야 합니다.
+
+## 배포
+
+Terraform을 실행합니다.
+
+```shell
+terraform init
+terraform plan
+terraform apply
+```
+
+ALB DNS 이름을 확인합니다.
+
+```shell
+terraform output alb_dns_name
+```
+
+## ECS 요청 테스트
+
+ALB 주소로 요청합니다.
+
+```shell
+ALB_DNS=$(terraform output -raw alb_dns_name)
+
+curl -sS "http://${ALB_DNS}/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer sk-replace-with-strong-random-value' \
+  -d '{
+    "model": "bedrock-claude",
+    "messages": [
+      {"role": "user", "content": "hello"}
+    ]
+  }'
+```
+
+## 정리
+
+실습 리소스를 삭제합니다.
+
+```shell
+terraform destroy
+```
+
+Secrets Manager secret과 ECR image는 이 Terraform 예제 밖에서 만들었으므로 별도로 정리합니다.
+
+## 확인 필요
+
+- ECS task가 public subnet에서 public IP를 갖는 구성이 요구사항에 맞는지 확인 필요.
+- 운영 환경에서는 private subnet, NAT Gateway 또는 VPC endpoint, HTTPS listener, WAF 적용 여부 확인 필요.
+- LiteLLM UI와 spend tracking까지 쓰려면 PostgreSQL/RDS 연결 설계 확인 필요.

--- a/mlops/litellm-proxy/docs/4-monitoring.md
+++ b/mlops/litellm-proxy/docs/4-monitoring.md
@@ -1,0 +1,85 @@
+# 운영 확인 항목
+
+## TL;DR
+
+- LiteLLM Proxy는 provider 앞단이므로 proxy와 provider 양쪽 지표를 같이 봐야 합니다.
+- 먼저 요청 수, 오류율, latency, Bedrock throttling, task restart를 확인합니다.
+- 비용과 quota는 기술 지표만으로 충분하지 않습니다. 모델별 사용량과 계정 quota를 같이 봐야 합니다.
+
+## LiteLLM Proxy에서 볼 것
+
+프록시는 client 요청을 받아 provider로 넘깁니다. 그래서 장애를 볼 때 "프록시 문제인지, provider 문제인지"를 나눠야 합니다.
+
+먼저 다음 항목을 봅니다.
+
+- 요청 수
+- 4xx, 5xx 응답 수
+- provider별 latency
+- provider별 error
+- streaming 요청 실패
+- virtual key별 사용량
+
+장점: proxy 기준으로 보면 client가 실제로 경험한 성공과 실패를 볼 수 있습니다.
+
+단점: provider 내부 quota, model access 문제는 proxy 지표만으로 원인을 확정하기 어렵습니다.
+
+## ECS에서 볼 것
+
+ECS에서는 task 생명주기와 컨테이너 로그를 먼저 봅니다.
+
+```shell
+aws ecs describe-services \
+  --cluster litellm-proxy-hands-on \
+  --services litellm-proxy-hands-on
+```
+
+CloudWatch Logs를 tail합니다.
+
+```shell
+aws logs tail /ecs/litellm-proxy-hands-on --follow
+```
+
+확인할 항목은 다음과 같습니다.
+
+- task restart 반복 여부
+- target group health check 실패 여부
+- container memory 부족 여부
+- image pull 실패 여부
+- secret 읽기 실패 여부
+
+## Bedrock에서 볼 것
+
+Bedrock 호출은 계정, 리전, 모델별 quota 영향을 받습니다.
+
+확인할 항목은 다음과 같습니다.
+
+- 모델 access 승인 상태
+- 리전별 지원 모델
+- throttling 발생 여부
+- invocation latency
+- streaming 호출 사용 여부
+- 비용 추적 기준
+
+확인 필요: Bedrock의 CloudWatch metric 이름과 차원은 사용하는 모델, inference profile, 호출 방식에 따라 실제 계정에서 다시 확인합니다.
+
+## 알람 후보
+
+처음에는 단순한 알람부터 둡니다.
+
+- ALB target 5xx 증가
+- ECS service running task count 감소
+- ECS task restart 반복
+- Bedrock throttling 증가
+- 요청 latency p95 증가
+
+장점: 운영 초기에 가장 눈에 띄는 실패를 빨리 잡을 수 있습니다.
+
+단점: 비용 급증이나 특정 사용자 남용은 별도 사용량 집계가 없으면 늦게 발견할 수 있습니다.
+
+## 다음에 보강할 것
+
+- HTTPS listener와 인증 경로
+- RDS 연결과 database pool 설정
+- LiteLLM virtual key별 budget
+- provider fallback과 retry 기준
+- dashboard와 runbook

--- a/mlops/litellm-proxy/ecs-image/.dockerignore
+++ b/mlops/litellm-proxy/ecs-image/.dockerignore
@@ -1,0 +1,3 @@
+.terraform/
+*.tfstate
+terraform.tfvars

--- a/mlops/litellm-proxy/ecs-image/Dockerfile
+++ b/mlops/litellm-proxy/ecs-image/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.litellm.ai/berriai/litellm:main-latest
+
+COPY ecs_litellm_config.yaml /app/config.yaml
+
+CMD ["--config", "/app/config.yaml", "--port", "4000"]

--- a/mlops/litellm-proxy/ecs-image/ecs_litellm_config.yaml
+++ b/mlops/litellm-proxy/ecs-image/ecs_litellm_config.yaml
@@ -1,0 +1,8 @@
+model_list:
+  - model_name: bedrock-claude
+    litellm_params:
+      model: bedrock/anthropic.claude-3-sonnet-20240229-v1:0
+      aws_region_name: os.environ/AWS_REGION_NAME
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY

--- a/mlops/litellm-proxy/litellm_config.yaml
+++ b/mlops/litellm-proxy/litellm_config.yaml
@@ -1,0 +1,10 @@
+model_list:
+  - model_name: local-mock
+    litellm_params:
+      model: openai/local-mock
+      api_base: http://mock-openai:8080/v1
+      api_key: os.environ/MOCK_API_KEY
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/DATABASE_URL

--- a/mlops/litellm-proxy/mock-openai/.dockerignore
+++ b/mlops/litellm-proxy/mock-openai/.dockerignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+.pytest_cache/

--- a/mlops/litellm-proxy/mock-openai/Dockerfile
+++ b/mlops/litellm-proxy/mock-openai/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN uv pip install --system --no-cache -r requirements.txt
+
+COPY app.py .
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/mlops/litellm-proxy/mock-openai/app.py
+++ b/mlops/litellm-proxy/mock-openai/app.py
@@ -1,0 +1,50 @@
+import os
+import time
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+  return {"status": "ok"}
+
+
+@app.post("/v1/chat/completions")
+def chat_completions(
+  payload: dict[str, Any],
+  authorization: str | None = Header(default=None),
+) -> dict[str, Any]:
+  expected = f"Bearer {os.environ.get('MOCK_API_KEY', 'mock-key')}"
+  if authorization != expected:
+    raise HTTPException(status_code=401, detail="invalid api key")
+
+  messages = payload.get("messages", [])
+  last_content = ""
+  if messages:
+    last_content = str(messages[-1].get("content", ""))
+
+  return {
+    "id": "chatcmpl-local-mock",
+    "object": "chat.completion",
+    "created": int(time.time()),
+    "model": payload.get("model", "local-mock"),
+    "choices": [
+      {
+        "index": 0,
+        "finish_reason": "stop",
+        "message": {
+          "role": "assistant",
+          "content": f"mock response through LiteLLM: {last_content}",
+        },
+      }
+    ],
+    "usage": {
+      "prompt_tokens": len(last_content.split()),
+      "completion_tokens": 5,
+      "total_tokens": len(last_content.split()) + 5,
+    },
+  }

--- a/mlops/litellm-proxy/mock-openai/requirements.txt
+++ b/mlops/litellm-proxy/mock-openai/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/mlops/litellm-proxy/terraform/.gitignore
+++ b/mlops/litellm-proxy/terraform/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+terraform.tfstate
+terraform.tfstate.*
+terraform.tfvars
+*.tfplan

--- a/mlops/litellm-proxy/terraform/alb.tf
+++ b/mlops/litellm-proxy/terraform/alb.tf
@@ -1,0 +1,35 @@
+resource "aws_lb" "this" {
+  name               = var.project_name
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = var.public_subnet_ids
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = var.project_name
+  port        = var.container_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    enabled             = true
+    path                = "/health/readiness"
+    matcher             = "200-399"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/mlops/litellm-proxy/terraform/ecs.tf
+++ b/mlops/litellm-proxy/terraform/ecs.tf
@@ -1,0 +1,79 @@
+resource "aws_cloudwatch_log_group" "litellm" {
+  name              = "/ecs/${var.project_name}"
+  retention_in_days = 7
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = var.project_name
+}
+
+resource "aws_ecs_task_definition" "litellm" {
+  family                   = var.project_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "litellm"
+      image     = var.container_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "AWS_REGION_NAME"
+          value = var.aws_region
+        }
+      ]
+
+      secrets = [
+        {
+          name      = "LITELLM_MASTER_KEY"
+          valueFrom = var.litellm_master_key_secret_arn
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.litellm.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "litellm"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "litellm" {
+  name            = var.project_name
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.litellm.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.public_subnet_ids
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "litellm"
+    container_port   = var.container_port
+  }
+
+  depends_on = [aws_lb_listener.http]
+}

--- a/mlops/litellm-proxy/terraform/iam.tf
+++ b/mlops/litellm-proxy/terraform/iam.tf
@@ -1,0 +1,64 @@
+data "aws_iam_policy_document" "ecs_task_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.project_name}-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "read_master_key" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+
+    resources = [var.litellm_master_key_secret_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "read_master_key" {
+  name   = "${var.project_name}-read-master-key"
+  role   = aws_iam_role.task_execution.id
+  policy = data.aws_iam_policy_document.read_master_key.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.project_name}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+}
+
+data "aws_iam_policy_document" "bedrock" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "bedrock" {
+  name   = "${var.project_name}-bedrock"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.bedrock.json
+}

--- a/mlops/litellm-proxy/terraform/network.tf
+++ b/mlops/litellm-proxy/terraform/network.tf
@@ -1,0 +1,43 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb"
+  description = "ALB access for LiteLLM proxy"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.allowed_cidr]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.project_name}-ecs"
+  description = "ECS task access for LiteLLM proxy"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "LiteLLM from ALB"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/mlops/litellm-proxy/terraform/outputs.tf
+++ b/mlops/litellm-proxy/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "alb_dns_name" {
+  description = "LiteLLM proxy ALB DNS name."
+  value       = aws_lb.this.dns_name
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.this.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.litellm.name
+}
+
+output "task_role_arn" {
+  description = "ECS task role ARN used for Bedrock calls."
+  value       = aws_iam_role.task.arn
+}

--- a/mlops/litellm-proxy/terraform/providers.tf
+++ b/mlops/litellm-proxy/terraform/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/mlops/litellm-proxy/terraform/terraform.tf
+++ b/mlops/litellm-proxy/terraform/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/mlops/litellm-proxy/terraform/terraform.tfvars.example
+++ b/mlops/litellm-proxy/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+aws_region                    = "ap-northeast-2"
+project_name                  = "litellm-proxy-hands-on"
+vpc_id                        = "vpc-00000000000000000"
+public_subnet_ids             = ["subnet-00000000000000000", "subnet-11111111111111111"]
+allowed_cidr                  = "0.0.0.0/0"
+container_image               = "123456789012.dkr.ecr.ap-northeast-2.amazonaws.com/litellm-proxy-hands-on:latest"
+litellm_master_key_secret_arn = "arn:aws:secretsmanager:ap-northeast-2:123456789012:secret:litellm-master-key-example"
+desired_count                 = 1

--- a/mlops/litellm-proxy/terraform/variables.tf
+++ b/mlops/litellm-proxy/terraform/variables.tf
@@ -1,0 +1,71 @@
+variable "aws_region" {
+  description = "AWS region for the ECS LiteLLM hands-on."
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "project_name" {
+  description = "Project name used for resource names."
+  type        = string
+  default     = "litellm-proxy-hands-on"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,50}[a-z0-9]$", var.project_name))
+    error_message = "project_name must use lowercase letters, numbers, and hyphens."
+  }
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the ALB and ECS service run."
+  type        = string
+}
+
+variable "public_subnet_ids" {
+  description = "Public subnet IDs for the ALB and Fargate tasks."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_ids) >= 2
+    error_message = "public_subnet_ids must include at least two subnets."
+  }
+}
+
+variable "allowed_cidr" {
+  description = "CIDR allowed to access the ALB. Narrow this before real use."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "container_image" {
+  description = "LiteLLM ECS image URI. Build and push ecs-image before applying."
+  type        = string
+}
+
+variable "litellm_master_key_secret_arn" {
+  description = "Secrets Manager secret ARN containing LITELLM_MASTER_KEY."
+  type        = string
+}
+
+variable "container_port" {
+  description = "LiteLLM proxy port."
+  type        = number
+  default     = 4000
+}
+
+variable "desired_count" {
+  description = "Number of ECS tasks."
+  type        = number
+  default     = 1
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Fargate task memory in MiB."
+  type        = number
+  default     = 1024
+}


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

LiteLLM Proxy가 어떤 문제를 해결하는지 로컬 Docker Compose와 AWS ECS 예시를 통해 직접 확인하는 공부용 핸즈온입니다. 실제 provider key 없이도 프록시 요청 경로를 먼저 확인하고, Bedrock과 ECS로 옮길 때 확인할 항목을 분리했습니다.

## 문제를 어떻게 해결 또는 공부했는가

`mlops/litellm-proxy/`에 로컬 Compose, mock OpenAI 호환 API, Bedrock 설정 예시, ECS용 이미지, Terraform 예시를 추가했습니다. 로컬 실습은 mock provider로 재현성을 확보하고, Bedrock 모델 리전/IAM/계정 model access처럼 환경 의존적인 부분은 `확인 필요`로 분리했습니다.

## GitHub Issue (선택)

Issue #438

## 파일 디렉터리 구조

```text
mlops/litellm-proxy/
├── README.md - 문서 링크 허브
├── Makefile - 로컬 compose up/down/request 명령
├── docker-compose.yml - LiteLLM, PostgreSQL, mock provider 로컬 실행
├── litellm_config.yaml - 로컬 mock provider용 LiteLLM 설정
├── mock-openai/ - OpenAI 호환 mock API
├── ecs-image/ - ECS 배포용 LiteLLM 이미지 예시
├── terraform/ - ECS Fargate, ALB, IAM, CloudWatch Logs 예시
└── docs/ - 로컬, Bedrock, ECS, 운영 확인 문서
```

확인 필요:

- Docker Desktop daemon이 실행 중이 아니어서 로컬 `docker compose up` 실기동은 검증하지 못했습니다.
- Bedrock 모델 access, 지원 리전, IAM resource 범위는 실제 AWS 계정에서 확인 필요합니다.
- ECS 예시는 public subnet + public ALB 기본 구성이므로 운영 적용 전 private subnet, HTTPS, WAF, RDS 연결 여부 확인 필요합니다.