### PR TITLE
akbun-shadowing-player 재생 버튼이 반복구간 시작점부터 재생하도록 수정

### DIFF
--- a/product/akbun-shadowing-player/src/renderer/renderer.ts
+++ b/product/akbun-shadowing-player/src/renderer/renderer.ts
@@ -281,8 +281,15 @@ document.getElementById("zoom-out")!.addEventListener("click", () => waveform?.z
 // ---------- 재생 컨트롤 ----------
 
 function togglePlay(): void {
-  if (audio.paused) void audio.play();
-  else audio.pause();
+  if (!audio.paused) {
+    audio.pause();
+    return;
+  }
+  // 구간 반복이 있고 재생 위치가 구간 밖이면 A부터 시작한다.
+  if (loopA !== null && loopB !== null && (audio.currentTime < loopA || audio.currentTime >= loopB)) {
+    audio.currentTime = loopA;
+  }
+  void audio.play();
 }
 
 playButton.addEventListener("click", togglePlay);


### PR DESCRIPTION
## Goal

파형을 드래그해 반복구간을 잡은 뒤 재생 버튼을 누르면 이전 재생 위치에서 시작했다. 반복구간 시작점부터 재생되게 한다.

## 어떻게 해결했는가

- togglePlay에서 재생을 시작할 때 반복구간이 있고 재생 위치가 구간 밖이면 A로 이동시킨다.
- 재생 위치가 구간 안이면 그대로 두어, 구간 안에서 일시정지한 뒤 재개하면 이어서 재생된다.
- 파형 드래그로 구간을 잡는 시점에는 playhead를 옮기지 않는다.
- 버전은 master의 0.7.0이 아직 릴리스되지 않았으므로 그대로 둔다.

Issue #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)