### PR TITLE
akbun-shadowing-player 홈 화면에 폴더 레이아웃, 파일 존재 검사, 새로고침 추가

### DIFF
--- a/product/akbun-shadowing-player/src/main/library.ts
+++ b/product/akbun-shadowing-player/src/main/library.ts
@@ -8,6 +8,8 @@ export interface LibraryItem {
   name: string;
   durationSec: number | null;
   addedAt: string;
+  /** 폴더 불러오기로 들어온 파일만 가진다. 홈 화면에서 폴더 단위로 묶는 기준이다. */
+  folder?: string;
 }
 
 export class Library {
@@ -32,8 +34,8 @@ export class Library {
     return this.items.some((item) => item.path === filePath);
   }
 
-  /** 새 파일 경로들을 추가한다. 이미 있는 경로는 건너뛴다. */
-  add(filePaths: string[]): LibraryItem[] {
+  /** 새 파일 경로들을 추가한다. 이미 있는 경로는 건너뛴다. folder를 주면 폴더 소속으로 묶는다. */
+  add(filePaths: string[], folder?: string): LibraryItem[] {
     const known = new Set(this.items.map((item) => item.path));
     for (const filePath of filePaths) {
       if (known.has(filePath)) continue;
@@ -42,9 +44,25 @@ export class Library {
         name: path.basename(filePath),
         durationSec: null,
         addedAt: new Date().toISOString(),
+        ...(folder ? { folder } : {}),
       });
     }
     this.save();
+    return this.items;
+  }
+
+  /** 목록에는 있지만 디스크에서 사라진 파일인지. */
+  missing(filePath: string): boolean {
+    return !fs.existsSync(filePath);
+  }
+
+  /** 디스크에서 사라진 파일을 목록에서 지운다. */
+  prune(): LibraryItem[] {
+    const remaining = this.items.filter((item) => !this.missing(item.path));
+    if (remaining.length !== this.items.length) {
+      this.items = remaining;
+      this.save();
+    }
     return this.items;
   }
 

--- a/product/akbun-shadowing-player/src/main/library.ts
+++ b/product/akbun-shadowing-player/src/main/library.ts
@@ -72,6 +72,13 @@ export class Library {
     return this.items;
   }
 
+  /** 폴더 한 칸을 통째로 지운다. 같은 폴더 소속 항목만 사라진다. */
+  removeFolder(folder: string): LibraryItem[] {
+    this.items = this.items.filter((item) => item.folder !== folder);
+    this.save();
+    return this.items;
+  }
+
   setDuration(filePath: string, durationSec: number): void {
     const item = this.items.find((entry) => entry.path === filePath);
     if (!item) return;

--- a/product/akbun-shadowing-player/src/main/main.ts
+++ b/product/akbun-shadowing-player/src/main/main.ts
@@ -172,9 +172,22 @@ function registerIpc(): void {
       properties: ["openDirectory"],
     });
     if (result.canceled) return library.list();
-    const files = (await Promise.all(result.filePaths.map(scanAudioFiles))).flat();
-    logger.info("main", `폴더에서 음성 파일 ${files.length}개 발견`);
-    return library.add(files);
+    for (const folder of result.filePaths) {
+      const files = await scanAudioFiles(folder);
+      logger.info("main", `폴더 ${folder}에서 음성 파일 ${files.length}개 발견`);
+      library.add(files, folder);
+    }
+    return library.list();
+  });
+
+  // 홈 화면 새로고침. 사라진 파일을 목록에서 지운다.
+  ipcMain.handle("library:refresh", () => {
+    const before = library.list().length;
+    const items = library.prune();
+    if (items.length !== before) {
+      logger.info("main", `새로고침: 사라진 파일 ${before - items.length}개를 목록에서 지웠다`);
+    }
+    return items;
   });
 
   ipcMain.handle("library:remove", (_event, filePath: string) => library.remove(filePath));
@@ -203,6 +216,12 @@ function registerIpc(): void {
     if (!library.has(filePath)) {
       logger.error("main", `목록에 없는 파일 읽기 거부: ${filePath}`);
       throw new Error("목록에 없는 파일은 읽을 수 없다");
+    }
+    // 파일이 사라졌으면 읽기 전에 목록에서도 지운다. 홈으로 돌아가면 사라진 항목이 보이지 않는다.
+    if (library.missing(filePath)) {
+      logger.error("main", `파일이 사라져 목록에서 지운다: ${filePath}`);
+      library.remove(filePath);
+      throw new Error("파일이 없다");
     }
     try {
       return await fs.readFile(filePath);

--- a/product/akbun-shadowing-player/src/main/main.ts
+++ b/product/akbun-shadowing-player/src/main/main.ts
@@ -172,8 +172,11 @@ function registerIpc(): void {
       properties: ["openDirectory"],
     });
     if (result.canceled) return library.list();
-    for (const folder of result.filePaths) {
-      const files = await scanAudioFiles(folder);
+    // 스캔은 폴더별로 함께 돌리고, 목록에는 어느 폴더에서 왔는지 남겨 묶는다.
+    const scanned = await Promise.all(
+      result.filePaths.map(async (folder) => ({ folder, files: await scanAudioFiles(folder) })),
+    );
+    for (const { folder, files } of scanned) {
       logger.info("main", `폴더 ${folder}에서 음성 파일 ${files.length}개 발견`);
       library.add(files, folder);
     }

--- a/product/akbun-shadowing-player/src/main/main.ts
+++ b/product/akbun-shadowing-player/src/main/main.ts
@@ -192,6 +192,8 @@ function registerIpc(): void {
 
   ipcMain.handle("library:remove", (_event, filePath: string) => library.remove(filePath));
 
+  ipcMain.handle("library:remove-folder", (_event, folder: string) => library.removeFolder(folder));
+
   ipcMain.handle("library:set-duration", (_event, filePath: string, durationSec: number) => {
     library.setDuration(filePath, durationSec);
   });

--- a/product/akbun-shadowing-player/src/main/preload.ts
+++ b/product/akbun-shadowing-player/src/main/preload.ts
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld("api", {
   addFiles: () => ipcRenderer.invoke("library:add"),
   addFolder: () => ipcRenderer.invoke("library:add-folder"),
   removeFile: (path: string) => ipcRenderer.invoke("library:remove", path),
+  removeFolder: (folder: string) => ipcRenderer.invoke("library:remove-folder", folder),
   refreshLibrary: () => ipcRenderer.invoke("library:refresh"),
   setDuration: (path: string, durationSec: number) =>
     ipcRenderer.invoke("library:set-duration", path, durationSec),

--- a/product/akbun-shadowing-player/src/main/preload.ts
+++ b/product/akbun-shadowing-player/src/main/preload.ts
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld("api", {
   addFiles: () => ipcRenderer.invoke("library:add"),
   addFolder: () => ipcRenderer.invoke("library:add-folder"),
   removeFile: (path: string) => ipcRenderer.invoke("library:remove", path),
+  refreshLibrary: () => ipcRenderer.invoke("library:refresh"),
   setDuration: (path: string, durationSec: number) =>
     ipcRenderer.invoke("library:set-duration", path, durationSec),
   readAudio: (path: string) => ipcRenderer.invoke("audio:read", path),

--- a/product/akbun-shadowing-player/src/renderer/api.d.ts
+++ b/product/akbun-shadowing-player/src/renderer/api.d.ts
@@ -20,6 +20,7 @@ interface Window {
     addFiles(): Promise<LibraryItem[]>;
     addFolder(): Promise<LibraryItem[]>;
     removeFile(path: string): Promise<LibraryItem[]>;
+    removeFolder(folder: string): Promise<LibraryItem[]>;
     refreshLibrary(): Promise<LibraryItem[]>;
     setDuration(path: string, durationSec: number): Promise<void>;
     readAudio(path: string): Promise<Uint8Array<ArrayBuffer>>;

--- a/product/akbun-shadowing-player/src/renderer/api.d.ts
+++ b/product/akbun-shadowing-player/src/renderer/api.d.ts
@@ -5,6 +5,7 @@ interface LibraryItem {
   name: string;
   durationSec: number | null;
   addedAt: string;
+  folder?: string;
 }
 
 interface AppInfo {
@@ -19,6 +20,7 @@ interface Window {
     addFiles(): Promise<LibraryItem[]>;
     addFolder(): Promise<LibraryItem[]>;
     removeFile(path: string): Promise<LibraryItem[]>;
+    refreshLibrary(): Promise<LibraryItem[]>;
     setDuration(path: string, durationSec: number): Promise<void>;
     readAudio(path: string): Promise<Uint8Array<ArrayBuffer>>;
     appInfo(): Promise<AppInfo>;

--- a/product/akbun-shadowing-player/src/renderer/renderer.ts
+++ b/product/akbun-shadowing-player/src/renderer/renderer.ts
@@ -65,9 +65,45 @@ async function refreshLibrary(items?: LibraryItem[]): Promise<void> {
   const library = items ?? (await window.api.listLibrary());
   fileList.innerHTML = "";
   emptyHint.hidden = library.length > 0;
+
+  // 폴더로 불러온 파일은 폴더 아래에 묶고, 파일로 불러온 것은 그대로 한 줄씩 놓는다.
+  const folders = new Map<string, HTMLUListElement>();
   for (const item of library) {
-    fileList.appendChild(buildFileRow(item));
+    if (item.folder === undefined) {
+      fileList.appendChild(buildFileRow(item));
+      continue;
+    }
+    let children = folders.get(item.folder);
+    if (!children) {
+      children = buildFolderGroup(item.folder);
+      folders.set(item.folder, children);
+    }
+    children.appendChild(buildFileRow(item));
   }
+}
+
+/** 폴더 한 칸을 만들어 목록에 붙이고, 하위 파일을 담을 ul을 돌려준다. */
+function buildFolderGroup(folder: string): HTMLUListElement {
+  const group = document.createElement("li");
+  group.className = "folder-group";
+
+  const header = document.createElement("div");
+  header.className = "folder-header";
+  const icon = document.createElement("span");
+  icon.textContent = "📁";
+  const name = document.createElement("span");
+  name.className = "folder-name";
+  name.textContent = folder.split("/").pop() || folder;
+  const pathLabel = document.createElement("span");
+  pathLabel.className = "file-meta";
+  pathLabel.textContent = folder;
+  header.append(icon, name, pathLabel);
+
+  const children = document.createElement("ul");
+  children.className = "folder-children";
+  group.append(header, children);
+  fileList.appendChild(group);
+  return children;
 }
 
 function buildFileRow(item: LibraryItem): HTMLLIElement {
@@ -110,6 +146,10 @@ document.getElementById("add-files")!.addEventListener("click", async () => {
 
 document.getElementById("add-folder")!.addEventListener("click", async () => {
   await refreshLibrary(await window.api.addFolder());
+});
+
+document.getElementById("refresh-library")!.addEventListener("click", async () => {
+  await refreshLibrary(await window.api.refreshLibrary());
 });
 
 // ---------- 설정 화면 ----------

--- a/product/akbun-shadowing-player/src/renderer/renderer.ts
+++ b/product/akbun-shadowing-player/src/renderer/renderer.ts
@@ -97,7 +97,8 @@ function buildFolderGroup(folder: string): HTMLUListElement {
   header.className = "folder-header";
   const name = document.createElement("span");
   name.className = "folder-name";
-  name.textContent = `📁 ${folder.split("/").pop() || folder}`;
+  // 렌더러에는 path 모듈이 없다. 구분자를 둘 다 나눠 OS와 상관없이 마지막 이름만 보여준다.
+  name.textContent = `📁 ${folder.split(/[\\/]/).pop() || folder}`;
   const pathLabel = document.createElement("span");
   pathLabel.className = "file-meta";
   pathLabel.textContent = folder;

--- a/product/akbun-shadowing-player/src/renderer/renderer.ts
+++ b/product/akbun-shadowing-player/src/renderer/renderer.ts
@@ -82,26 +82,43 @@ async function refreshLibrary(items?: LibraryItem[]): Promise<void> {
   }
 }
 
-/** 폴더 한 칸을 만들어 목록에 붙이고, 하위 파일을 담을 ul을 돌려준다. */
+/**
+ * 폴더 한 칸을 만들어 목록에 붙이고, 하위 파일을 담을 ul을 돌려준다.
+ * 접기와 펼치기는 details/summary가 스스로 하므로 따로 다루지 않는다.
+ */
 function buildFolderGroup(folder: string): HTMLUListElement {
   const group = document.createElement("li");
   group.className = "folder-group";
 
-  const header = document.createElement("div");
+  const details = document.createElement("details");
+  details.open = true;
+
+  const header = document.createElement("summary");
   header.className = "folder-header";
-  const icon = document.createElement("span");
-  icon.textContent = "📁";
   const name = document.createElement("span");
   name.className = "folder-name";
-  name.textContent = folder.split("/").pop() || folder;
+  name.textContent = `📁 ${folder.split("/").pop() || folder}`;
   const pathLabel = document.createElement("span");
   pathLabel.className = "file-meta";
   pathLabel.textContent = folder;
-  header.append(icon, name, pathLabel);
+
+  const removeButton = document.createElement("button");
+  removeButton.className = "file-remove";
+  removeButton.textContent = "폴더 삭제";
+  removeButton.addEventListener("click", async (event) => {
+    // summary 안의 클릭은 접기/펼치기까지 일으키므로 막는다.
+    event.preventDefault();
+    event.stopPropagation();
+    if (!confirm(`${folder}\n\n이 폴더의 파일을 목록에서 모두 지운다. 실제 파일은 남는다.`)) return;
+    await refreshLibrary(await window.api.removeFolder(folder));
+  });
+
+  header.append(name, pathLabel, removeButton);
 
   const children = document.createElement("ul");
   children.className = "folder-children";
-  group.append(header, children);
+  details.append(header, children);
+  group.appendChild(details);
   fileList.appendChild(group);
   return children;
 }

--- a/product/akbun-shadowing-player/static/index.html
+++ b/product/akbun-shadowing-player/static/index.html
@@ -14,6 +14,7 @@
       <div class="home-actions">
         <button id="add-files" class="primary">음성 파일 불러오기</button>
         <button id="add-folder">폴더 불러오기</button>
+        <button id="refresh-library" title="사라진 파일을 목록에서 지운다">새로고침</button>
       </div>
     </header>
     <ul id="file-list"></ul>

--- a/product/akbun-shadowing-player/static/style.css
+++ b/product/akbun-shadowing-player/static/style.css
@@ -199,14 +199,20 @@ select {
 
 .folder-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   font-weight: 600;
   min-width: 0;
+  cursor: pointer;
 }
 
 .folder-name {
   flex-shrink: 0;
+}
+
+/* 경로가 길어도 삭제 버튼이 밀려나지 않게 경로만 줄인다. */
+.folder-header .file-meta {
+  flex: 1;
 }
 
 .folder-children {

--- a/product/akbun-shadowing-player/static/style.css
+++ b/product/akbun-shadowing-player/static/style.css
@@ -190,6 +190,35 @@ select {
   white-space: nowrap;
 }
 
+.folder-group {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 16px;
+}
+
+.folder-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-weight: 600;
+  min-width: 0;
+}
+
+.folder-name {
+  flex-shrink: 0;
+}
+
+.folder-children {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+  padding-left: 20px;
+  border-left: 1px solid var(--border);
+}
+
 #empty-hint {
   color: var(--muted);
   font-size: 14px;

--- a/product/akbun-shadowing-player/test/library.test.js
+++ b/product/akbun-shadowing-player/test/library.test.js
@@ -94,6 +94,36 @@ test("폴더로 불러온 파일만 folder를 가진다", () => {
   }
 });
 
+// 폴더 삭제는 한 번에 여러 항목을 지운다. 조건이 어긋나면 다른 폴더나 낱개 파일까지
+// 조용히 사라지므로, 지우는 범위를 테스트로 고정한다.
+test("removeFolder는 해당 폴더의 파일만 지운다", () => {
+  const { dir, library } = makeLibrary();
+  try {
+    const lesson = path.join(dir, "lesson");
+    const lesson2 = path.join(dir, "lesson2"); // 이름이 접두사로 겹치는 폴더
+    fs.mkdirSync(lesson);
+    fs.mkdirSync(lesson2);
+    const inLesson = makeAudioFile(lesson, "one.mp3");
+    const inLesson2 = makeAudioFile(lesson2, "two.mp3");
+    const single = makeAudioFile(dir, "single.mp3");
+
+    library.add([inLesson], lesson);
+    library.add([inLesson2], lesson2);
+    library.add([single]);
+
+    const items = library.removeFolder(lesson);
+
+    assert.deepStrictEqual(
+      items.map((item) => item.path).sort(),
+      [inLesson2, single].sort(),
+      "다른 폴더와 낱개 파일은 남아야 한다",
+    );
+    assert.strictEqual(new Library(dir).list().length, 2, "폴더 삭제가 저장되지 않았다");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("파일 열기는 목록에 없거나 사라진 파일을 막는다", () => {
   const mainSource = fs.readFileSync(path.join(__dirname, "../dist/main/main.js"), "utf-8");
   const readHandler = mainSource.slice(mainSource.indexOf('"audio:read"'));

--- a/product/akbun-shadowing-player/test/library.test.js
+++ b/product/akbun-shadowing-player/test/library.test.js
@@ -1,0 +1,103 @@
+/**
+ * 목록(library.json)이 디스크의 실제 파일과 어긋나지 않는지 검증한다.
+ *
+ * 파일은 앱 밖에서 지워지거나 옮겨진다. 목록에만 남은 경로를 그대로 읽으면
+ * 재생 화면이 빈 채로 열리므로, 파일 열기 전 검사(missing)와 홈 새로고침
+ * 정리(prune)가 실제로 도는지 확인한다.
+ *
+ * 실행: npm test (dist/를 읽으므로 build가 먼저 돈다)
+ */
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { Library } = require("../dist/main/library.js");
+
+/** 빈 userData 디렉터리와 그 안의 Library를 만든다. */
+function makeLibrary() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "akbun-shadowing-player-test-"));
+  return { dir, library: new Library(dir) };
+}
+
+function makeAudioFile(dir, name) {
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, "audio");
+  return filePath;
+}
+
+test("missing은 사라진 파일만 참이다", () => {
+  const { dir, library } = makeLibrary();
+  try {
+    const alive = makeAudioFile(dir, "alive.mp3");
+    const gone = makeAudioFile(dir, "gone.mp3");
+    library.add([alive, gone]);
+    fs.rmSync(gone);
+
+    assert.strictEqual(library.missing(alive), false);
+    assert.strictEqual(library.missing(gone), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("prune은 사라진 파일만 목록에서 지운다", () => {
+  const { dir, library } = makeLibrary();
+  try {
+    const alive = makeAudioFile(dir, "alive.mp3");
+    const gone = makeAudioFile(dir, "gone.mp3");
+    library.add([alive, gone]);
+    fs.rmSync(gone);
+
+    const items = library.prune();
+
+    assert.deepStrictEqual(
+      items.map((item) => item.path),
+      [alive],
+      "살아 있는 파일만 남아야 한다",
+    );
+    // 다시 읽어도 지워진 상태여야 한다. prune이 저장하지 않으면 여기서 걸린다.
+    assert.strictEqual(new Library(dir).list().length, 1, "prune 결과가 저장되지 않았다");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("prune은 사라진 파일이 없으면 목록을 그대로 둔다", () => {
+  const { dir, library } = makeLibrary();
+  try {
+    library.add([makeAudioFile(dir, "a.mp3"), makeAudioFile(dir, "b.mp3")]);
+    assert.strictEqual(library.prune().length, 2);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("폴더로 불러온 파일만 folder를 가진다", () => {
+  const { dir, library } = makeLibrary();
+  try {
+    const folder = path.join(dir, "lesson");
+    fs.mkdirSync(folder);
+    const inFolder = makeAudioFile(folder, "one.mp3");
+    const single = makeAudioFile(dir, "single.mp3");
+
+    library.add([inFolder], folder);
+    library.add([single]);
+
+    const byPath = Object.fromEntries(library.list().map((item) => [item.path, item.folder]));
+    assert.strictEqual(byPath[inFolder], folder);
+    assert.strictEqual(byPath[single], undefined);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("파일 열기는 목록에 없거나 사라진 파일을 막는다", () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, "../dist/main/main.js"), "utf-8");
+  const readHandler = mainSource.slice(mainSource.indexOf('"audio:read"'));
+
+  assert.match(readHandler, /library\.has\(/, "목록에 없는 파일 검사가 사라졌다");
+  assert.match(readHandler, /library\.missing\(/, "파일 존재 검사가 사라졌다");
+});


### PR DESCRIPTION
## Goal

akbun-shadowing-player 홈 화면은 불러온 방식과 상관없이 파일을 평면 목록으로만 보여주고, 목록의 파일이 디스크에서 사라져도 항목이 그대로 남아 눌러도 아무 일이 일어나지 않는다. 홈에서 파일과 폴더를 구분해 보여주고 사라진 파일을 정리한다.

## 어떻게 해결했는가

- 폴더 불러오기로 들어온 파일에만 folder 필드를 붙이고, 홈에서 폴더 아이콘과 하위 목록으로 묶어 보여준다. 파일 불러오기로 들어온 파일은 이전처럼 한 줄씩 보여준다.
- 폴더는 details와 summary 요소로 그려 접고 펼친다. 폴더 헤더의 삭제 버튼은 해당 폴더 소속 항목만 목록에서 지우며, 실제 파일은 지우지 않는다는 사실을 확인 대화상자로 알린다.
- 파일 열기는 audio:read IPC 핸들러에서 디스크에 파일이 있는지 검사한다. 렌더러의 모든 재생 경로가 이 핸들러를 지나므로 검사가 한 곳에 있다. 파일이 없으면 목록에서도 지우고 오류를 던져 홈으로 돌아간다.
- 홈 헤더에 새로고침 버튼을 두고, 사라진 파일을 목록에서 지우는 prune을 실행한다.
- test/library.test.js에 존재 검사, 새로고침 정리, 폴더 삭제 범위를 검증하는 테스트를 추가한다. 목록에서 데이터가 조용히 사라질 수 있는 동작만 남겼다.
- pull request에서 테스트를 실행하는 action은 release-akbun-shadowing-player.yml의 verify job으로 이미 있어 새로 만들지 않았다.

Issue #549