### PR TITLE
feat(k8supgradeview): add name copy, EC2NodeClass grouping, error highlight

### DIFF
--- a/product/akbun-k8supgradeview/adr/2026-07-name-copy-and-error-highlight.md
+++ b/product/akbun-k8supgradeview/adr/2026-07-name-copy-and-error-highlight.md
@@ -1,0 +1,25 @@
+---
+type: Decision
+title: 이름 복사, EC2NodeClass 그룹핑, error 키워드 하이라이트
+description: 업그레이드 작업 중 눈과 손이 자주 오가는 세 지점을 화면에서 줄이기로 한다.
+tags: [kubernetes, electron, karpenter]
+timestamp: 2026-07-27T00:00:00Z
+---
+
+## 결정
+
+노드 이름 오른쪽에 복사 버튼을 둔다. 복사는 renderer의 `navigator.clipboard`가 아니라 main 프로세스의 `clipboard.writeText`를 IPC(`clipboard:write`)로 호출한다.
+
+NodePool / EC2NodeClass 탭에서 EC2NodeClass 목록을 그 클래스를 참조하는 NodePool 이름으로 묶는다. 묶는 기준은 NodePool의 `spec.template.spec.nodeClassRef.name`이며, NodePool 표에도 NodeClass 칼럼을 더한다. 어느 NodePool도 참조하지 않는 클래스는 맨 뒤에 따로 묶는다.
+
+Karpenter Event 탭의 event(reason, object, message)와 pod log(파드 이름, 본문)에서 error 낱말만 대소문자 구분 없이 빨갛게 칠한다.
+
+## 이유
+
+- 노드 이름은 이 앱을 보다가 터미널로 옮겨 갈 때 가장 자주 옮기는 값이다. 드래그 선택은 `ip-10-0-1-11.ap-northeast-2.compute.internal` 같은 긴 이름에서 앞뒤가 잘리기 쉬워 붙여넣고 나서야 틀린 것을 안다. 버튼은 값 전체를 그대로 넘긴다.
+- 복사를 main에 둔 이유는 `navigator.clipboard`가 문서 focus와 권한 상태를 타기 때문이다. 실패해도 조용히 아무 일이 없어 사용자가 왜 안 되는지 알 수 없다. main의 clipboard는 그런 조건이 없고, 실패하면 IPC가 에러를 던져 화면 배너에 남는다.
+- 업그레이드 때 실제로 묻는 질문은 "이 NodePool이 지금 어떤 AMI로 노드를 띄우는가"다. 두 목록을 따로 두면 `nodeClassRef`를 눈으로 이어야 하고, NodePool이 여럿이면 매번 다시 이어야 한다. 화면이 그 연결을 대신 그린다.
+- 한 EC2NodeClass를 여러 NodePool이 참조할 수 있어 같은 클래스가 여러 그룹에 나온다. 중복을 없애려고 한 곳에만 두면 나머지 NodePool 아래가 비어 "이 NodePool에는 클래스가 없다"로 잘못 읽힌다. 참조 관계를 그대로 그리는 쪽을 택했다.
+- 참조가 가리키는 클래스를 찾지 못한 NodePool은 그룹을 비우지 않고 찾지 못했다고 적는다. 오타나 삭제된 클래스는 노드가 안 떠서야 드러나는데, 목록에서 먼저 보이면 그 전에 안다.
+- log는 한 파드에서만 수백 줄이 나온다. 눈으로 error를 찾는 동안 정작 봐야 할 줄을 지나친다. 색은 읽기 전에 위치를 알려주므로 훑는 시간이 줄어든다. Warning type 색과 겹치지 않게 배경까지 줘서 낱말 단위로 구분한다.
+- 하이라이트는 조각을 `textContent`로만 넣어 붙인다. event message와 log 본문은 클러스터가 준 문자열이라 HTML로 해석될 여지를 남기지 않는다.

--- a/product/akbun-k8supgradeview/adr/2026-07-name-copy-and-error-highlight.md
+++ b/product/akbun-k8supgradeview/adr/2026-07-name-copy-and-error-highlight.md
@@ -12,7 +12,7 @@ timestamp: 2026-07-27T00:00:00Z
 
 NodePool / EC2NodeClass 탭에서 EC2NodeClass 목록을 그 클래스를 참조하는 NodePool 이름으로 묶는다. 묶는 기준은 NodePool의 `spec.template.spec.nodeClassRef.name`이며, NodePool 표에도 NodeClass 칼럼을 더한다. 어느 NodePool도 참조하지 않는 클래스는 맨 뒤에 따로 묶는다.
 
-Karpenter Event 탭의 event(reason, object, message)와 pod log(파드 이름, 본문)에서 error 낱말만 대소문자 구분 없이 빨갛게 칠한다.
+Karpenter Event 탭의 event(reason, object, message)와 pod log(파드 이름, 본문)에서 error를 대소문자 구분 없이 빨갛게 칠한다. 낱말 경계를 두지 않아 NodeClaimRegistrationError나 errorCode처럼 다른 낱말 안에 든 error도 함께 칠한다.
 
 ## 이유
 
@@ -21,5 +21,6 @@ Karpenter Event 탭의 event(reason, object, message)와 pod log(파드 이름, 
 - 업그레이드 때 실제로 묻는 질문은 "이 NodePool이 지금 어떤 AMI로 노드를 띄우는가"다. 두 목록을 따로 두면 `nodeClassRef`를 눈으로 이어야 하고, NodePool이 여럿이면 매번 다시 이어야 한다. 화면이 그 연결을 대신 그린다.
 - 한 EC2NodeClass를 여러 NodePool이 참조할 수 있어 같은 클래스가 여러 그룹에 나온다. 중복을 없애려고 한 곳에만 두면 나머지 NodePool 아래가 비어 "이 NodePool에는 클래스가 없다"로 잘못 읽힌다. 참조 관계를 그대로 그리는 쪽을 택했다.
 - 참조가 가리키는 클래스를 찾지 못한 NodePool은 그룹을 비우지 않고 찾지 못했다고 적는다. 오타나 삭제된 클래스는 노드가 안 떠서야 드러나는데, 목록에서 먼저 보이면 그 전에 안다.
-- log는 한 파드에서만 수백 줄이 나온다. 눈으로 error를 찾는 동안 정작 봐야 할 줄을 지나친다. 색은 읽기 전에 위치를 알려주므로 훑는 시간이 줄어든다. Warning type 색과 겹치지 않게 배경까지 줘서 낱말 단위로 구분한다.
+- log는 한 파드에서만 수백 줄이 나온다. 눈으로 error를 찾는 동안 정작 봐야 할 줄을 지나친다. 색은 읽기 전에 위치를 알려주므로 훑는 시간이 줄어든다. Warning type의 글자색과 겹치지 않게 배경까지 준다.
+- 낱말 경계(`\berror\b`)를 두지 않는다. karpenter가 실제로 뱉는 값은 `NodeClaimRegistrationError`, `errorCode`, `InsufficientCapacityError`처럼 다른 낱말에 붙어 있는 경우가 많아, 경계를 두면 정작 봐야 할 줄을 놓친다. 그 대신 terror 같은 오탐을 얻지만 클러스터 로그에 나오지 않는 낱말이라 비용이 없다.
 - 하이라이트는 조각을 `textContent`로만 넣어 붙인다. event message와 log 본문은 클러스터가 준 문자열이라 HTML로 해석될 여지를 남기지 않는다.

--- a/product/akbun-k8supgradeview/adr/index.md
+++ b/product/akbun-k8supgradeview/adr/index.md
@@ -9,3 +9,4 @@ akbun-k8supgradeview 프로젝트의 의사결정을 "결정 - 이유" 구조로
 * [package.json version 기반 macOS arm64 전용 릴리즈](2026-07-release-workflow.md) - version을 태그로 쓰고 macOS arm64 dmg만 빌드하기로 한 결정.
 * [업데이트는 dmg 직접 내려받기와 번들 교체](2026-07-update-download-and-swap.md) - GitHub Release 조회와 .app 교체로 업데이트를 구현하고 디스크 누수 방지를 테스트로 검증하기로 한 결정.
 * [cordon과 uncordon은 노드 행의 토글 버튼 하나로 둔다](2026-07-node-cordon-toggle.md) - Action 칼럼에 상태에서 파생되는 버튼 하나를 두고 실행 전 확인 dialog를 두기로 한 결정.
+* [이름 복사, EC2NodeClass 그룹핑, error 키워드 하이라이트](2026-07-name-copy-and-error-highlight.md) - 노드 이름 복사를 main clipboard로 두고, EC2NodeClass를 nodeClassRef 기준으로 묶고, error 낱말을 색으로 표시하기로 한 결정.

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -56,7 +56,7 @@ event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는�
 
 로그는 label selector로 파드를 먼저 찾고 파드마다 따로 조회한다. 한 파드의 조회가 실패해도 나머지 로그는 보여줘야 하므로 실패를 예외로 던지지 않고 `PodLog.error`에 담아 화면에 표시한다.
 
-event의 reason, object, message와 로그의 파드 이름, 본문에서는 error 낱말만 대소문자 구분 없이 빨갛게 칠한다(`.error-keyword`). 수백 줄에서 눈으로 찾는 시간을 줄이기 위해서다. 조각을 `textContent`로만 넣어 붙이므로 클러스터가 준 문자열이 HTML로 해석되지 않는다. 배경은 [하이라이트 ADR](../adr/2026-07-name-copy-and-error-highlight.md)에 있다.
+event의 reason, object, message와 로그의 파드 이름, 본문에서는 error를 대소문자 구분 없이 빨갛게 칠한다(`.error-keyword`). 낱말 경계를 두지 않아 `NodeClaimRegistrationError`처럼 다른 낱말 안에 든 error도 칠한다. 수백 줄에서 눈으로 찾는 시간을 줄이기 위해서다. 조각을 `textContent`로만 넣어 붙이므로 클러스터가 준 문자열이 HTML로 해석되지 않는다. 배경은 [하이라이트 ADR](../adr/2026-07-name-copy-and-error-highlight.md)에 있다.
 
 | 설정 | 기본값 |
 |---|---|
@@ -74,7 +74,7 @@ nodes는 NodePool status에 없어서 노드 목록의 `karpenter.sh/nodepool` l
 
 karpenter가 없거나 CRD 조회 권한이 없는 클러스터도 있으므로 세 조회(NodePool, EC2NodeClass, 노드)는 서로 독립이다. 한쪽이 실패하면 그 표 위에만 이유를 적고 다른 표는 그대로 보여준다.
 
-EC2NodeClass 목록은 그 클래스를 참조하는 NodePool 이름으로 묶어서 보여준다. 묶는 기준은 NodePool의 `spec.template.spec.nodeClassRef.name`이다. 한 클래스를 여러 NodePool이 참조하면 같은 클래스가 여러 그룹에 나오고, 참조가 가리키는 클래스를 찾지 못한 NodePool은 그룹을 비우지 않고 찾지 못했다고 적는다. 어느 NodePool도 참조하지 않는 클래스는 "연결된 NodePool 없음"으로 맨 뒤에 묶는다. NodePool 조회가 실패해도 이 묶음으로 떨어져 EC2NodeClass 목록 자체는 그대로 보인다.
+EC2NodeClass 목록은 그 클래스를 참조하는 NodePool 이름으로 묶어서 보여준다. 묶는 기준은 NodePool의 `spec.template.spec.nodeClassRef.name`이다. 한 클래스를 여러 NodePool이 참조하면 같은 클래스가 여러 그룹에 나오고, 그룹이 비면 이유를 나눠 적는다. 참조가 아예 없으면 지정되지 않았다고, 참조가 가리키는 클래스를 못 찾으면 그 이름과 함께 찾지 못했다고 적는다. 손볼 곳이 다르기 때문이다. EC2NodeClass가 하나도 없으면 그룹을 그리지 않고 표 아래 안내만 남긴다. 어느 NodePool도 참조하지 않는 클래스는 "연결된 NodePool 없음"으로 맨 뒤에 묶는다. NodePool 조회가 실패해도 이 묶음으로 떨어져 EC2NodeClass 목록 자체는 그대로 보인다.
 
 빈 값 처리 규칙은 화면에서 알아채기 어려워 `test/karpenter-resources.test.js`가 목업 데이터로 검증한다. 그룹 기준이 되는 `nodeClassRef` 파싱도 같은 테스트가 확인한다. 파싱 규칙을 고치면 이 테스트를 함께 본다.
 

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -11,7 +11,7 @@ Electron + TypeScript 데스크톱 앱이다. 클러스터 조회는 Kubernetes 
   - `preload.ts`: contextBridge로 renderer에 `window.api` 노출
 - `workspace/src/renderer/`: 화면. Nodes, Pods, Karpenter Event, NodePool / EC2NodeClass, Settings 5개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
 
-renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:set-node-cordon`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `kubectl:karpenter-versions`, `settings:get`, `settings:save`)로만 통신한다.
+renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:set-node-cordon`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `kubectl:karpenter-versions`, `clipboard:write`, `settings:get`, `settings:save`)로만 통신한다.
 
 ## kubectl 실행 흐름
 
@@ -56,6 +56,8 @@ event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는�
 
 로그는 label selector로 파드를 먼저 찾고 파드마다 따로 조회한다. 한 파드의 조회가 실패해도 나머지 로그는 보여줘야 하므로 실패를 예외로 던지지 않고 `PodLog.error`에 담아 화면에 표시한다.
 
+event의 reason, object, message와 로그의 파드 이름, 본문에서는 error 낱말만 대소문자 구분 없이 빨갛게 칠한다(`.error-keyword`). 수백 줄에서 눈으로 찾는 시간을 줄이기 위해서다. 조각을 `textContent`로만 넣어 붙이므로 클러스터가 준 문자열이 HTML로 해석되지 않는다. 배경은 [하이라이트 ADR](../adr/2026-07-name-copy-and-error-highlight.md)에 있다.
+
 | 설정 | 기본값 |
 |---|---|
 | `karpenterNamespace` | `karpenter` |
@@ -64,7 +66,7 @@ event는 core/v1과 events.k8s.io/v1의 필드 이름이 달라 둘 다 읽는�
 
 ## NodePool / EC2NodeClass 탭
 
-NodePool은 name, ami, weight, nodes, ready, age를, EC2NodeClass는 name, ami, weight를 보여준다. NodePool에는 ami가 없고 EC2NodeClass에는 weight가 없으므로 없는 필드는 `-`로 채운다. `spec.weight`나 Ready condition처럼 있을 수도 없을 수도 있는 필드도 마찬가지다.
+NodePool은 name, nodeClass, ami, weight, nodes, ready, age를, EC2NodeClass는 name, ami, weight를 보여준다. NodePool에는 ami가 없고 EC2NodeClass에는 weight가 없으므로 없는 필드는 `-`로 채운다. `spec.weight`나 Ready condition처럼 있을 수도 없을 수도 있는 필드도 마찬가지다.
 
 ami는 `spec.amiSelectorTerms`를 `alias=al2023@latest` 같은 표기로 이어 붙여 보여주고, term이 없으면 예전 필드인 `spec.amiFamily`를 쓴다. 둘 다 없으면 `-`다.
 
@@ -72,7 +74,9 @@ nodes는 NodePool status에 없어서 노드 목록의 `karpenter.sh/nodepool` l
 
 karpenter가 없거나 CRD 조회 권한이 없는 클러스터도 있으므로 세 조회(NodePool, EC2NodeClass, 노드)는 서로 독립이다. 한쪽이 실패하면 그 표 위에만 이유를 적고 다른 표는 그대로 보여준다.
 
-빈 값 처리 규칙은 화면에서 알아채기 어려워 `test/karpenter-resources.test.js`가 목업 데이터로 검증한다. 파싱 규칙을 고치면 이 테스트를 함께 본다.
+EC2NodeClass 목록은 그 클래스를 참조하는 NodePool 이름으로 묶어서 보여준다. 묶는 기준은 NodePool의 `spec.template.spec.nodeClassRef.name`이다. 한 클래스를 여러 NodePool이 참조하면 같은 클래스가 여러 그룹에 나오고, 참조가 가리키는 클래스를 찾지 못한 NodePool은 그룹을 비우지 않고 찾지 못했다고 적는다. 어느 NodePool도 참조하지 않는 클래스는 "연결된 NodePool 없음"으로 맨 뒤에 묶는다. NodePool 조회가 실패해도 이 묶음으로 떨어져 EC2NodeClass 목록 자체는 그대로 보인다.
+
+빈 값 처리 규칙은 화면에서 알아채기 어려워 `test/karpenter-resources.test.js`가 목업 데이터로 검증한다. 그룹 기준이 되는 `nodeClassRef` 파싱도 같은 테스트가 확인한다. 파싱 규칙을 고치면 이 테스트를 함께 본다.
 
 ## cordon / uncordon
 
@@ -83,6 +87,12 @@ Nodes 탭 노드 행 끝 Action 칼럼에 버튼 하나를 두고, 글자를 `un
 행 클릭은 파드 조회에 이미 쓰고 있으므로 버튼 클릭에서 `stopPropagation`으로 전파를 멈춘다. 실행 중에는 버튼을 `disabled`로 잠근다.
 
 subcommand를 반대로 넘기면 노드를 열려다 닫으므로 `test/node-cordon.test.js`가 실제 실행 경로에서 넘어간 인자를 확인한다.
+
+## 노드 이름 복사
+
+Nodes 탭 Name 칼럼의 이름 오른쪽에 복사 버튼을 둔다. 클릭하면 renderer가 `clipboard:write` IPC로 이름을 넘기고 main이 electron `clipboard.writeText`로 복사한다. renderer의 `navigator.clipboard`를 쓰지 않는 이유는 focus와 권한 상태를 타서 조용히 실패하기 때문이며, 배경은 [이름 복사 ADR](../adr/2026-07-name-copy-and-error-highlight.md)에 있다.
+
+복사에 성공하면 버튼 글자를 1.5초 동안 "복사됨"으로 바꾼다. 행 클릭은 파드 조회에 쓰고 있으므로 cordon 버튼과 마찬가지로 `stopPropagation`으로 전파를 멈춘다. `td`를 직접 flex로 만들면 표 정렬이 깨지므로 칸 안에 감싸는 요소(`.name-box`)를 하나 두고 그것을 flex로 만든다.
 
 ## 노드 분류 기준
 

--- a/product/akbun-k8supgradeview/workspace/package.json
+++ b/product/akbun-k8supgradeview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-k8supgradeview",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "EKS 업그레이드 작업 중 노드와 파드 상태를 확인하는 데스크톱 뷰어",
   "author": "akbun",
   "license": "MIT",

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -48,6 +48,8 @@ export interface NodePoolInfo extends KarpenterResource {
   nodes: string;
   ready: string;
   creationTimestamp: string;
+  // 이 NodePool이 참조하는 EC2NodeClass 이름. 참조가 없으면 빈 문자열이다.
+  nodeClassName: string;
 }
 
 export interface KarpenterResources {
@@ -293,6 +295,14 @@ function toEc2NodeClass(item: any): KarpenterResource {
   };
 }
 
+/**
+ * NodePool이 어떤 EC2NodeClass를 쓰는지는 template의 nodeClassRef에 있다.
+ * 이 이름이 두 리소스를 잇는 유일한 값이라 화면의 그룹 기준이 된다.
+ */
+function nodeClassName(spec: any): string {
+  return spec?.template?.spec?.nodeClassRef?.name ?? "";
+}
+
 /** NodePool은 ami가 없고, 만든 노드 수는 노드 목록을 세어 채운다. */
 function toNodePool(item: any, nodeCounts: Map<string, number> | null): NodePoolInfo {
   const spec = item.spec ?? {};
@@ -304,6 +314,7 @@ function toNodePool(item: any, nodeCounts: Map<string, number> | null): NodePool
     nodes: nodeCounts ? String(nodeCounts.get(name) ?? 0) : NO_VALUE,
     ready: readyStatus(item),
     creationTimestamp: item.metadata?.creationTimestamp ?? "",
+    nodeClassName: nodeClassName(spec),
   };
 }
 

--- a/product/akbun-k8supgradeview/workspace/src/main/main.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, ipcMain, Menu, shell } from "electron";
+import { app, BrowserWindow, clipboard, dialog, ipcMain, Menu, shell } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as fs from "node:fs/promises";
 import * as path from "path";
@@ -74,6 +74,16 @@ function registerIpcHandlers(): void {
   ipcMain.handle("kubectl:karpenter-logs", () => getKarpenterLogs());
   ipcMain.handle("kubectl:karpenter-resources", () => getKarpenterResources());
   ipcMain.handle("kubectl:karpenter-versions", () => getKarpenterVersions());
+  /**
+   * renderer의 navigator.clipboard는 권한과 focus 상태를 타므로 main의 clipboard를 쓴다.
+   * 화면에 보여준 값을 그대로 복사하는 동작이라 별도 확인은 두지 않는다.
+   */
+  ipcMain.handle("clipboard:write", (_event, text: unknown) => {
+    if (typeof text !== "string") {
+      throw new Error("복사할 값이 잘못되었다: 문자열이어야 한다");
+    }
+    clipboard.writeText(text);
+  });
   ipcMain.handle("settings:get", () => loadSettings());
   ipcMain.handle("settings:save", (_event, settings: unknown) => {
     // IPC 경계에서 형식을 검증한다. renderer가 잘못된 값을 보내면 명확한 에러로 알린다.

--- a/product/akbun-k8supgradeview/workspace/src/main/preload.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/preload.ts
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld("api", {
   getKarpenterLogs: () => ipcRenderer.invoke("kubectl:karpenter-logs"),
   getKarpenterResources: () => ipcRenderer.invoke("kubectl:karpenter-resources"),
   getKarpenterVersions: () => ipcRenderer.invoke("kubectl:karpenter-versions"),
+  copyText: (text: string) => ipcRenderer.invoke("clipboard:write", text),
   getSettings: () => ipcRenderer.invoke("settings:get"),
   saveSettings: (settings: unknown) => ipcRenderer.invoke("settings:save", settings),
 });

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -149,6 +149,7 @@
           <thead>
             <tr>
               <th>Name</th>
+              <th>NodeClass</th>
               <th>AMI</th>
               <th>Weight</th>
               <th>Nodes</th>
@@ -163,6 +164,7 @@
 
       <section class="karpenter-panel">
         <h2>EC2NodeClass</h2>
+        <p class="help">NodePool이 참조하는 nodeClassRef 이름으로 묶어서 보여준다.</p>
         <p id="ec2nodeclass-error" class="resource-error hidden"></p>
         <table id="ec2nodeclass-table">
           <thead>

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -483,6 +483,8 @@ function renderNodePools(nodePools: NodePoolInfo[], error: string): void {
 
 interface Ec2NodeClassGroup {
   nodePoolName: string;
+  // 이 그룹을 만든 NodePool의 nodeClassRef 이름. 참조가 없으면 빈 문자열이다.
+  nodeClassName: string;
   resources: KarpenterResource[];
 }
 
@@ -491,7 +493,8 @@ interface Ec2NodeClassGroup {
  * "이 NodePool이 지금 어떤 AMI로 노드를 띄우는가"를 봐야 하는데, 두 목록을 따로 두면
  * nodeClassRef를 눈으로 이어야 한다. 그룹으로 묶어 그 연결을 화면이 대신 보여준다.
  *
- * 한 EC2NodeClass를 여러 NodePool이 참조할 수 있으므로 같은 클래스가 여러 그룹에 나온다.
+ * 이름은 클러스터 안에서 유일하므로 이름으로 찾는 map을 한 번 만들어 쓴다.
+ * 한 EC2NodeClass를 여러 NodePool이 참조하면 같은 클래스가 여러 그룹에 나온다.
  * 어느 NodePool도 참조하지 않는 클래스는 맨 뒤에 따로 묶는다. NodePool 조회가 실패했을
  * 때도 이 묶음으로 떨어져 EC2NodeClass 목록 자체는 그대로 보인다.
  */
@@ -499,17 +502,24 @@ function groupEc2NodeClasses(
   nodePools: NodePoolInfo[],
   resources: KarpenterResource[]
 ): Ec2NodeClassGroup[] {
-  const groups: Ec2NodeClassGroup[] = [];
+  const byName = new Map(resources.map((resource) => [resource.name, resource]));
   const linked = new Set<string>();
+  const groups: Ec2NodeClassGroup[] = [];
 
   for (const nodePool of nodePools) {
-    const matched = resources.filter((resource) => resource.name === nodePool.nodeClassName);
-    matched.forEach((resource) => linked.add(resource.name));
-    groups.push({ nodePoolName: nodePool.name, resources: matched });
+    const matched = byName.get(nodePool.nodeClassName);
+    if (matched) linked.add(matched.name);
+    groups.push({
+      nodePoolName: nodePool.name,
+      nodeClassName: nodePool.nodeClassName,
+      resources: matched ? [matched] : [],
+    });
   }
 
   const unlinked = resources.filter((resource) => !linked.has(resource.name));
-  if (unlinked.length > 0) groups.push({ nodePoolName: UNLINKED_GROUP, resources: unlinked });
+  if (unlinked.length > 0) {
+    groups.push({ nodePoolName: UNLINKED_GROUP, nodeClassName: "", resources: unlinked });
+  }
   return groups;
 }
 
@@ -526,12 +536,22 @@ function appendGroupHeaderRow(
   cell.textContent = title;
 }
 
-function appendEmptyGroupRow(tbody: HTMLTableSectionElement, columns: number): void {
+/**
+ * 그룹이 빈 이유는 둘이다. 참조 자체가 없거나, 참조가 가리키는 클래스를 못 찾았거나다.
+ * 앞은 NodePool 설정이 덜 된 것이고 뒤는 이름이 어긋난 것이라 손볼 곳이 다르므로 나눠 적는다.
+ */
+function appendEmptyGroupRow(
+  tbody: HTMLTableSectionElement,
+  nodeClassName: string,
+  columns: number
+): void {
   const row = tbody.insertRow();
   const cell = row.insertCell();
   cell.colSpan = columns;
   cell.className = "empty";
-  cell.textContent = "참조하는 EC2NodeClass를 찾지 못했습니다.";
+  cell.textContent = nodeClassName
+    ? `참조하는 EC2NodeClass ${nodeClassName}을 찾지 못했습니다.`
+    : "참조하는 EC2NodeClass가 지정되어 있지 않습니다.";
 }
 
 function renderEc2NodeClasses(
@@ -540,10 +560,13 @@ function renderEc2NodeClasses(
   error: string
 ): void {
   const tbody = prepareResourceTable("ec2nodeclass", resources.length, error);
+  // 클래스가 하나도 없으면 표 아래 안내만 남긴다. 그룹까지 그리면 없다는 안내와 겹쳐 보인다.
+  if (resources.length === 0) return;
+
   for (const group of groupEc2NodeClasses(nodePools, resources)) {
     appendGroupHeaderRow(tbody, group.nodePoolName, 3);
     if (group.resources.length === 0) {
-      appendEmptyGroupRow(tbody, 3);
+      appendEmptyGroupRow(tbody, group.nodeClassName, 3);
       continue;
     }
     for (const resource of group.resources) {

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -61,6 +61,7 @@ interface NodePoolInfo extends KarpenterResource {
   nodes: string;
   ready: string;
   creationTimestamp: string;
+  nodeClassName: string;
 }
 
 interface KarpenterResources {
@@ -85,6 +86,7 @@ interface Api {
   getKarpenterLogs(): Promise<KarpenterLogs>;
   getKarpenterVersions(): Promise<KarpenterVersions>;
   getKarpenterResources(): Promise<KarpenterResources>;
+  copyText(text: string): Promise<void>;
   getSettings(): Promise<AppSettings>;
   saveSettings(settings: AppSettings): Promise<AppSettings>;
 }
@@ -138,6 +140,75 @@ function appendCell(row: HTMLTableRowElement, text: string, className?: string):
   if (className) cell.className = className;
 }
 
+const ERROR_KEYWORD_PATTERN = /error/gi;
+
+/**
+ * error 키워드만 빨갛게 칠한다. 조각을 textContent로만 넣으므로 로그나 event 본문이
+ * HTML로 해석되지 않는다. 대소문자를 가리지 않아야 Error와 error를 함께 잡는다.
+ */
+function appendErrorHighlighted(target: HTMLElement, text: string): void {
+  let lastIndex = 0;
+  for (const match of text.matchAll(ERROR_KEYWORD_PATTERN)) {
+    const start = match.index ?? 0;
+    target.appendChild(document.createTextNode(text.slice(lastIndex, start)));
+    const keyword = document.createElement("span");
+    keyword.className = "error-keyword";
+    keyword.textContent = match[0];
+    target.appendChild(keyword);
+    lastIndex = start + match[0].length;
+  }
+  target.appendChild(document.createTextNode(text.slice(lastIndex)));
+}
+
+function appendHighlightedCell(
+  row: HTMLTableRowElement,
+  text: string,
+  className?: string
+): HTMLTableCellElement {
+  const cell = row.insertCell();
+  appendErrorHighlighted(cell, text);
+  if (className) cell.className = className;
+  return cell;
+}
+
+/** 복사에 성공하면 버튼 글자를 잠깐 바꿔 눌렸다는 것을 알린다. */
+async function copyToClipboard(text: string, button: HTMLButtonElement): Promise<void> {
+  try {
+    clearError();
+    await api.copyText(text);
+    button.textContent = "복사됨";
+    setTimeout(() => {
+      button.textContent = "복사";
+    }, 1500);
+  } catch (error) {
+    showError(String(error));
+  }
+}
+
+/** 노드 이름은 kubectl 명령에 그대로 붙여 쓰는 값이라 이름 옆에 복사 버튼을 둔다. */
+function appendNameCellWithCopy(row: HTMLTableRowElement, name: string): void {
+  const cell = row.insertCell();
+  cell.className = "name-cell";
+  const box = document.createElement("div");
+  box.className = "name-box";
+  cell.appendChild(box);
+
+  const label = document.createElement("span");
+  label.textContent = name;
+  box.appendChild(label);
+
+  const button = document.createElement("button");
+  button.className = "copy-button";
+  button.textContent = "복사";
+  button.title = `${name} 복사`;
+  // 행 클릭은 파드 조회다. 복사할 때 그 동작까지 함께 돌지 않게 막는다.
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    void copyToClipboard(name, button);
+  });
+  box.appendChild(button);
+}
+
 function matchesFilter(node: NodeInfo): boolean {
   if (nodeFilter === "karpenter") return node.isKarpenter;
   if (nodeFilter === "managed") return node.isManagedNodeGroup;
@@ -186,7 +257,7 @@ function renderNodes(): void {
     const row = tbody.insertRow();
     row.dataset.name = node.name;
     if (node.name === selectedNode) row.classList.add("selected");
-    appendCell(row, node.name);
+    appendNameCellWithCopy(row, node.name);
     appendCell(row, node.internalIp);
     appendCell(row, node.version);
     appendCell(row, node.status, statusClass(node.status));
@@ -298,16 +369,15 @@ function renderKarpenterEvents(events: EventInfo[]): void {
   tbody.innerHTML = "";
   $("#karpenter-event-empty").classList.toggle("hidden", events.length > 0);
 
+  // reason과 message에 섞여 있는 error를 눈으로 먼저 찾도록 그 낱말만 빨갛게 칠한다.
   for (const event of events) {
     const row = tbody.insertRow();
     appendCell(row, formatEventTime(event.timestamp));
     appendCell(row, event.type, event.type === "Warning" ? "status-warning" : "");
-    appendCell(row, event.reason);
-    appendCell(row, event.object);
+    appendHighlightedCell(row, event.reason);
+    appendHighlightedCell(row, event.object);
     appendCell(row, String(event.count));
-    const message = row.insertCell();
-    message.textContent = event.message;
-    message.className = "message-cell";
+    appendHighlightedCell(row, event.message, "message-cell");
   }
 }
 
@@ -316,7 +386,7 @@ function createLogBlock(log: PodLog): HTMLElement {
   block.className = "log-block";
 
   const title = document.createElement("h3");
-  title.textContent = log.podName;
+  appendErrorHighlighted(title, log.podName);
   block.appendChild(title);
 
   const body = document.createElement("pre");
@@ -324,7 +394,7 @@ function createLogBlock(log: PodLog): HTMLElement {
     body.className = "log-error";
     body.textContent = log.error;
   } else {
-    body.textContent = log.text || "해당 기간에 남은 로그가 없습니다.";
+    appendErrorHighlighted(body, log.text || "해당 기간에 남은 로그가 없습니다.");
   }
   block.appendChild(body);
   return block;
@@ -394,11 +464,15 @@ function prepareResourceTable(
   return tbody;
 }
 
+const NO_VALUE = "-";
+const UNLINKED_GROUP = "연결된 NodePool 없음";
+
 function renderNodePools(nodePools: NodePoolInfo[], error: string): void {
   const tbody = prepareResourceTable("nodepool", nodePools.length, error);
   for (const nodePool of nodePools) {
     const row = tbody.insertRow();
     appendCell(row, nodePool.name);
+    appendCell(row, nodePool.nodeClassName || NO_VALUE);
     appendCell(row, nodePool.ami);
     appendCell(row, nodePool.weight);
     appendCell(row, nodePool.nodes);
@@ -407,13 +481,77 @@ function renderNodePools(nodePools: NodePoolInfo[], error: string): void {
   }
 }
 
-function renderEc2NodeClasses(resources: KarpenterResource[], error: string): void {
+interface Ec2NodeClassGroup {
+  nodePoolName: string;
+  resources: KarpenterResource[];
+}
+
+/**
+ * EC2NodeClass를 그 클래스를 참조하는 NodePool 이름으로 묶는다. 업그레이드 때는
+ * "이 NodePool이 지금 어떤 AMI로 노드를 띄우는가"를 봐야 하는데, 두 목록을 따로 두면
+ * nodeClassRef를 눈으로 이어야 한다. 그룹으로 묶어 그 연결을 화면이 대신 보여준다.
+ *
+ * 한 EC2NodeClass를 여러 NodePool이 참조할 수 있으므로 같은 클래스가 여러 그룹에 나온다.
+ * 어느 NodePool도 참조하지 않는 클래스는 맨 뒤에 따로 묶는다. NodePool 조회가 실패했을
+ * 때도 이 묶음으로 떨어져 EC2NodeClass 목록 자체는 그대로 보인다.
+ */
+function groupEc2NodeClasses(
+  nodePools: NodePoolInfo[],
+  resources: KarpenterResource[]
+): Ec2NodeClassGroup[] {
+  const groups: Ec2NodeClassGroup[] = [];
+  const linked = new Set<string>();
+
+  for (const nodePool of nodePools) {
+    const matched = resources.filter((resource) => resource.name === nodePool.nodeClassName);
+    matched.forEach((resource) => linked.add(resource.name));
+    groups.push({ nodePoolName: nodePool.name, resources: matched });
+  }
+
+  const unlinked = resources.filter((resource) => !linked.has(resource.name));
+  if (unlinked.length > 0) groups.push({ nodePoolName: UNLINKED_GROUP, resources: unlinked });
+  return groups;
+}
+
+/** 그룹 이름을 표 안에 한 줄로 넣어 어디부터 어느 NodePool의 것인지 구분한다. */
+function appendGroupHeaderRow(
+  tbody: HTMLTableSectionElement,
+  title: string,
+  columns: number
+): void {
+  const row = tbody.insertRow();
+  row.className = "group-row";
+  const cell = row.insertCell();
+  cell.colSpan = columns;
+  cell.textContent = title;
+}
+
+function appendEmptyGroupRow(tbody: HTMLTableSectionElement, columns: number): void {
+  const row = tbody.insertRow();
+  const cell = row.insertCell();
+  cell.colSpan = columns;
+  cell.className = "empty";
+  cell.textContent = "참조하는 EC2NodeClass를 찾지 못했습니다.";
+}
+
+function renderEc2NodeClasses(
+  nodePools: NodePoolInfo[],
+  resources: KarpenterResource[],
+  error: string
+): void {
   const tbody = prepareResourceTable("ec2nodeclass", resources.length, error);
-  for (const resource of resources) {
-    const row = tbody.insertRow();
-    appendCell(row, resource.name);
-    appendCell(row, resource.ami);
-    appendCell(row, resource.weight);
+  for (const group of groupEc2NodeClasses(nodePools, resources)) {
+    appendGroupHeaderRow(tbody, group.nodePoolName, 3);
+    if (group.resources.length === 0) {
+      appendEmptyGroupRow(tbody, 3);
+      continue;
+    }
+    for (const resource of group.resources) {
+      const row = tbody.insertRow();
+      appendCell(row, resource.name);
+      appendCell(row, resource.ami);
+      appendCell(row, resource.weight);
+    }
   }
 }
 
@@ -422,7 +560,7 @@ async function refreshKarpenterResources(): Promise<void> {
     clearError();
     const result = await api.getKarpenterResources();
     renderNodePools(result.nodePools, result.nodePoolsError);
-    renderEc2NodeClasses(result.ec2NodeClasses, result.ec2NodeClassesError);
+    renderEc2NodeClasses(result.nodePools, result.ec2NodeClasses, result.ec2NodeClassesError);
     nodePoolsLoaded = true;
   } catch (error) {
     showError(String(error));

--- a/product/akbun-k8supgradeview/workspace/src/renderer/style.css
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/style.css
@@ -135,6 +135,27 @@ th {
   background: #dbeafe;
 }
 
+/* td 자체를 flex로 만들면 표 정렬이 깨지므로 칸 안에 감싸는 요소를 하나 둔다. */
+.name-cell > .name-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.copy-button {
+  padding: 2px 8px;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #57606a;
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.copy-button:hover {
+  background: #f3f4f6;
+}
+
 /* 행 클릭(파드 조회)과 구분되도록 테두리를 준다. */
 .cordon-button {
   padding: 3px 10px;
@@ -161,6 +182,22 @@ th {
 
 .status-error {
   color: #b91c1c;
+  font-weight: 600;
+}
+
+/* event와 로그에서 error 낱말만 눈에 띄게 칠한다. 배경까지 줘야 긴 본문에서도 먼저 보인다. */
+.error-keyword {
+  color: #b91c1c;
+  font-weight: 700;
+  background: #fee2e2;
+  border-radius: 3px;
+  padding: 0 2px;
+}
+
+/* 어느 NodePool의 EC2NodeClass인지 표 안에서 나누는 줄이다. */
+.group-row td {
+  background: #eef2ff;
+  color: #3730a3;
   font-weight: 600;
 }
 

--- a/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
+++ b/product/akbun-k8supgradeview/workspace/test/karpenter-resources.test.js
@@ -50,7 +50,10 @@ const NODE_POOLS = {
   items: [
     {
       metadata: { name: "default", creationTimestamp: "2026-07-01T00:00:00Z" },
-      spec: { weight: 50 },
+      spec: {
+        weight: 50,
+        template: { spec: { nodeClassRef: { name: "default" } } },
+      },
       status: { conditions: [{ type: "Ready", status: "True" }] },
     },
     // weight도 Ready condition도 없는 NodePool
@@ -251,6 +254,15 @@ test("event는 오래된 것부터 정렬하고 시각을 읽을 수 없어도 �
     "2026-07-27T01:00:00Z",
     "2026-07-27T02:00:00Z",
   ]);
+});
+
+// 화면이 EC2NodeClass를 NodePool 이름으로 묶는 기준이 이 값이다. 비면 묶을 수 없다.
+test("nodeClassRef 이름을 읽고 없으면 빈 문자열이다", async () => {
+  useFakeKubectl(ALL_OK);
+  const { nodePools } = await getKarpenterResources();
+
+  assert.strictEqual(nodePools[0].nodeClassName, "default", "template의 nodeClassRef를 읽어야 한다");
+  assert.strictEqual(nodePools[1].nodeClassName, "", "참조가 없으면 빈 문자열이다");
 });
 
 test("age는 NodePool의 creationTimestamp를 그대로 넘긴다", async () => {


### PR DESCRIPTION
## Goal

During an EKS upgrade the same three moves repeat: retyping a node name into a terminal, tracing which EC2NodeClass a NodePool refers to, and scanning logs for errors. This PR moves all three into the screen.

## 어떻게 해결했는가

- Added a copy button next to each node name in the Nodes tab. The click sends the name over a new clipboard:write IPC and the main process writes it with electron clipboard. The renderer navigator.clipboard is not used because it depends on document focus and permission state, so a failure would be silent.
- The button label turns into a short confirmation for 1.5 seconds, and the click stops propagation so the row click that lists pods does not also run.
- Parsed spec.template.spec.nodeClassRef.name from NodePool and added a NodeClass column to the NodePool table.
- Grouped the EC2NodeClass table by the NodePool that references each class. A class referenced by several NodePools appears in each group, a NodePool whose reference resolves to nothing says so instead of showing an empty group, and classes no NodePool refers to are collected in a last group.
- Highlighted the error keyword, case insensitive, in Karpenter event reason, object and message, and in pod log names and bodies. Fragments are inserted as text nodes only, so cluster strings are never parsed as HTML.
- Extended test/karpenter-resources.test.js to cover nodeClassRef parsing and the empty reference case. All 18 tests pass.
- Verified the three features by loading the built renderer in headless Chromium with a stubbed api: the copied value matched the full node name, four error keywords were highlighted, and the three expected groups rendered.
- Recorded the decisions in adr/2026-07-name-copy-and-error-highlight.md, updated adr/index.md and wiki/architecture.md, and bumped the app version to 0.5.0 as the release procedure requires.

Issue #573


---
_Generated by [Claude Code](https://claude.ai/code/session_019vXjfpcxapoKd6UuMk8vEd)_