### PR TITLE
workspace 초기화 시 master 최신화 규칙 추가

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -2,6 +2,19 @@
 
 GitHub 생태계 안에서 작업한다. 글쓰기 원칙은 [philosophy.md](./philosophy.md)를 따른다.
 
+## Workspace 초기화
+
+worktree나 branch를 만드는 등 새 workspace에서 작업을 시작할 때, 가장 먼저 master를 최신화한다. 모든 작업이 최신 master 위에서 시작하도록 하기 위함이다.
+
+master 최신화 절차:
+
+```bash
+git pull origin master --rebase
+```
+
+- conflict가 발생하면 해결하고 rebase를 완료한 뒤 작업을 시작한다.
+- 이 최신화는 workspace 초기화 작업이므로 실행 승인 없이 수행한다.
+
 ## 실행 승인
 
 git commit, push, PR 생성, Issue 생성은 사용자가 명시적으로 지시할 때만 실행한다. agent는 구현과 검증까지만 하고 멈춘 뒤 변경 요약을 보고하고 지시를 기다린다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,6 @@ Claude Code에서 plugin 설치:
 
 ## 작업 흐름
 
-Worktree에서 작업하고 commit 1개로 PR을 만든다. PR을 만들 때 기록용 GitHub Issue를 함께 만들어 연결한다.
+Worktree나 branch를 만들어 workspace를 초기화할 때 가장 먼저 master를 최신화한다(git pull origin master --rebase, conflict 해결 포함). Worktree에서 작업하고 commit 1개로 PR을 만든다. PR을 만들 때 기록용 GitHub Issue를 함께 만들어 연결한다.
 
 **git commit, push, PR 생성, Issue 생성은 사용자가 명시적으로 지시할 때만 실행한다.** agent는 구현과 검증까지만 하고 멈춘 뒤 변경 요약을 보고한다. plan 승인이나 이 문서의 표준 흐름은 실행 허가가 아니다. 자세한 규칙은 [.claude/rules/workflow.md](./.claude/rules/workflow.md)를 따른다.


### PR DESCRIPTION
## Goal

AI agent가 worktree나 branch를 만들어 workspace를 초기화할 때 오래된 master 위에서 작업을 시작하는 문제를 막는다. 초기화 시점에 master를 먼저 최신화하는 규칙을 agent 문서에 추가한다.

## 어떻게 해결했는가

- .claude/rules/workflow.md 맨 앞에 Workspace 초기화 섹션을 추가했다. git pull origin master --rebase로 master를 최신화하고 conflict를 해결한 뒤 작업을 시작하도록 했다.
- 이 최신화는 workspace 준비 작업이므로 commit, push 등의 실행 승인 규칙과 별개로 승인 없이 수행한다고 명시했다.
- AGENTS.md 작업 흐름 절 첫 문장에 초기화 시 master 최신화를 먼저 한다는 요약을 추가하고 세부 절차는 workflow.md에 위임했다.

Issue #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
