### PR TITLE
hprof-oom-analyzer 빌드 deprecated warning 제거와 GitHub Release 자동화

### DIFF
--- a/.github/workflows/build-hprof-oom-analyzer.yml
+++ b/.github/workflows/build-hprof-oom-analyzer.yml
@@ -75,3 +75,59 @@ jobs:
         with:
           name: hprof-oom-analyzer-${{ runner.os }}
           path: product/hprof-oom-analyzer/release/*.dmg
+
+  release:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=hprof-oom-analyzer-$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check existing release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download build artifacts
+        if: steps.check.outputs.exists == 'false'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: hprof-oom-analyzer-*
+          path: product/hprof-oom-analyzer/release-assets
+          merge-multiple: true
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > release-notes.md <<'EOF'
+          hprof-oom-analyzer ${VERSION} 데스크톱 빌드. dmg(mac) 포함.
+
+          코드 서명이 없어 mac에서 처음 실행하면 "damaged and can't be opened" 오류가 난다. 앱 설치 후 아래 명령으로 quarantine 속성을 지우면 실행된다.
+
+          ```bash
+          xattr -cr /Applications/hprof-oom-analyzer.app
+          ```
+          EOF
+          sed -i "s/\${VERSION}/${{ steps.version.outputs.version }}/" release-notes.md
+          gh release create "${{ steps.version.outputs.tag }}" release-assets/* \
+            --target "${{ github.sha }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file release-notes.md
+>>>>>>> df77434 (hprof-oom-analyzer 빌드 정리: deprecated warning 제거와 GitHub Release 자동화)

--- a/.github/workflows/build-hprof-oom-analyzer.yml
+++ b/.github/workflows/build-hprof-oom-analyzer.yml
@@ -130,4 +130,3 @@ jobs:
             --target "${{ github.sha }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file release-notes.md
->>>>>>> df77434 (hprof-oom-analyzer 빌드 정리: deprecated warning 제거와 GitHub Release 자동화)

--- a/product/hprof-oom-analyzer/README.md
+++ b/product/hprof-oom-analyzer/README.md
@@ -28,7 +28,7 @@ JVM heap dump(hprof) 파일에서 OOM 원인을 찾는 데스크톱 도구다. E
 
 ## 실행
 
-의존성 설치 후 Electron 앱을 띄운다.
+Node.js 22.12 이상이 필요하다. electron-builder의 의존성인 @electron/get v3가 ESM 전용이라, npm 호이스팅 결과에 따라 electron 설치 스크립트가 이를 require()로 불러올 수 있는데 require(ESM)은 Node 22.12부터 지원된다. 의존성 설치 후 Electron 앱을 띄운다.
 
 ```bash
 cd product/hprof-oom-analyzer
@@ -55,10 +55,29 @@ npm test
 
 ## 빌드와 아티팩트
 
-GitHub Actions 워크플로우 build-hprof-oom-analyzer가 테스트와 CLI 스모크 테스트를 통과하면 ubuntu, macos, windows 3개 러너에서 electron-builder로 설치 파일(AppImage, dmg, nsis 인스톨러)을 빌드하고 OS별 아티팩트로 업로드한다. 로컬 빌드는 다음 명령을 쓴다.
+GitHub Actions 워크플로우 build-hprof-oom-analyzer가 PR에서는 테스트와 CLI 스모크 테스트를 실행하고, master push에서는 macos 러너에서 electron-builder로 dmg를 빌드해 아티팩트로 업로드한다. 이어서 release job이 package.json의 version을 읽어 hprof-oom-analyzer-{version} 태그로 GitHub Release를 만들고 dmg를 첨부한다. 같은 태그의 release가 이미 있으면 건너뛰므로, 새 release를 내려면 version을 올린다. 로컬 빌드는 다음 명령을 쓴다.
 
 ```bash
 npm run dist
+```
+
+## 트러블슈팅
+
+### mac에서 "damaged and can't be opened" 오류
+
+빌드 아티팩트는 코드 서명과 notarization이 없다. 인터넷에서 내려받은 파일에는 macOS가 quarantine 속성을 붙이는데, 서명 없는 앱에 quarantine이 붙어 있으면 Gatekeeper가 손상된 앱으로 취급한다. 앱 자체 문제가 아니므로 quarantine 속성을 지우면 실행된다.
+
+```bash
+xattr -cr /Applications/hprof-oom-analyzer.app
+```
+
+### npm start 시 ERR_REQUIRE_ESM 오류
+
+Node.js가 22.12 미만이면 electron 설치 스크립트가 ESM 전용인 @electron/get을 require()하다 실패할 수 있다. Node.js를 22.12 이상으로 올리고 node_modules를 지운 뒤 다시 설치한다.
+
+```bash
+rm -rf node_modules
+npm install
 ```
 
 ## 한계
@@ -67,4 +86,4 @@ npm run dist
 - shallow size의 객체/배열 헤더는 근사값(16/20바이트)이다. JVM 설정에 따라 실제와 다를 수 있다.
 - 64비트 객체 id를 number로 다루므로 2^53을 넘는 id는 정밀도를 잃는다. 실제 힙 주소 범위에서는 문제가 없다.
 - HotSpot JVM의 HPROF 1.0.2 형식만 지원한다. Android(ART) hprof는 지원하지 않는다.
-- 빌드 아티팩트는 코드 서명이 없다. mac/windows에서 처음 실행할 때 보안 경고를 지나야 한다.
+- 빌드 아티팩트는 코드 서명이 없다. mac/windows에서 처음 실행할 때 보안 경고를 지나야 한다. mac에서 손상된 앱으로 나오면 트러블슈팅 절을 참고한다.

--- a/product/hprof-oom-analyzer/knowledge/decisions/2026-07-npm-overrides-deprecated-deps.md
+++ b/product/hprof-oom-analyzer/knowledge/decisions/2026-07-npm-overrides-deprecated-deps.md
@@ -1,0 +1,19 @@
+---
+type: Decision
+title: deprecated transitive 의존성은 scoped overrides로 교체
+description: electron-builder가 끌어오는 glob 7(inflight 포함)과 rimraf 2를 npm overrides로 상위 패키지 아래에서만 최신 버전으로 교체한다.
+tags: [npm, electron-builder, ci]
+timestamp: 2026-07-19T00:00:00Z
+---
+
+## 결정
+
+package.json overrides에 @electron/asar 아래 glob을 ^13으로, temp 아래 rimraf를 ^6으로 교체한다. 전역 override가 아니라 상위 패키지를 지정한 scoped override를 쓴다.
+
+## 이유
+
+- npm install 때 deprecated warning(glob@7, inflight, rimraf@2)이 CI 로그를 오염시킨다. 상위 업그레이드로는 해결이 안 된다. app-builder-lib 최신도 @electron/asar 3.4.1을 고정하고, glob 13을 쓰는 asar v4는 ESM 전용이라 CJS인 app-builder-lib이 채택하지 못했다.
+- glob 13은 콜백 API가 없어 asar 3.x의 crawl 경로와 호환되지 않지만, electron-builder는 asar의 createPackageFromStreams만 호출하고 glob을 쓰는 crawl은 실행하지 않는 것을 코드로 확인했다. rimraf도 squirrel(Windows) 빌드 전용 경로라 nsis 타겟인 이 프로젝트에서 실행되지 않는다.
+- 실행되지 않는 코드 경로만 교체하므로 안전하다. npm install, build, test, dist(dmg 패키징)까지 로컬에서 재현해 검증했다.
+- boolean@3.2.0 warning은 남는다. 모든 버전이 deprecated라 override로 제거할 수 없고, @electron/get이 global-agent 의존을 버려야 사라진다.
+- 대가: electron-builder가 언젠가 asar의 glob 경로를 실행하도록 바뀌면 override가 런타임 오류를 낸다. electron-builder를 올릴 때 dist까지 돌려 확인해야 한다.

--- a/product/hprof-oom-analyzer/knowledge/decisions/2026-07-unsigned-mac-distribution.md
+++ b/product/hprof-oom-analyzer/knowledge/decisions/2026-07-unsigned-mac-distribution.md
@@ -1,0 +1,18 @@
+---
+type: Decision
+title: mac 배포는 서명 없이 xattr 안내로 대응
+description: 코드 서명과 notarization 없이 GitHub Release로 배포하고, Gatekeeper의 damaged 오류는 release notes의 xattr 안내로 해결한다.
+tags: [macos, electron-builder, release]
+timestamp: 2026-07-19T00:00:00Z
+---
+
+## 결정
+
+CI 빌드는 코드 서명 없이 배포한다. mac에서 나는 "damaged and can't be opened" 오류는 release notes와 README 트러블슈팅에 xattr -cr 안내를 넣어 대응한다.
+
+## 이유
+
+- 서명 없는 앱에 macOS quarantine 속성이 붙으면 Gatekeeper가 손상된 앱으로 표시한다. 앱 자체 문제가 아니라 xattr -cr로 quarantine을 지우면 실행된다.
+- 근본 해결은 Developer ID 서명 + notarization인데 둘 다 Apple Developer Program(연 99달러) 가입이 전제다. 학습용 개인 도구에는 비용 대비 과하다.
+- ad-hoc 서명(무료)은 인터넷에서 내려받은 앱의 quarantine 검사를 통과하지 못해 배포용 우회가 되지 않는다.
+- 실제 배포 제품으로 키우면 그때 가입한다. electron-builder가 CSC_LINK, CSC_KEY_PASSWORD와 mac.notarize 설정으로 서명·notarization 자동화를 지원하므로 워크플로우 변경 부담은 작다.

--- a/product/hprof-oom-analyzer/knowledge/decisions/index.md
+++ b/product/hprof-oom-analyzer/knowledge/decisions/index.md
@@ -7,3 +7,5 @@
 * [TypeScript + Electron 전환](2026-07-electron-typescript-rewrite.md) - Python/Tkinter 구현을 TypeScript + Electron으로 다시 만든 결정.
 * [retained size는 클래스 제거 근사로 계산](2026-07-retained-size-approximation.md) - dominator tree 대신 도달 가능 바이트 감소량으로 근사한 결정.
 * [renderer는 모듈 없는 스크립트로 작성](2026-07-renderer-script-without-modules.md) - 렌더러 코드를 import/export 없이 module: none으로 컴파일하는 결정.
+* [deprecated transitive 의존성은 scoped overrides로 교체](2026-07-npm-overrides-deprecated-deps.md) - electron-builder가 끌어오는 glob 7, rimraf 2를 실행되지 않는 경로만 골라 교체한 결정.
+* [mac 배포는 서명 없이 xattr 안내로 대응](2026-07-unsigned-mac-distribution.md) - notarization 대신 release notes의 xattr 안내로 Gatekeeper 오류에 대응한 결정.

--- a/product/hprof-oom-analyzer/knowledge/log.md
+++ b/product/hprof-oom-analyzer/knowledge/log.md
@@ -1,5 +1,10 @@
 # Knowledge Update Log
 
+## 2026-07-19
+
+* **Creation**: [deprecated transitive 의존성은 scoped overrides로 교체](decisions/2026-07-npm-overrides-deprecated-deps.md) 결정 기록.
+* **Creation**: [mac 배포는 서명 없이 xattr 안내로 대응](decisions/2026-07-unsigned-mac-distribution.md) 결정 기록.
+
 ## 2026-07-18
 
 * **Initialization**: hprof-oom-analyzer 프로젝트 지식 번들 생성.

--- a/product/hprof-oom-analyzer/package.json
+++ b/product/hprof-oom-analyzer/package.json
@@ -4,6 +4,9 @@
   "description": "JVM heap dump(hprof) OOM 분석 데스크톱 도구",
   "main": "dist/main/main.js",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.renderer.json",
     "start": "npm run build && electron .",
@@ -11,6 +14,14 @@
     "report": "node dist/cli.js",
     "make-sample": "node dist/tools/make-sample.js",
     "dist": "npm run build && electron-builder --publish never"
+  },
+  "overrides": {
+    "@electron/asar": {
+      "glob": "^13.0.2"
+    },
+    "temp": {
+      "rimraf": "^6.0.1"
+    }
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Goal

hprof-oom-analyzer CI의 install dependencies 단계에서 나오는 npm deprecated warning(rimraf 2, inflight, glob 7)을 제거한다. 빌드 산출물을 아티팩트로만 두지 않고 release-tistory-skin과 같은 방식으로 GitHub Release로 배포한다.

## 어떻게 해결했는가

- package.json에 scoped overrides를 추가해 @electron/asar 아래 glob을 13으로, temp 아래 rimraf를 6으로 교체했다. electron-builder는 asar의 createPackageFromStreams만 호출하고 glob을 쓰는 crawl 경로를 실행하지 않으며, rimraf는 squirrel(Windows) 빌드 전용 경로라 실행되지 않음을 확인했다.
- 로컬에서 install, build, test, dist(dmg 패키징)까지 CI와 동일하게 재현해 warning 제거와 빌드 정상 동작을 검증했다.
- 워크플로우에 release job을 추가했다. master push 시 package.json version으로 태그를 만들고, macos 빌드 아티팩트인 dmg를 내려받아 Release에 첨부한다. 같은 태그가 있으면 건너뛴다. PR 527에서 빌드가 macOS 전용으로 바뀌어 release 대상도 dmg 하나다.
- 서명 없는 mac 앱의 damaged 오류 해결 명령(xattr)을 release notes와 README 트러블슈팅에 문서화했다.
- ESM 전용 @electron/get v3 때문에 Node 22.12 미만에서 설치가 깨질 수 있어 engines를 명시하고 README에 기록했다.
- 의사결정 2건(overrides 교체, 서명 없는 mac 배포)을 knowledge/decisions에 기록했다.

Issue #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)