### PR TITLE
akbun-shadowing-player 릴리스 버전 0.8.0으로 올림

### DIFF
--- a/product/akbun-shadowing-player/package.json
+++ b/product/akbun-shadowing-player/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-shadowing-player",
   "productName": "akbun-shadowing-player",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "언어 공부(쉐도잉)용 구간 반복 오디오 플레이어",
   "main": "dist/main/main.js",
   "author": "akbun",


### PR DESCRIPTION
## Goal

이전 PR에서 코드를 수정하고도 package.json version을 올리지 않아 릴리스 tag가 만들어지지 않았다. version을 0.8.0으로 올려 릴리스가 정상으로 나가도록 한다.

## 어떻게 해결했는가

- product/akbun-shadowing-player/package.json의 version을 0.7.0에서 0.8.0으로 올렸다.
- akbun-shadowing-player-v0.7.0 tag가 이미 있으므로 마이너 +1 규칙에 따라 0.8.0을 선택했다.
- 버전 출처를 package.json으로 쓰는 workflow는 이미 반영되어 있어 수정하지 않았다.

Issue #557