### PR TITLE
akbun-shadowing-player 릴리스를 빌드 성공 뒤 tag, tag 뒤 release 순서로 정리

### DIFF
--- a/.github/workflows/release-akbun-shadowing-player.yml
+++ b/.github/workflows/release-akbun-shadowing-player.yml
@@ -44,27 +44,28 @@ jobs:
       - name: Compile TypeScript and run tests
         run: npm test
 
-  # 가장 최근 tag의 마이너 버전을 +1 해서 새 tag와 release를 만든다.
+  # macOS 전용 빌드. dmg 빌드가 성공해야 tag를 만들고, tag가 만들어져야 release를 만든다.
+  # 가장 최근 tag의 마이너 버전을 +1 해서 새 버전을 정한다.
   # 예전 prefix(shadowing-player-v*)의 tag도 이전 버전으로 인정한다.
-  tag:
+  release:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: write
-    outputs:
-      tag: ${{ steps.version.outputs.tag }}
-      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
 
       - name: Compute next version (previous minor +1)
         id: version
         working-directory: .
         run: |
-          latest=$(git ls-remote --tags origin \
-              'refs/tags/akbun-shadowing-player-v*' 'refs/tags/shadowing-player-v*' \
-            | sed 's|.*refs/tags/||' \
-            | grep -E '\-v[0-9]+\.[0-9]+\.[0-9]+$' \
+          latest=$(git tag --list 'akbun-shadowing-player-v*' 'shadowing-player-v*' \
             | sed 's|.*-v||' \
             | sort -V | tail -1)
           if [ -z "$latest" ]; then
@@ -78,56 +79,40 @@ jobs:
           echo "tag=akbun-shadowing-player-v$version" >> "$GITHUB_OUTPUT"
           echo "Previous: ${latest:-none}, next: $version"
 
-      - name: Create tag and release
-        working-directory: .
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
-        run: |
-          cat > release-notes.md <<'EOF'
-          언어 공부(쉐도잉)용 구간 반복 오디오 플레이어 macOS 빌드. dmg(arm64, x64) 포함.
-
-          코드 서명이 없어 처음 실행하면 "damaged and can't be opened" 오류가 난다. 앱 설치 후 아래 명령으로 quarantine 속성을 지우면 실행된다.
-
-          ```bash
-          xattr -cr /Applications/akbun-shadowing-player.app
-          ```
-          EOF
-          gh release create "$TAG" \
-            --target "$GITHUB_SHA" \
-            --title "$TAG" \
-            --notes-file release-notes.md
-
-  # macOS 전용 빌드. tag job이 계산한 버전으로 dmg를 만들어 release에 업로드한다.
-  build:
-    needs: tag
-    runs-on: macos-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: '24'
-
       - name: Install dependencies
         run: npm install
 
       - name: Set package version to release version
-        run: npm version "${{ needs.tag.outputs.version }}" --no-git-tag-version
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Build dmg
         run: npm run dist
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
-      - name: Upload dmg to release
+      # 빌드가 성공한 뒤에만 tag를 만든다.
+      - name: Create tag
+        working-directory: .
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      # tag 생성이 성공한 뒤에만 release를 만든다.
+      - name: Create release with dmg
         working-directory: .
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.tag.outputs.tag }}
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
-          gh release upload "$TAG" \
-            product/akbun-shadowing-player/release/*.dmg \
-            --clobber
+          cat > release-notes.md <<'EOF'
+          - 언어 공부(쉐도잉)용 구간 반복 오디오 플레이어 macOS 빌드다.
+          - dmg는 Apple Silicon(arm64) 전용이다.
+          - 코드 서명이 없어 처음 실행하면 "damaged and can't be opened" 오류가 난다.
+          - 설치 후 `xattr -cr /Applications/akbun-shadowing-player.app`로 quarantine 속성을 지우면 실행된다.
+          EOF
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            product/akbun-shadowing-player/release/*.dmg

--- a/.github/workflows/release-akbun-shadowing-player.yml
+++ b/.github/workflows/release-akbun-shadowing-player.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - master
+    # workflow 파일만 바뀐 경우는 빌드할 이유가 없으므로 트리거에서 뺀다.
     paths:
       - 'product/akbun-shadowing-player/**'
-      - '.github/workflows/release-akbun-shadowing-player.yml'
   pull_request:
+    # workflow 파일만 바뀐 경우는 빌드할 이유가 없으므로 트리거에서 뺀다.
     paths:
       - 'product/akbun-shadowing-player/**'
-      - '.github/workflows/release-akbun-shadowing-player.yml'
   workflow_dispatch:
 
 permissions:

--- a/knowledge/decisions/2026-07-build-before-tag-and-release.md
+++ b/knowledge/decisions/2026-07-build-before-tag-and-release.md
@@ -1,0 +1,23 @@
+---
+type: Decision
+title: 릴리스는 빌드 성공 뒤에 tag, tag 뒤에 release
+description: 빌드 결과물이 나온 뒤에만 tag를 만들고, tag가 만들어진 뒤에만 release를 만든다.
+tags: [github-actions, electron, release]
+timestamp: 2026-07-25T00:00:00Z
+---
+
+## 결정
+
+product 릴리스 workflow는 빌드 -> tag -> release 순서를 지킨다.
+
+* 빌드 job이 성공해야 tag를 만든다.
+* tag push가 성공해야 release를 만든다.
+* artifact를 job 사이로 넘기지 않도록 세 단계를 한 job 안의 연속된 step으로 둔다.
+
+## 이유
+
+akbun-shadowing-player workflow는 tag job이 tag와 release를 먼저 만들고 build job이 뒤에서 dmg를 업로드했다. 빌드가 실패하면 첨부 파일 없는 release와 그 release에 딸린 tag가 저장소에 남았고, 다음 실행은 그 tag를 이전 버전으로 인정해 버전만 올라갔다.
+
+세 단계를 한 job의 step으로 두면 실패 시 뒤 단계가 자동으로 멈춘다. 별도 job으로 나누면 dmg를 upload-artifact와 download-artifact로 주고받아야 하는데, 얻는 것 없이 단계만 늘어난다. akbun-gitdesktop 릴리스 workflow가 이미 같은 구조다.
+
+관련 결정: [릴리스 버전은 태그에서 계산한다](2026-07-release-version-from-tags.md), [Electron 릴리스 빌드는 macOS만](2026-07-electron-release-macos-only.md)

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -10,3 +10,4 @@
 * [ElastiCache는 Valkey + RBAC/IAM 기본](2026-07-elasticache-valkey-rbac.md) - ElastiCache를 Redis 대신 Valkey로, AUTH token 단독 대신 RBAC/IAM 인증으로 만드는 결정.
 * [Electron 릴리스 빌드는 macOS만](2026-07-electron-release-macos-only.md) - Windows 러너의 checkout 실패와 수요 부재로 릴리스 workflow를 macOS 빌드만 유지하는 결정.
 * [릴리스 버전은 태그에서 계산한다](2026-07-release-version-from-tags.md) - 기존 태그의 patch를 +1 해서 매 실행마다 새 릴리스를 만드는 결정.
+* [릴리스는 빌드 성공 뒤에 tag, tag 뒤에 release](2026-07-build-before-tag-and-release.md) - 빌드가 실패해도 빈 release가 남던 문제를 순서로 막는 결정.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -4,6 +4,7 @@
 
 * **Creation**: [Electron 릴리스 빌드는 macOS만](decisions/2026-07-electron-release-macos-only.md) 결정 기록. akbun-gitdesktop 릴리스 workflow의 Windows checkout 실패 수정과 함께 남긴다.
 * **Creation**: [릴리스 버전은 태그에서 계산한다](decisions/2026-07-release-version-from-tags.md) 결정 기록. akbun-gitdesktop 릴리스 workflow를 태그 기반 patch 자동 증가로 바꾸면서 남긴다.
+* **Creation**: [릴리스는 빌드 성공 뒤에 tag, tag 뒤에 release](decisions/2026-07-build-before-tag-and-release.md) 결정 기록. akbun-shadowing-player 릴리스 workflow의 job 순서를 바꾸면서 남긴다.
 
 ## 2026-07-11
 

--- a/product/akbun-shadowing-player/AGENTS.md
+++ b/product/akbun-shadowing-player/AGENTS.md
@@ -61,8 +61,9 @@ test/에 node:test로 도는 검증이 있다. 프레임워크를 넣지 않고 
 .github/workflows/release-akbun-shadowing-player.yml이 담당한다.
 
 - PR: ubuntu에서 npm test로 tsc 컴파일과 테스트를 검증한다 (electron 바이너리 다운로드 생략).
-- master push: 기존 tag 중 가장 최근 버전의 마이너를 +1 한 akbun-shadowing-player-v{버전} tag와 GitHub Release를 만들고, macos-latest에서 dmg(arm64, x64)를 빌드해 release에 업로드한다. 예전 prefix(shadowing-player-v*)의 tag도 이전 버전으로 인정한다.
-- 버전은 tag에서 자동 계산하므로 package.json의 version은 릴리스에 쓰지 않는다. 빌드 job이 npm version으로 계산된 버전을 주입해 dmg 파일명에 반영한다.
+- master push: macos-latest에서 dmg(arm64)를 빌드하고, 빌드가 성공하면 기존 tag 중 가장 최근 버전의 마이너를 +1 한 akbun-shadowing-player-v{버전} tag를 만들고, tag push가 성공하면 dmg를 첨부한 GitHub Release를 만든다. 예전 prefix(shadowing-player-v*)의 tag도 이전 버전으로 인정한다.
+- 빌드 -> tag -> release 순서는 빌드가 실패했을 때 빈 release가 남지 않게 하려는 것이다. [ADR](../../knowledge/decisions/2026-07-build-before-tag-and-release.md) 참조.
+- 버전은 tag에서 자동 계산하므로 package.json의 version은 릴리스에 쓰지 않는다. 빌드 전에 npm version으로 계산된 버전을 주입해 dmg 파일명에 반영한다.
 
 ## 주의사항
 

--- a/product/akbun-shadowing-player/package.json
+++ b/product/akbun-shadowing-player/package.json
@@ -37,8 +37,7 @@
         {
           "target": "dmg",
           "arch": [
-            "arm64",
-            "x64"
+            "arm64"
           ]
         }
       ],


### PR DESCRIPTION
## Goal

akbun-shadowing-player 릴리스 workflow는 tag와 release를 먼저 만들고 dmg를 나중에 올려서, 빌드가 실패하면 첨부 파일 없는 release가 남았다. 빌드가 성공한 뒤에만 tag와 release를 만들도록 순서를 바꾼다.

## 어떻게 해결했는가

- 릴리스 workflow의 tag job과 build job을 한 job으로 합치고, 빌드 -> tag 생성 -> release 생성 순서의 step으로 재배치했다. 앞 단계가 실패하면 뒤 단계가 자동으로 멈춘다.
- job을 나누지 않아 dmg를 artifact로 주고받을 필요가 없어졌다. akbun-gitdesktop 릴리스 workflow와 같은 구조다.
- 버전 계산을 git ls-remote 대신 fetch-depth 0과 git tag --list로 바꿨다. 같은 job에서 tag를 만들기 때문에 로컬에 전체 tag가 필요하다.
- release note를 한 문장씩의 리스트로 직접 작성했다. 빌드 산출물의 특성과 quarantine 해제 방법을 담는다.
- macOS 빌드를 arm64 하나로 줄였다.
- workflow 파일 자신을 트리거 paths에서 뺐다. workflow만 바뀐 경우 빌드와 릴리스를 돌릴 이유가 없다.
- 라이브러리 업그레이드는 하지 않았다. 직접 의존성 electron, electron-builder, typescript, types/node는 모두 최신이고, npm install의 deprecated 경고는 electron-builder 내부 트리에서 나온다. glob은 메이저 업그레이드에서 API가 바뀌었고 boolean은 3.2.0이 마지막 버전이라 overrides로 강제하면 빌드가 깨진다.
- 의사결정은 knowledge/decisions에 기록하고 AGENTS.md의 릴리스 설명을 갱신했다.

Issue #547
