### PR TITLE
feat(k8supgradeview): Karpenter Event 탭 추가

### DIFF
--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -45,7 +45,7 @@ kubectl get ec2nodeclasses.karpenter.k8s.aws -o json
 
 버전은 karpenter deployment에서 읽는다. helm chart가 붙이는 `app.kubernetes.io/version` label을 먼저 보고, 없으면 container image의 tag를 쓴다. registry에 port가 붙은 image(`registry:5000/karpenter:1.1.0`)를 tag와 혼동하지 않도록 마지막 `/` 뒤에서만 `:`를 찾는다. tag 없이 digest만 있으면 `-`다. deployment 조회 권한이 없어도 event와 log는 봐야 하므로 실패는 값으로 담아 그 표 위에만 표시한다.
 
-event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는다. 시각은 `lastTimestamp`, `series.lastObservedTime`, `eventTime`, `firstTimestamp`, `metadata.creationTimestamp` 순으로 찾고, 대상은 `involvedObject` 또는 `regarding`, 본문은 `message` 또는 `note`를 쓴다. 목록은 오래된 것부터 시간순으로 정렬한다.
+event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는다. 시각은 `lastTimestamp`, `series.lastObservedTime`, `eventTime`, `firstTimestamp`, `metadata.creationTimestamp` 순으로 찾고, 대상은 `involvedObject` 또는 `regarding`, 본문은 `message` 또는 `note`를 쓴다. 목록은 오래된 것부터 시간순으로 정렬한다. 읽을 수 없는 시각은 정렬 비교에서 0으로 맞춘다. `NaN`을 비교에 넣으면 순서가 보장되지 않기 때문이다.
 
 로그는 label selector로 파드를 먼저 찾고 파드마다 따로 조회한다. 한 파드의 조회가 실패해도 나머지 로그는 보여줘야 하므로 실패를 예외로 던지지 않고 `PodLog.error`에 담아 화면에 표시한다.
 

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -9,9 +9,9 @@ Electron + TypeScript 데스크톱 앱이다. 클러스터 조회는 Kubernetes 
   - `kubectl.ts`: kubectl 실행과 노드/파드 JSON 파싱
   - `settings.ts`: userData 경로의 settings.json 읽기/쓰기
   - `preload.ts`: contextBridge로 renderer에 `window.api` 노출
-- `workspace/src/renderer/`: 화면. Nodes, Pods, Settings 3개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
+- `workspace/src/renderer/`: 화면. Nodes, Pods, Karpenter Event, Settings 4개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
 
-renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `settings:get`, `settings:save`)로만 통신한다.
+renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `settings:get`, `settings:save`)로만 통신한다.
 
 ## kubectl 실행 흐름
 
@@ -24,6 +24,26 @@ kubectl get nodes -o json
 kubectl get pods --all-namespaces -o json
 kubectl get pods --all-namespaces -o json --field-selector spec.nodeName=<노드이름>
 ```
+
+Karpenter Event 탭이 사용하는 명령. namespace, label selector, 조회 범위는 Settings 값이다.
+
+```bash
+kubectl get events -n <namespace> -o json
+kubectl get pods -n <namespace> -l <label selector> -o json
+kubectl logs <파드이름> -n <namespace> --all-containers=true --timestamps --since=<분>m
+```
+
+## Karpenter Event 탭
+
+event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는다. 시각은 `lastTimestamp`, `series.lastObservedTime`, `eventTime`, `firstTimestamp`, `metadata.creationTimestamp` 순으로 찾고, 대상은 `involvedObject` 또는 `regarding`, 본문은 `message` 또는 `note`를 쓴다. 목록은 오래된 것부터 시간순으로 정렬한다.
+
+로그는 label selector로 파드를 먼저 찾고 파드마다 따로 조회한다. 한 파드의 조회가 실패해도 나머지 로그는 보여줘야 하므로 실패를 예외로 던지지 않고 `PodLog.error`에 담아 화면에 표시한다.
+
+| 설정 | 기본값 |
+|---|---|
+| `karpenterNamespace` | `karpenter` |
+| `karpenterPodLabelSelector` | `app.kubernetes.io/name=karpenter` |
+| `karpenterLogSinceMinutes` | `15` (1~1440으로 제한) |
 
 ## 노드 분류 기준
 

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -54,11 +54,15 @@ event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는�
 
 ## NodePool / EC2NodeClass 탭
 
-두 리소스를 name, ami, weight 세 칼럼으로 같이 보여준다. NodePool에는 ami가 없고 EC2NodeClass에는 weight가 없으므로 없는 필드는 `-`로 채운다. `kubectl get`의 List 항목에는 kind가 없어서 어느 리소스를 읽는지는 조회부가 알려준다.
+NodePool은 name, ami, weight, nodes, ready, age를, EC2NodeClass는 name, ami, weight를 보여준다. NodePool에는 ami가 없고 EC2NodeClass에는 weight가 없으므로 없는 필드는 `-`로 채운다. `spec.weight`나 Ready condition처럼 있을 수도 없을 수도 있는 필드도 마찬가지다.
 
 ami는 `spec.amiSelectorTerms`를 `alias=al2023@latest` 같은 표기로 이어 붙여 보여주고, term이 없으면 예전 필드인 `spec.amiFamily`를 쓴다. 둘 다 없으면 `-`다.
 
-karpenter가 없거나 CRD 조회 권한이 없는 클러스터도 있으므로 두 조회는 서로 독립이다. 한쪽이 실패하면 그 표 위에만 이유를 적고 다른 표는 그대로 보여준다.
+nodes는 NodePool status에 없어서 노드 목록의 `karpenter.sh/nodepool` label을 세어 채운다. 노드 조회가 실패하면 0과 구분해야 하므로 0이 아니라 `-`를 표시한다. `-`는 "셀 수 없었다"이고 0은 "정말 노드가 없다"다.
+
+karpenter가 없거나 CRD 조회 권한이 없는 클러스터도 있으므로 세 조회(NodePool, EC2NodeClass, 노드)는 서로 독립이다. 한쪽이 실패하면 그 표 위에만 이유를 적고 다른 표는 그대로 보여준다.
+
+빈 값 처리 규칙은 화면에서 알아채기 어려워 `test/karpenter-resources.test.js`가 목업 데이터로 검증한다. 파싱 규칙을 고치면 이 테스트를 함께 본다.
 
 ## 노드 분류 기준
 

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -11,7 +11,7 @@ Electron + TypeScript 데스크톱 앱이다. 클러스터 조회는 Kubernetes 
   - `preload.ts`: contextBridge로 renderer에 `window.api` 노출
 - `workspace/src/renderer/`: 화면. Nodes, Pods, Karpenter Event, NodePool / EC2NodeClass, Settings 5개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
 
-renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `settings:get`, `settings:save`)로만 통신한다.
+renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `kubectl:karpenter-versions`, `settings:get`, `settings:save`)로만 통신한다.
 
 ## kubectl 실행 흐름
 
@@ -28,6 +28,7 @@ kubectl get pods --all-namespaces -o json --field-selector spec.nodeName=<노드
 Karpenter Event 탭이 사용하는 명령. namespace, label selector, 조회 범위는 Settings 값이다.
 
 ```bash
+kubectl get deployments -n <namespace> -l <label selector> -o json
 kubectl get events -n <namespace> -o json
 kubectl get pods -n <namespace> -l <label selector> -o json
 kubectl logs <파드이름> -n <namespace> --all-containers=true --timestamps --since=<분>m
@@ -41,6 +42,8 @@ kubectl get ec2nodeclasses.karpenter.k8s.aws -o json
 ```
 
 ## Karpenter Event 탭
+
+버전은 karpenter deployment에서 읽는다. helm chart가 붙이는 `app.kubernetes.io/version` label을 먼저 보고, 없으면 container image의 tag를 쓴다. registry에 port가 붙은 image(`registry:5000/karpenter:1.1.0`)를 tag와 혼동하지 않도록 마지막 `/` 뒤에서만 `:`를 찾는다. tag 없이 digest만 있으면 `-`다. deployment 조회 권한이 없어도 event와 log는 봐야 하므로 실패는 값으로 담아 그 표 위에만 표시한다.
 
 event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는다. 시각은 `lastTimestamp`, `series.lastObservedTime`, `eventTime`, `firstTimestamp`, `metadata.creationTimestamp` 순으로 찾고, 대상은 `involvedObject` 또는 `regarding`, 본문은 `message` 또는 `note`를 쓴다. 목록은 오래된 것부터 시간순으로 정렬한다.
 

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -9,9 +9,9 @@ Electron + TypeScript 데스크톱 앱이다. 클러스터 조회는 Kubernetes 
   - `kubectl.ts`: kubectl 실행과 노드/파드 JSON 파싱
   - `settings.ts`: userData 경로의 settings.json 읽기/쓰기
   - `preload.ts`: contextBridge로 renderer에 `window.api` 노출
-- `workspace/src/renderer/`: 화면. Nodes, Pods, Karpenter Event, Settings 4개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
+- `workspace/src/renderer/`: 화면. Nodes, Pods, Karpenter Event, NodePool / EC2NodeClass, Settings 5개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
 
-renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `settings:get`, `settings:save`)로만 통신한다.
+renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `settings:get`, `settings:save`)로만 통신한다.
 
 ## kubectl 실행 흐름
 
@@ -33,6 +33,13 @@ kubectl get pods -n <namespace> -l <label selector> -o json
 kubectl logs <파드이름> -n <namespace> --all-containers=true --timestamps --since=<분>m
 ```
 
+NodePool / EC2NodeClass 탭이 사용하는 명령. 둘 다 cluster scope 리소스다. 다른 CRD와 이름이 겹치지 않도록 group까지 붙여 조회한다.
+
+```bash
+kubectl get nodepools.karpenter.sh -o json
+kubectl get ec2nodeclasses.karpenter.k8s.aws -o json
+```
+
 ## Karpenter Event 탭
 
 event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는다. 시각은 `lastTimestamp`, `series.lastObservedTime`, `eventTime`, `firstTimestamp`, `metadata.creationTimestamp` 순으로 찾고, 대상은 `involvedObject` 또는 `regarding`, 본문은 `message` 또는 `note`를 쓴다. 목록은 오래된 것부터 시간순으로 정렬한다.
@@ -44,6 +51,14 @@ event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는�
 | `karpenterNamespace` | `karpenter` |
 | `karpenterPodLabelSelector` | `app.kubernetes.io/name=karpenter` |
 | `karpenterLogSinceMinutes` | `15` (1~1440으로 제한) |
+
+## NodePool / EC2NodeClass 탭
+
+두 리소스를 name, ami, weight 세 칼럼으로 같이 보여준다. NodePool에는 ami가 없고 EC2NodeClass에는 weight가 없으므로 없는 필드는 `-`로 채운다. `kubectl get`의 List 항목에는 kind가 없어서 어느 리소스를 읽는지는 조회부가 알려준다.
+
+ami는 `spec.amiSelectorTerms`를 `alias=al2023@latest` 같은 표기로 이어 붙여 보여주고, term이 없으면 예전 필드인 `spec.amiFamily`를 쓴다. 둘 다 없으면 `-`다.
+
+karpenter가 없거나 CRD 조회 권한이 없는 클러스터도 있으므로 두 조회는 서로 독립이다. 한쪽이 실패하면 그 표 위에만 이유를 적고 다른 표는 그대로 보여준다.
 
 ## 노드 분류 기준
 

--- a/product/akbun-k8supgradeview/workspace/README.md
+++ b/product/akbun-k8supgradeview/workspace/README.md
@@ -8,7 +8,9 @@ EKS 업그레이드 작업 중 노드와 파드 상태를 한눈에 확인하는
 - 노드 필터: Karpenter 노드, Managed NodeGroup 노드, cordon(SchedulingDisabled) 노드
 - 노드 클릭 시 해당 노드에 스케줄된 파드 목록 표시
 - 파드 목록 조회: namespace, 파드 이름, 상태, 스케줄된 노드. namespace 필터와 이름 검색 지원
+- Karpenter Event 탭: karpenter namespace의 event를 시간순으로 보여주고, label selector로 찾은 karpenter 파드의 최근 로그를 함께 보여준다
 - Settings에서 kubectl 실행 명령 변경. teleport를 쓰면 tsh kubectl로 설정한다
+- Settings에서 karpenter namespace(기본 karpenter), 파드 label selector(기본 app.kubernetes.io/name=karpenter), 로그 조회 범위(기본 15분) 변경
 - 상단 메뉴 {앱 이름} > 업데이트 확인. GitHub Release의 최신 버전과 비교해 새 버전이면 dmg를 받아 앱을 교체하고 재실행한다
 
 ## 요구사항
@@ -40,5 +42,5 @@ master 브랜치에 이 디렉터리 변경이 머지되면 GitHub Actions(relea
 ## 구조
 
 - src/main: Electron main 프로세스. kubectl 실행, 설정 저장, IPC 핸들러
-- src/renderer: 화면. 탭(Nodes, Pods, Settings)과 테이블 렌더링
+- src/renderer: 화면. 탭(Nodes, Pods, Karpenter Event, Settings)과 테이블 렌더링
 - 노드 분류 기준: karpenter.sh/nodepool 또는 karpenter.sh/provisioner-name label이 있으면 Karpenter 노드, eks.amazonaws.com/nodegroup label이 있으면 Managed NodeGroup 노드로 판단한다

--- a/product/akbun-k8supgradeview/workspace/README.md
+++ b/product/akbun-k8supgradeview/workspace/README.md
@@ -9,7 +9,7 @@ EKS 업그레이드 작업 중 노드와 파드 상태를 한눈에 확인하는
 - 노드 클릭 시 해당 노드에 스케줄된 파드 목록 표시
 - 파드 목록 조회: namespace, 파드 이름, 상태, 스케줄된 노드. namespace 필터와 이름 검색 지원
 - Karpenter Event 탭: karpenter namespace의 event를 시간순으로 보여주고, label selector로 찾은 karpenter 파드의 최근 로그를 함께 보여준다
-- NodePool / EC2NodeClass 탭: karpenter NodePool과 EC2NodeClass 목록을 name, ami, weight 칼럼으로 보여준다. 리소스에 없는 필드는 -로 표시한다
+- NodePool / EC2NodeClass 탭: NodePool은 name, ami, weight, nodes(그 NodePool이 만든 노드 수), ready, age를, EC2NodeClass는 name, ami, weight를 보여준다. 리소스에 없는 필드는 -로 표시한다
 - Settings에서 kubectl 실행 명령 변경. teleport를 쓰면 tsh kubectl로 설정한다
 - Settings에서 karpenter namespace(기본 karpenter), 파드 label selector(기본 app.kubernetes.io/name=karpenter), 로그 조회 범위(기본 15분) 변경
 - 상단 메뉴 {앱 이름} > 업데이트 확인. GitHub Release의 최신 버전과 비교해 새 버전이면 dmg를 받아 앱을 교체하고 재실행한다

--- a/product/akbun-k8supgradeview/workspace/README.md
+++ b/product/akbun-k8supgradeview/workspace/README.md
@@ -9,6 +9,7 @@ EKS 업그레이드 작업 중 노드와 파드 상태를 한눈에 확인하는
 - 노드 클릭 시 해당 노드에 스케줄된 파드 목록 표시
 - 파드 목록 조회: namespace, 파드 이름, 상태, 스케줄된 노드. namespace 필터와 이름 검색 지원
 - Karpenter Event 탭: karpenter namespace의 event를 시간순으로 보여주고, label selector로 찾은 karpenter 파드의 최근 로그를 함께 보여준다
+- NodePool / EC2NodeClass 탭: karpenter NodePool과 EC2NodeClass 목록을 name, ami, weight 칼럼으로 보여준다. 리소스에 없는 필드는 -로 표시한다
 - Settings에서 kubectl 실행 명령 변경. teleport를 쓰면 tsh kubectl로 설정한다
 - Settings에서 karpenter namespace(기본 karpenter), 파드 label selector(기본 app.kubernetes.io/name=karpenter), 로그 조회 범위(기본 15분) 변경
 - 상단 메뉴 {앱 이름} > 업데이트 확인. GitHub Release의 최신 버전과 비교해 새 버전이면 dmg를 받아 앱을 교체하고 재실행한다
@@ -42,5 +43,5 @@ master 브랜치에 이 디렉터리 변경이 머지되면 GitHub Actions(relea
 ## 구조
 
 - src/main: Electron main 프로세스. kubectl 실행, 설정 저장, IPC 핸들러
-- src/renderer: 화면. 탭(Nodes, Pods, Karpenter Event, Settings)과 테이블 렌더링
+- src/renderer: 화면. 탭(Nodes, Pods, Karpenter Event, NodePool / EC2NodeClass, Settings)과 테이블 렌더링
 - 노드 분류 기준: karpenter.sh/nodepool 또는 karpenter.sh/provisioner-name label이 있으면 Karpenter 노드, eks.amazonaws.com/nodegroup label이 있으면 Managed NodeGroup 노드로 판단한다

--- a/product/akbun-k8supgradeview/workspace/README.md
+++ b/product/akbun-k8supgradeview/workspace/README.md
@@ -8,7 +8,7 @@ EKS 업그레이드 작업 중 노드와 파드 상태를 한눈에 확인하는
 - 노드 필터: Karpenter 노드, Managed NodeGroup 노드, cordon(SchedulingDisabled) 노드
 - 노드 클릭 시 해당 노드에 스케줄된 파드 목록 표시
 - 파드 목록 조회: namespace, 파드 이름, 상태, 스케줄된 노드. namespace 필터와 이름 검색 지원
-- Karpenter Event 탭: karpenter namespace의 event를 시간순으로 보여주고, label selector로 찾은 karpenter 파드의 최근 로그를 함께 보여준다
+- Karpenter Event 탭: karpenter deployment에서 읽은 버전과 image, karpenter namespace의 event를 시간순으로, label selector로 찾은 karpenter 파드의 최근 로그를 함께 보여준다
 - NodePool / EC2NodeClass 탭: NodePool은 name, ami, weight, nodes(그 NodePool이 만든 노드 수), ready, age를, EC2NodeClass는 name, ami, weight를 보여준다. 리소스에 없는 필드는 -로 표시한다
 - Settings에서 kubectl 실행 명령 변경. teleport를 쓰면 tsh kubectl로 설정한다
 - Settings에서 karpenter namespace(기본 karpenter), 파드 label selector(기본 app.kubernetes.io/name=karpenter), 로그 조회 범위(기본 15분) 변경

--- a/product/akbun-k8supgradeview/workspace/package.json
+++ b/product/akbun-k8supgradeview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-k8supgradeview",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "EKS 업그레이드 작업 중 노드와 파드 상태를 확인하는 데스크톱 뷰어",
   "author": "akbun",
   "license": "MIT",

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -37,6 +37,20 @@ export interface PodLog {
   error: string;
 }
 
+export interface KarpenterResource {
+  name: string;
+  ami: string;
+  weight: string;
+}
+
+export interface KarpenterResources {
+  nodePools: KarpenterResource[];
+  // NodePool 또는 EC2NodeClass CRD가 없는 클러스터도 있으므로 조회 실패를 값으로 담는다.
+  nodePoolsError: string;
+  ec2NodeClasses: KarpenterResource[];
+  ec2NodeClassesError: string;
+}
+
 export interface KarpenterLogs {
   namespace: string;
   labelSelector: string;
@@ -209,6 +223,66 @@ async function getPodLog(
   } catch (error) {
     return { podName, text: "", error: String(error instanceof Error ? error.message : error) };
   }
+}
+
+const NO_VALUE = "-";
+
+/** amiSelectorTerms의 항목을 alias=al2023@latest 같은 한 줄 표기로 만든다. */
+function amiTermText(term: Record<string, any>): string {
+  return Object.entries(term)
+    .map(([key, value]) => `${key}=${typeof value === "object" ? JSON.stringify(value) : value}`)
+    .join(" ");
+}
+
+/**
+ * EC2NodeClass가 어떤 AMI를 쓰는지 한 칸에 담는다.
+ * amiSelectorTerms를 우선 보고, 없으면 예전 필드인 amiFamily를 쓴다.
+ */
+function amiText(spec: any): string {
+  const terms: any[] = spec?.amiSelectorTerms ?? [];
+  if (terms.length > 0) return terms.map(amiTermText).join(", ");
+  return spec?.amiFamily ?? NO_VALUE;
+}
+
+/**
+ * NodePool에는 ami가, EC2NodeClass에는 weight가 없다. 없는 필드는 -로 표시한다.
+ * List 안의 항목에는 kind가 없으므로 어느 리소스를 읽는지는 호출부가 알려준다.
+ */
+function toKarpenterResource(item: any, hasAmi: boolean): KarpenterResource {
+  const spec = item.spec ?? {};
+  return {
+    name: item.metadata?.name ?? "",
+    ami: hasAmi ? amiText(spec) : NO_VALUE,
+    weight: spec.weight === undefined ? NO_VALUE : String(spec.weight),
+  };
+}
+
+/** CRD가 없는 클러스터도 있으므로 실패를 던지지 않고 에러 메시지와 함께 돌려준다. */
+async function getKarpenterResource(
+  resource: string,
+  hasAmi: boolean
+): Promise<{ items: KarpenterResource[]; error: string }> {
+  try {
+    const stdout = await runKubectl(["get", resource, "-o", "json"]);
+    const items: any[] = JSON.parse(stdout).items ?? [];
+    return { items: items.map((item) => toKarpenterResource(item, hasAmi)), error: "" };
+  } catch (error) {
+    return { items: [], error: String(error instanceof Error ? error.message : error) };
+  }
+}
+
+/** NodePool과 EC2NodeClass 목록. 둘 다 cluster scope 리소스라 namespace를 쓰지 않는다. */
+export async function getKarpenterResources(): Promise<KarpenterResources> {
+  const [nodePools, ec2NodeClasses] = await Promise.all([
+    getKarpenterResource("nodepools.karpenter.sh", false),
+    getKarpenterResource("ec2nodeclasses.karpenter.k8s.aws", true),
+  ]);
+  return {
+    nodePools: nodePools.items,
+    nodePoolsError: nodePools.error,
+    ec2NodeClasses: ec2NodeClasses.items,
+    ec2NodeClassesError: ec2NodeClasses.error,
+  };
 }
 
 /** label selector로 찾은 karpenter pod들의 최근 log를 모은다. */

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -58,6 +58,18 @@ export interface KarpenterResources {
   ec2NodeClassesError: string;
 }
 
+export interface KarpenterVersion {
+  deployment: string;
+  version: string;
+  image: string;
+}
+
+export interface KarpenterVersions {
+  versions: KarpenterVersion[];
+  // deployment 조회 권한이 없어도 event와 log는 봐야 하므로 실패를 값으로 담는다.
+  error: string;
+}
+
 export interface KarpenterLogs {
   namespace: string;
   labelSelector: string;
@@ -321,6 +333,54 @@ export async function getKarpenterResources(): Promise<KarpenterResources> {
     ec2NodeClasses: ec2NodeClasses.items.map(toEc2NodeClass),
     ec2NodeClassesError: ec2NodeClasses.error,
   };
+}
+
+/**
+ * image 문자열에서 tag를 뽑는다. registry에 port가 붙어 있으면(host:5000/karpenter)
+ * 마지막 / 뒤에서만 :를 찾아야 tag와 port를 혼동하지 않는다.
+ */
+function imageTag(image: string): string {
+  const name = image.split("@")[0];
+  const lastSlash = name.lastIndexOf("/");
+  const colon = name.indexOf(":", lastSlash + 1);
+  return colon === -1 ? "" : name.slice(colon + 1);
+}
+
+function containerImage(deployment: any): string {
+  const containers: any[] = deployment.spec?.template?.spec?.containers ?? [];
+  return containers[0]?.image ?? "";
+}
+
+/** helm chart가 붙이는 app.kubernetes.io/version label을 먼저 보고, 없으면 image tag를 쓴다. */
+function toKarpenterVersion(deployment: any): KarpenterVersion {
+  const image = containerImage(deployment);
+  const labelVersion = deployment.metadata?.labels?.["app.kubernetes.io/version"];
+  return {
+    deployment: deployment.metadata?.name ?? "",
+    version: labelVersion || imageTag(image) || NO_VALUE,
+    image: image || NO_VALUE,
+  };
+}
+
+/** karpenter deployment에서 읽은 버전. label selector는 pod 조회와 같은 설정을 쓴다. */
+export async function getKarpenterVersions(): Promise<KarpenterVersions> {
+  const settings = loadSettings();
+  try {
+    const stdout = await runKubectl([
+      "get",
+      "deployments",
+      "-n",
+      settings.karpenterNamespace,
+      "-l",
+      settings.karpenterPodLabelSelector,
+      "-o",
+      "json",
+    ]);
+    const items: any[] = JSON.parse(stdout).items ?? [];
+    return { versions: items.map(toKarpenterVersion), error: "" };
+  } catch (error) {
+    return { versions: [], error: String(error instanceof Error ? error.message : error) };
+  }
 }
 
 /** label selector로 찾은 karpenter pod들의 최근 log를 모은다. */

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -21,6 +21,29 @@ export interface PodInfo {
   creationTimestamp: string;
 }
 
+export interface EventInfo {
+  timestamp: string;
+  type: string;
+  reason: string;
+  object: string;
+  message: string;
+  count: number;
+}
+
+export interface PodLog {
+  podName: string;
+  // log 본문. 조회에 실패하면 빈 문자열이고 error에 이유가 담긴다.
+  text: string;
+  error: string;
+}
+
+export interface KarpenterLogs {
+  namespace: string;
+  labelSelector: string;
+  sinceMinutes: number;
+  logs: PodLog[];
+}
+
 const KARPENTER_LABELS = ["karpenter.sh/nodepool", "karpenter.sh/provisioner-name"];
 const MANAGED_NODEGROUP_LABEL = "eks.amazonaws.com/nodegroup";
 
@@ -110,4 +133,94 @@ export async function getPods(nodeName?: string): Promise<PodInfo[]> {
   const stdout = await runKubectl(args);
   const items: any[] = JSON.parse(stdout).items ?? [];
   return items.map(toPodInfo);
+}
+
+// core/v1 Event와 events.k8s.io/v1 Event의 필드 이름이 달라 둘 다 읽는다.
+function eventTimestamp(event: any): string {
+  return (
+    event.lastTimestamp ??
+    event.series?.lastObservedTime ??
+    event.eventTime ??
+    event.firstTimestamp ??
+    event.metadata?.creationTimestamp ??
+    ""
+  );
+}
+
+function eventObject(event: any): string {
+  const target = event.involvedObject ?? event.regarding ?? {};
+  if (!target.kind) return target.name ?? "";
+  return `${target.kind}/${target.name ?? ""}`;
+}
+
+function toEventInfo(event: any): EventInfo {
+  return {
+    timestamp: eventTimestamp(event),
+    type: event.type ?? "",
+    reason: event.reason ?? "",
+    object: eventObject(event),
+    message: (event.message ?? event.note ?? "").trim(),
+    count: event.count ?? event.series?.count ?? event.deprecatedCount ?? 1,
+  };
+}
+
+/** karpenter namespace의 event를 오래된 것부터 시간순으로 돌려준다. */
+export async function getKarpenterEvents(): Promise<EventInfo[]> {
+  const namespace = loadSettings().karpenterNamespace;
+  const stdout = await runKubectl(["get", "events", "-n", namespace, "-o", "json"]);
+  const items: any[] = JSON.parse(stdout).items ?? [];
+  return items
+    .map(toEventInfo)
+    .sort((a, b) => Date.parse(a.timestamp || "0") - Date.parse(b.timestamp || "0"));
+}
+
+async function getPodNames(namespace: string, labelSelector: string): Promise<string[]> {
+  const stdout = await runKubectl([
+    "get",
+    "pods",
+    "-n",
+    namespace,
+    "-l",
+    labelSelector,
+    "-o",
+    "json",
+  ]);
+  const items: any[] = JSON.parse(stdout).items ?? [];
+  return items.map((pod) => pod.metadata?.name ?? "").filter(Boolean);
+}
+
+/** pod 하나의 log. 한 pod가 실패해도 나머지 pod의 log는 보여줘야 하므로 에러를 값으로 담는다. */
+async function getPodLog(
+  namespace: string,
+  podName: string,
+  sinceMinutes: number
+): Promise<PodLog> {
+  try {
+    const text = await runKubectl([
+      "logs",
+      podName,
+      "-n",
+      namespace,
+      "--all-containers=true",
+      "--timestamps",
+      `--since=${sinceMinutes}m`,
+    ]);
+    return { podName, text: text.trimEnd(), error: "" };
+  } catch (error) {
+    return { podName, text: "", error: String(error instanceof Error ? error.message : error) };
+  }
+}
+
+/** label selector로 찾은 karpenter pod들의 최근 log를 모은다. */
+export async function getKarpenterLogs(): Promise<KarpenterLogs> {
+  const settings = loadSettings();
+  const namespace = settings.karpenterNamespace;
+  const labelSelector = settings.karpenterPodLabelSelector;
+  const sinceMinutes = settings.karpenterLogSinceMinutes;
+
+  const podNames = await getPodNames(namespace, labelSelector);
+  const logs = await Promise.all(
+    podNames.map((podName) => getPodLog(namespace, podName, sinceMinutes))
+  );
+  return { namespace, labelSelector, sinceMinutes, logs };
 }

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -43,8 +43,15 @@ export interface KarpenterResource {
   weight: string;
 }
 
+export interface NodePoolInfo extends KarpenterResource {
+  // 이 NodePool이 만든 노드 수. 노드 조회가 실패하면 "-"다.
+  nodes: string;
+  ready: string;
+  creationTimestamp: string;
+}
+
 export interface KarpenterResources {
-  nodePools: KarpenterResource[];
+  nodePools: NodePoolInfo[];
   // NodePool 또는 EC2NodeClass CRD가 없는 클러스터도 있으므로 조회 실패를 값으로 담는다.
   nodePoolsError: string;
   ec2NodeClasses: KarpenterResource[];
@@ -244,43 +251,74 @@ function amiText(spec: any): string {
   return spec?.amiFamily ?? NO_VALUE;
 }
 
-/**
- * NodePool에는 ami가, EC2NodeClass에는 weight가 없다. 없는 필드는 -로 표시한다.
- * List 안의 항목에는 kind가 없으므로 어느 리소스를 읽는지는 호출부가 알려준다.
- */
-function toKarpenterResource(item: any, hasAmi: boolean): KarpenterResource {
+/** status.conditions의 Ready 상태. condition이 아직 없으면 -다. */
+function readyStatus(item: any): string {
+  const conditions: any[] = item.status?.conditions ?? [];
+  return conditions.find((condition) => condition.type === "Ready")?.status ?? NO_VALUE;
+}
+
+/** EC2NodeClass는 ami만 있고 weight가 없다. 없는 필드는 -로 표시한다. */
+function toEc2NodeClass(item: any): KarpenterResource {
   const spec = item.spec ?? {};
   return {
     name: item.metadata?.name ?? "",
-    ami: hasAmi ? amiText(spec) : NO_VALUE,
+    ami: amiText(spec),
     weight: spec.weight === undefined ? NO_VALUE : String(spec.weight),
   };
 }
 
+/** NodePool은 ami가 없고, 만든 노드 수는 노드 목록을 세어 채운다. */
+function toNodePool(item: any, nodeCounts: Map<string, number> | null): NodePoolInfo {
+  const spec = item.spec ?? {};
+  const name = item.metadata?.name ?? "";
+  return {
+    name,
+    ami: NO_VALUE,
+    weight: spec.weight === undefined ? NO_VALUE : String(spec.weight),
+    nodes: nodeCounts ? String(nodeCounts.get(name) ?? 0) : NO_VALUE,
+    ready: readyStatus(item),
+    creationTimestamp: item.metadata?.creationTimestamp ?? "",
+  };
+}
+
 /** CRD가 없는 클러스터도 있으므로 실패를 던지지 않고 에러 메시지와 함께 돌려준다. */
-async function getKarpenterResource(
-  resource: string,
-  hasAmi: boolean
-): Promise<{ items: KarpenterResource[]; error: string }> {
+async function getResourceItems(resource: string): Promise<{ items: any[]; error: string }> {
   try {
     const stdout = await runKubectl(["get", resource, "-o", "json"]);
-    const items: any[] = JSON.parse(stdout).items ?? [];
-    return { items: items.map((item) => toKarpenterResource(item, hasAmi)), error: "" };
+    return { items: JSON.parse(stdout).items ?? [], error: "" };
   } catch (error) {
     return { items: [], error: String(error instanceof Error ? error.message : error) };
   }
 }
 
+/**
+ * NodePool 이름별 노드 수. NodePool status에는 노드 수가 없어서 노드 label로 센다.
+ * 노드 조회가 실패하면 0과 구분하려고 null을 돌려준다.
+ */
+async function countNodesByNodePool(): Promise<Map<string, number> | null> {
+  try {
+    const counts = new Map<string, number>();
+    for (const node of await getNodes()) {
+      if (!node.isKarpenter) continue;
+      counts.set(node.group, (counts.get(node.group) ?? 0) + 1);
+    }
+    return counts;
+  } catch {
+    return null;
+  }
+}
+
 /** NodePool과 EC2NodeClass 목록. 둘 다 cluster scope 리소스라 namespace를 쓰지 않는다. */
 export async function getKarpenterResources(): Promise<KarpenterResources> {
-  const [nodePools, ec2NodeClasses] = await Promise.all([
-    getKarpenterResource("nodepools.karpenter.sh", false),
-    getKarpenterResource("ec2nodeclasses.karpenter.k8s.aws", true),
+  const [nodePools, ec2NodeClasses, nodeCounts] = await Promise.all([
+    getResourceItems("nodepools.karpenter.sh"),
+    getResourceItems("ec2nodeclasses.karpenter.k8s.aws"),
+    countNodesByNodePool(),
   ]);
   return {
-    nodePools: nodePools.items,
+    nodePools: nodePools.items.map((item) => toNodePool(item, nodeCounts)),
     nodePoolsError: nodePools.error,
-    ec2NodeClasses: ec2NodeClasses.items,
+    ec2NodeClasses: ec2NodeClasses.items.map(toEc2NodeClass),
     ec2NodeClassesError: ec2NodeClasses.error,
   };
 }

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -197,6 +197,12 @@ function toEventInfo(event: any): EventInfo {
   };
 }
 
+/** 정렬용 시각. 비었거나 읽을 수 없는 값이 NaN이 되어 정렬을 흐트러뜨리지 않게 0으로 맞춘다. */
+function eventSortKey(timestamp: string): number {
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
 /** karpenter namespace의 event를 오래된 것부터 시간순으로 돌려준다. */
 export async function getKarpenterEvents(): Promise<EventInfo[]> {
   const namespace = loadSettings().karpenterNamespace;
@@ -204,7 +210,7 @@ export async function getKarpenterEvents(): Promise<EventInfo[]> {
   const items: any[] = JSON.parse(stdout).items ?? [];
   return items
     .map(toEventInfo)
-    .sort((a, b) => Date.parse(a.timestamp || "0") - Date.parse(b.timestamp || "0"));
+    .sort((a, b) => eventSortKey(a.timestamp) - eventSortKey(b.timestamp));
 }
 
 async function getPodNames(namespace: string, labelSelector: string): Promise<string[]> {

--- a/product/akbun-k8supgradeview/workspace/src/main/main.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/main.ts
@@ -2,7 +2,13 @@ import { app, BrowserWindow, dialog, ipcMain, Menu, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as fs from "node:fs/promises";
 import * as path from "path";
-import { getKarpenterEvents, getKarpenterLogs, getNodes, getPods } from "./kubectl";
+import {
+  getKarpenterEvents,
+  getKarpenterLogs,
+  getKarpenterResources,
+  getNodes,
+  getPods,
+} from "./kubectl";
 import { AppSettings, loadSettings, saveSettings } from "./settings";
 import { checkUpdate, cleanupTempDirs, downloadDmg, spawnSwap } from "./update";
 
@@ -24,6 +30,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle("kubectl:pods", (_event, nodeName?: string) => getPods(nodeName));
   ipcMain.handle("kubectl:karpenter-events", () => getKarpenterEvents());
   ipcMain.handle("kubectl:karpenter-logs", () => getKarpenterLogs());
+  ipcMain.handle("kubectl:karpenter-resources", () => getKarpenterResources());
   ipcMain.handle("settings:get", () => loadSettings());
   ipcMain.handle("settings:save", (_event, settings: unknown) => {
     // IPC 경계에서 형식을 검증한다. renderer가 잘못된 값을 보내면 명확한 에러로 알린다.

--- a/product/akbun-k8supgradeview/workspace/src/main/main.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, Menu, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as fs from "node:fs/promises";
 import * as path from "path";
-import { getNodes, getPods } from "./kubectl";
+import { getKarpenterEvents, getKarpenterLogs, getNodes, getPods } from "./kubectl";
 import { AppSettings, loadSettings, saveSettings } from "./settings";
 import { checkUpdate, cleanupTempDirs, downloadDmg, spawnSwap } from "./update";
 
@@ -22,14 +22,25 @@ function createWindow(): void {
 function registerIpcHandlers(): void {
   ipcMain.handle("kubectl:nodes", () => getNodes());
   ipcMain.handle("kubectl:pods", (_event, nodeName?: string) => getPods(nodeName));
+  ipcMain.handle("kubectl:karpenter-events", () => getKarpenterEvents());
+  ipcMain.handle("kubectl:karpenter-logs", () => getKarpenterLogs());
   ipcMain.handle("settings:get", () => loadSettings());
   ipcMain.handle("settings:save", (_event, settings: unknown) => {
     // IPC 경계에서 형식을 검증한다. renderer가 잘못된 값을 보내면 명확한 에러로 알린다.
-    const kubectlCommand = (settings as Partial<AppSettings> | null)?.kubectlCommand;
-    if (typeof kubectlCommand !== "string") {
+    const input = settings as Partial<AppSettings> | null;
+    if (typeof input?.kubectlCommand !== "string") {
       throw new Error("settings 형식이 잘못되었다: kubectlCommand는 문자열이어야 한다");
     }
-    return saveSettings({ kubectlCommand });
+    if (typeof input.karpenterNamespace !== "string") {
+      throw new Error("settings 형식이 잘못되었다: karpenterNamespace는 문자열이어야 한다");
+    }
+    if (typeof input.karpenterPodLabelSelector !== "string") {
+      throw new Error("settings 형식이 잘못되었다: karpenterPodLabelSelector는 문자열이어야 한다");
+    }
+    if (typeof input.karpenterLogSinceMinutes !== "number") {
+      throw new Error("settings 형식이 잘못되었다: karpenterLogSinceMinutes는 숫자여야 한다");
+    }
+    return saveSettings(input);
   });
 }
 

--- a/product/akbun-k8supgradeview/workspace/src/main/main.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/main.ts
@@ -6,6 +6,7 @@ import {
   getKarpenterEvents,
   getKarpenterLogs,
   getKarpenterResources,
+  getKarpenterVersions,
   getNodes,
   getPods,
 } from "./kubectl";
@@ -31,6 +32,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle("kubectl:karpenter-events", () => getKarpenterEvents());
   ipcMain.handle("kubectl:karpenter-logs", () => getKarpenterLogs());
   ipcMain.handle("kubectl:karpenter-resources", () => getKarpenterResources());
+  ipcMain.handle("kubectl:karpenter-versions", () => getKarpenterVersions());
   ipcMain.handle("settings:get", () => loadSettings());
   ipcMain.handle("settings:save", (_event, settings: unknown) => {
     // IPC 경계에서 형식을 검증한다. renderer가 잘못된 값을 보내면 명확한 에러로 알린다.

--- a/product/akbun-k8supgradeview/workspace/src/main/preload.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/preload.ts
@@ -3,6 +3,8 @@ import { contextBridge, ipcRenderer } from "electron";
 contextBridge.exposeInMainWorld("api", {
   getNodes: () => ipcRenderer.invoke("kubectl:nodes"),
   getPods: (nodeName?: string) => ipcRenderer.invoke("kubectl:pods", nodeName),
+  getKarpenterEvents: () => ipcRenderer.invoke("kubectl:karpenter-events"),
+  getKarpenterLogs: () => ipcRenderer.invoke("kubectl:karpenter-logs"),
   getSettings: () => ipcRenderer.invoke("settings:get"),
   saveSettings: (settings: unknown) => ipcRenderer.invoke("settings:save", settings),
 });

--- a/product/akbun-k8supgradeview/workspace/src/main/preload.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/preload.ts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld("api", {
   getPods: (nodeName?: string) => ipcRenderer.invoke("kubectl:pods", nodeName),
   getKarpenterEvents: () => ipcRenderer.invoke("kubectl:karpenter-events"),
   getKarpenterLogs: () => ipcRenderer.invoke("kubectl:karpenter-logs"),
+  getKarpenterResources: () => ipcRenderer.invoke("kubectl:karpenter-resources"),
   getSettings: () => ipcRenderer.invoke("settings:get"),
   saveSettings: (settings: unknown) => ipcRenderer.invoke("settings:save", settings),
 });

--- a/product/akbun-k8supgradeview/workspace/src/main/preload.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/preload.ts
@@ -6,6 +6,7 @@ contextBridge.exposeInMainWorld("api", {
   getKarpenterEvents: () => ipcRenderer.invoke("kubectl:karpenter-events"),
   getKarpenterLogs: () => ipcRenderer.invoke("kubectl:karpenter-logs"),
   getKarpenterResources: () => ipcRenderer.invoke("kubectl:karpenter-resources"),
+  getKarpenterVersions: () => ipcRenderer.invoke("kubectl:karpenter-versions"),
   getSettings: () => ipcRenderer.invoke("settings:get"),
   saveSettings: (settings: unknown) => ipcRenderer.invoke("settings:save", settings),
 });

--- a/product/akbun-k8supgradeview/workspace/src/main/settings.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/settings.ts
@@ -5,37 +5,69 @@ import * as path from "path";
 export interface AppSettings {
   // kubectl 실행 명령. teleport 등 proxy를 쓰면 "tsh kubectl"처럼 설정한다.
   kubectlCommand: string;
+  // karpenter가 설치된 namespace. event와 pod log를 이 namespace에서 조회한다.
+  karpenterNamespace: string;
+  // karpenter pod를 찾는 label selector. kubectl -l 값과 같은 형식이다.
+  karpenterPodLabelSelector: string;
+  // pod log를 몇 분 전까지 볼지. kubectl logs --since 값으로 쓴다.
+  karpenterLogSinceMinutes: number;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
   kubectlCommand: "kubectl",
+  karpenterNamespace: "karpenter",
+  karpenterPodLabelSelector: "app.kubernetes.io/name=karpenter",
+  karpenterLogSinceMinutes: 15,
 };
+
+const MIN_LOG_SINCE_MINUTES = 1;
+const MAX_LOG_SINCE_MINUTES = 1440;
 
 function settingsPath(): string {
   return path.join(app.getPath("userData"), "settings.json");
 }
 
+/** 문자열이 아니거나 비어 있으면 기본값으로 폴백한다. */
+function normalizeText(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+/** 숫자가 아니거나 범위를 벗어나면 허용 범위 안으로 맞춘다. */
+function normalizeSinceMinutes(value: unknown): number {
+  const minutes = Math.floor(Number(value));
+  if (!Number.isFinite(minutes)) return DEFAULT_SETTINGS.karpenterLogSinceMinutes;
+  if (minutes < MIN_LOG_SINCE_MINUTES) return MIN_LOG_SINCE_MINUTES;
+  if (minutes > MAX_LOG_SINCE_MINUTES) return MAX_LOG_SINCE_MINUTES;
+  return minutes;
+}
+
+/** 손상되었거나 예전 버전이라 필드가 없는 설정을 기본값으로 채운다. */
+function normalize(parsed: Partial<AppSettings>): AppSettings {
+  return {
+    kubectlCommand: normalizeText(parsed.kubectlCommand, DEFAULT_SETTINGS.kubectlCommand),
+    karpenterNamespace: normalizeText(
+      parsed.karpenterNamespace,
+      DEFAULT_SETTINGS.karpenterNamespace
+    ),
+    karpenterPodLabelSelector: normalizeText(
+      parsed.karpenterPodLabelSelector,
+      DEFAULT_SETTINGS.karpenterPodLabelSelector
+    ),
+    karpenterLogSinceMinutes: normalizeSinceMinutes(parsed.karpenterLogSinceMinutes),
+  };
+}
+
 export function loadSettings(): AppSettings {
   try {
     const raw = fs.readFileSync(settingsPath(), "utf-8");
-    const parsed = JSON.parse(raw) as Partial<AppSettings>;
-    // 파일이 손상되어 kubectlCommand가 문자열이 아니면 기본값으로 폴백한다.
-    const kubectlCommand =
-      typeof parsed.kubectlCommand === "string" && parsed.kubectlCommand.trim()
-        ? parsed.kubectlCommand
-        : DEFAULT_SETTINGS.kubectlCommand;
-    return { kubectlCommand };
+    return normalize(JSON.parse(raw) as Partial<AppSettings>);
   } catch {
     return { ...DEFAULT_SETTINGS };
   }
 }
 
-export function saveSettings(settings: AppSettings): AppSettings {
-  const merged: AppSettings = {
-    ...DEFAULT_SETTINGS,
-    ...settings,
-    kubectlCommand: settings.kubectlCommand.trim() || DEFAULT_SETTINGS.kubectlCommand,
-  };
+export function saveSettings(settings: Partial<AppSettings>): AppSettings {
+  const merged = normalize(settings);
   fs.mkdirSync(path.dirname(settingsPath()), { recursive: true });
   fs.writeFileSync(settingsPath(), JSON.stringify(merged, null, 2));
   return merged;

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -13,6 +13,7 @@
       <button class="tab-button active" data-tab="nodes">Nodes</button>
       <button class="tab-button" data-tab="pods">Pods</button>
       <button class="tab-button" data-tab="karpenter">Karpenter Event</button>
+      <button class="tab-button" data-tab="nodepools">NodePool / EC2NodeClass</button>
       <button class="tab-button" data-tab="settings">Settings</button>
     </nav>
   </header>
@@ -115,6 +116,45 @@
         <h2>Pod log</h2>
         <div id="karpenter-logs"></div>
         <p id="karpenter-log-empty" class="empty hidden">label selector에 맞는 파드가 없습니다.</p>
+      </section>
+    </section>
+
+    <!-- NodePool / EC2NodeClass tab -->
+    <section id="tab-nodepools" class="tab">
+      <div class="toolbar">
+        <button id="refresh-nodepools">새로고침</button>
+      </div>
+
+      <section class="karpenter-panel">
+        <h2>NodePool</h2>
+        <p id="nodepool-error" class="resource-error hidden"></p>
+        <table id="nodepool-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>AMI</th>
+              <th>Weight</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <p id="nodepool-empty" class="empty hidden">NodePool이 없습니다.</p>
+      </section>
+
+      <section class="karpenter-panel">
+        <h2>EC2NodeClass</h2>
+        <p id="ec2nodeclass-error" class="resource-error hidden"></p>
+        <table id="ec2nodeclass-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>AMI</th>
+              <th>Weight</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <p id="ec2nodeclass-empty" class="empty hidden">EC2NodeClass가 없습니다.</p>
       </section>
     </section>
 

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -95,6 +95,22 @@
       </div>
 
       <section class="karpenter-panel">
+        <h2>Version</h2>
+        <p id="karpenter-version-error" class="resource-error hidden"></p>
+        <table id="karpenter-version-table">
+          <thead>
+            <tr>
+              <th>Deployment</th>
+              <th>Version</th>
+              <th>Image</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <p id="karpenter-version-empty" class="empty hidden">karpenter deployment를 찾지 못했습니다.</p>
+      </section>
+
+      <section class="karpenter-panel">
         <h2>Event</h2>
         <table id="karpenter-event-table">
           <thead>

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -134,6 +134,9 @@
               <th>Name</th>
               <th>AMI</th>
               <th>Weight</th>
+              <th>Nodes</th>
+              <th>Ready</th>
+              <th>Age</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -12,6 +12,7 @@
     <nav>
       <button class="tab-button active" data-tab="nodes">Nodes</button>
       <button class="tab-button" data-tab="pods">Pods</button>
+      <button class="tab-button" data-tab="karpenter">Karpenter Event</button>
       <button class="tab-button" data-tab="settings">Settings</button>
     </nav>
   </header>
@@ -85,6 +86,38 @@
       <p id="pod-empty" class="empty hidden">파드가 없습니다.</p>
     </section>
 
+    <!-- Karpenter Event tab -->
+    <section id="tab-karpenter" class="tab">
+      <div class="toolbar">
+        <span id="karpenter-scope" class="help"></span>
+        <button id="refresh-karpenter">새로고침</button>
+      </div>
+
+      <section class="karpenter-panel">
+        <h2>Event</h2>
+        <table id="karpenter-event-table">
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Type</th>
+              <th>Reason</th>
+              <th>Object</th>
+              <th>Count</th>
+              <th>Message</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <p id="karpenter-event-empty" class="empty hidden">event가 없습니다.</p>
+      </section>
+
+      <section class="karpenter-panel">
+        <h2>Pod log</h2>
+        <div id="karpenter-logs"></div>
+        <p id="karpenter-log-empty" class="empty hidden">label selector에 맞는 파드가 없습니다.</p>
+      </section>
+    </section>
+
     <!-- Settings tab -->
     <section id="tab-settings" class="tab">
       <h2>kubectl 설정</h2>
@@ -95,6 +128,31 @@
       <div class="settings-form">
         <label for="kubectl-command">kubectl 명령</label>
         <input id="kubectl-command" type="text" placeholder="kubectl" />
+      </div>
+
+      <h2>Karpenter 설정</h2>
+      <p class="help">
+        Karpenter Event 탭이 조회할 namespace와 pod label selector, log 조회 범위를 정한다.
+        log 범위는 1분에서 1440분(24시간) 사이로 제한한다.
+      </p>
+      <div class="settings-form">
+        <label for="karpenter-namespace">namespace</label>
+        <input id="karpenter-namespace" type="text" placeholder="karpenter" />
+      </div>
+      <div class="settings-form">
+        <label for="karpenter-label-selector">pod label selector</label>
+        <input
+          id="karpenter-label-selector"
+          type="text"
+          placeholder="app.kubernetes.io/name=karpenter"
+        />
+      </div>
+      <div class="settings-form">
+        <label for="karpenter-log-since">log 조회 범위(분)</label>
+        <input id="karpenter-log-since" type="number" min="1" max="1440" placeholder="15" />
+      </div>
+
+      <div class="settings-form">
         <button id="save-settings">저장</button>
         <span id="settings-saved" class="hidden">저장되었습니다.</span>
       </div>

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -33,6 +33,17 @@ interface PodLog {
   error: string;
 }
 
+interface KarpenterVersion {
+  deployment: string;
+  version: string;
+  image: string;
+}
+
+interface KarpenterVersions {
+  versions: KarpenterVersion[];
+  error: string;
+}
+
 interface KarpenterLogs {
   namespace: string;
   labelSelector: string;
@@ -71,6 +82,7 @@ interface Api {
   getPods(nodeName?: string): Promise<PodInfo[]>;
   getKarpenterEvents(): Promise<EventInfo[]>;
   getKarpenterLogs(): Promise<KarpenterLogs>;
+  getKarpenterVersions(): Promise<KarpenterVersions>;
   getKarpenterResources(): Promise<KarpenterResources>;
   getSettings(): Promise<AppSettings>;
   saveSettings(settings: AppSettings): Promise<AppSettings>;
@@ -296,13 +308,25 @@ function renderKarpenterLogs(result: KarpenterLogs): void {
     `namespace ${result.namespace} / label ${result.labelSelector} / 최근 ${result.sinceMinutes}분`;
 }
 
+function renderKarpenterVersions(result: KarpenterVersions): void {
+  const tbody = prepareResourceTable("karpenter-version", result.versions.length, result.error);
+  for (const version of result.versions) {
+    const row = tbody.insertRow();
+    appendCell(row, version.deployment);
+    appendCell(row, version.version);
+    appendCell(row, version.image);
+  }
+}
+
 async function refreshKarpenter(): Promise<void> {
   try {
     clearError();
-    const [events, logs] = await Promise.all([
+    const [versions, events, logs] = await Promise.all([
+      api.getKarpenterVersions(),
       api.getKarpenterEvents(),
       api.getKarpenterLogs(),
     ]);
+    renderKarpenterVersions(versions);
     renderKarpenterEvents(events);
     renderKarpenterLogs(logs);
     karpenterLoaded = true;

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -46,8 +46,14 @@ interface KarpenterResource {
   weight: string;
 }
 
+interface NodePoolInfo extends KarpenterResource {
+  nodes: string;
+  ready: string;
+  creationTimestamp: string;
+}
+
 interface KarpenterResources {
-  nodePools: KarpenterResource[];
+  nodePools: NodePoolInfo[];
   nodePoolsError: string;
   ec2NodeClasses: KarpenterResource[];
   ec2NodeClassesError: string;
@@ -311,17 +317,41 @@ function renderResourceError(selector: string, message: string): void {
   paragraph.classList.toggle("hidden", !message);
 }
 
-function renderKarpenterResourceTable(
+// Ready condition이 아직 없으면 "-"라 좋고 나쁨을 말할 수 없으므로 색을 주지 않는다.
+function readyClass(ready: string): string {
+  if (ready === "True") return "status-ready";
+  if (ready === "False") return "status-error";
+  return "";
+}
+
+/** 조회 자체가 실패했으면 비었다는 안내 대신 에러만 보여준다. */
+function prepareResourceTable(
   prefix: string,
-  resources: KarpenterResource[],
+  count: number,
   error: string
-): void {
+): HTMLTableSectionElement {
   renderResourceError(`#${prefix}-error`, error);
+  $(`#${prefix}-empty`).classList.toggle("hidden", count > 0 || Boolean(error));
   const tbody = $(`#${prefix}-table tbody`) as HTMLTableSectionElement;
   tbody.innerHTML = "";
-  // 조회 자체가 실패했으면 비었다는 안내 대신 에러만 보여준다.
-  $(`#${prefix}-empty`).classList.toggle("hidden", resources.length > 0 || Boolean(error));
+  return tbody;
+}
 
+function renderNodePools(nodePools: NodePoolInfo[], error: string): void {
+  const tbody = prepareResourceTable("nodepool", nodePools.length, error);
+  for (const nodePool of nodePools) {
+    const row = tbody.insertRow();
+    appendCell(row, nodePool.name);
+    appendCell(row, nodePool.ami);
+    appendCell(row, nodePool.weight);
+    appendCell(row, nodePool.nodes);
+    appendCell(row, nodePool.ready, readyClass(nodePool.ready));
+    appendCell(row, formatAge(nodePool.creationTimestamp));
+  }
+}
+
+function renderEc2NodeClasses(resources: KarpenterResource[], error: string): void {
+  const tbody = prepareResourceTable("ec2nodeclass", resources.length, error);
   for (const resource of resources) {
     const row = tbody.insertRow();
     appendCell(row, resource.name);
@@ -334,12 +364,8 @@ async function refreshKarpenterResources(): Promise<void> {
   try {
     clearError();
     const result = await api.getKarpenterResources();
-    renderKarpenterResourceTable("nodepool", result.nodePools, result.nodePoolsError);
-    renderKarpenterResourceTable(
-      "ec2nodeclass",
-      result.ec2NodeClasses,
-      result.ec2NodeClassesError
-    );
+    renderNodePools(result.nodePools, result.nodePoolsError);
+    renderEc2NodeClasses(result.ec2NodeClasses, result.ec2NodeClassesError);
     nodePoolsLoaded = true;
   } catch (error) {
     showError(String(error));

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -18,13 +18,40 @@ interface PodInfo {
   creationTimestamp: string;
 }
 
+interface EventInfo {
+  timestamp: string;
+  type: string;
+  reason: string;
+  object: string;
+  message: string;
+  count: number;
+}
+
+interface PodLog {
+  podName: string;
+  text: string;
+  error: string;
+}
+
+interface KarpenterLogs {
+  namespace: string;
+  labelSelector: string;
+  sinceMinutes: number;
+  logs: PodLog[];
+}
+
 interface AppSettings {
   kubectlCommand: string;
+  karpenterNamespace: string;
+  karpenterPodLabelSelector: string;
+  karpenterLogSinceMinutes: number;
 }
 
 interface Api {
   getNodes(): Promise<NodeInfo[]>;
   getPods(nodeName?: string): Promise<PodInfo[]>;
+  getKarpenterEvents(): Promise<EventInfo[]>;
+  getKarpenterLogs(): Promise<KarpenterLogs>;
   getSettings(): Promise<AppSettings>;
   saveSettings(settings: AppSettings): Promise<AppSettings>;
 }
@@ -37,6 +64,7 @@ let allNodes: NodeInfo[] = [];
 let allPods: PodInfo[] = [];
 let nodeFilter: NodeFilterKind = "all";
 let selectedNode = "";
+let karpenterLoaded = false;
 
 function $(selector: string): HTMLElement {
   return document.querySelector(selector) as HTMLElement;
@@ -189,6 +217,79 @@ async function refreshPods(): Promise<void> {
   }
 }
 
+// event는 언제 일어났는지가 중요하므로 age 대신 로컬 시각을 그대로 보여준다.
+function formatEventTime(timestamp: string): string {
+  if (!timestamp) return "";
+  const time = new Date(timestamp);
+  if (Number.isNaN(time.getTime())) return timestamp;
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const date = `${pad(time.getMonth() + 1)}-${pad(time.getDate())}`;
+  return `${date} ${pad(time.getHours())}:${pad(time.getMinutes())}:${pad(time.getSeconds())}`;
+}
+
+function renderKarpenterEvents(events: EventInfo[]): void {
+  const tbody = $("#karpenter-event-table tbody") as HTMLTableSectionElement;
+  tbody.innerHTML = "";
+  $("#karpenter-event-empty").classList.toggle("hidden", events.length > 0);
+
+  for (const event of events) {
+    const row = tbody.insertRow();
+    appendCell(row, formatEventTime(event.timestamp));
+    appendCell(row, event.type, event.type === "Warning" ? "status-warning" : "");
+    appendCell(row, event.reason);
+    appendCell(row, event.object);
+    appendCell(row, String(event.count));
+    const message = row.insertCell();
+    message.textContent = event.message;
+    message.className = "message-cell";
+  }
+}
+
+function createLogBlock(log: PodLog): HTMLElement {
+  const block = document.createElement("section");
+  block.className = "log-block";
+
+  const title = document.createElement("h3");
+  title.textContent = log.podName;
+  block.appendChild(title);
+
+  const body = document.createElement("pre");
+  if (log.error) {
+    body.className = "log-error";
+    body.textContent = log.error;
+  } else {
+    body.textContent = log.text || "해당 기간에 남은 로그가 없습니다.";
+  }
+  block.appendChild(body);
+  return block;
+}
+
+function renderKarpenterLogs(result: KarpenterLogs): void {
+  const container = $("#karpenter-logs");
+  container.innerHTML = "";
+  $("#karpenter-log-empty").classList.toggle("hidden", result.logs.length > 0);
+  for (const log of result.logs) {
+    container.appendChild(createLogBlock(log));
+  }
+  $("#karpenter-scope").textContent =
+    `namespace ${result.namespace} / label ${result.labelSelector} / 최근 ${result.sinceMinutes}분`;
+}
+
+async function refreshKarpenter(): Promise<void> {
+  try {
+    clearError();
+    const [events, logs] = await Promise.all([
+      api.getKarpenterEvents(),
+      api.getKarpenterLogs(),
+    ]);
+    renderKarpenterEvents(events);
+    renderKarpenterLogs(logs);
+    karpenterLoaded = true;
+  } catch (error) {
+    showError(String(error));
+  }
+}
+
 function activateTab(tab: string): void {
   document.querySelectorAll(".tab-button").forEach((button) => {
     button.classList.toggle("active", (button as HTMLElement).dataset.tab === tab);
@@ -197,22 +298,39 @@ function activateTab(tab: string): void {
     section.classList.toggle("active", section.id === `tab-${tab}`);
   });
   if (tab === "pods" && allPods.length === 0) void refreshPods();
+  if (tab === "karpenter" && !karpenterLoaded) void refreshKarpenter();
+}
+
+function fillSettingsForm(settings: AppSettings): void {
+  ($("#kubectl-command") as HTMLInputElement).value = settings.kubectlCommand;
+  ($("#karpenter-namespace") as HTMLInputElement).value = settings.karpenterNamespace;
+  ($("#karpenter-label-selector") as HTMLInputElement).value = settings.karpenterPodLabelSelector;
+  ($("#karpenter-log-since") as HTMLInputElement).value = String(settings.karpenterLogSinceMinutes);
 }
 
 async function loadSettingsForm(): Promise<void> {
   try {
-    const settings = await api.getSettings();
-    ($("#kubectl-command") as HTMLInputElement).value = settings.kubectlCommand;
+    fillSettingsForm(await api.getSettings());
   } catch (error) {
     showError(String(error));
   }
 }
 
+function readSettingsForm(): AppSettings {
+  return {
+    kubectlCommand: ($("#kubectl-command") as HTMLInputElement).value,
+    karpenterNamespace: ($("#karpenter-namespace") as HTMLInputElement).value,
+    karpenterPodLabelSelector: ($("#karpenter-label-selector") as HTMLInputElement).value,
+    karpenterLogSinceMinutes: Number(($("#karpenter-log-since") as HTMLInputElement).value),
+  };
+}
+
 async function submitSettings(): Promise<void> {
   try {
-    const kubectlCommand = ($("#kubectl-command") as HTMLInputElement).value;
-    const saved = await api.saveSettings({ kubectlCommand });
-    ($("#kubectl-command") as HTMLInputElement).value = saved.kubectlCommand;
+    const saved = await api.saveSettings(readSettingsForm());
+    fillSettingsForm(saved);
+    // 조회 범위가 바뀌었을 수 있으므로 Karpenter 탭을 다시 열 때 새로 불러오게 한다.
+    karpenterLoaded = false;
     const badge = $("#settings-saved");
     badge.classList.remove("hidden");
     setTimeout(() => badge.classList.add("hidden"), 2000);
@@ -235,6 +353,7 @@ function registerEventHandlers(): void {
   });
   $("#refresh-nodes").addEventListener("click", () => void refreshNodes());
   $("#refresh-pods").addEventListener("click", () => void refreshPods());
+  $("#refresh-karpenter").addEventListener("click", () => void refreshKarpenter());
   $("#namespace-filter").addEventListener("change", renderPods);
   $("#pod-search").addEventListener("input", renderPods);
   $("#save-settings").addEventListener("click", () => void submitSettings());

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -40,6 +40,19 @@ interface KarpenterLogs {
   logs: PodLog[];
 }
 
+interface KarpenterResource {
+  name: string;
+  ami: string;
+  weight: string;
+}
+
+interface KarpenterResources {
+  nodePools: KarpenterResource[];
+  nodePoolsError: string;
+  ec2NodeClasses: KarpenterResource[];
+  ec2NodeClassesError: string;
+}
+
 interface AppSettings {
   kubectlCommand: string;
   karpenterNamespace: string;
@@ -52,6 +65,7 @@ interface Api {
   getPods(nodeName?: string): Promise<PodInfo[]>;
   getKarpenterEvents(): Promise<EventInfo[]>;
   getKarpenterLogs(): Promise<KarpenterLogs>;
+  getKarpenterResources(): Promise<KarpenterResources>;
   getSettings(): Promise<AppSettings>;
   saveSettings(settings: AppSettings): Promise<AppSettings>;
 }
@@ -65,6 +79,7 @@ let allPods: PodInfo[] = [];
 let nodeFilter: NodeFilterKind = "all";
 let selectedNode = "";
 let karpenterLoaded = false;
+let nodePoolsLoaded = false;
 
 function $(selector: string): HTMLElement {
   return document.querySelector(selector) as HTMLElement;
@@ -290,6 +305,47 @@ async function refreshKarpenter(): Promise<void> {
   }
 }
 
+function renderResourceError(selector: string, message: string): void {
+  const paragraph = $(selector);
+  paragraph.textContent = message;
+  paragraph.classList.toggle("hidden", !message);
+}
+
+function renderKarpenterResourceTable(
+  prefix: string,
+  resources: KarpenterResource[],
+  error: string
+): void {
+  renderResourceError(`#${prefix}-error`, error);
+  const tbody = $(`#${prefix}-table tbody`) as HTMLTableSectionElement;
+  tbody.innerHTML = "";
+  // 조회 자체가 실패했으면 비었다는 안내 대신 에러만 보여준다.
+  $(`#${prefix}-empty`).classList.toggle("hidden", resources.length > 0 || Boolean(error));
+
+  for (const resource of resources) {
+    const row = tbody.insertRow();
+    appendCell(row, resource.name);
+    appendCell(row, resource.ami);
+    appendCell(row, resource.weight);
+  }
+}
+
+async function refreshKarpenterResources(): Promise<void> {
+  try {
+    clearError();
+    const result = await api.getKarpenterResources();
+    renderKarpenterResourceTable("nodepool", result.nodePools, result.nodePoolsError);
+    renderKarpenterResourceTable(
+      "ec2nodeclass",
+      result.ec2NodeClasses,
+      result.ec2NodeClassesError
+    );
+    nodePoolsLoaded = true;
+  } catch (error) {
+    showError(String(error));
+  }
+}
+
 function activateTab(tab: string): void {
   document.querySelectorAll(".tab-button").forEach((button) => {
     button.classList.toggle("active", (button as HTMLElement).dataset.tab === tab);
@@ -299,6 +355,7 @@ function activateTab(tab: string): void {
   });
   if (tab === "pods" && allPods.length === 0) void refreshPods();
   if (tab === "karpenter" && !karpenterLoaded) void refreshKarpenter();
+  if (tab === "nodepools" && !nodePoolsLoaded) void refreshKarpenterResources();
 }
 
 function fillSettingsForm(settings: AppSettings): void {
@@ -329,8 +386,9 @@ async function submitSettings(): Promise<void> {
   try {
     const saved = await api.saveSettings(readSettingsForm());
     fillSettingsForm(saved);
-    // 조회 범위가 바뀌었을 수 있으므로 Karpenter 탭을 다시 열 때 새로 불러오게 한다.
+    // 조회 대상이 바뀌었을 수 있으므로 karpenter 탭들을 다시 열 때 새로 불러오게 한다.
     karpenterLoaded = false;
+    nodePoolsLoaded = false;
     const badge = $("#settings-saved");
     badge.classList.remove("hidden");
     setTimeout(() => badge.classList.add("hidden"), 2000);
@@ -354,6 +412,7 @@ function registerEventHandlers(): void {
   $("#refresh-nodes").addEventListener("click", () => void refreshNodes());
   $("#refresh-pods").addEventListener("click", () => void refreshPods());
   $("#refresh-karpenter").addEventListener("click", () => void refreshKarpenter());
+  $("#refresh-nodepools").addEventListener("click", () => void refreshKarpenterResources());
   $("#namespace-filter").addEventListener("change", renderPods);
   $("#pod-search").addEventListener("input", renderPods);
   $("#save-settings").addEventListener("click", () => void submitSettings());

--- a/product/akbun-k8supgradeview/workspace/src/renderer/style.css
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/style.css
@@ -91,6 +91,7 @@ button {
 #refresh-nodes,
 #refresh-pods,
 #refresh-karpenter,
+#refresh-nodepools,
 #save-settings {
   padding: 6px 14px;
   border: 1px solid #d0d7de;
@@ -189,6 +190,25 @@ th {
 
 /* message는 길어서 한 줄로 두면 표가 가로로 넘친다. 이 칸만 줄바꿈을 허용한다. */
 .message-cell {
+  max-width: 620px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* CRD가 없거나 권한이 없어 한쪽 조회만 실패했을 때 그 표 위에만 이유를 적는다. */
+.resource-error {
+  margin: 0 0 8px;
+  padding: 8px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 13px;
+  white-space: pre-wrap;
+}
+
+/* amiSelectorTerms는 길어질 수 있어 AMI 칸만 줄바꿈을 허용한다. */
+#ec2nodeclass-table td:nth-child(2) {
   max-width: 620px;
   white-space: pre-wrap;
   word-break: break-word;

--- a/product/akbun-k8supgradeview/workspace/src/renderer/style.css
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/style.css
@@ -90,6 +90,7 @@ button {
 
 #refresh-nodes,
 #refresh-pods,
+#refresh-karpenter,
 #save-settings {
   padding: 6px 14px;
   border: 1px solid #d0d7de;
@@ -177,9 +178,59 @@ th {
   display: none !important;
 }
 
+.karpenter-panel {
+  margin-bottom: 24px;
+}
+
+.karpenter-panel h2 {
+  font-size: 15px;
+  margin: 0 0 8px;
+}
+
+/* message는 길어서 한 줄로 두면 표가 가로로 넘친다. 이 칸만 줄바꿈을 허용한다. */
+.message-cell {
+  max-width: 620px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.log-block {
+  margin-bottom: 12px;
+}
+
+.log-block h3 {
+  font-size: 13px;
+  margin: 0 0 4px;
+  color: #57606a;
+}
+
+.log-block pre {
+  margin: 0;
+  max-height: 320px;
+  overflow: auto;
+  padding: 10px 12px;
+  border: 1px solid #d0d7de;
+  border-radius: 8px;
+  background: #ffffff;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.log-block pre.log-error {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
 #namespace-filter,
 #pod-search,
-#kubectl-command {
+#kubectl-command,
+#karpenter-namespace,
+#karpenter-label-selector,
+#karpenter-log-since {
   padding: 6px 10px;
   border: 1px solid #d0d7de;
   border-radius: 6px;
@@ -199,10 +250,17 @@ th {
 
 .settings-form label {
   font-size: 14px;
+  min-width: 150px;
 }
 
-#kubectl-command {
+#kubectl-command,
+#karpenter-namespace,
+#karpenter-label-selector {
   min-width: 260px;
+}
+
+#karpenter-log-since {
+  width: 100px;
 }
 
 #settings-saved {

--- a/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
+++ b/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
@@ -1,11 +1,12 @@
 /**
- * NodePool / EC2NodeClass 조회의 파싱 규칙을 검증한다.
+ * karpenter 리소스 조회의 파싱 규칙을 검증한다.
  *
  * 이 화면은 필드가 없는 경우가 정상이다. NodePool에는 ami가 없고 EC2NodeClass에는
  * weight가 없으며, weight와 Ready condition은 있을 수도 없을 수도 있다. 빈 값을
  * 0이나 빈 문자열로 잘못 채우면 화면에서 알아채기 어려우므로 목업으로 확인한다.
  * 노드 수는 NodePool status에 없어서 노드 label로 세는데, 조회 실패(-)와 0개를
  * 구분하지 못하면 "노드가 하나도 없다"고 잘못 읽히므로 함께 검증한다.
+ * 버전도 label이 없으면 image tag로 폴백하므로 같은 이유로 검증한다.
  *
  * 실행: npm test (dist/를 읽으므로 build가 먼저 돈다)
  *
@@ -35,7 +36,7 @@ require.cache["electron-stub"] = {
 };
 
 const { saveSettings } = require("../dist/main/settings.js");
-const { getKarpenterResources } = require("../dist/main/kubectl.js");
+const { getKarpenterResources, getKarpenterVersions } = require("../dist/main/kubectl.js");
 
 const NODE_POOLS = {
   items: [
@@ -142,6 +143,43 @@ test("한쪽 CRD 조회가 실패해도 다른 쪽 목록은 그대로 나온다
   assert.strictEqual(result.nodePoolsError, "");
   assert.deepStrictEqual(result.ec2NodeClasses, []);
   assert.match(result.ec2NodeClassesError, /CRD not found/);
+});
+
+test("버전은 label을 먼저 보고 없으면 image tag를 쓴다", async () => {
+  useFakeKubectl({
+    deployments: {
+      items: [
+        {
+          metadata: { name: "karpenter", labels: { "app.kubernetes.io/version": "1.0.5" } },
+          spec: { template: { spec: { containers: [{ image: "public.ecr.aws/karpenter:0.37.0" }] } } },
+        },
+        // label이 없어 image tag로 폴백한다. registry port의 :5000을 tag로 읽으면 안 된다.
+        {
+          metadata: { name: "karpenter-old" },
+          spec: { template: { spec: { containers: [{ image: "registry:5000/karpenter:1.1.0" }] } } },
+        },
+        // tag 없이 digest만 있는 image
+        {
+          metadata: { name: "karpenter-digest" },
+          spec: { template: { spec: { containers: [{ image: "public.ecr.aws/karpenter@sha256:abc" }] } } },
+        },
+      ],
+    },
+  });
+  const { versions, error } = await getKarpenterVersions();
+
+  assert.strictEqual(error, "");
+  assert.strictEqual(versions[0].version, "1.0.5", "label을 먼저 써야 한다");
+  assert.strictEqual(versions[1].version, "1.1.0", "registry port를 tag로 읽으면 안 된다");
+  assert.strictEqual(versions[2].version, "-", "tag가 없으면 -여야 한다");
+});
+
+test("deployment 조회가 실패해도 에러만 담고 던지지 않는다", async () => {
+  useFakeKubectl({ deployments: "forbidden" });
+  const { versions, error } = await getKarpenterVersions();
+
+  assert.deepStrictEqual(versions, []);
+  assert.match(error, /forbidden/);
 });
 
 test("age는 NodePool의 creationTimestamp를 그대로 넘긴다", async () => {

--- a/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
+++ b/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
@@ -1,0 +1,152 @@
+/**
+ * NodePool / EC2NodeClass 조회의 파싱 규칙을 검증한다.
+ *
+ * 이 화면은 필드가 없는 경우가 정상이다. NodePool에는 ami가 없고 EC2NodeClass에는
+ * weight가 없으며, weight와 Ready condition은 있을 수도 없을 수도 있다. 빈 값을
+ * 0이나 빈 문자열로 잘못 채우면 화면에서 알아채기 어려우므로 목업으로 확인한다.
+ * 노드 수는 NodePool status에 없어서 노드 label로 세는데, 조회 실패(-)와 0개를
+ * 구분하지 못하면 "노드가 하나도 없다"고 잘못 읽히므로 함께 검증한다.
+ *
+ * 실행: npm test (dist/를 읽으므로 build가 먼저 돈다)
+ *
+ * kubectl 자리에 mock 데이터를 뱉는 셸 스크립트를 두고 실제 조회 경로를 그대로 돈다.
+ */
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "akbun-k8supgradeview-test-"));
+
+// settings는 electron의 app.getPath만 쓴다. 테스트 임시 디렉터리를 주어 실제 앱 설정을 건드리지 않는다.
+const Module = require("node:module");
+const resolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (request === "electron") return "electron-stub";
+  return resolveFilename.call(this, request, ...rest);
+};
+require.cache["electron-stub"] = {
+  id: "electron-stub",
+  filename: "electron-stub",
+  loaded: true,
+  exports: { app: { getPath: () => workDir } },
+};
+
+const { saveSettings } = require("../dist/main/settings.js");
+const { getKarpenterResources } = require("../dist/main/kubectl.js");
+
+const NODE_POOLS = {
+  items: [
+    {
+      metadata: { name: "default", creationTimestamp: "2026-07-01T00:00:00Z" },
+      spec: { weight: 50 },
+      status: { conditions: [{ type: "Ready", status: "True" }] },
+    },
+    // weight도 Ready condition도 없는 NodePool
+    { metadata: { name: "spot", creationTimestamp: "2026-07-02T00:00:00Z" }, spec: {} },
+  ],
+};
+
+const EC2_NODE_CLASSES = {
+  items: [
+    { metadata: { name: "default" }, spec: { amiSelectorTerms: [{ alias: "al2023@latest" }] } },
+    { metadata: { name: "legacy" }, spec: { amiFamily: "AL2" } },
+    { metadata: { name: "bare" }, spec: {} },
+  ],
+};
+
+// default nodepool 노드 2개, 다른 nodepool 노드 1개, karpenter가 만들지 않은 노드 1개
+const NODES = {
+  items: [
+    { metadata: { name: "n1", labels: { "karpenter.sh/nodepool": "default" } } },
+    { metadata: { name: "n2", labels: { "karpenter.sh/nodepool": "default" } } },
+    { metadata: { name: "n3", labels: { "karpenter.sh/nodepool": "other" } } },
+    { metadata: { name: "n4", labels: { "eks.amazonaws.com/nodegroup": "managed" } } },
+  ],
+};
+
+/**
+ * mock 데이터를 뱉는 가짜 kubectl을 만들어 settings에 등록한다.
+ * responses의 값이 문자열이면 그 리소스 조회를 실패시킨다.
+ */
+function useFakeKubectl(responses) {
+  const cases = Object.entries(responses)
+    .map(([resource, value]) =>
+      typeof value === "string"
+        ? `  ${resource}) echo ${JSON.stringify(value)} >&2; exit 1 ;;`
+        : `  ${resource}) cat <<'JSON'\n${JSON.stringify(value)}\nJSON\n  ;;`
+    )
+    .join("\n");
+  const script = `#!/bin/bash\ncase "$2" in\n${cases}\n  *) echo '{"items":[]}' ;;\nesac\n`;
+
+  const scriptPath = path.join(workDir, "fake-kubectl");
+  fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+  saveSettings({
+    kubectlCommand: scriptPath,
+    karpenterNamespace: "karpenter",
+    karpenterPodLabelSelector: "app.kubernetes.io/name=karpenter",
+    karpenterLogSinceMinutes: 15,
+  });
+}
+
+const ALL_OK = {
+  "nodepools.karpenter.sh": NODE_POOLS,
+  "ec2nodeclasses.karpenter.k8s.aws": EC2_NODE_CLASSES,
+  nodes: NODES,
+};
+
+test.after(() => fs.rmSync(workDir, { recursive: true, force: true }));
+
+test("없는 필드는 -로 채운다", async () => {
+  useFakeKubectl(ALL_OK);
+  const { nodePools, ec2NodeClasses } = await getKarpenterResources();
+
+  const [withWeight, withoutWeight] = nodePools;
+  assert.strictEqual(withWeight.weight, "50");
+  assert.strictEqual(withoutWeight.weight, "-", "weight가 없으면 -여야 한다");
+  assert.strictEqual(withWeight.ami, "-", "NodePool에는 ami가 없다");
+  assert.strictEqual(withWeight.ready, "True");
+  assert.strictEqual(withoutWeight.ready, "-", "Ready condition이 없으면 -여야 한다");
+
+  const [terms, family, bare] = ec2NodeClasses;
+  assert.strictEqual(terms.ami, "alias=al2023@latest");
+  assert.strictEqual(family.ami, "AL2", "amiSelectorTerms가 없으면 amiFamily를 쓴다");
+  assert.strictEqual(bare.ami, "-");
+  assert.strictEqual(terms.weight, "-", "EC2NodeClass에는 weight가 없다");
+});
+
+test("nodes는 그 NodePool이 만든 노드만 센다", async () => {
+  useFakeKubectl(ALL_OK);
+  const { nodePools } = await getKarpenterResources();
+
+  assert.strictEqual(nodePools[0].nodes, "2", "default nodepool 노드만 세야 한다");
+  assert.strictEqual(nodePools[1].nodes, "0", "노드가 없으면 0이다");
+});
+
+test("노드 조회가 실패하면 nodes는 0이 아니라 -다", async () => {
+  useFakeKubectl({ ...ALL_OK, nodes: "connection refused" });
+  const { nodePools } = await getKarpenterResources();
+
+  for (const nodePool of nodePools) {
+    assert.strictEqual(nodePool.nodes, "-", "조회 실패를 0개로 보여주면 안 된다");
+  }
+});
+
+test("한쪽 CRD 조회가 실패해도 다른 쪽 목록은 그대로 나온다", async () => {
+  useFakeKubectl({ ...ALL_OK, "ec2nodeclasses.karpenter.k8s.aws": "CRD not found" });
+  const result = await getKarpenterResources();
+
+  assert.strictEqual(result.nodePools.length, 2);
+  assert.strictEqual(result.nodePoolsError, "");
+  assert.deepStrictEqual(result.ec2NodeClasses, []);
+  assert.match(result.ec2NodeClassesError, /CRD not found/);
+});
+
+test("age는 NodePool의 creationTimestamp를 그대로 넘긴다", async () => {
+  useFakeKubectl(ALL_OK);
+  const { nodePools } = await getKarpenterResources();
+
+  assert.strictEqual(nodePools[0].creationTimestamp, "2026-07-01T00:00:00Z");
+});

--- a/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
+++ b/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
@@ -36,7 +36,15 @@ require.cache["electron-stub"] = {
 };
 
 const { saveSettings } = require("../dist/main/settings.js");
-const { getKarpenterResources, getKarpenterVersions } = require("../dist/main/kubectl.js");
+const {
+  getKarpenterEvents,
+  getKarpenterResources,
+  getKarpenterVersions,
+} = require("../dist/main/kubectl.js");
+
+// 모듈을 다 읽었으면 전역 오버라이드를 되돌린다. 이 파일이 다른 모듈 로딩에 영향을 주면 안 된다.
+Module._resolveFilename = resolveFilename;
+delete require.cache["electron-stub"];
 
 const NODE_POOLS = {
   items: [
@@ -180,6 +188,69 @@ test("deployment 조회가 실패해도 에러만 담고 던지지 않는다", a
 
   assert.deepStrictEqual(versions, []);
   assert.match(error, /forbidden/);
+});
+
+// core/v1과 events.k8s.io/v1은 같은 event를 다른 필드 이름으로 담는다. 둘 다 읽어야 한다.
+const EVENTS = {
+  items: [
+    {
+      // core/v1
+      metadata: { creationTimestamp: "2026-07-27T00:00:00Z" },
+      type: "Normal",
+      reason: "Nominated",
+      involvedObject: { kind: "Pod", name: "web-1" },
+      message: " pod should schedule ",
+      lastTimestamp: "2026-07-27T02:00:00Z",
+      count: 3,
+    },
+    {
+      // events.k8s.io/v1
+      eventTime: "2026-07-27T00:30:00Z",
+      type: "Warning",
+      reason: "FailedScheduling",
+      regarding: { kind: "NodeClaim", name: "nc-1" },
+      note: "no instance type",
+      series: { count: 2, lastObservedTime: "2026-07-27T01:00:00Z" },
+    },
+    // 시각을 읽을 수 없는 event. 정렬을 흐트러뜨리지 않고 맨 앞에 와야 한다.
+    {
+      type: "Normal",
+      reason: "Unknown",
+      involvedObject: { name: "orphan" },
+      message: "",
+      lastTimestamp: "not-a-date",
+    },
+  ],
+};
+
+test("event는 두 API 버전의 필드를 모두 읽는다", async () => {
+  useFakeKubectl({ events: EVENTS });
+  const events = await getKarpenterEvents();
+  const [orphan, series, core] = events;
+
+  assert.strictEqual(series.timestamp, "2026-07-27T01:00:00Z", "series의 마지막 관측 시각을 쓴다");
+  assert.strictEqual(series.object, "NodeClaim/nc-1", "regarding도 대상으로 읽어야 한다");
+  assert.strictEqual(series.message, "no instance type", "note도 본문으로 읽어야 한다");
+  assert.strictEqual(series.count, 2, "series.count를 읽어야 한다");
+
+  assert.strictEqual(core.timestamp, "2026-07-27T02:00:00Z", "lastTimestamp를 먼저 쓴다");
+  assert.strictEqual(core.object, "Pod/web-1");
+  assert.strictEqual(core.message, "pod should schedule");
+  assert.strictEqual(core.count, 3);
+
+  assert.strictEqual(orphan.object, "orphan", "kind가 없으면 이름만 보여준다");
+  assert.strictEqual(orphan.count, 1, "count가 없으면 1이다");
+});
+
+test("event는 오래된 것부터 정렬하고 시각을 읽을 수 없어도 순서가 깨지지 않는다", async () => {
+  useFakeKubectl({ events: EVENTS });
+  const timestamps = (await getKarpenterEvents()).map((event) => event.timestamp);
+
+  assert.deepStrictEqual(timestamps, [
+    "not-a-date",
+    "2026-07-27T01:00:00Z",
+    "2026-07-27T02:00:00Z",
+  ]);
 });
 
 test("age는 NodePool의 creationTimestamp를 그대로 넘긴다", async () => {


### PR DESCRIPTION
karpenter namespace의 event를 시간순으로 보여주고 label selector로 찾은
karpenter 파드의 최근 로그를 함께 보여주는 탭을 추가한다.

- namespace, pod label selector, 로그 조회 범위를 Settings에서 설정한다.
  기본값은 karpenter, app.kubernetes.io/name=karpenter, 15분이다.
- event는 core/v1과 events.k8s.io/v1 필드를 모두 읽어 오래된 것부터 정렬한다.
- 파드 로그는 파드마다 따로 조회하고 실패는 값으로 담아 나머지 로그를 가리지 않는다.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrQ1fsHSDKFW1GCAKQb67y