### PR TITLE
JVM Metaspace OOM 덤프 로컬 재현 핸즈온

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 80. client -> HAProxy or EnvoyProxy -> server pod구조에서 TCP통신 끊기는지 확인 (26.6.3) - [링크](./computer_science/k8s_haproxy_tcp/)
 81. ECR lifecycle을 설정할 때 운영환경에서 사용하는 이미지를 보호하는 방법 (26.6.21) - [링크](./aws/ecr/tag_vs_digest/)
 82. AWS CodeBuild에서 GitHub App connection으로 GitHub repository 연결 (26.6.21) - [링크](./aws/codebuild/github_connection/)
+83. JVM Metaspace OOM 덤프 로컬 재현 핸즈온 (26.7.1) - [링크](./computer_science/jvm_metaspace_oom/)
 
 ## 직접 만든 제품
 

--- a/computer_science/jvm_metaspace_oom/Makefile
+++ b/computer_science/jvm_metaspace_oom/Makefile
@@ -1,0 +1,17 @@
+.PHONY: up down logs dumps clean-dumps
+
+up:
+	mkdir -p dumps
+	docker compose up --build
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f metaspace-oom
+
+dumps:
+	ls -lh dumps
+
+clean-dumps:
+	rm -f dumps/*.hprof dumps/*.log

--- a/computer_science/jvm_metaspace_oom/README.md
+++ b/computer_science/jvm_metaspace_oom/README.md
@@ -1,0 +1,9 @@
+# JVM Metaspace OOM Lab
+
+JVM Metaspace OOM을 로컬 Docker Compose 환경에서 재현하고, OOM 이후 남는 hprof와 JVM 로그를 확인하는 핸즈온입니다.
+
+## 문서
+
+1. [Metaspace OOM은 왜 발생할까](./docs/1-metaspace-oom.md)
+2. [Docker Compose로 OOM 재현하기](./docs/2-local-reproduce.md)
+3. [덤프와 로그는 어떻게 확인할까](./docs/3-dump-and-diagnostics.md)

--- a/computer_science/jvm_metaspace_oom/app/Dockerfile
+++ b/computer_science/jvm_metaspace_oom/app/Dockerfile
@@ -1,0 +1,12 @@
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+COPY src ./src
+
+RUN javac -d out $(find src -name "*.java") \
+  && jar --create --file app.jar --main-class com.example.metaspace.MetaspaceOomLab -C out .
+
+RUN mkdir -p /dumps /tmp/metaspace-lab
+
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/computer_science/jvm_metaspace_oom/app/src/main/java/com/example/metaspace/MetaspaceOomLab.java
+++ b/computer_science/jvm_metaspace_oom/app/src/main/java/com/example/metaspace/MetaspaceOomLab.java
@@ -1,0 +1,156 @@
+package com.example.metaspace;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+public final class MetaspaceOomLab {
+  private static final List<ClassLoader> RETAINED_LOADERS = new ArrayList<>();
+  private static final List<Class<?>> RETAINED_CLASSES = new ArrayList<>();
+
+  private MetaspaceOomLab() {
+  }
+
+  public static void main(String[] args) throws Exception {
+    LabConfig config = LabConfig.fromEnv();
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+    if (compiler == null) {
+      throw new IllegalStateException("JDK compiler is required. Run this lab with a JDK image.");
+    }
+
+    Files.createDirectories(config.sourceRoot());
+    Files.createDirectories(config.classRoot());
+
+    long loadedClassCount = 0;
+    while (true) {
+      Batch batch = createSourceBatch(config, loadedClassCount);
+      compileBatch(compiler, config, batch.sourceFiles());
+      loadBatch(config, batch.classNames());
+      loadedClassCount += batch.classNames().size();
+
+      System.out.printf(
+        Locale.ROOT,
+        "loaded_classes=%d retained_class_loaders=%d java_opts=\"%s\"%n",
+        loadedClassCount,
+        RETAINED_LOADERS.size(),
+        env("JAVA_OPTS", "")
+      );
+
+      if (config.pauseMillis() > 0) {
+        Thread.sleep(config.pauseMillis());
+      }
+    }
+  }
+
+  private static Batch createSourceBatch(LabConfig config, long loadedClassCount) throws IOException {
+    List<Path> sourceFiles = new ArrayList<>();
+    List<String> classNames = new ArrayList<>();
+
+    for (int index = 0; index < config.batchSize(); index += 1) {
+      long classNumber = loadedClassCount + index;
+      String simpleName = "Generated" + classNumber;
+      String className = "com.example.generated." + simpleName;
+      Path sourceFile = config.sourceRoot()
+        .resolve("com")
+        .resolve("example")
+        .resolve("generated")
+        .resolve(simpleName + ".java");
+
+      Files.createDirectories(sourceFile.getParent());
+      Files.writeString(sourceFile, sourceFor(simpleName, classNumber, config.methodCount()), StandardCharsets.UTF_8);
+
+      sourceFiles.add(sourceFile);
+      classNames.add(className);
+    }
+
+    return new Batch(sourceFiles, classNames);
+  }
+
+  private static String sourceFor(String simpleName, long classNumber, int methodCount) {
+    StringBuilder source = new StringBuilder();
+    source.append("package com.example.generated;\n\n");
+    source.append("public final class ").append(simpleName).append(" {\n");
+    source.append("  private final long id = ").append(classNumber).append("L;\n\n");
+    source.append("  public long id() {\n");
+    source.append("    return id;\n");
+    source.append("  }\n\n");
+
+    for (int index = 0; index < methodCount; index += 1) {
+      source.append("  public long value").append(index).append("() {\n");
+      source.append("    return id + ").append(index).append("L;\n");
+      source.append("  }\n\n");
+    }
+
+    source.append("}\n");
+    return source.toString();
+  }
+
+  private static void compileBatch(JavaCompiler compiler, LabConfig config, List<Path> sourceFiles) throws IOException {
+    try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, Locale.ROOT, StandardCharsets.UTF_8)) {
+      fileManager.setLocationFromPaths(StandardLocation.CLASS_OUTPUT, List.of(config.classRoot()));
+      Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromPaths(sourceFiles);
+      Boolean success = compiler.getTask(null, fileManager, null, List.of("-g:none"), null, compilationUnits).call();
+
+      if (!Boolean.TRUE.equals(success)) {
+        throw new IllegalStateException("Failed to compile generated classes.");
+      }
+    }
+  }
+
+  private static void loadBatch(LabConfig config, List<String> classNames) throws Exception {
+    URLClassLoader classLoader = new URLClassLoader(new URL[] {config.classRoot().toUri().toURL()}, null);
+
+    for (String className : classNames) {
+      RETAINED_CLASSES.add(Class.forName(className, true, classLoader));
+    }
+
+    RETAINED_LOADERS.add(classLoader);
+  }
+
+  private record Batch(List<Path> sourceFiles, List<String> classNames) {
+  }
+
+  private record LabConfig(Path sourceRoot, Path classRoot, int batchSize, int methodCount, long pauseMillis) {
+    static LabConfig fromEnv() {
+      Path workDir = Path.of(env("WORK_DIR", "/tmp/metaspace-lab"));
+
+      return new LabConfig(
+        workDir.resolve("src"),
+        workDir.resolve("classes"),
+        readInt("CLASS_BATCH_SIZE", 200),
+        readInt("CLASS_METHOD_COUNT", 20),
+        readLong("PAUSE_MILLIS", 0)
+      );
+    }
+  }
+
+  private static int readInt(String name, int defaultValue) {
+    return Integer.parseInt(env(name, Integer.toString(defaultValue)));
+  }
+
+  private static long readLong(String name, long defaultValue) {
+    return Long.parseLong(env(name, Long.toString(defaultValue)));
+  }
+
+  private static String env(String name, String defaultValue) {
+    String value = System.getenv(name);
+
+    if (value == null || value.isBlank()) {
+      return defaultValue;
+    }
+
+    return value;
+  }
+}

--- a/computer_science/jvm_metaspace_oom/docker-compose.yml
+++ b/computer_science/jvm_metaspace_oom/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  metaspace-oom:
+    build: ./app
+    container_name: jvm-metaspace-oom
+    environment:
+      JAVA_OPTS: >-
+        -XX:MaxMetaspaceSize=32m
+        -XX:+HeapDumpOnOutOfMemoryError
+        -XX:HeapDumpPath=/dumps/metaspace-oom.hprof
+        -XX:ErrorFile=/dumps/hs_err_pid%p.log
+        -Xlog:gc*,metaspace=info:file=/dumps/jvm-metaspace.log:time,level,tags
+      CLASS_BATCH_SIZE: "200"
+      CLASS_METHOD_COUNT: "20"
+      PAUSE_MILLIS: "0"
+    volumes:
+      - ./dumps:/dumps

--- a/computer_science/jvm_metaspace_oom/docs/1-metaspace-oom.md
+++ b/computer_science/jvm_metaspace_oom/docs/1-metaspace-oom.md
@@ -1,0 +1,36 @@
+# Metaspace OOM은 왜 발생할까
+
+Java 애플리케이션에서 `java.lang.OutOfMemoryError`가 발생하면 보통 heap부터 떠올립니다. 그런데 로그에 `Metaspace`가 붙어 있으면 원인이 조금 다릅니다. heap이 아니라 클래스 메타데이터를 저장하는 영역이 부족해진 상황이기 때문입니다.
+
+왜 객체를 많이 만들지 않아도 OOM이 날까요?
+
+## Metaspace는 무엇을 담을까
+
+Metaspace는 JVM이 로드한 클래스의 메타데이터를 저장하는 native memory 영역입니다. 클래스 이름, 메서드, 필드, 상속 관계, constant pool 같은 정보가 이 영역에 올라갑니다. Java 8 이후 PermGen이 사라지고 Metaspace가 그 역할을 맡았습니다.
+
+heap과 다른 점은 저장 대상입니다. heap은 애플리케이션 객체를 담고, Metaspace는 JVM이 클래스를 이해하고 실행하기 위해 필요한 구조 정보를 담습니다. 그래서 큰 배열이나 큰 문자열을 만들지 않아도, 클래스를 계속 새로 로드하면 Metaspace가 늘어납니다.
+
+**Metaspace OOM은 객체 수보다 클래스 로딩 패턴을 먼저 의심해야 하는 OOM입니다.**
+
+## 왜 클래스 로더를 붙잡으면 위험할까
+
+클래스는 클래스 로더가 살아 있는 동안 쉽게 내려가지 않습니다. JVM은 클래스 로더가 더 이상 참조되지 않을 때 그 로더가 로드한 클래스도 함께 언로드할 수 있습니다. 반대로 애플리케이션이 클래스 로더나 `Class<?>` 객체를 계속 참조하면 클래스 메타데이터도 계속 남습니다.
+
+이 핸즈온은 이 성질을 의도적으로 이용합니다. JDK compiler API로 매번 새로운 Java 클래스를 만들고, 새 `URLClassLoader`로 로드한 뒤, 클래스 로더와 클래스를 리스트에 보관합니다. 이러면 GC가 heap 객체는 정리하려고 해도 클래스 메타데이터를 내려놓기 어렵습니다.
+
+이 방식의 장점은 원리가 직접 보인다는 점입니다. 외부 라이브러리 없이도 "클래스를 계속 로드하면 Metaspace가 찬다"를 확인할 수 있습니다. 단점은 실제 운영 장애의 원인을 그대로 재현하지는 않는다는 점입니다. 운영에서는 프레임워크 reload, 동적 proxy, 스크립트 엔진, 플러그인 구조처럼 간접적인 클래스 생성 경로가 원인일 수 있습니다.
+
+## MaxMetaspaceSize를 왜 작게 잡을까
+
+로컬 실습에서는 `-XX:MaxMetaspaceSize=32m`로 제한합니다. 제한을 작게 잡으면 짧은 시간 안에 OOM을 재현할 수 있습니다. 운영 환경의 권장값이라는 뜻은 아닙니다.
+
+이 선택의 장점은 재현 시간이 짧고 결과가 명확하다는 점입니다. 단점은 작은 제한값 때문에 운영에서 보는 증가 속도와 다를 수 있다는 점입니다. 그래서 실습 결과를 운영 설정으로 바로 옮기면 안 됩니다. 운영에서는 애플리케이션의 클래스 수, 프레임워크, 배포 방식, 관측 지표를 같이 보고 판단해야 합니다.
+
+## 정리
+
+정리하면, 객체를 많이 만들지 않아도 OOM이 날 수 있는 이유는 JVM이 클래스 메타데이터를 heap 바깥의 Metaspace에 저장하기 때문입니다. 클래스가 계속 생성되고, 그 클래스를 로드한 클래스 로더가 계속 참조되면 Metaspace가 줄어들지 않습니다. 이 핸즈온은 그 현상을 작은 제한값에서 안전하게 재현하는 실습입니다.
+
+## 참고자료
+
+- [Oracle Java SE Troubleshooting Guide - Understand the OutOfMemoryError Exception](https://docs.oracle.com/en/java/javase/21/troubleshoot/troubleshooting-memory-leaks.html)
+- [HotSpot Virtual Machine Garbage Collection Tuning Guide - Other Considerations](https://docs.oracle.com/en/java/javase/21/gctuning/other-considerations.html)

--- a/computer_science/jvm_metaspace_oom/docs/2-local-reproduce.md
+++ b/computer_science/jvm_metaspace_oom/docs/2-local-reproduce.md
@@ -1,0 +1,91 @@
+# Docker Compose로 OOM 재현하기
+
+Metaspace OOM은 말로만 보면 heap OOM과 잘 구분되지 않습니다. 로컬에서 직접 재현하면 로그, dump 파일, JVM 옵션의 역할을 분리해서 볼 수 있습니다.
+
+어떤 최소 환경이면 Metaspace OOM을 재현할 수 있을까요?
+
+## 실습은 무엇을 실행할까
+
+이 실습의 Java 프로그램은 JDK compiler API로 새로운 Java source를 계속 생성합니다. 생성한 source를 class 파일로 컴파일하고, 새 `URLClassLoader`로 로드합니다. 로드한 클래스와 클래스 로더는 static list에 보관합니다.
+
+이 구조는 일부러 메모리를 놓지 않는 구조입니다. 운영 코드에서 이렇게 작성하라는 의미가 아닙니다. Metaspace가 어떤 조건에서 증가하는지 관찰하기 위한 재현 장치입니다.
+
+## 사전 준비
+
+Docker와 Docker Compose가 필요합니다. 실습 디렉터리로 이동합니다.
+
+```bash
+cd computer_science/jvm_metaspace_oom
+```
+
+이전 실행에서 남은 dump 파일이 있으면 먼저 정리합니다. 같은 이름의 hprof가 이미 있으면 JVM이 새 dump를 만들지 못할 수 있습니다.
+
+```bash
+make clean-dumps
+```
+
+## 환경 실행
+
+Docker 이미지를 빌드하고 컨테이너를 실행합니다.
+
+```bash
+make up
+```
+
+직접 Docker Compose 명령을 사용해도 됩니다.
+
+```bash
+docker compose up --build
+```
+
+컨테이너가 실행되면 아래와 비슷한 로그가 반복됩니다.
+
+```text
+loaded_classes=200 retained_class_loaders=1 java_opts="-XX:MaxMetaspaceSize=32m ..."
+loaded_classes=400 retained_class_loaders=2 java_opts="-XX:MaxMetaspaceSize=32m ..."
+loaded_classes=600 retained_class_loaders=3 java_opts="-XX:MaxMetaspaceSize=32m ..."
+```
+
+`loaded_classes`가 늘어나다가 Metaspace 제한에 도달하면 JVM이 `OutOfMemoryError: Metaspace`를 남기고 종료합니다.
+
+## JVM 옵션은 무엇을 의미할까
+
+핵심 옵션은 `docker-compose.yml`의 `JAVA_OPTS`에 있습니다.
+
+```yaml
+JAVA_OPTS: >-
+  -XX:MaxMetaspaceSize=32m
+  -XX:+HeapDumpOnOutOfMemoryError
+  -XX:HeapDumpPath=/dumps/metaspace-oom.hprof
+  -XX:ErrorFile=/dumps/hs_err_pid%p.log
+  -Xlog:gc*,metaspace=info:file=/dumps/jvm-metaspace.log:time,level,tags
+```
+
+`-XX:MaxMetaspaceSize=32m`는 Metaspace 상한을 작게 잡아 OOM을 빠르게 만듭니다. `-XX:+HeapDumpOnOutOfMemoryError`와 `-XX:HeapDumpPath`는 OOM 시점에 hprof를 남깁니다. `-Xlog:gc*,metaspace=info`는 GC와 Metaspace 관련 로그를 파일로 남깁니다.
+
+`-XX:ErrorFile`은 JVM fatal error 로그 경로입니다. 일반적인 Java `OutOfMemoryError`에서는 hs_err 파일이 항상 생성되는 것은 아닙니다. 이 파일이 없다고 해서 실습이 실패한 것은 아닙니다.
+
+## 재현 강도를 어떻게 조정할까
+
+재현 속도는 환경 변수로 조정합니다.
+
+```yaml
+CLASS_BATCH_SIZE: "200"
+CLASS_METHOD_COUNT: "20"
+PAUSE_MILLIS: "0"
+```
+
+`CLASS_BATCH_SIZE`를 키우면 한 번에 더 많은 클래스를 생성합니다. 장점은 OOM까지 걸리는 시간이 짧아진다는 점입니다. 단점은 로그를 천천히 관찰하기 어렵고, 컴파일 작업도 한 번에 커진다는 점입니다.
+
+`CLASS_METHOD_COUNT`를 키우면 각 클래스의 메서드 수가 늘어납니다. 장점은 클래스 하나가 차지하는 메타데이터가 커져 더 빨리 OOM에 도달할 수 있다는 점입니다. 단점은 실제 서비스 클래스의 형태와 멀어질 수 있다는 점입니다.
+
+`PAUSE_MILLIS`를 키우면 batch 사이에 쉬는 시간이 생깁니다. 장점은 로그와 dump 생성 시점을 관찰하기 쉽다는 점입니다. 단점은 재현 시간이 길어집니다.
+
+## 정리
+
+정리하면, 이 실습은 "클래스를 계속 만들고, 로드하고, 참조를 유지하면 Metaspace가 찬다"는 질문에 답하기 위한 최소 Docker Compose 환경입니다. 운영 설정을 흉내 내기보다 원인을 잘라서 보는 것이 목적입니다.
+
+## 참고자료
+
+- [Oracle Java SE Tools Reference - java command](https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html)
+- [Oracle Java SE Tools Reference - javac command](https://docs.oracle.com/en/java/javase/21/docs/specs/man/javac.html)

--- a/computer_science/jvm_metaspace_oom/docs/3-dump-and-diagnostics.md
+++ b/computer_science/jvm_metaspace_oom/docs/3-dump-and-diagnostics.md
@@ -1,0 +1,101 @@
+# 덤프와 로그는 어떻게 확인할까
+
+OOM을 재현하는 것만으로는 부족합니다. 장애 대응에서는 "발생했다"와 "무엇을 남겼다"를 구분해야 합니다. 이 실습은 hprof, JVM 로그, 운영 수집 체크리스트를 따로 확인합니다.
+
+Metaspace OOM 이후에는 어떤 파일을 먼저 봐야 할까요?
+
+## 생성 파일 확인
+
+컨테이너가 OOM으로 종료된 뒤 dump 디렉터리를 확인합니다.
+
+```bash
+make dumps
+```
+
+직접 확인하려면 아래 명령을 사용합니다.
+
+```bash
+ls -lh dumps
+```
+
+성공하면 아래 파일이 생깁니다.
+
+```text
+metaspace-oom.hprof
+jvm-metaspace.log
+```
+
+`hs_err_pid*.log`는 없을 수 있습니다. Java level의 `OutOfMemoryError`가 발생했다고 해서 항상 fatal error 파일이 만들어지는 것은 아닙니다.
+
+## hprof는 무엇을 보여줄까
+
+`metaspace-oom.hprof`는 heap dump입니다. 이름 때문에 Metaspace 자체를 그대로 떠 준다고 생각하기 쉽지만, hprof는 heap에 남아 있는 객체와 참조 관계를 보는 자료입니다.
+
+그럼 Metaspace OOM에서 hprof가 왜 필요할까요? 클래스 로더를 누가 붙잡고 있는지 볼 수 있기 때문입니다. 이 실습에서는 `MetaspaceOomLab.RETAINED_LOADERS`와 `MetaspaceOomLab.RETAINED_CLASSES`가 클래스 로더와 클래스를 계속 참조합니다.
+
+MAT, VisualVM, IntelliJ profiler 같은 도구로 hprof를 열어 아래 대상을 찾습니다.
+
+```text
+java.net.URLClassLoader
+java.lang.Class
+com.example.generated.Generated*
+com.example.metaspace.MetaspaceOomLab
+```
+
+이 실습의 장점은 참조 경로가 단순하다는 점입니다. 단점은 운영 장애처럼 여러 framework와 agent가 얽힌 복잡한 경로를 그대로 보여주지는 않는다는 점입니다.
+
+## JVM 로그는 무엇을 보여줄까
+
+`jvm-metaspace.log`는 GC와 Metaspace 관련 로그입니다. 로그를 보면 Metaspace 사용량이 증가하는 흐름과 OOM 직전의 JVM 동작을 확인할 수 있습니다.
+
+아래 명령으로 Metaspace 관련 줄을 확인합니다.
+
+```bash
+grep -i metaspace dumps/jvm-metaspace.log | tail -40
+```
+
+로그는 hprof와 역할이 다릅니다. hprof는 "누가 참조하고 있는가"를 보는 데 유리하고, JVM 로그는 "언제 얼마나 증가했는가"를 보는 데 유리합니다. 둘 중 하나만 보면 원인을 좁히기 어렵습니다.
+
+## 운영 환경에서는 무엇을 일반화해야 할까
+
+AWS Auto Scaling Group, systemd, S3 jar 배포 같은 환경에서는 실제 계정, bucket, host, path를 문서나 코드에 고정하지 않습니다. 대신 아래 체크리스트로 일반화합니다.
+
+- JVM 옵션은 서비스 단위 환경 변수나 systemd drop-in으로 관리한다.
+- dump 저장 위치는 애플리케이션 쓰기 권한이 있는 로컬 디렉터리로 둔다.
+- OOM 이후에는 dump를 별도 보관소로 복사한다.
+- dump 파일에는 민감한 값이 들어갈 수 있으므로 접근 권한과 보관 기간을 정한다.
+- 분석은 운영 서버가 아니라 별도 환경에서 수행한다.
+
+예시 형태는 아래처럼 값이 없는 template로만 둡니다.
+
+```ini
+[Service]
+Environment="JAVA_OPTS=-XX:MaxMetaspaceSize=<size> -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=<dump-dir>/<app>.hprof"
+```
+
+S3 같은 외부 보관소로 옮길 때도 실제 bucket 이름은 쓰지 않습니다.
+
+```bash
+aws s3 cp <dump-dir>/<app>.hprof s3://<dump-bucket>/<service>/<date>/<app>.hprof
+```
+
+## 추가 진단 옵션은 무엇을 볼까
+
+Metaspace OOM을 더 자세히 봐야 한다면 `NativeMemoryTracking`을 검토할 수 있습니다.
+
+```text
+-XX:NativeMemoryTracking=summary
+```
+
+장점은 JVM native memory 분류를 더 자세히 볼 수 있다는 점입니다. 단점은 약간의 overhead가 있고, 실행 중 `jcmd`로 별도 조회해야 하므로 운영 환경에서 권한과 절차가 필요합니다. 이 실습에서는 기본 옵션에 넣지 않았습니다.
+
+Metaspace OOM 상황에서 반드시 남겨야 할 추가 JVM 진단 옵션은 서비스의 JVM 버전, 컨테이너 제한, 운영 수집 체계에 따라 달라집니다. 이 부분은 `확인 필요`입니다.
+
+## 정리
+
+정리하면, Metaspace OOM 이후에는 hprof와 JVM 로그를 분리해서 봐야 합니다. hprof는 참조 관계를 보여주고, JVM 로그는 증가 흐름을 보여줍니다. 운영 환경으로 옮길 때는 실제 인프라 값을 코드나 문서에 박지 않고, dump 수집과 보관 절차만 일반화해야 합니다.
+
+## 참고자료
+
+- [Oracle Java SE Troubleshooting Guide - Diagnostic Tools](https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html)
+- [Oracle Java SE Tools Reference - jcmd](https://docs.oracle.com/en/java/javase/21/docs/specs/man/jcmd.html)

--- a/computer_science/jvm_metaspace_oom/dumps/.gitignore
+++ b/computer_science/jvm_metaspace_oom/dumps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

JVM Metaspace OOM을 Docker Compose로 로컬 재현하고, OOM 시점의 hprof와 JVM 로그를 수집하는 과정을 공부하려 했습니다.

## 문제를 어떻게 해결 또는 공부했는가

외부 라이브러리 없이 JDK compiler API로 Java 클래스를 계속 생성하고 새 ClassLoader로 로드하는 예제를 만들었습니다. MaxMetaspaceSize, heap dump, JVM 로그 옵션을 Docker Compose에 넣고, 재현 절차와 dump 확인 절차를 질문식 문서로 나눴습니다.

## GitHub Issue (선택)

Issue #448

## 파일 디렉터리 구조

```text
computer_science/jvm_metaspace_oom/
├── README.md
│   └── 목적과 docs 링크 허브
├── Makefile
│   └── up/down/logs/dumps 실행 단축 명령
├── docker-compose.yml
│   └── Metaspace 제한과 dump 경로가 포함된 실행 환경
├── app/
│   ├── Dockerfile
│   │   └── JDK 기반 예제 빌드/실행 이미지
│   └── src/main/java/com/example/metaspace/MetaspaceOomLab.java
│       └── 동적 클래스 생성/로드로 Metaspace OOM을 재현하는 Java 예제
├── docs/
│   ├── 1-metaspace-oom.md
│   │   └── Metaspace OOM 원리
│   ├── 2-local-reproduce.md
│   │   └── Docker Compose 재현 절차
│   └── 3-dump-and-diagnostics.md
│       └── hprof/JVM 로그 확인과 운영 체크리스트
└── dumps/.gitignore
    └── 로컬 dump 산출물 커밋 방지
```
