### PR TITLE
vLLM 로컬 GPU 서버와 Kubernetes 핸즈온

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 81. ECR lifecycle을 설정할 때 운영환경에서 사용하는 이미지를 보호하는 방법 (26.6.21) - [링크](./aws/ecr/tag_vs_digest/)
 82. AWS CodeBuild에서 GitHub App connection으로 GitHub repository 연결 (26.6.21) - [링크](./aws/codebuild/github_connection/)
 83. Github Pull requset가 생성되면 Argo CD Pull Request Generator로 kubernetes 리소스를 자동으로 생성 (26.6.28) - [링크](./kubernetes/argocd/pull_request_generator/)
+84. vLLM 로컬 GPU 서버와 Kubernetes 핸즈온 (26.7.2) - [링크](./computer_science/ai/vllm-local-gpu-kubernetes/)
 
 ## 직접 만든 제품
 

--- a/computer_science/ai/vllm-local-gpu-kubernetes/Makefile
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/Makefile
@@ -1,0 +1,42 @@
+COMPOSE ?= docker compose
+KUBECTL ?= kubectl
+NAMESPACE ?= vllm-local
+MODEL_ID ?= Qwen/Qwen3-0.6B
+DEVICE_PLUGIN_VERSION ?= v0.17.1
+
+.PHONY: up down logs health chat k3s-device-plugin k3s-apply k3s-delete k3s-wait k3s-logs k3s-port-forward
+
+up:
+	$(COMPOSE) up -d
+
+down:
+	$(COMPOSE) down
+
+logs:
+	$(COMPOSE) logs -f vllm
+
+health:
+	curl -fsS http://localhost:8000/health
+
+chat:
+	curl -fsS http://localhost:8000/v1/chat/completions \
+		-H "Content-Type: application/json" \
+		-d '{"model":"$(MODEL_ID)","messages":[{"role":"user","content":"vLLM을 한 문장으로 설명해줘"}],"max_tokens":64}'
+
+k3s-device-plugin:
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/$(DEVICE_PLUGIN_VERSION)/deployments/static/nvidia-device-plugin.yml
+
+k3s-apply:
+	$(KUBECTL) apply -k manifests/k3s
+
+k3s-delete:
+	$(KUBECTL) delete -k manifests/k3s
+
+k3s-wait:
+	$(KUBECTL) -n $(NAMESPACE) rollout status deployment/vllm-server --timeout=15m
+
+k3s-logs:
+	$(KUBECTL) -n $(NAMESPACE) logs -f deployment/vllm-server
+
+k3s-port-forward:
+	$(KUBECTL) -n $(NAMESPACE) port-forward svc/vllm-server 8000:8000

--- a/computer_science/ai/vllm-local-gpu-kubernetes/README.md
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/README.md
@@ -1,0 +1,64 @@
+# vLLM 로컬 GPU 서버와 Kubernetes 핸즈온
+
+로컬 Linux GPU 서버에서 vLLM을 먼저 단일 컨테이너로 실행하고, 같은 구성을 Kubernetes Pod로 옮길 때 GPU 런타임과 device plugin이 어떤 역할을 하는지 확인한다.
+
+## TL;DR
+
+- Docker에서는 NVIDIA Container Toolkit과 `--gpus all` 조건을 먼저 확인한다.
+- Kubernetes는 kind를 먼저 검토하되, 실제 GPU 노드 실습은 k3s를 기본 경로로 둔다.
+- 민감한 토큰은 문서와 manifest에 넣지 않고 실행 시 환경변수나 Secret으로만 주입한다.
+
+## 학습 순서
+
+1. [로컬 GPU 서버에서 vLLM을 먼저 띄우는 이유](docs/1-local-gpu-server.md)
+2. [Kubernetes 환경은 왜 kind보다 k3s로 가는가](docs/2-kubernetes-runtime-choice.md)
+3. [k3s에서 vLLM Pod를 실행하고 API를 검증하는 방법](docs/3-kubernetes-vllm-serving.md)
+
+## 파일 구조
+
+```text
+.
+├── README.md
+├── Makefile
+├── docker-compose.yml
+├── docs/
+│   ├── 1-local-gpu-server.md
+│   ├── 2-kubernetes-runtime-choice.md
+│   └── 3-kubernetes-vllm-serving.md
+└── manifests/
+    └── k3s/
+        ├── deployment.yaml
+        ├── kustomization.yaml
+        ├── namespace.yaml
+        ├── pvc.yaml
+        └── service.yaml
+```
+
+## 빠른 시작
+
+로컬 Docker 실행:
+
+```bash
+make up
+make logs
+make health
+make chat
+make down
+```
+
+k3s 배포:
+
+```bash
+make k3s-device-plugin
+make k3s-apply
+make k3s-wait
+make k3s-port-forward
+```
+
+## 참고자료
+
+- [vLLM Docker deployment](https://docs.vllm.ai/en/latest/deployment/docker/)
+- [vLLM Kubernetes deployment](https://docs.vllm.ai/en/latest/deployment/k8s/)
+- [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- [K3s NVIDIA Container Runtime support](https://docs.k3s.io/advanced#nvidia-container-runtime-support)
+- [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin)

--- a/computer_science/ai/vllm-local-gpu-kubernetes/docker-compose.yml
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  vllm:
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:latest}
+    ipc: host
+    ports:
+      - "8000:8000"
+    volumes:
+      - huggingface-cache:/root/.cache/huggingface
+    environment:
+      HF_TOKEN: ${HF_TOKEN:-}
+    command:
+      - --model
+      - ${MODEL_ID:-Qwen/Qwen3-0.6B}
+      - --max-model-len
+      - ${MAX_MODEL_LEN:-2048}
+      - --gpu-memory-utilization
+      - ${GPU_MEMORY_UTILIZATION:-0.85}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu
+
+volumes:
+  huggingface-cache:

--- a/computer_science/ai/vllm-local-gpu-kubernetes/docs/1-local-gpu-server.md
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/docs/1-local-gpu-server.md
@@ -1,0 +1,104 @@
+# 로컬 GPU 서버에서 vLLM을 먼저 띄우는 이유
+
+## TL;DR
+
+vLLM은 Kubernetes에 올리기 전에 Docker 단일 컨테이너로 먼저 검증하는 편이 좋습니다. 실패 원인이 모델 다운로드, GPU 드라이버, NVIDIA Container Toolkit, vLLM 옵션, Kubernetes 런타임 중 어디에 있는지 분리하기 쉽기 때문입니다.
+
+## 왜 Kubernetes보다 Docker를 먼저 봐야 할까
+
+vLLM을 처음 실행하면 모델을 내려받고 GPU 메모리에 로드하고 OpenAI 호환 API 서버를 연다. 이 과정에서 실패할 수 있는 지점이 많습니다. 바로 Kubernetes로 시작하면 Pod 스케줄링 문제인지, GPU가 컨테이너 안에 노출되지 않은 문제인지, 모델이 너무 커서 메모리가 부족한 문제인지 구분하기 어렵습니다.
+
+그래서 첫 단계는 Docker입니다. Docker에서 `nvidia-smi`와 vLLM API 호출이 통과하면, 적어도 호스트 드라이버와 컨테이너 GPU 노출은 확인한 상태가 됩니다. **Kubernetes 실습은 그 다음에 같은 조건을 Pod 스펙으로 옮기는 과정입니다.**
+
+## 로컬 서버는 어떤 조건을 만족해야 할까
+
+먼저 호스트에서 GPU가 보여야 합니다.
+
+GPU 드라이버 상태를 확인합니다.
+
+```bash
+nvidia-smi
+```
+
+이 명령이 실패하면 vLLM 문제가 아닙니다. NVIDIA driver 설치부터 확인해야 합니다. NVIDIA Container Toolkit 문서도 먼저 Linux 배포판에 맞는 GPU driver 설치를 전제로 둡니다.
+
+다음으로 Docker 컨테이너에서 GPU가 보여야 합니다.
+
+NVIDIA CUDA 컨테이너에서 GPU 접근을 확인합니다.
+
+```bash
+docker run --rm --gpus all nvidia/cuda:12.5.0-base-ubuntu22.04 nvidia-smi
+```
+
+이 명령이 실패하면 Docker가 NVIDIA runtime을 사용하지 못하는 상태입니다. 이때는 NVIDIA Container Toolkit을 설치하고 Docker runtime을 구성합니다.
+
+Docker runtime을 NVIDIA Container Toolkit으로 구성합니다.
+
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+장점은 Docker에서 바로 GPU 노출을 확인할 수 있다는 점입니다. 단점은 이 단계만으로 Kubernetes의 device plugin이나 RuntimeClass 문제까지 검증되지는 않는다는 점입니다.
+
+## 어떤 모델로 시작해야 할까
+
+처음 실습 모델은 `Qwen/Qwen3-0.6B`로 둡니다. vLLM Docker 문서의 예시와 같고, 7B급 모델보다 로컬 GPU 메모리 부담이 작습니다.
+
+그런데 작은 모델이면 충분할까요? 목적이 성능 벤치마크라면 부족합니다. 하지만 이 핸즈온의 목적은 vLLM 서버 실행, GPU 런타임 연결, OpenAI 호환 API 호출 검증입니다. 그래서 작은 공개 모델로 시작하는 편이 실패 원인을 줄입니다.
+
+로컬 GPU 메모리 요구사항은 GPU 종류, dtype, context length, vLLM 버전에 따라 달라집니다. 정확한 최소 VRAM은 확인 필요입니다. 이 문서에서는 첫 실행 안정성을 위해 `--max-model-len 2048`로 시작합니다.
+
+## Docker Compose로 어떻게 실행할까
+
+이 디렉터리의 `docker-compose.yml`은 공식 `vllm/vllm-openai:latest` 이미지를 사용합니다. 공식 Docker 문서처럼 Hugging Face cache를 마운트하고, GPU를 컨테이너에 노출하고, 서버 포트 `8000`을 엽니다.
+
+vLLM 서버를 백그라운드로 실행합니다.
+
+```bash
+make up
+```
+
+모델 다운로드와 서버 시작 로그를 확인합니다.
+
+```bash
+make logs
+```
+
+서버 health endpoint를 확인합니다.
+
+```bash
+make health
+```
+
+OpenAI 호환 chat completions API를 호출합니다.
+
+```bash
+make chat
+```
+
+정리합니다.
+
+```bash
+make down
+```
+
+## 토큰은 어디에 넣어야 할까
+
+공개 모델이면 Hugging Face token 없이도 동작할 수 있습니다. 하지만 rate limit이나 gated model 때문에 토큰이 필요할 수 있습니다.
+
+이때 토큰을 문서, compose 파일, manifest에 직접 적지 않습니다. 현재 셸에서만 환경변수로 넣습니다.
+
+Hugging Face token을 현재 셸에만 설정합니다.
+
+```bash
+export HF_TOKEN="replace-with-your-token"
+make up
+```
+
+장점은 저장소에 민감정보가 남지 않는다는 점입니다. 단점은 터미널 세션이 바뀌면 다시 설정해야 한다는 점입니다. `.env` 파일을 쓸 수도 있지만, 그 파일은 커밋하면 안 됩니다.
+
+## 참고자료
+
+- [vLLM Docker deployment](https://docs.vllm.ai/en/latest/deployment/docker/)
+- [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)

--- a/computer_science/ai/vllm-local-gpu-kubernetes/docs/2-kubernetes-runtime-choice.md
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/docs/2-kubernetes-runtime-choice.md
@@ -1,0 +1,76 @@
+# Kubernetes 환경은 왜 kind보다 k3s로 가는가
+
+## TL;DR
+
+kind는 로컬 Kubernetes 실습 기본값으로 좋지만, GPU inference 실습에서는 노드 자체가 Docker 컨테이너라는 점이 제약이 됩니다. 이 핸즈온은 kind를 검토 대상으로 남기되, 실제 GPU Pod 실행은 k3s를 기본 경로로 선택합니다.
+
+## 왜 처음에는 kind를 검토할까
+
+이 저장소의 Kubernetes 로컬 실습 기본값은 kind입니다. kind는 빠르게 만들고 지우기 쉽고, 클러스터 상태를 실험하기 좋습니다.
+
+그런데 vLLM GPU 실습에서도 kind가 좋은 선택일까요? 컨트롤 플레인이나 일반 Pod 실습이라면 좋습니다. 하지만 GPU는 다릅니다. Pod가 GPU를 쓰려면 아래 조건이 동시에 맞아야 합니다.
+
+- 호스트에 NVIDIA driver가 설치되어 있어야 한다.
+- 컨테이너 런타임이 NVIDIA runtime을 알아야 한다.
+- Kubernetes node가 `nvidia.com/gpu` 리소스를 advertise해야 한다.
+- Pod가 GPU 리소스를 request 또는 limit으로 요청해야 한다.
+
+kind의 node는 호스트 프로세스가 아니라 Docker 컨테이너입니다. kind 문서의 `extraMounts`로 host path를 node 컨테이너에 넘길 수는 있지만, GPU device, runtime, device plugin, kubelet device plugin socket까지 안정적으로 엮는 구성은 실습의 초점보다 복잡해집니다.
+
+## kind를 쓰면 무엇을 얻고 무엇을 잃을까
+
+kind를 선택하면 얻는 것은 간단한 클러스터 생명주기입니다. `kind create cluster`와 `kind delete cluster`만으로 클러스터를 관리할 수 있습니다.
+
+잃는 것은 GPU 경로의 단순성입니다. node가 컨테이너이기 때문에 호스트 GPU 장치와 NVIDIA runtime을 kind node 내부로 전달해야 합니다. 이 구성은 가능 여부가 호스트 Docker, NVIDIA Container Toolkit, kind node image, device plugin 설정에 영향을 많이 받습니다. 이 문서에서는 안정적인 재현 경로로 단정하지 않고 확인 필요로 둡니다.
+
+## k3s를 선택하면 무엇이 달라질까
+
+k3s는 실제 Linux GPU 서버 위에서 kubelet과 containerd를 직접 실행하는 경로에 가깝습니다. K3s 문서는 NVIDIA runtime이 설치되어 있으면 k3s가 대체 container runtime을 감지하고, 기본 runtime을 바꾸지 않았다면 Pod에 `runtimeClassName: nvidia`를 명시하라고 설명합니다.
+
+장점은 GPU 서버 운영 구조와 더 비슷하다는 점입니다. NVIDIA Container Runtime, NVIDIA device plugin, `nvidia.com/gpu` 리소스 요청 흐름을 그대로 볼 수 있습니다.
+
+단점은 kind보다 설치와 정리가 무겁다는 점입니다. 로컬 노트북에서 가볍게 클러스터만 만들고 지우는 경험과는 다릅니다. 그래도 vLLM GPU inference 실습의 목적은 GPU runtime 경로를 이해하는 것이므로, 이 단점은 받아들일 수 있습니다.
+
+## k3d는 왜 기본값으로 두지 않았을까
+
+k3d는 Docker 위에서 k3s를 실행합니다. kind보다 k3s 생태계에 가깝지만, GPU 관점에서는 여전히 node가 컨테이너라는 제약이 남습니다.
+
+그래서 선택지는 이렇게 정리합니다.
+
+| 선택지 | 장점 | 단점 | 이 핸즈온 판단 |
+| --- | --- | --- | --- |
+| kind | 가장 가볍고 익숙함 | GPU runtime 전달이 복잡함 | 검토만 남김 |
+| k3d | k3s를 Docker로 쉽게 실행 | GPU는 여전히 컨테이너 node 제약 | 대안으로만 둠 |
+| k3s | 실제 GPU 서버 운영 흐름과 가까움 | 설치와 정리가 무거움 | 기본 실습 경로 |
+
+## k3s에서는 무엇을 확인해야 할까
+
+k3s 설치 전에 NVIDIA runtime이 호스트에 있어야 합니다.
+
+containerd용 NVIDIA runtime 구성을 적용합니다.
+
+```bash
+sudo nvidia-ctk runtime configure --runtime=containerd
+sudo systemctl restart containerd
+```
+
+k3s를 설치하거나 이미 설치되어 있으면 재시작합니다.
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+sudo systemctl restart k3s
+```
+
+k3s containerd 설정에 NVIDIA runtime이 들어갔는지 확인합니다.
+
+```bash
+sudo grep nvidia /var/lib/rancher/k3s/agent/etc/containerd/config.toml
+```
+
+이 값이 보이지 않으면 Pod manifest를 고쳐도 GPU Pod가 안정적으로 뜨지 않습니다. 먼저 runtime 감지부터 해결해야 합니다.
+
+## 참고자료
+
+- [kind configuration](https://kind.sigs.k8s.io/docs/user/configuration/)
+- [K3s NVIDIA Container Runtime support](https://docs.k3s.io/advanced#nvidia-container-runtime-support)
+- [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)

--- a/computer_science/ai/vllm-local-gpu-kubernetes/docs/3-kubernetes-vllm-serving.md
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/docs/3-kubernetes-vllm-serving.md
@@ -1,0 +1,162 @@
+# k3s에서 vLLM Pod를 실행하고 API를 검증하는 방법
+
+## TL;DR
+
+k3s에서는 NVIDIA runtime, NVIDIA device plugin, vLLM Deployment가 순서대로 맞아야 합니다. Pod가 `runtimeClassName: nvidia`와 `nvidia.com/gpu: 1`을 요청하고, `/health`와 `/v1/chat/completions` 호출이 통과하면 기본 경로를 확인한 것입니다.
+
+## 왜 device plugin이 필요할까
+
+Kubernetes 스케줄러는 기본적으로 GPU가 몇 개인지 모릅니다. NVIDIA device plugin이 node의 GPU를 `nvidia.com/gpu` 리소스로 등록해야 Pod가 GPU를 요청할 수 있습니다.
+
+그럼 NVIDIA runtime만 있으면 충분할까요? 충분하지 않습니다. runtime은 컨테이너 안에 GPU 장치를 넣는 역할에 가깝고, device plugin은 Kubernetes가 스케줄링 가능한 GPU 리소스를 알게 하는 역할에 가깝습니다. **vLLM Pod가 뜨려면 두 조건이 같이 필요합니다.**
+
+## NVIDIA device plugin을 어떻게 설치할까
+
+NVIDIA device plugin DaemonSet을 설치합니다.
+
+```bash
+make k3s-device-plugin
+```
+
+device plugin Pod 상태를 확인합니다.
+
+```bash
+kubectl -n kube-system get pods -l name=nvidia-device-plugin-ds
+```
+
+node에 GPU 리소스가 잡혔는지 확인합니다.
+
+```bash
+kubectl describe node | grep -A5 "nvidia.com/gpu"
+```
+
+이 값이 보이지 않으면 vLLM Deployment를 적용해도 `Insufficient nvidia.com/gpu` 또는 runtime 관련 오류가 날 수 있습니다.
+
+## vLLM manifest는 무엇을 담고 있을까
+
+이 핸즈온의 manifest는 `manifests/k3s`에 있습니다.
+
+```text
+manifests/k3s/
+├── deployment.yaml
+├── kustomization.yaml
+├── namespace.yaml
+├── pvc.yaml
+└── service.yaml
+```
+
+중요한 부분은 Deployment입니다.
+
+```yaml
+runtimeClassName: nvidia
+containers:
+  - name: vllm
+    image: vllm/vllm-openai:latest
+    args:
+      - --model
+      - Qwen/Qwen3-0.6B
+    resources:
+      limits:
+        nvidia.com/gpu: "1"
+```
+
+`runtimeClassName: nvidia`는 k3s가 감지한 NVIDIA runtime을 명시적으로 사용하게 합니다. `nvidia.com/gpu: "1"`은 device plugin이 등록한 GPU 하나를 요청합니다.
+
+## 어떻게 배포할까
+
+manifest를 적용합니다.
+
+```bash
+make k3s-apply
+```
+
+Deployment rollout을 기다립니다.
+
+```bash
+make k3s-wait
+```
+
+로그를 확인합니다.
+
+```bash
+make k3s-logs
+```
+
+모델 다운로드 때문에 첫 시작은 시간이 걸릴 수 있습니다. `Application startup complete` 로그가 보이면 API 서버가 열린 상태입니다.
+
+## API는 어떻게 검증할까
+
+로컬에서 접근하기 위해 port-forward를 엽니다.
+
+```bash
+make k3s-port-forward
+```
+
+다른 터미널에서 health endpoint를 확인합니다.
+
+```bash
+curl -fsS http://localhost:8000/health
+```
+
+OpenAI 호환 chat completions API를 호출합니다.
+
+```bash
+curl -fsS http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [
+      {
+        "role": "user",
+        "content": "vLLM을 한 문장으로 설명해줘"
+      }
+    ],
+    "max_tokens": 64
+  }'
+```
+
+응답 JSON에 `choices`가 있으면 기본 검증은 통과입니다.
+
+## 토큰이 필요한 모델은 어떻게 다룰까
+
+gated model을 쓰면 Hugging Face token이 필요할 수 있습니다. 이 저장소에는 토큰을 넣지 않습니다.
+
+현재 셸의 `HF_TOKEN`으로 Kubernetes Secret을 만듭니다.
+
+```bash
+kubectl -n vllm-local create secret generic hf-token-secret \
+  --from-literal=token="$HF_TOKEN" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+```
+
+그리고 Deployment에 `HF_TOKEN` 환경변수를 추가합니다. 공개 모델 실습에서는 이 단계를 생략합니다.
+
+장점은 토큰이 Git에 남지 않는다는 점입니다. 단점은 클러스터 Secret은 여전히 운영자가 접근할 수 있으므로, 실제 운영에서는 Secret 관리 체계를 따로 잡아야 한다는 점입니다.
+
+## 문제가 생기면 어디부터 볼까
+
+Pod가 `Pending`이면 GPU 리소스 등록을 먼저 봅니다.
+
+```bash
+kubectl describe pod -n vllm-local -l app.kubernetes.io/name=vllm
+kubectl describe node | grep -A5 "nvidia.com/gpu"
+```
+
+Pod가 시작되지만 vLLM이 죽으면 로그를 봅니다.
+
+```bash
+kubectl -n vllm-local logs deployment/vllm-server
+```
+
+메모리 부족이면 더 작은 모델을 쓰거나 `--max-model-len`을 줄입니다. 정확한 GPU별 한계값은 확인 필요입니다.
+
+## 정리하면 무엇을 확인한 걸까
+
+정리하면, k3s vLLM 실습은 "Kubernetes에 YAML을 적용했다"보다 "GPU runtime, device plugin, Pod resource request, OpenAI 호환 API 호출이 한 줄로 이어졌다"를 확인하는 작업입니다. 이 흐름이 보이면 EKS나 GPU node pool로 옮길 때도 어느 레이어에서 문제가 나는지 나눠 볼 수 있습니다.
+
+## 참고자료
+
+- [vLLM Kubernetes deployment](https://docs.vllm.ai/en/latest/deployment/k8s/)
+- [K3s NVIDIA Container Runtime support](https://docs.k3s.io/advanced#nvidia-container-runtime-support)
+- [NVIDIA Kubernetes device plugin](https://github.com/NVIDIA/k8s-device-plugin)

--- a/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/deployment.yaml
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-server
+  namespace: vllm-local
+  labels:
+    app.kubernetes.io/name: vllm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vllm
+    spec:
+      runtimeClassName: nvidia
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: vllm-model-cache
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:latest
+          args:
+            - --model
+            - Qwen/Qwen3-0.6B
+            - --max-model-len
+            - "2048"
+            - --gpu-memory-utilization
+            - "0.85"
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            requests:
+              cpu: "2"
+              memory: 6Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "8"
+              memory: 16Gi
+              nvidia.com/gpu: "1"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /root/.cache/huggingface
+            - name: shm
+              mountPath: /dev/shm
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 120
+            periodSeconds: 10

--- a/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/kustomization.yaml
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml

--- a/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/namespace.yaml
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vllm-local

--- a/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/pvc.yaml
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-model-cache
+  namespace: vllm-local
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/service.yaml
+++ b/computer_science/ai/vllm-local-gpu-kubernetes/manifests/k3s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-server
+  namespace: vllm-local
+  labels:
+    app.kubernetes.io/name: vllm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: vllm
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http


### PR DESCRIPTION
## 어떤 문제를 해결 또는 공부하려 했는가

vLLM을 로컬 Linux GPU 서버에서 단일 컨테이너로 실행하고, 같은 흐름을 Kubernetes Pod로 옮기는 방법을 공부하려 했습니다. GPU 런타임, NVIDIA device plugin, OpenAI 호환 API 검증 순서를 재현 가능한 핸즈온으로 정리했습니다.

## 문제를 어떻게 해결 또는 공부했는가

Docker Compose로 vLLM 단일 컨테이너 실행 경로를 먼저 만들고, Kubernetes는 kind/k3d/k3s 선택지를 장단점으로 비교했습니다. 실제 GPU Pod 실습은 k3s와 NVIDIA runtime, NVIDIA device plugin, `nvidia.com/gpu` 요청을 기준으로 manifest를 작성했습니다.

## GitHub Issue (선택)

Issue #452

## 파일 디렉터리 구조

```text
computer_science/ai/vllm-local-gpu-kubernetes/
├── README.md                 # 링크 허브와 빠른 시작
├── Makefile                  # Docker Compose와 k3s 실습 명령
├── docker-compose.yml        # vLLM 단일 컨테이너 실행
├── docs/                     # 순서별 핸즈온 문서
└── manifests/k3s/            # k3s용 vLLM Deployment, Service, PVC
```