### PR TITLE
hprof-oom-analyzer 워크플로우 정리: macOS 빌드만 유지하고 액션과 의존성 최신화

### DIFF
--- a/.github/workflows/build-hprof-oom-analyzer.yml
+++ b/.github/workflows/build-hprof-oom-analyzer.yml
@@ -21,12 +21,14 @@ defaults:
     working-directory: product/hprof-oom-analyzer
 
 jobs:
+  # test는 PR 검증용으로만 실행한다. master merge 시에는 build만 실행한다.
   test:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -48,16 +50,16 @@ jobs:
           node dist/cli.js sample.hprof
 
   build:
-    needs: test
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -69,10 +71,7 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: hprof-oom-analyzer-${{ runner.os }}
-          path: |
-            product/hprof-oom-analyzer/release/*.AppImage
-            product/hprof-oom-analyzer/release/*.dmg
-            product/hprof-oom-analyzer/release/*.exe
+          path: product/hprof-oom-analyzer/release/*.dmg

--- a/product/hprof-oom-analyzer/package.json
+++ b/product/hprof-oom-analyzer/package.json
@@ -14,10 +14,10 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "electron": "^35.0.0",
-    "electron-builder": "^26.0.12",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "electron": "^43.0.0",
+    "electron-builder": "^26.15.3",
+    "typescript": "^5.9.0",
+    "vitest": "^4.0.0"
   },
   "build": {
     "appId": "dev.akbun.hprof-oom-analyzer",


### PR DESCRIPTION
## Goal

hprof-oom-analyzer 빌드 워크플로우에서 실패하는 windows 빌드를 정리하고, Node 20 deprecation warning과 npm deprecated warning으로 드러난 구버전을 최신화한다.

## 어떻게 해결했는가

- build 매트릭스에서 windows-latest, ubuntu-latest를 제거하고 macos-latest만 남겼다. windows 빌드는 저장소 안의 물음표가 들어간 파일 경로 때문에 checkout부터 실패하던 상태였다. upload-artifact 경로도 dmg만 남겼다.
- checkout, setup-node, upload-artifact 액션을 v7로 올려 Node 20 deprecation warning을 해결했다.
- test job은 pull_request에서만, build job은 master push와 수동 실행에서만 동작하게 분리했다. merge 시점의 test 중복 실행을 없앴다.
- electron 43, electron-builder 26.15, typescript 5.9, vitest 4로 devDependencies를 올리고 로컬에서 build, test 9건, CLI smoke test 통과를 확인했다. 남은 npm deprecated warning 4개는 최신 electron-builder의 전이 의존성이라 업스트림 해결 대상이다.

Issue #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)