### PR TITLE
Add AI agent sandbox hands-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 80. client -> HAProxy or EnvoyProxy -> server pod구조에서 TCP통신 끊기는지 확인 (26.6.3) - [링크](./computer_science/k8s_haproxy_tcp/)
 81. ECR lifecycle을 설정할 때 운영환경에서 사용하는 이미지를 보호하는 방법 (26.6.21) - [링크](./aws/ecr/tag_vs_digest/)
 82. AWS CodeBuild에서 GitHub App connection으로 GitHub repository 연결 (26.6.21) - [링크](./aws/codebuild/github_connection/)
+83. AI agent sandbox 로컬 권한 제한 실험 (26.6.29) - [링크](./computer_science/ai/ai-agent-sandbox/)
 
 ## 직접 만든 제품
 

--- a/computer_science/ai/ai-agent-sandbox/.gitignore
+++ b/computer_science/ai/ai-agent-sandbox/.gitignore
@@ -1,0 +1,3 @@
+.sandbox-probe-workspace.txt
+.uv-cache/
+.venv/

--- a/computer_science/ai/ai-agent-sandbox/Makefile
+++ b/computer_science/ai/ai-agent-sandbox/Makefile
@@ -1,0 +1,14 @@
+.PHONY: check test clean
+
+UV := UV_CACHE_DIR=.uv-cache uv
+
+check:
+	$(UV) run python scripts/sandbox_probe.py
+
+test:
+	$(UV) run python -m unittest discover -s tests
+
+clean:
+	rm -f .sandbox-probe-workspace.txt
+	rm -f /tmp/ai-agent-sandbox-outside-write.txt
+	-rm -f /Users/Shared/ai-agent-sandbox-outside-write.txt

--- a/computer_science/ai/ai-agent-sandbox/README.md
+++ b/computer_science/ai/ai-agent-sandbox/README.md
@@ -1,0 +1,48 @@
+# AI agent sandbox 로컬 권한 제한 실험
+
+AI agent가 로컬 명령을 실행할 때 파일 시스템, 네트워크, Git 명령, 승인 흐름이 어디서 허용되고 어디서 멈추는지 직접 확인하기 위한 핸즈온이다.
+
+## 빠른 시작
+
+실험 스크립트 실행:
+
+```bash
+make check
+```
+
+테스트 실행:
+
+```bash
+make test
+```
+
+실험 파일 정리:
+
+```bash
+make clean
+```
+
+## 학습 순서
+
+1. [sandbox 경계는 무엇을 막고 무엇을 남길까](docs/01-sandbox-boundary.md)
+2. [Codex CLI에서 권한 경계를 어떻게 관찰할까](docs/02-codex-cli-experiment.md)
+3. [Codex App과 Claude Code에서는 무엇을 수동 확인해야 할까](docs/03-codex-app-and-claude-checklist.md)
+4. [auto approve는 sandbox를 넓히는 설정일까](docs/04-auto-approve.md)
+
+## 디렉터리 구조
+
+```text
+.
+├── Makefile
+├── README.md
+├── docs/
+│   ├── 01-sandbox-boundary.md
+│   ├── 02-codex-cli-experiment.md
+│   ├── 03-codex-app-and-claude-checklist.md
+│   └── 04-auto-approve.md
+├── pyproject.toml
+├── scripts/
+│   └── sandbox_probe.py
+└── tests/
+    └── test_sandbox_probe.py
+```

--- a/computer_science/ai/ai-agent-sandbox/docs/01-sandbox-boundary.md
+++ b/computer_science/ai/ai-agent-sandbox/docs/01-sandbox-boundary.md
@@ -1,0 +1,49 @@
+# sandbox 경계는 무엇을 막고 무엇을 남길까
+
+AI agent에게 로컬 저장소를 맡기면 파일을 읽고, 코드를 고치고, 테스트를 실행합니다. 그런데 같은 agent가 홈 디렉터리나 네트워크까지 마음대로 접근해도 될까요?
+
+이 핸즈온의 질문은 하나입니다. **agent sandbox는 자동화가 계속 움직이게 하면서 어떤 권한 경계를 남길까요?**
+
+## sandbox와 approval은 왜 나뉠까
+
+sandbox는 기술적인 경계입니다. 파일 시스템에서 어디를 쓸 수 있는지, 명령이 네트워크를 사용할 수 있는지, 프로세스가 어떤 범위 안에서 실행되는지를 제한합니다.
+
+approval은 그 경계를 넘어가려는 순간의 의사결정입니다. 예를 들어 workspace 안 파일을 읽고 테스트를 돌리는 작업은 그대로 진행되지만, workspace 밖에 파일을 쓰거나 네트워크가 필요한 명령을 실행하려면 승인이 필요할 수 있습니다.
+
+둘은 같은 설정이 아닙니다. sandbox가 좁으면 agent가 실제로 할 수 있는 일이 줄어듭니다. approval이 엄격하면 경계를 넘는 순간 사람이 확인하거나 자동 리뷰어가 판단합니다.
+
+## 왜 성공과 실패를 모두 관찰해야 할까
+
+권한 실험은 성공만 보면 의미가 약합니다. 로컬 셸에서 `curl`이 성공한다고 해서 agent sandbox에서도 네트워크가 열려 있다고 볼 수 없습니다. 반대로 일반 셸에서 가능한 파일 쓰기가 sandbox에서는 막힐 수 있습니다.
+
+그래서 이 실험은 같은 항목을 반복해서 봅니다.
+
+| 항목 | 제한된 환경에서 기대하는 값 | 관찰 이유 |
+|---|---|---|
+| workspace 파일 읽기 | allowed | agent가 저장소를 이해해야 한다 |
+| workspace 파일 쓰기 | allowed | 코드 수정이 가능한지 확인한다 |
+| workspace 밖 파일 읽기 | profile dependent | 설정에 따라 읽기 범위가 달라질 수 있다 |
+| workspace 밖 파일 쓰기 | blocked | 불필요한 로컬 오염을 막는지 본다 |
+| 네트워크 요청 | blocked | 외부 전송 경계를 확인한다 |
+| 로컬 명령 실행 | allowed | 테스트와 진단 명령 실행 가능성을 본다 |
+| Git 상태 확인 | allowed | 변경 검토가 가능한지 본다 |
+
+## 제한이 강하면 작업성이 떨어지지 않을까
+
+강한 제한은 안전하지만 불편합니다. 예를 들어 네트워크가 막혀 있으면 패키지 설치, 원격 API 확인, GitHub 조회가 멈춥니다. 장점은 민감 정보 전송과 의도하지 않은 외부 통신을 줄일 수 있다는 점입니다.
+
+반대로 full access는 작업성이 좋습니다. 하지만 workspace 밖 파일, 네트워크, 로컬 서비스에 대한 경계가 약해집니다. 그래서 기본값으로는 좁은 sandbox를 두고, 필요한 순간에만 좁게 승인하는 편이 설명 가능성이 좋습니다.
+
+## 이 실험에서 조심할 점은 무엇일까
+
+스크립트는 위험한 삭제나 민감 파일 접근을 하지 않습니다. workspace 안의 작은 probe 파일과 `/Users/Shared/ai-agent-sandbox-outside-write.txt`만 생성하려고 시도합니다.
+
+다만 결과 해석은 실행 환경에 묶입니다. 같은 스크립트라도 일반 터미널, Codex CLI, Codex App, Claude Code에서 다르게 보일 수 있습니다. 다르면 한쪽이 틀렸다는 뜻이 아니라, 실행 주체와 권한 설정이 다르다는 뜻입니다.
+
+정리하면, sandbox는 agent를 멈추게 하려는 장치가 아니라 agent가 어디까지 스스로 움직일 수 있는지 설명 가능하게 만드는 경계입니다. 이 경계를 먼저 확인해야 auto approve나 full access 같은 설정을 판단할 수 있습니다.
+
+## 참고자료
+
+- [OpenAI Codex - Agent approvals & security](https://developers.openai.com/codex/agent-approvals-security)
+- [OpenAI Codex - Sandbox](https://developers.openai.com/codex/concepts/sandboxing)
+- [OpenAI Codex - Permissions](https://developers.openai.com/codex/permissions)

--- a/computer_science/ai/ai-agent-sandbox/docs/02-codex-cli-experiment.md
+++ b/computer_science/ai/ai-agent-sandbox/docs/02-codex-cli-experiment.md
@@ -1,0 +1,72 @@
+# Codex CLI에서 권한 경계를 어떻게 관찰할까
+
+Codex CLI는 로컬 저장소에서 명령을 실행합니다. 그런데 `codex`가 실행하는 명령과 내가 터미널에서 직접 실행하는 명령은 같은 권한을 가질까요?
+
+이 문서는 같은 probe를 일반 셸과 Codex CLI 안에서 실행해 차이를 기록하는 방법을 정리합니다.
+
+## 먼저 일반 셸 결과를 왜 봐야 할까
+
+일반 셸 결과는 baseline입니다. 이 값은 sandbox 결과가 아니라 현재 사용자 계정의 평범한 권한입니다.
+
+프로젝트 루트에서 실행합니다.
+
+```bash
+cd computer_science/ai/ai-agent-sandbox
+make check
+```
+
+예상되는 관찰 포인트는 다음과 같습니다.
+
+| 항목 | 일반 셸에서 자주 보이는 결과 | 해석 |
+|---|---|---|
+| workspace file read | allowed | 현재 디렉터리를 읽을 수 있다 |
+| workspace file write | allowed | probe 파일을 만들 수 있다 |
+| outside workspace file read | allowed | `/etc/hosts`는 보통 읽을 수 있다 |
+| outside workspace file write | allowed | `/tmp` 쓰기가 보통 가능하다 |
+| network request | allowed | 네트워크가 열려 있으면 성공한다 |
+| shell command | allowed | `uname` 실행 가능 |
+| git status | allowed | 저장소 상태 확인 가능 |
+
+일반 셸에서 실패한 항목이 있다면 sandbox 문제가 아닐 수 있습니다. 로컬 네트워크, Python, Git, 파일 권한부터 먼저 봐야 합니다.
+
+## Codex CLI에서는 어떤 프롬프트로 실행할까
+
+Codex CLI 안에서 agent에게 같은 명령을 실행하게 해야 합니다. 사람이 직접 터미널에서 `make check`를 실행하면 Codex sandbox가 아니라 일반 셸 권한을 본 것입니다.
+
+예시 프롬프트:
+
+```text
+computer_science/ai/ai-agent-sandbox 로 이동해서 make check를 실행하고, 각 observed 결과를 표로 정리해줘. 승인 요청이 나오면 어떤 항목 때문에 필요한지도 같이 적어줘.
+```
+
+권한 모드를 명시하고 싶다면 CLI 실행 시 다음처럼 시작합니다.
+
+```bash
+codex --sandbox workspace-write --ask-for-approval on-request
+```
+
+이 모드는 workspace 안 작업은 자동으로 진행하고, workspace 밖 쓰기나 네트워크처럼 경계를 넘는 작업은 승인 흐름으로 보낼 수 있습니다.
+
+## 결과는 어떻게 기록할까
+
+관찰 결과는 아래 형식으로 문서 작업자에게 넘기면 좋습니다.
+
+| 실행 환경 | workspace write | outside write | network | approval 요청 | 메모 |
+|---|---|---|---|---|---|
+| 일반 셸 | 확인 필요 | 확인 필요 | 확인 필요 | 없음 | baseline |
+| Codex CLI workspace-write/on-request | 확인 필요 | 확인 필요 | 확인 필요 | 확인 필요 | agent 실행 결과 |
+
+여기서 중요한 값은 성공 여부 자체보다 차이입니다. 일반 셸에서는 네트워크가 되는데 Codex CLI에서는 막힌다면, 그것이 sandbox의 네트워크 경계입니다.
+
+## 어떤 결과가 나오면 의심해야 할까
+
+workspace 밖 쓰기가 바로 성공하면 설정을 다시 봐야 합니다. `/tmp`가 writable root로 들어가 있거나 full access에 가까운 설정일 수 있습니다. 장점은 임시 파일 기반 도구가 잘 돈다는 점입니다. 단점은 agent가 workspace 밖에 흔적을 남길 수 있다는 점입니다.
+
+네트워크가 바로 성공하면 `sandbox_workspace_write.network_access`, permission profile, full access 여부를 확인해야 합니다. 장점은 패키지 설치와 원격 API 확인이 빠르다는 점입니다. 단점은 외부 전송 경계가 약해진다는 점입니다.
+
+정리하면, Codex CLI 실험은 "무엇이 가능한가"보다 "어떤 요청이 승인 경계로 올라오는가"를 보는 실험입니다. 그 경계를 알아야 자동화에 필요한 최소 권한을 정할 수 있습니다.
+
+## 참고자료
+
+- [OpenAI Codex - CLI features](https://developers.openai.com/codex/cli/features)
+- [OpenAI Codex - Agent approvals & security](https://developers.openai.com/codex/agent-approvals-security)

--- a/computer_science/ai/ai-agent-sandbox/docs/03-codex-app-and-claude-checklist.md
+++ b/computer_science/ai/ai-agent-sandbox/docs/03-codex-app-and-claude-checklist.md
@@ -1,0 +1,74 @@
+# Codex App과 Claude Code에서는 무엇을 수동 확인해야 할까
+
+Codex App과 Claude Code는 모두 agent가 로컬 작업을 도와주는 도구입니다. 하지만 같은 "sandbox"라는 말을 써도 설정 위치, 승인 UI, 기본 권한은 다를 수 있습니다. 그러면 비교할 때 무엇을 맞춰야 할까요?
+
+이 문서는 자동 스크립트만으로 끝내기 어려운 수동 확인 항목을 정리합니다.
+
+## Codex App에서는 어디를 봐야 할까
+
+Codex App은 앱 설정과 `config.toml` 계열 설정을 함께 봐야 합니다. 앱의 permissions selector에서 현재 모드가 무엇인지 확인하고, 고급 설정이 있으면 `config.toml`의 sandbox, approval, network 설정도 확인합니다.
+
+수동 체크리스트:
+
+| 항목 | 확인 값 |
+|---|---|
+| 현재 permissions mode | 확인 필요 |
+| workspace root | 확인 필요 |
+| writable root에 `/tmp`가 포함되는지 | 확인 필요 |
+| network access가 켜져 있는지 | 확인 필요 |
+| approval reviewer가 user인지 auto_review인지 | 확인 필요 |
+| `.git`, `.codex`, `.agents` 보호 경로가 쓰기 차단되는지 | 확인 필요 |
+
+실험 프롬프트:
+
+```text
+computer_science/ai/ai-agent-sandbox 에서 make check를 실행하고, blocked/allowed 결과와 승인 요청 항목을 표로 정리해줘.
+```
+
+## Claude Code에서는 무엇을 같은 형식으로 맞출까
+
+Claude Code의 세부 sandbox 설정 명칭은 현재 로컬 설치와 정책에 따라 확인해야 합니다. 확인 필요. 다만 비교 형식은 Codex와 같게 둘 수 있습니다.
+
+수동 체크리스트:
+
+| 항목 | 확인 값 |
+|---|---|
+| 현재 권한 모드 또는 approval 모드 | 확인 필요 |
+| workspace root | 확인 필요 |
+| workspace 밖 쓰기 요청이 차단되는지 | 확인 필요 |
+| 네트워크 요청이 승인 대상으로 올라오는지 | 확인 필요 |
+| Git 명령 실행이 허용되는지 | 확인 필요 |
+| 민감 파일 패턴을 deny할 수 있는지 | 확인 필요 |
+
+같은 스크립트를 실행하게 하되, 결과 표는 도구 이름만 바꿔 같은 열로 기록합니다.
+
+| 도구 | workspace write | outside write | network | approval 요청 | 비고 |
+|---|---|---|---|---|---|
+| Codex App | 확인 필요 | 확인 필요 | 확인 필요 | 확인 필요 | 앱 설정 포함 |
+| Claude Code | 확인 필요 | 확인 필요 | 확인 필요 | 확인 필요 | 로컬 정책 확인 필요 |
+
+## 왜 같은 명령보다 같은 질문이 중요할까
+
+도구마다 UI와 설정 이름이 다르면 같은 명령을 완전히 같은 방식으로 실행하기 어렵습니다. 그래서 비교 기준은 명령어 문자열이 아니라 질문이어야 합니다.
+
+- workspace 안 파일은 쓸 수 있는가?
+- workspace 밖 파일 쓰기는 멈추는가?
+- 네트워크 요청은 승인 대상인가?
+- 승인 주체는 사람인가 자동 리뷰어인가?
+- 민감 파일은 read deny로 막을 수 있는가?
+
+이 질문을 같은 표로 기록하면 도구 차이를 과장하지 않고 볼 수 있습니다.
+
+## 어떤 설정을 추천할 수 있을까
+
+기본 추천은 workspace write와 on-request 계열 승인입니다. 장점은 agent가 일반적인 코드 수정과 테스트를 계속 진행할 수 있다는 점입니다. 단점은 네트워크, 외부 경로, Docker socket 같은 작업에서 승인이 자주 필요할 수 있다는 점입니다.
+
+full access는 로컬 실험이 막힐 때 유혹적입니다. 장점은 설정 마찰이 적다는 점입니다. 단점은 실수나 prompt injection이 로컬 전체 권한으로 이어질 수 있다는 점입니다. 실습에서는 full access를 기본값으로 두지 않습니다.
+
+정리하면, Codex App과 Claude Code 비교는 제품 이름을 맞추는 실험이 아니라 권한 질문을 같은 표로 맞추는 실험입니다. 설정 이름은 달라도 경계 질문은 같게 가져갈 수 있습니다.
+
+## 참고자료
+
+- [OpenAI Codex - App settings](https://developers.openai.com/codex/app/settings)
+- [OpenAI Codex - Sandbox](https://developers.openai.com/codex/concepts/sandboxing)
+- Claude Code sandbox 세부 문서: 확인 필요

--- a/computer_science/ai/ai-agent-sandbox/docs/04-auto-approve.md
+++ b/computer_science/ai/ai-agent-sandbox/docs/04-auto-approve.md
@@ -1,0 +1,51 @@
+# auto approve는 sandbox를 넓히는 설정일까
+
+agent 자동화를 오래 돌리면 승인 요청이 귀찮아집니다. 그래서 auto approve를 켜면 sandbox가 넓어졌다고 느끼기 쉽습니다. 정말 그럴까요?
+
+핵심은 다릅니다. **auto approve는 권한 경계를 넓히는 설정이 아니라, 경계를 넘으려는 요청을 누가 검토하는지 바꾸는 설정입니다.**
+
+## auto approve와 auto review는 무엇을 바꿀까
+
+Codex의 auto-review 흐름은 사람이 보던 승인 요청을 별도 reviewer agent가 판단하게 합니다. 이때 main agent의 sandbox는 그대로입니다.
+
+예를 들어 network가 막힌 workspace-write 환경에서 agent가 외부 요청을 하려 하면 승인 요청이 생깁니다. reviewer가 승인하면 그 요청은 실행될 수 있지만, 그렇다고 모든 네트워크가 항상 열린 상태가 되는 것은 아닙니다.
+
+## 어떤 항목이 자동 검토 대상이 될까
+
+자동 검토 대상은 이미 approval이 필요한 요청입니다.
+
+| 요청 | 자동 검토 가능성 | 이유 |
+|---|---|---|
+| workspace 안 파일 수정 | 낮음 | sandbox 안에서 허용되면 검토가 필요 없다 |
+| workspace 밖 파일 쓰기 | 높음 | 경계를 넘는 쓰기다 |
+| 네트워크 요청 | 높음 | 기본 sandbox에서 막히기 쉽다 |
+| destructive 명령 | 높음 | 위험도가 크다 |
+| side-effect가 있는 MCP/app tool | 높음 | 도구 annotation과 정책에 따라 승인 대상이다 |
+
+그래서 auto approve 실험은 `make check` 결과만 보는 것으로 끝나지 않습니다. 어떤 항목에서 승인 요청이 생겼고, 그 요청이 사람에게 갔는지 reviewer agent에게 갔는지를 같이 기록해야 합니다.
+
+## auto approve를 켜면 무엇을 얻고 무엇을 잃을까
+
+장점은 긴 작업의 중단이 줄어든다는 점입니다. 테스트 중 네트워크가 필요한 패키지 설치, GitHub 조회, 임시 경로 접근 같은 항목이 정책상 허용 가능하면 사람이 매번 눌러주지 않아도 됩니다.
+
+단점은 승인 판단을 사람이 직접 보지 않는다는 점입니다. reviewer가 위험 요청을 막도록 설계되어 있어도, 제품 문서 기준으로 deterministic security guarantee는 아닙니다. 그래서 민감 정보 접근, credential 탐색, 광범위한 보안 완화, destructive 명령은 여전히 조심해야 합니다.
+
+## 실험 기록은 어떻게 남길까
+
+아래 표를 사용합니다.
+
+| 실행 환경 | approval reviewer | 요청 항목 | 결과 | 사람이 다시 볼 내용 |
+|---|---|---|---|---|
+| Codex CLI | user | network request | 확인 필요 | 실제 목적과 대상 도메인 |
+| Codex CLI | auto_review | network request | 확인 필요 | reviewer 판단 이유 |
+| Codex App | auto_review | outside write | 확인 필요 | 쓰기 대상 경로 |
+
+권한을 넓혀야 한다면 broad full access보다 좁은 writable root나 구체적인 command prefix rule부터 검토합니다. 장점은 반복 작업의 마찰을 줄이면서 경계를 설명할 수 있다는 점입니다. 단점은 설정 관리가 조금 더 복잡해진다는 점입니다.
+
+정리하면, auto approve는 "agent를 더 믿는다"가 아니라 "승인 경계의 검토자를 바꾼다"에 가깝습니다. sandbox를 넓히는 결정은 별도 설정으로 다루고, auto approve는 그 경계에서 반복되는 승인 비용을 줄이는 도구로 봐야 합니다.
+
+## 참고자료
+
+- [OpenAI Codex - Auto-review](https://developers.openai.com/codex/concepts/sandboxing/auto-review)
+- [OpenAI Codex - Agent approvals & security](https://developers.openai.com/codex/agent-approvals-security)
+- [OpenAI Codex - Permissions](https://developers.openai.com/codex/permissions)

--- a/computer_science/ai/ai-agent-sandbox/pyproject.toml
+++ b/computer_science/ai/ai-agent-sandbox/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "ai-agent-sandbox"
+version = "0.1.0"
+description = "Local probes for AI agent sandbox permission boundaries"
+requires-python = ">=3.11"
+dependencies = []

--- a/computer_science/ai/ai-agent-sandbox/scripts/sandbox_probe.py
+++ b/computer_science/ai/ai-agent-sandbox/scripts/sandbox_probe.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import subprocess
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+NETWORK_URL = "https://example.com"
+WORKSPACE_PROBE_FILE = Path(".sandbox-probe-workspace.txt")
+OUTSIDE_PROBE_FILE = Path("/Users/Shared/ai-agent-sandbox-outside-write.txt")
+OUTSIDE_READ_FILE = Path("/etc/hosts")
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+  name: str
+  expected_when_restricted: str
+  outcome: str
+  detail: str
+
+
+def read_text(path: Path) -> str:
+  return path.read_text(encoding="utf-8")
+
+
+def write_text(path: Path, content: str) -> str:
+  path.write_text(content, encoding="utf-8")
+  return str(path)
+
+
+def run_command(command: list[str]) -> str:
+  completed = subprocess.run(
+    command,
+    check=True,
+    capture_output=True,
+    text=True,
+    timeout=10,
+  )
+  return completed.stdout.strip() or completed.stderr.strip() or "ok"
+
+
+def request_url(url: str) -> str:
+  with urllib.request.urlopen(url, timeout=5) as response:
+    return f"HTTP {response.status}"
+
+
+def run_probe(
+  name: str,
+  expected_when_restricted: str,
+  action: Callable[[], str],
+) -> ProbeResult:
+  try:
+    detail = action()
+    return ProbeResult(name, expected_when_restricted, "allowed", detail)
+  except Exception as error:
+    error_name = error.__class__.__name__
+    return ProbeResult(name, expected_when_restricted, "blocked", f"{error_name}: {error}")
+
+
+def workspace_read() -> str:
+  text = read_text(Path("README.md"))
+  return f"README.md {len(text)} bytes"
+
+
+def workspace_write() -> str:
+  return write_text(WORKSPACE_PROBE_FILE, "workspace write probe\n")
+
+
+def outside_read() -> str:
+  text = read_text(OUTSIDE_READ_FILE)
+  return f"{OUTSIDE_READ_FILE} {len(text)} bytes"
+
+
+def outside_write() -> str:
+  return write_text(OUTSIDE_PROBE_FILE, "outside workspace write probe\n")
+
+
+def network_access() -> str:
+  return request_url(NETWORK_URL)
+
+
+def shell_command() -> str:
+  return run_command(["uname", "-s"])
+
+
+def git_status() -> str:
+  return run_command(["git", "status", "--short"])
+
+
+def collect_results() -> list[ProbeResult]:
+  return [
+    run_probe("workspace file read", "allowed", workspace_read),
+    run_probe("workspace file write", "allowed", workspace_write),
+    run_probe("outside workspace file read", "profile dependent", outside_read),
+    run_probe("outside workspace file write", "blocked", outside_write),
+    run_probe("network request", "blocked", network_access),
+    run_probe("shell command", "allowed", shell_command),
+    run_probe("git status", "allowed", git_status),
+  ]
+
+
+def format_result(result: ProbeResult) -> str:
+  return (
+    f"{result.name:<30} "
+    f"expected={result.expected_when_restricted:<17} "
+    f"observed={result.outcome:<7} "
+    f"{result.detail}"
+  )
+
+
+def main() -> None:
+  print("AI agent sandbox probe")
+  print(f"cwd={Path.cwd()}")
+  print()
+
+  for result in collect_results():
+    print(format_result(result))
+
+  print()
+  print("해석: observed 값은 현재 실행 환경의 결과입니다. Codex/Claude 권한 설정이 바뀌면 결과도 달라질 수 있습니다.")
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/ai-agent-sandbox/tests/test_sandbox_probe.py
+++ b/computer_science/ai/ai-agent-sandbox/tests/test_sandbox_probe.py
@@ -1,0 +1,32 @@
+import unittest
+
+from scripts.sandbox_probe import ProbeResult, format_result, run_probe
+
+
+class SandboxProbeTest(unittest.TestCase):
+  def test_run_probe_returns_allowed_when_action_succeeds(self) -> None:
+    result = run_probe("sample", "allowed", lambda: "ok")
+
+    self.assertEqual(result.outcome, "allowed")
+    self.assertEqual(result.detail, "ok")
+
+  def test_run_probe_returns_blocked_when_action_fails(self) -> None:
+    def fail() -> str:
+      raise PermissionError("denied")
+
+    result = run_probe("sample", "blocked", fail)
+
+    self.assertEqual(result.outcome, "blocked")
+    self.assertIn("PermissionError", result.detail)
+
+  def test_format_result_contains_expected_and_observed(self) -> None:
+    result = ProbeResult("sample", "blocked", "allowed", "ok")
+
+    formatted = format_result(result)
+
+    self.assertIn("expected=blocked", formatted)
+    self.assertIn("observed=allowed", formatted)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/computer_science/ai/ai-agent-sandbox/uv.lock
+++ b/computer_science/ai/ai-agent-sandbox/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "ai-agent-sandbox"
+version = "0.1.0"
+source = { virtual = "." }


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

AI agent sandbox가 파일 시스템, 네트워크, 명령 실행, 승인 흐름을 어떻게 제한하는지 로컬에서 재현 가능한 실험으로 공부합니다. Codex CLI/App과 Claude Code 비교를 같은 관찰 표로 정리할 수 있게 했습니다.

## 문제를 어떻게 해결 또는 공부했는가

`computer_science/ai/ai-agent-sandbox/`에 uv 기반 Python probe, Makefile, 번호가 붙은 docs 문서를 추가했습니다. probe는 workspace 읽기/쓰기, workspace 밖 읽기/쓰기, 네트워크 요청, shell command, git status를 같은 형식으로 출력합니다. 문서는 akbun 질문식 흐름으로 sandbox 경계, Codex CLI 실험, Codex App/Claude Code 수동 체크리스트, auto approve 해석을 분리했습니다.

검증:

```bash
make test
make check
git diff --check
```

## GitHub Issue (선택)

Issue #444

## 파일 디렉터리 구조

```text
README.md
└── 루트 목차에 AI agent sandbox 핸즈온 링크 추가
computer_science/ai/ai-agent-sandbox/
├── .gitignore                  # probe/uv 실행 산출물 제외
├── Makefile                    # check, test, clean 타깃
├── README.md                   # 목적과 docs 링크 허브
├── docs/
│   ├── 01-sandbox-boundary.md  # sandbox와 approval 경계 설명
│   ├── 02-codex-cli-experiment.md # Codex CLI 실행/기록 가이드
│   ├── 03-codex-app-and-claude-checklist.md # App/Claude 수동 체크리스트
│   └── 04-auto-approve.md      # auto approve/auto-review 해석
├── pyproject.toml              # uv 프로젝트 설정
├── scripts/
│   ├── __init__.py
│   └── sandbox_probe.py        # 권한 관찰 probe
├── tests/
│   └── test_sandbox_probe.py   # probe 단위 테스트
└── uv.lock                     # uv lockfile
```