### PR TITLE
akbun-shadowing-player 파형 드래그 구간 반복과 홈 전체 삭제 추가

### DIFF
--- a/product/akbun-shadowing-player/src/main/library.ts
+++ b/product/akbun-shadowing-player/src/main/library.ts
@@ -72,6 +72,13 @@ export class Library {
     return this.items;
   }
 
+  /** 목록을 통째로 비운다. 실제 파일은 지우지 않는다. */
+  removeAll(): LibraryItem[] {
+    this.items = [];
+    this.save();
+    return this.items;
+  }
+
   /** 폴더 한 칸을 통째로 지운다. 같은 폴더 소속 항목만 사라진다. */
   removeFolder(folder: string): LibraryItem[] {
     this.items = this.items.filter((item) => item.folder !== folder);

--- a/product/akbun-shadowing-player/src/main/main.ts
+++ b/product/akbun-shadowing-player/src/main/main.ts
@@ -197,6 +197,8 @@ function registerIpc(): void {
 
   ipcMain.handle("library:remove-folder", (_event, folder: string) => library.removeFolder(folder));
 
+  ipcMain.handle("library:remove-all", () => library.removeAll());
+
   ipcMain.handle("library:set-duration", (_event, filePath: string, durationSec: number) => {
     library.setDuration(filePath, durationSec);
   });

--- a/product/akbun-shadowing-player/src/main/preload.ts
+++ b/product/akbun-shadowing-player/src/main/preload.ts
@@ -8,6 +8,7 @@ contextBridge.exposeInMainWorld("api", {
   addFolder: () => ipcRenderer.invoke("library:add-folder"),
   removeFile: (path: string) => ipcRenderer.invoke("library:remove", path),
   removeFolder: (folder: string) => ipcRenderer.invoke("library:remove-folder", folder),
+  removeAll: () => ipcRenderer.invoke("library:remove-all"),
   refreshLibrary: () => ipcRenderer.invoke("library:refresh"),
   setDuration: (path: string, durationSec: number) =>
     ipcRenderer.invoke("library:set-duration", path, durationSec),

--- a/product/akbun-shadowing-player/src/renderer/api.d.ts
+++ b/product/akbun-shadowing-player/src/renderer/api.d.ts
@@ -21,6 +21,7 @@ interface Window {
     addFolder(): Promise<LibraryItem[]>;
     removeFile(path: string): Promise<LibraryItem[]>;
     removeFolder(folder: string): Promise<LibraryItem[]>;
+    removeAll(): Promise<LibraryItem[]>;
     refreshLibrary(): Promise<LibraryItem[]>;
     setDuration(path: string, durationSec: number): Promise<void>;
     readAudio(path: string): Promise<Uint8Array<ArrayBuffer>>;

--- a/product/akbun-shadowing-player/src/renderer/renderer.ts
+++ b/product/akbun-shadowing-player/src/renderer/renderer.ts
@@ -170,6 +170,11 @@ document.getElementById("refresh-library")!.addEventListener("click", async () =
   await refreshLibrary(await window.api.refreshLibrary());
 });
 
+document.getElementById("remove-all")!.addEventListener("click", async () => {
+  if (!confirm("목록의 모든 파일을 지운다. 실제 파일은 남는다.")) return;
+  await refreshLibrary(await window.api.removeAll());
+});
+
 // ---------- 설정 화면 ----------
 
 async function openSettings(): Promise<void> {
@@ -239,6 +244,8 @@ async function openPlayer(item: LibraryItem): Promise<void> {
     audio.currentTime = timeSec;
     void audio.play();
   };
+  // 파형 드래그로 구간을 잡는다. 기존 구간이 있어도 그대로 새 구간으로 바꾼다.
+  waveform.onLoopSelect = (a, b) => setLoop(a, b);
   waveLoading.hidden = true;
 
   if (item.durationSec === null) {

--- a/product/akbun-shadowing-player/src/renderer/waveform.ts
+++ b/product/akbun-shadowing-player/src/renderer/waveform.ts
@@ -14,6 +14,8 @@ class Waveform {
   private static readonly MAX_PPS = 800;
   /** 이 픽셀 이상 움직이면 클릭이 아니라 드래그로 본다. */
   private static readonly DRAG_THRESHOLD_PX = 5;
+  /** 이보다 짧은 구간은 반복해도 소리가 나지 않으므로 만들지 않는다. */
+  private static readonly MIN_LOOP_SEC = 0.05;
 
   readonly duration: number;
   onSeek: ((timeSec: number) => void) | null = null;
@@ -38,6 +40,9 @@ class Waveform {
   private dragMoved = false;
   private dragStartX = 0;
   private dragStartSec = 0;
+  /** 드래그를 시작할 때의 구간. 쓸 수 없는 드래그로 끝나면 여기로 되돌린다. */
+  private dragPrevLoopA: number | null = null;
+  private dragPrevLoopB: number | null = null;
   private readonly resizeObserver: ResizeObserver;
 
   constructor(canvas: HTMLCanvasElement, buffer: AudioBuffer) {
@@ -157,6 +162,8 @@ class Waveform {
     this.dragMoved = false;
     this.dragStartX = event.clientX;
     this.dragStartSec = this.timeAt(event.clientX);
+    this.dragPrevLoopA = this.loopA;
+    this.dragPrevLoopB = this.loopB;
   };
 
   private readonly onMouseMove = (event: MouseEvent): void => {
@@ -173,7 +180,15 @@ class Waveform {
     this.dragging = false;
     const timeSec = this.timeAt(event.clientX);
     if (this.dragMoved) {
-      this.onLoopSelect?.(Math.min(this.dragStartSec, timeSec), Math.max(this.dragStartSec, timeSec));
+      const a = Math.min(this.dragStartSec, timeSec);
+      const b = Math.max(this.dragStartSec, timeSec);
+      // 곡 밖으로 끌면 timeAt이 양 끝을 같은 값으로 잘라 0길이 구간이 나온다.
+      // 그대로 두면 재생 헤드가 그 지점에 묶이므로 버리고 이전 구간을 되살린다.
+      if (b - a < Waveform.MIN_LOOP_SEC) {
+        this.setLoop(this.dragPrevLoopA, this.dragPrevLoopB);
+        return;
+      }
+      this.onLoopSelect?.(a, b);
       return;
     }
     this.onSeek?.(timeSec);

--- a/product/akbun-shadowing-player/src/renderer/waveform.ts
+++ b/product/akbun-shadowing-player/src/renderer/waveform.ts
@@ -3,8 +3,9 @@
  * 확대/스크롤 가능한 파형과 재생 헤드, 구간 반복(A-B) 영역을 그린다.
  *
  * 마우스 조작:
- * - 왼쪽 버튼을 누른 채 좌우로 끌면 파형이 스크롤된다.
+ * - 왼쪽 버튼을 누른 채 좌우로 끌면 그 구간이 구간 반복(A-B)으로 잡힌다 (onLoopSelect 콜백).
  * - 끌지 않고 누르면(클릭) 그 지점부터 재생한다 (onSeek 콜백).
+ * - 스크롤은 휠(트랙패드 좌우 포함)로 한다.
  */
 class Waveform {
   /** peak 1블록이 담는 샘플 수. 그리기 성능과 해상도의 절충값. */
@@ -16,6 +17,7 @@ class Waveform {
 
   readonly duration: number;
   onSeek: ((timeSec: number) => void) | null = null;
+  onLoopSelect: ((a: number, b: number) => void) | null = null;
 
   private readonly canvas: HTMLCanvasElement;
   private readonly ctx: CanvasRenderingContext2D;
@@ -35,7 +37,7 @@ class Waveform {
   private dragging = false;
   private dragMoved = false;
   private dragStartX = 0;
-  private dragStartViewSec = 0;
+  private dragStartSec = 0;
   private readonly resizeObserver: ResizeObserver;
 
   constructor(canvas: HTMLCanvasElement, buffer: AudioBuffer) {
@@ -142,30 +144,39 @@ class Waveform {
     this.viewStartSec = Math.min(maxStart, Math.max(0, sec));
   }
 
+  /** 화면 x좌표를 곡 안의 시각(초)으로 바꾼다. 곡 범위 밖이면 잘라낸다. */
+  private timeAt(clientX: number): number {
+    const rect = this.canvas.getBoundingClientRect();
+    const timeSec = this.viewStartSec + (clientX - rect.left) / this.pixelsPerSecond;
+    return Math.min(this.duration, Math.max(0, timeSec));
+  }
+
   private readonly onMouseDown = (event: MouseEvent): void => {
     if (event.button !== 0) return;
     this.dragging = true;
     this.dragMoved = false;
     this.dragStartX = event.clientX;
-    this.dragStartViewSec = this.viewStartSec;
+    this.dragStartSec = this.timeAt(event.clientX);
   };
 
   private readonly onMouseMove = (event: MouseEvent): void => {
     if (!this.dragging) return;
-    const dx = event.clientX - this.dragStartX;
-    if (Math.abs(dx) > Waveform.DRAG_THRESHOLD_PX) this.dragMoved = true;
+    if (Math.abs(event.clientX - this.dragStartX) > Waveform.DRAG_THRESHOLD_PX) this.dragMoved = true;
     if (!this.dragMoved) return;
-    this.setViewStart(this.dragStartViewSec - dx / this.pixelsPerSecond);
-    this.draw();
+    // 끄는 동안 잡히는 구간을 미리 보여준다. 확정은 mouseup에서 콜백으로 한다.
+    const current = this.timeAt(event.clientX);
+    this.setLoop(Math.min(this.dragStartSec, current), Math.max(this.dragStartSec, current));
   };
 
   private readonly onMouseUp = (event: MouseEvent): void => {
     if (!this.dragging) return;
     this.dragging = false;
-    if (this.dragMoved) return;
-    const rect = this.canvas.getBoundingClientRect();
-    const timeSec = this.viewStartSec + (event.clientX - rect.left) / this.pixelsPerSecond;
-    if (timeSec >= 0 && timeSec <= this.duration && this.onSeek) this.onSeek(timeSec);
+    const timeSec = this.timeAt(event.clientX);
+    if (this.dragMoved) {
+      this.onLoopSelect?.(Math.min(this.dragStartSec, timeSec), Math.max(this.dragStartSec, timeSec));
+      return;
+    }
+    this.onSeek?.(timeSec);
   };
 
   private readonly onWheel = (event: WheelEvent): void => {

--- a/product/akbun-shadowing-player/static/index.html
+++ b/product/akbun-shadowing-player/static/index.html
@@ -15,6 +15,7 @@
         <button id="add-files" class="primary">음성 파일 불러오기</button>
         <button id="add-folder">폴더 불러오기</button>
         <button id="refresh-library" title="사라진 파일을 목록에서 지운다">새로고침</button>
+        <button id="remove-all" title="목록의 모든 파일을 지운다. 실제 파일은 남는다">전체 삭제</button>
       </div>
     </header>
     <ul id="file-list"></ul>

--- a/product/akbun-shadowing-player/test/library.test.js
+++ b/product/akbun-shadowing-player/test/library.test.js
@@ -124,6 +124,18 @@ test("removeFolder는 해당 폴더의 파일만 지운다", () => {
   }
 });
 
+test("removeAll은 목록을 비우고 저장한다", () => {
+  const { dir, library } = makeLibrary();
+  try {
+    library.add([makeAudioFile(dir, "a.mp3"), makeAudioFile(dir, "b.mp3")]);
+
+    assert.strictEqual(library.removeAll().length, 0);
+    assert.strictEqual(new Library(dir).list().length, 0, "전체 삭제가 저장되지 않았다");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("파일 열기는 목록에 없거나 사라진 파일을 막는다", () => {
   const mainSource = fs.readFileSync(path.join(__dirname, "../dist/main/main.js"), "utf-8");
   const readHandler = mainSource.slice(mainSource.indexOf('"audio:read"'));

--- a/product/akbun-shadowing-player/test/waveform.test.js
+++ b/product/akbun-shadowing-player/test/waveform.test.js
@@ -1,0 +1,34 @@
+/**
+ * 파형 드래그로 만든 구간이 재생을 막지 않는지 검증한다.
+ *
+ * 드래그를 곡 밖에서 놓으면 양 끝이 같은 값으로 잘려 0길이 구간이 나온다.
+ * 이 구간이 renderer의 반복 조건(currentTime >= loopB)에 들어가면 재생 헤드가
+ * 그 지점에 묶여 재생이 멈춘 것처럼 보인다. 캔버스를 띄우지 않고 확인할 수 있게
+ * 컴파일 결과에 가드가 남아 있는지만 본다.
+ *
+ * 실행: npm test (dist/를 읽으므로 build가 먼저 돈다)
+ */
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const waveformSource = fs.readFileSync(
+  path.join(__dirname, "../dist/renderer/waveform.js"),
+  "utf-8",
+);
+
+test("0길이 구간을 버리는 가드가 남아 있다", () => {
+  assert.match(waveformSource, /MIN_LOOP_SEC/, "최소 구간 길이 기준이 사라졌다");
+
+  const mouseUp = waveformSource.slice(waveformSource.indexOf("onMouseUp"));
+  assert.match(mouseUp, /MIN_LOOP_SEC/, "mouseup에서 최소 길이를 검사하지 않는다");
+});
+
+test("최소 구간 길이는 0보다 크다", () => {
+  const declared = waveformSource.match(/MIN_LOOP_SEC\s*=\s*([\d.]+)/);
+
+  assert.ok(declared, "MIN_LOOP_SEC 선언을 찾을 수 없다");
+  assert.ok(Number(declared[1]) > 0, "0길이 구간을 그대로 통과시킨다");
+});


### PR DESCRIPTION
## Goal

구간 반복을 잡으려면 재생 위치를 맞춘 뒤 A와 B 버튼을 각각 눌러야 해서 조작이 번거로웠다. 홈 화면에서는 파일을 하나씩 또는 폴더 단위로만 지울 수 있어 목록을 비우려면 같은 동작을 반복해야 했다.

## 어떻게 해결했는가

- 파형에서 마우스로 끌면 그 구간이 구간 반복으로 잡히게 했다. 끄는 동안 잡히는 범위를 미리 그리고 버튼을 뗄 때 확정한다.
- 기존 구간이 설정되어 있어도 확인 없이 새 구간으로 바꾼다.
- 드래그가 구간 선택을 맡게 되면서 파형 스크롤은 휠과 트랙패드 좌우 제스처로 옮겼다. 5픽셀 미만 이동은 기존과 같이 클릭 재생으로 처리한다.
- 홈 화면에 전체 삭제 버튼을 추가했다. 확인 대화상자를 거쳐 목록만 비우고 실제 파일은 남긴다. 기존 파일 삭제, 폴더 삭제와 동작을 맞췄다.
- Library.removeAll에 대한 테스트를 추가했다. 빌드와 테스트 11개가 통과한다.

## 리뷰어가 알아야 할 것

파형을 끌어서 스크롤하던 동작이 사라졌다. 스크롤은 휠로만 한다. 마우스 휠만 쓰는 환경에서 좌우 스크롤이 불편하다면 조정이 필요하다.

Issue #551