### PR TITLE
feat(product): add akbun-terraform-apply-remote, an Atlantis-style terraform PR automation server

### DIFF
--- a/.github/workflows/build-terraform-apply-remote.yml
+++ b/.github/workflows/build-terraform-apply-remote.yml
@@ -1,0 +1,64 @@
+name: build-terraform-apply-remote
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'product/akbun-terraform-apply-remote/**'
+      - '.github/workflows/build-terraform-apply-remote.yml'
+  pull_request:
+    paths:
+      - 'product/akbun-terraform-apply-remote/**'
+      - '.github/workflows/build-terraform-apply-remote.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: product/akbun-terraform-apply-remote
+
+jobs:
+  # test는 PR 검증용으로만 실행한다. master merge 시에는 build만 실행한다.
+  test:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      # ubuntu 러너에 rustup stable이 기본 설치되어 있어 별도 toolchain 설치가 필요 없다.
+      - name: Show toolchain
+        run: rustc --version && cargo --version
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: product/akbun-terraform-apply-remote
+
+      # 저장소 규칙상 lock 파일을 커밋하지 않으므로 --locked 없이 빌드한다.
+      - name: Build with warnings as errors
+        run: cargo build
+        env:
+          RUSTFLAGS: -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+  build:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: product/akbun-terraform-apply-remote
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: akbun-terraform-apply-remote-linux-x86_64
+          path: product/akbun-terraform-apply-remote/target/release/akbun-terraform-apply-remote

--- a/.github/workflows/build-terraform-apply-remote.yml
+++ b/.github/workflows/build-terraform-apply-remote.yml
@@ -6,11 +6,9 @@ on:
       - master
     paths:
       - 'product/akbun-terraform-apply-remote/**'
-      - '.github/workflows/build-terraform-apply-remote.yml'
   pull_request:
     paths:
       - 'product/akbun-terraform-apply-remote/**'
-      - '.github/workflows/build-terraform-apply-remote.yml'
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@
 - [git graph 데스크톱 앱 (akbun-gitdesktop)](./product/akbun-gitdesktop/) (26.7.25)
 - [언어 공부용 구간 반복 오디오 플레이어 (akbun-shadowing-player)](./product/akbun-shadowing-player/) (26.7.25)
 - [EKS 업그레이드용 노드/파드 조회 데스크톱 앱 (akbun-k8supgradeview)](./product/akbun-k8supgradeview/) (26.7.26)
+- [GitHub PR에서 terraform plan/apply를 실행하는 Atlantis 방식 서버 (akbun-terraform-apply-remote)](./product/akbun-terraform-apply-remote/) (26.7.29)
 
 ## Dockerfile
 

--- a/knowledge/decisions/2026-07-deploy-drain-and-persisted-takeover.md
+++ b/knowledge/decisions/2026-07-deploy-drain-and-persisted-takeover.md
@@ -1,0 +1,18 @@
+---
+type: Decision
+title: Deploys drain in-flight runs and hand state over via disk
+description: akbun-terraform-apply-remote survives redeployment by draining running terraform jobs on SIGTERM and persisting locks and plan records to the data directory, which the next instance loads at boot.
+tags: [terraform, automation, deployment, product]
+timestamp: 2026-07-29T00:00:00Z
+---
+
+## Decision
+
+Deployment safety for akbun-terraform-apply-remote is built from two mechanisms instead of a multi-node HA cluster. First, on SIGTERM the server stops accepting webhooks and waits (up to 30 minutes) for in-flight plan/apply jobs to finish before exiting. Second, locks and planned-SHA records are written to state.json in the data directory after every handled event and loaded at startup, so the next instance takes over where the previous one stopped. Self-deployment rides on these: the EC2 stack runs a systemd timer that swaps the binary when the published binary URL changes and restarts the service, and the ECS stack does a rolling task replacement (minimum healthy 100%, maximum 200%) with the data directory on EFS.
+
+## Reason
+
+- The worst deploy outcome is a terraform apply killed halfway, leaving state partially mutated. Draining removes that failure mode at the source; it is cheaper and more reliable than trying to resume a half-finished apply on another node.
+- Active-active HA needs distributed locking and plan-artifact replication for a service whose real workload is a few webhook deliveries a day. Single active instance + persisted state gives the takeover property that actually matters (a deploy or crash does not lose locks or force surprise re-reviews) at a fraction of the complexity.
+- Handover through a file on the data directory works identically for a systemd restart on EC2 (same disk) and an ECS rolling replacement (shared EFS), so both deploy targets reuse the same server code path with no deployment-specific logic.
+- Fargate caps stopTimeout at 120 seconds, so the ECS variant cannot honor the full 30-minute drain. This is accepted and documented: state on EFS means an interrupted run is recoverable by re-planning, and users with long applies are pointed to the EC2 variant.

--- a/knowledge/decisions/2026-07-github-app-tokens-for-terraform-bot.md
+++ b/knowledge/decisions/2026-07-github-app-tokens-for-terraform-bot.md
@@ -1,0 +1,18 @@
+---
+type: Decision
+title: GitHub App installation tokens as the recommended auth for the terraform bot
+description: akbun-terraform-apply-remote supports PAT and GitHub App auth; App mode mints cached one-hour installation tokens from an RS256 JWT and is the recommended option.
+tags: [github, security, product, automation]
+timestamp: 2026-07-29T00:00:00Z
+---
+
+## Decision
+
+akbun-terraform-apply-remote authenticates with exactly one of two modes, selected by environment variables and validated at boot: a static fine-grained PAT (ATR_GITHUB_TOKEN), or a GitHub App (ATR_GITHUB_APP_ID, ATR_GITHUB_APP_PRIVATE_KEY_PATH, ATR_GITHUB_APP_INSTALLATION_ID). In App mode the server signs a short-lived RS256 JWT with the App private key, exchanges it for a one-hour installation token, caches it, and re-mints it ten minutes before expiry. Every GitHub API call and git fetch pulls the current token from this provider. App mode is documented as the recommended option; PAT stays supported for quick setups.
+
+## Reason
+
+- A terraform bot's token can post comments and read private repos; a long-lived PAT sitting on a server (or in an SSM parameter) is the kind of credential that leaks quietly. With App auth the only durable secret is a private key that never leaves disk, and the tokens actually in use expire within an hour and can be revoked centrally by uninstalling the App.
+- Comments arrive under the App's bot identity instead of a person's account, which keeps the audit trail honest and survives people leaving.
+- The token-provider abstraction (token per call, cached with a refresh margin) means long terraform runs never hold an expiring token, and no call site knows which auth mode is active — so both modes share one code path.
+- Misconfiguration (both modes set, or partial App settings) fails at startup rather than on the first webhook, because an auth failure discovered mid-apply is much harder to diagnose.

--- a/knowledge/decisions/2026-07-rust-sync-stack-for-webhook-server.md
+++ b/knowledge/decisions/2026-07-rust-sync-stack-for-webhook-server.md
@@ -1,0 +1,18 @@
+---
+type: Decision
+title: Rust with a small synchronous stack for the terraform PR server
+description: akbun-terraform-apply-remote is written in Rust using tiny_http and ureq instead of an async framework, with unit tests only on the core logic.
+tags: [rust, product, automation]
+timestamp: 2026-07-29T00:00:00Z
+---
+
+## Decision
+
+akbun-terraform-apply-remote is a Rust binary built on a synchronous stack: tiny_http for the webhook listener, ureq for GitHub API calls, and hmac/sha2 for signature verification. No async runtime or web framework. Webhook deliveries are acknowledged immediately and processed on plain spawned threads. Automated tests cover only the pure core logic (command parsing, signature verification, project detection, comment formatting, lock manager); the GitHub client, git workspace, and terraform runner are thin process/HTTP wrappers left untested.
+
+## Reason
+
+- The workload is a handful of webhook deliveries per day, each dominated by a terraform run that takes seconds to minutes. An async runtime (tokio + axum) buys nothing here and roughly triples the dependency tree, which slows CI builds and enlarges the audit surface.
+- Rust gives a single static release binary, so deploying to any Linux host is copy-and-run — no runtime, no package manager on the server.
+- The code is maintained by AI agents, not read line-by-line by the owner. The guardrail is therefore the test suite on the decision-making core, where a regression silently changes what gets applied to infrastructure. The untested modules only shell out to git/terraform or call the GitHub REST API; their failures are loud (error comments, non-zero exits), not silent.
+- Blocking I/O with one thread per event keeps the orchestration code straight-line and easy for an agent to modify correctly; shared state is limited to two mutex-guarded maps (locks, planned SHAs).

--- a/knowledge/decisions/2026-07-terraform-apply-saved-plan.md
+++ b/knowledge/decisions/2026-07-terraform-apply-saved-plan.md
@@ -1,0 +1,18 @@
+---
+type: Decision
+title: Apply only the saved plan file, never a fresh plan
+description: akbun-terraform-apply-remote applies the exact tfplan file produced by the last plan run and refuses to apply when the PR head moved since that plan.
+tags: [terraform, automation, product]
+timestamp: 2026-07-29T00:00:00Z
+---
+
+## Decision
+
+In akbun-terraform-apply-remote, the apply command never runs a fresh plan-and-apply. It applies the tfplan file saved by the latest plan run (terraform apply .akbun.tfplan). The server records the PR head SHA at plan time; if the PR head has changed when apply is requested, apply is refused and the user must plan again. A per-project-directory lock is taken at plan time and released on apply success, PR close, or explicit unlock.
+
+## Reason
+
+- What the reviewer approved must be exactly what reaches the infrastructure. terraform apply without a plan file recomputes the diff at apply time, so a push after review — or drift in the remote state — could apply changes nobody reviewed. Applying the saved binary plan makes terraform itself fail if the state changed underneath (stale plan error), which is the safe failure mode.
+- The head-SHA check turns "the PR changed after review" from a silent hazard into an explicit re-plan request in the PR comment thread.
+- The project-directory lock serializes PRs that touch the same state. Two PRs planning the same directory would otherwise race: the second apply would either fail on a stale plan or, worse, revert the first PR's change.
+- Atlantis made the same choices (saved plan artifact plus project locks), which validates the model; this tool reimplements it in a minimal form instead of adopting Atlantis because the repository only needs comment-driven plan/apply, not Atlantis's full feature surface.

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -12,3 +12,5 @@
 * [릴리스 버전은 태그에서 계산한다](2026-07-release-version-from-tags.md) - 기존 태그의 patch를 +1 해서 매 실행마다 새 릴리스를 만드는 결정.
 * [릴리스는 빌드 성공 뒤에 tag, tag 뒤에 release](2026-07-build-before-tag-and-release.md) - 빌드가 실패해도 빈 release가 남던 문제를 순서로 막는 결정.
 * [규칙 문서는 도구 중립으로 쓰고 상시 로드 비용으로 정리한다](2026-07-agents-md-tool-neutral.md) - AGENTS.md에 도구 전용 내용을 두지 않고 규칙 파일을 코드 템플릿 대신 규칙 문장으로 유지하는 결정.
+* [Apply only the saved plan file, never a fresh plan](2026-07-terraform-apply-saved-plan.md) - akbun-terraform-apply-remote가 마지막 plan이 저장한 tfplan 파일만 apply하고 PR head가 바뀌면 거부하는 결정.
+* [Rust with a small synchronous stack for the terraform PR server](2026-07-rust-sync-stack-for-webhook-server.md) - async 프레임워크 없이 tiny_http/ureq 동기 스택으로 만들고 핵심 로직만 테스트하는 결정.

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -14,3 +14,4 @@
 * [규칙 문서는 도구 중립으로 쓰고 상시 로드 비용으로 정리한다](2026-07-agents-md-tool-neutral.md) - AGENTS.md에 도구 전용 내용을 두지 않고 규칙 파일을 코드 템플릿 대신 규칙 문장으로 유지하는 결정.
 * [Apply only the saved plan file, never a fresh plan](2026-07-terraform-apply-saved-plan.md) - akbun-terraform-apply-remote가 마지막 plan이 저장한 tfplan 파일만 apply하고 PR head가 바뀌면 거부하는 결정.
 * [Rust with a small synchronous stack for the terraform PR server](2026-07-rust-sync-stack-for-webhook-server.md) - async 프레임워크 없이 tiny_http/ureq 동기 스택으로 만들고 핵심 로직만 테스트하는 결정.
+* [Deploys drain in-flight runs and hand state over via disk](2026-07-deploy-drain-and-persisted-takeover.md) - 멀티 노드 HA 대신 SIGTERM drain과 state.json 영속화로 배포 중 인수인계를 해결하는 결정.

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -15,3 +15,4 @@
 * [Apply only the saved plan file, never a fresh plan](2026-07-terraform-apply-saved-plan.md) - akbun-terraform-apply-remote가 마지막 plan이 저장한 tfplan 파일만 apply하고 PR head가 바뀌면 거부하는 결정.
 * [Rust with a small synchronous stack for the terraform PR server](2026-07-rust-sync-stack-for-webhook-server.md) - async 프레임워크 없이 tiny_http/ureq 동기 스택으로 만들고 핵심 로직만 테스트하는 결정.
 * [Deploys drain in-flight runs and hand state over via disk](2026-07-deploy-drain-and-persisted-takeover.md) - 멀티 노드 HA 대신 SIGTERM drain과 state.json 영속화로 배포 중 인수인계를 해결하는 결정.
+* [GitHub App installation tokens as the recommended auth for the terraform bot](2026-07-github-app-tokens-for-terraform-bot.md) - 장기 PAT 대신 1시간짜리 App installation token을 권장 인증으로 두는 결정.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-29
 
+* **Creation**: [Deploys drain in-flight runs and hand state over via disk](decisions/2026-07-deploy-drain-and-persisted-takeover.md) 결정 기록. akbun-terraform-apply-remote에 graceful drain, 상태 영속화, EC2/ECS 배포 스택을 추가하면서 남긴다.
 * **Creation**: [Apply only the saved plan file, never a fresh plan](decisions/2026-07-terraform-apply-saved-plan.md) 결정 기록. akbun-terraform-apply-remote 제품을 만들면서 남긴다.
 * **Creation**: [Rust with a small synchronous stack for the terraform PR server](decisions/2026-07-rust-sync-stack-for-webhook-server.md) 결정 기록. 같은 작업에서 기술 스택 선택 이유를 남긴다.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-29
 
+* **Creation**: [GitHub App installation tokens as the recommended auth for the terraform bot](decisions/2026-07-github-app-tokens-for-terraform-bot.md) 결정 기록. akbun-terraform-apply-remote에 GitHub App 인증과 import 명령을 추가하면서 남긴다.
 * **Creation**: [Deploys drain in-flight runs and hand state over via disk](decisions/2026-07-deploy-drain-and-persisted-takeover.md) 결정 기록. akbun-terraform-apply-remote에 graceful drain, 상태 영속화, EC2/ECS 배포 스택을 추가하면서 남긴다.
 * **Creation**: [Apply only the saved plan file, never a fresh plan](decisions/2026-07-terraform-apply-saved-plan.md) 결정 기록. akbun-terraform-apply-remote 제품을 만들면서 남긴다.
 * **Creation**: [Rust with a small synchronous stack for the terraform PR server](decisions/2026-07-rust-sync-stack-for-webhook-server.md) 결정 기록. 같은 작업에서 기술 스택 선택 이유를 남긴다.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,10 @@
 # Knowledge Update Log
 
+## 2026-07-29
+
+* **Creation**: [Apply only the saved plan file, never a fresh plan](decisions/2026-07-terraform-apply-saved-plan.md) 결정 기록. akbun-terraform-apply-remote 제품을 만들면서 남긴다.
+* **Creation**: [Rust with a small synchronous stack for the terraform PR server](decisions/2026-07-rust-sync-stack-for-webhook-server.md) 결정 기록. 같은 작업에서 기술 스택 선택 이유를 남긴다.
+
 ## 2026-07-28
 
 * **Creation**: [규칙 문서는 도구 중립으로 쓰고 상시 로드 비용으로 정리한다](decisions/2026-07-agents-md-tool-neutral.md) 결정 기록. AGENTS.md 정리와 `.claude/rules/terraform.md`의 코드 템플릿 제거와 함께 남긴다.

--- a/product/README.md
+++ b/product/README.md
@@ -12,6 +12,7 @@
 | [hprof-oom-analyzer](./hprof-oom-analyzer/) | JVM heap dump(hprof)에서 OOM 원인을 찾는 데스크톱 도구 |
 | [akbun-k8supgradeview](./akbun-k8supgradeview/) | EKS 업그레이드 작업용 노드/파드 조회 Electron 데스크톱 앱 |
 | [akbun-shadowing-player](./akbun-shadowing-player/) | 언어 공부(쉐도잉)용 구간 반복 오디오 플레이어 Electron 앱 |
+| [akbun-terraform-apply-remote](./akbun-terraform-apply-remote/) | GitHub PR comment로 terraform plan/apply를 실행하는 Atlantis 방식 자동화 서버 |
 | [slide-reference](./slide-reference/) | AI agent용 슬라이드 레이아웃 레퍼런스 |
 | [slo](./slo/) | SLO 가용성을 입력하면 허용 다운타임을 계산하는 웹 도구 |
 | [tistory-skin](./tistory-skin/) | Tistory 블로그 스킨 |

--- a/product/akbun-terraform-apply-remote/.gitignore
+++ b/product/akbun-terraform-apply-remote/.gitignore
@@ -1,0 +1,3 @@
+/target
+/data
+Cargo.lock

--- a/product/akbun-terraform-apply-remote/.gitignore
+++ b/product/akbun-terraform-apply-remote/.gitignore
@@ -1,3 +1,7 @@
 /target
 /data
 Cargo.lock
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup

--- a/product/akbun-terraform-apply-remote/Cargo.toml
+++ b/product/akbun-terraform-apply-remote/Cargo.toml
@@ -14,6 +14,7 @@ hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 signal-hook = "0.3"
+jsonwebtoken = "10"
 
 [profile.release]
 strip = true

--- a/product/akbun-terraform-apply-remote/Cargo.toml
+++ b/product/akbun-terraform-apply-remote/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1"
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
+signal-hook = "0.3"
 
 [profile.release]
 strip = true

--- a/product/akbun-terraform-apply-remote/Cargo.toml
+++ b/product/akbun-terraform-apply-remote/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "akbun-terraform-apply-remote"
+version = "0.1.0"
+edition = "2021"
+description = "Atlantis-style terraform plan/apply automation driven by GitHub pull request comments"
+license = "MIT"
+
+[dependencies]
+tiny_http = "0.12"
+ureq = { version = "2", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+
+[profile.release]
+strip = true

--- a/product/akbun-terraform-apply-remote/Dockerfile
+++ b/product/akbun-terraform-apply-remote/Dockerfile
@@ -1,0 +1,20 @@
+# ECS 배포용 이미지. buildx의 TARGETARCH로 arm64/amd64를 모두 지원한다.
+FROM rust:1-bookworm AS build
+WORKDIR /src
+COPY Cargo.toml ./
+COPY src ./src
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+ARG TERRAFORM_VERSION=1.15.8
+ARG TARGETARCH
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates curl unzip \
+  && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip" -o /tmp/terraform.zip \
+  && unzip /tmp/terraform.zip -d /usr/local/bin \
+  && rm /tmp/terraform.zip
+COPY --from=build /src/target/release/akbun-terraform-apply-remote /usr/local/bin/akbun-terraform-apply-remote
+ENV ATR_DATA_DIR=/data
+EXPOSE 4141
+ENTRYPOINT ["akbun-terraform-apply-remote"]

--- a/product/akbun-terraform-apply-remote/README.md
+++ b/product/akbun-terraform-apply-remote/README.md
@@ -9,10 +9,12 @@ GitHub pull request에서 terraform plan/apply를 실행하는 셀프호스팅 �
 3. plan 결과를 PR comment로 남기고, plan 파일(`.akbun.tfplan`)을 저장한다.
 4. `akbun apply` comment를 받으면 저장된 plan 파일을 apply한다. plan 이후 PR head가 바뀌었으면 거부하고 재plan을 요구한다.
 5. 프로젝트 디렉터리 단위 lock으로 여러 PR이 같은 state를 동시에 건드리는 것을 막는다.
+6. lock과 plan 기록을 state.json으로 영속화하고 SIGTERM 시 진행 중인 실행을 drain하므로, 재배포해도 새 인스턴스가 상태를 이어받는다.
 
 ## 문서
 
 - 설치와 사용법: [docs/user-guide.md](./docs/user-guide.md)
+- AWS 배포(EC2, ECS Terraform 코드): [docs/deploy-guide.md](./docs/deploy-guide.md)
 
 ## 개발
 

--- a/product/akbun-terraform-apply-remote/README.md
+++ b/product/akbun-terraform-apply-remote/README.md
@@ -1,0 +1,26 @@
+# akbun-terraform-apply-remote
+
+GitHub pull request에서 terraform plan/apply를 실행하는 셀프호스팅 자동화 서버다. Atlantis와 같은 방식으로 동작한다. PR이 열리면 변경된 terraform 프로젝트를 자동으로 plan하고, 리뷰어가 comment로 `akbun apply`를 남기면 리뷰한 plan 파일을 그대로 apply한다.
+
+## 동작 방식
+
+1. GitHub webhook(`issue_comment`, `pull_request`)을 받는다. HMAC-SHA256 서명을 검증한다.
+2. PR이 열리거나 갱신되면 변경된 파일에서 terraform 프로젝트 디렉터리를 찾아 자동으로 plan한다.
+3. plan 결과를 PR comment로 남기고, plan 파일(`.akbun.tfplan`)을 저장한다.
+4. `akbun apply` comment를 받으면 저장된 plan 파일을 apply한다. plan 이후 PR head가 바뀌었으면 거부하고 재plan을 요구한다.
+5. 프로젝트 디렉터리 단위 lock으로 여러 PR이 같은 state를 동시에 건드리는 것을 막는다.
+
+## 문서
+
+- 설치와 사용법: [docs/user-guide.md](./docs/user-guide.md)
+
+## 개발
+
+빌드와 테스트:
+
+```bash
+cargo test
+cargo build --release
+```
+
+핵심 로직(comment 명령 파싱, webhook 서명 검증, 프로젝트 탐지, comment 포맷, lock)은 단위 테스트로 검증한다. 소스는 AI agent가 유지보수하는 것을 전제로 작성했다.

--- a/product/akbun-terraform-apply-remote/README.md
+++ b/product/akbun-terraform-apply-remote/README.md
@@ -7,13 +7,15 @@ GitHub pull request에서 terraform plan/apply를 실행하는 셀프호스팅 �
 1. GitHub webhook(`issue_comment`, `pull_request`)을 받는다. HMAC-SHA256 서명을 검증한다.
 2. PR이 열리거나 갱신되면 변경된 파일에서 terraform 프로젝트 디렉터리를 찾아 자동으로 plan한다.
 3. plan 결과를 PR comment로 남기고, plan 파일(`.akbun.tfplan`)을 저장한다.
-4. `akbun apply` comment를 받으면 저장된 plan 파일을 apply한다. plan 이후 PR head가 바뀌었으면 거부하고 재plan을 요구한다.
+4. `akbun apply` comment를 받으면 저장된 plan 파일을 apply한다. plan 이후 PR head가 바뀌었으면 거부하고 재plan을 요구한다. `akbun import`로 기존 리소스를 state에 넣을 수도 있다.
 5. 프로젝트 디렉터리 단위 lock으로 여러 PR이 같은 state를 동시에 건드리는 것을 막는다.
 6. lock과 plan 기록을 state.json으로 영속화하고 SIGTERM 시 진행 중인 실행을 drain하므로, 재배포해도 새 인스턴스가 상태를 이어받는다.
+7. 인증은 PAT 또는 GitHub App 임시 토큰(installation token, 1시간) 중 선택한다.
 
 ## 문서
 
-- 설치와 사용법: [docs/user-guide.md](./docs/user-guide.md)
+- 아키텍처(mermaid 다이어그램): [docs/architecture.md](./docs/architecture.md)
+- 설치와 사용법, 인증 옵션: [docs/user-guide.md](./docs/user-guide.md)
 - AWS 배포(EC2, ECS Terraform 코드): [docs/deploy-guide.md](./docs/deploy-guide.md)
 
 ## 개발

--- a/product/akbun-terraform-apply-remote/deploy/ec2/data.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/data.tf
@@ -1,0 +1,39 @@
+locals {
+  al2023_ami_name = var.arch == "arm64" ? "al2023-ami-*-kernel-6.1-arm64" : "al2023-ami-*-kernel-6.1-x86_64"
+}
+
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = [local.al2023_ami_name]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [var.arch]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/ec2.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/ec2.tf
@@ -1,0 +1,35 @@
+resource "aws_instance" "server" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  subnet_id              = data.aws_subnets.default.ids[0]
+  vpc_security_group_ids = [aws_security_group.server.id]
+  iam_instance_profile   = aws_iam_instance_profile.server.name
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 30
+    encrypted   = true
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    binary_url           = var.binary_url
+    terraform_version    = var.terraform_version
+    server_port          = var.server_port
+    trigger_word         = var.trigger_word
+    aws_region           = var.aws_region
+    webhook_secret_param = aws_ssm_parameter.webhook_secret.name
+    github_token_param   = aws_ssm_parameter.github_token.name
+  })
+
+  tags = {
+    Name = var.project_name
+  }
+}
+
+resource "aws_eip" "server" {
+  instance = aws_instance.server.id
+
+  tags = {
+    Name = var.project_name
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/iam.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/iam.tf
@@ -1,0 +1,49 @@
+data "aws_iam_policy_document" "assume_ec2" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "server" {
+  name               = var.project_name
+  assume_role_policy = data.aws_iam_policy_document.assume_ec2.json
+}
+
+# SSM Session Manager 접속용. SSH를 열지 않는다.
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.server.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "read_secrets" {
+  statement {
+    actions = ["ssm:GetParameter"]
+    resources = [
+      aws_ssm_parameter.webhook_secret.arn,
+      aws_ssm_parameter.github_token.arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "read_secrets" {
+  name   = "read-secrets"
+  role   = aws_iam_role.server.id
+  policy = data.aws_iam_policy_document.read_secrets.json
+}
+
+# 서버 안의 terraform이 AWS 리소스를 만들 때 쓰는 권한.
+# 실습 편의로 PowerUserAccess를 붙인다. 운영에서는 관리 대상 리소스에 맞게 좁힌다.
+resource "aws_iam_role_policy_attachment" "terraform_runner" {
+  role       = aws_iam_role.server.name
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+}
+
+resource "aws_iam_instance_profile" "server" {
+  name = var.project_name
+  role = aws_iam_role.server.name
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/outputs.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/outputs.tf
@@ -1,0 +1,9 @@
+output "public_ip" {
+  description = "Elastic IP of the webhook server"
+  value       = aws_eip.server.public_ip
+}
+
+output "webhook_url" {
+  description = "Payload URL to register in the GitHub webhook settings"
+  value       = "http://${aws_eip.server.public_ip}:${var.server_port}/events"
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/providers.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/security_group.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/security_group.tf
@@ -1,0 +1,23 @@
+resource "aws_security_group" "server" {
+  name        = var.project_name
+  description = "akbun-terraform-apply-remote webhook server"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+# GitHub webhook 발신 IP 대역은 수시로 바뀌므로 전체 공개로 두고,
+# 요청 인증은 HMAC-SHA256 서명 검증에 맡긴다. SSH(22)는 열지 않는다(SSM 사용).
+resource "aws_vpc_security_group_ingress_rule" "webhook" {
+  security_group_id = aws_security_group.server.id
+  description       = "GitHub webhook deliveries"
+  from_port         = var.server_port
+  to_port           = var.server_port
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.server.id
+  description       = "GitHub API, git clone, terraform providers"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/ssm.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/ssm.tf
@@ -1,0 +1,14 @@
+# 자격증명은 코드와 user_data에 남기지 않고 SSM SecureString으로만 전달한다.
+# systemd 유닛이 기동 시 이 파라미터를 읽어 환경변수로 주입한다.
+
+resource "aws_ssm_parameter" "webhook_secret" {
+  name  = "/${var.project_name}/webhook-secret"
+  type  = "SecureString"
+  value = var.webhook_secret
+}
+
+resource "aws_ssm_parameter" "github_token" {
+  name  = "/${var.project_name}/github-token"
+  type  = "SecureString"
+  value = var.github_token
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/terraform.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ec2/user_data.sh.tpl
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/user_data.sh.tpl
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+
+dnf install -y git unzip
+
+# terraform 설치 (아키텍처에 맞는 아카이브 선택)
+case "$(uname -m)" in
+  aarch64) TF_ARCH=arm64 ;;
+  x86_64) TF_ARCH=amd64 ;;
+esac
+curl -fsSL "https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_$${TF_ARCH}.zip" -o /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+rm -f /tmp/terraform.zip
+
+# 서버 바이너리 설치
+mkdir -p /opt/atr/data
+curl -fsSL "${binary_url}" -o /opt/atr/akbun-terraform-apply-remote
+chmod +x /opt/atr/akbun-terraform-apply-remote
+
+# 기동 시 SSM SecureString에서 secret을 읽어 env 파일을 만든다.
+# secret이 디스크의 user_data나 terraform state 외에 코드에 남지 않게 한다.
+cat > /usr/local/bin/atr-fetch-env <<'FETCH'
+#!/bin/bash
+set -euo pipefail
+REGION="__AWS_REGION__"
+WEBHOOK_SECRET=$(aws ssm get-parameter --region "$REGION" --name "__WEBHOOK_SECRET_PARAM__" --with-decryption --query Parameter.Value --output text)
+GITHUB_TOKEN=$(aws ssm get-parameter --region "$REGION" --name "__GITHUB_TOKEN_PARAM__" --with-decryption --query Parameter.Value --output text)
+umask 077
+cat > /opt/atr/env <<ENV
+ATR_WEBHOOK_SECRET=$WEBHOOK_SECRET
+ATR_GITHUB_TOKEN=$GITHUB_TOKEN
+ATR_PORT=__SERVER_PORT__
+ATR_TRIGGER=__TRIGGER_WORD__
+ATR_DATA_DIR=/opt/atr/data
+ENV
+FETCH
+sed -i \
+  -e "s|__AWS_REGION__|${aws_region}|" \
+  -e "s|__WEBHOOK_SECRET_PARAM__|${webhook_secret_param}|" \
+  -e "s|__GITHUB_TOKEN_PARAM__|${github_token_param}|" \
+  -e "s|__SERVER_PORT__|${server_port}|" \
+  -e "s|__TRIGGER_WORD__|${trigger_word}|" \
+  /usr/local/bin/atr-fetch-env
+chmod +x /usr/local/bin/atr-fetch-env
+
+# systemd 서비스. TimeoutStopSec을 길게 잡아 서버가 진행 중인
+# terraform 실행을 끝까지 마치고(drain) 내려가게 한다.
+cat > /etc/systemd/system/atr.service <<'UNIT'
+[Unit]
+Description=akbun-terraform-apply-remote
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStartPre=/usr/local/bin/atr-fetch-env
+EnvironmentFile=/opt/atr/env
+ExecStart=/opt/atr/akbun-terraform-apply-remote
+WorkingDirectory=/opt/atr
+KillSignal=SIGTERM
+TimeoutStopSec=1830
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+# self-deploy: binary_url을 주기적으로 확인해 바이너리가 바뀌면
+# 교체하고 graceful restart한다. 새 바이너리를 URL에 올리는 것이 곧 배포다.
+cat > /usr/local/bin/atr-self-update <<'UPDATE'
+#!/bin/bash
+set -euo pipefail
+URL="__BINARY_URL__"
+CURRENT=/opt/atr/akbun-terraform-apply-remote
+CANDIDATE=$(mktemp)
+trap 'rm -f "$CANDIDATE"' EXIT
+curl -fsSL "$URL" -o "$CANDIDATE"
+if ! cmp -s "$CANDIDATE" "$CURRENT"; then
+  chmod +x "$CANDIDATE"
+  mv "$CANDIDATE" "$CURRENT"
+  trap - EXIT
+  echo "new binary detected; restarting atr"
+  systemctl restart atr
+fi
+UPDATE
+sed -i "s|__BINARY_URL__|${binary_url}|" /usr/local/bin/atr-self-update
+chmod +x /usr/local/bin/atr-self-update
+
+cat > /etc/systemd/system/atr-update.service <<'UNIT'
+[Unit]
+Description=akbun-terraform-apply-remote self-update
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/atr-self-update
+UNIT
+
+cat > /etc/systemd/system/atr-update.timer <<'UNIT'
+[Unit]
+Description=Poll for a new akbun-terraform-apply-remote binary
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable --now atr.service atr-update.timer

--- a/product/akbun-terraform-apply-remote/deploy/ec2/variables.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ec2/variables.tf
@@ -1,0 +1,58 @@
+variable "project_name" {
+  description = "Tag and resource name prefix"
+  type        = string
+  default     = "akbun-terraform-apply-remote"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "arch" {
+  description = "Instance architecture: arm64 or x86_64"
+  type        = string
+  default     = "arm64"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t4g.small"
+}
+
+variable "binary_url" {
+  description = "URL of the linux server binary. The instance downloads it at boot and the self-update timer polls it; publishing a new binary here is a deployment."
+  type        = string
+}
+
+variable "terraform_version" {
+  description = "Terraform version installed on the instance"
+  type        = string
+  default     = "1.15.8"
+}
+
+variable "webhook_secret" {
+  description = "GitHub webhook secret. Stored as an SSM SecureString parameter."
+  type        = string
+  sensitive   = true
+}
+
+variable "github_token" {
+  description = "GitHub API token for the server. Stored as an SSM SecureString parameter."
+  type        = string
+  sensitive   = true
+}
+
+variable "trigger_word" {
+  description = "Comment trigger word for plan/apply commands"
+  type        = string
+  default     = "akbun"
+}
+
+variable "server_port" {
+  description = "Port the webhook server listens on"
+  type        = number
+  default     = 4141
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/alb.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/alb.tf
@@ -1,0 +1,54 @@
+resource "aws_lb" "server" {
+  name               = var.project_name
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = data.aws_subnets.default.ids
+}
+
+resource "aws_lb_target_group" "server" {
+  name        = var.project_name
+  port        = var.server_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = data.aws_vpc.default.id
+
+  # 배포 시 이전 task가 새 webhook은 받지 않되 진행 중인 terraform 실행을
+  # 마칠 시간을 준다.
+  deregistration_delay = 60
+
+  health_check {
+    path                = "/healthz"
+    interval            = 15
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.server.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.acm_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.server.arn
+  }
+}
+
+resource "aws_lb_listener" "http_redirect" {
+  load_balancer_arn = aws_lb.server.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/data.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/data.tf
@@ -1,0 +1,15 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+
+  filter {
+    name   = "default-for-az"
+    values = ["true"]
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/ecs.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/ecs.tf
@@ -1,0 +1,114 @@
+resource "aws_cloudwatch_log_group" "server" {
+  name              = "/ecs/${var.project_name}"
+  retention_in_days = 30
+}
+
+resource "aws_ecs_cluster" "server" {
+  name = var.project_name
+}
+
+resource "aws_ecs_task_definition" "server" {
+  family                   = var.project_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  # Graviton 규칙에 맞춰 Fargate도 ARM64로 실행한다. 이미지도 arm64로 빌드한다.
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  volume {
+    name = "data"
+
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.data.id
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = aws_efs_access_point.data.id
+        iam             = "DISABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "server"
+      image     = var.image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.server_port
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        { name = "ATR_PORT", value = tostring(var.server_port) },
+        { name = "ATR_TRIGGER", value = var.trigger_word },
+        { name = "ATR_DATA_DIR", value = "/data" },
+      ]
+
+      secrets = [
+        { name = "ATR_WEBHOOK_SECRET", valueFrom = aws_ssm_parameter.webhook_secret.arn },
+        { name = "ATR_GITHUB_TOKEN", valueFrom = aws_ssm_parameter.github_token.arn },
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "data"
+          containerPath = "/data"
+        }
+      ]
+
+      # Fargate가 허용하는 최대 drain 시간. SIGTERM 후 120초 안에 끝나지
+      # 않는 apply는 잘릴 수 있다. 더 긴 drain이 필요하면 EC2 배포를 쓴다.
+      stopTimeout = 120
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.server.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "server"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "server" {
+  name            = var.project_name
+  cluster         = aws_ecs_cluster.server.id
+  task_definition = aws_ecs_task_definition.server.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  # 새 task가 healthy가 된 뒤에만 이전 task를 내려 무중단으로 교체한다.
+  # 겹치는 몇 초 동안 두 task가 같은 EFS state를 볼 수 있으나, 이전 task는
+  # ALB에서 빠져 새 webhook을 받지 않으므로 실제 경합은 발생하지 않는다.
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+  health_check_grace_period_seconds = 60
+
+  network_configuration {
+    subnets          = data.aws_subnets.default.ids
+    security_groups  = [aws_security_group.service.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.server.arn
+    container_name   = "server"
+    container_port   = var.server_port
+  }
+
+  depends_on = [aws_lb_listener.https]
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/efs.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/efs.tf
@@ -1,0 +1,38 @@
+# state.json, PR checkout, 저장된 plan 파일을 담는 공유 스토리지.
+# 새 task가 이 볼륨을 이어받아 이전 task의 lock과 plan 기록으로 기동한다.
+
+resource "aws_efs_file_system" "data" {
+  creation_token = "${var.project_name}-data"
+  encrypted      = true
+
+  tags = {
+    Name = "${var.project_name}-data"
+  }
+}
+
+resource "aws_efs_mount_target" "data" {
+  for_each = toset(data.aws_subnets.default.ids)
+
+  file_system_id  = aws_efs_file_system.data.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.efs.id]
+}
+
+resource "aws_efs_access_point" "data" {
+  file_system_id = aws_efs_file_system.data.id
+
+  posix_user {
+    uid = 0
+    gid = 0
+  }
+
+  root_directory {
+    path = "/atr-data"
+
+    creation_info {
+      owner_uid   = 0
+      owner_gid   = 0
+      permissions = "700"
+    }
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/iam.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/iam.tf
@@ -1,0 +1,50 @@
+data "aws_iam_policy_document" "assume_ecs_tasks" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# 실행 role: 이미지 pull, 로그 전송, SSM secret 주입에 쓴다.
+resource "aws_iam_role" "execution" {
+  name               = "${var.project_name}-execution"
+  assume_role_policy = data.aws_iam_policy_document.assume_ecs_tasks.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "inject_secrets" {
+  statement {
+    actions = ["ssm:GetParameters"]
+    resources = [
+      aws_ssm_parameter.webhook_secret.arn,
+      aws_ssm_parameter.github_token.arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "inject_secrets" {
+  name   = "inject-secrets"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.inject_secrets.json
+}
+
+# task role: 컨테이너 안의 terraform이 AWS 리소스를 만들 때 쓴다.
+resource "aws_iam_role" "task" {
+  name               = "${var.project_name}-task"
+  assume_role_policy = data.aws_iam_policy_document.assume_ecs_tasks.json
+}
+
+resource "aws_iam_role_policy_attachment" "task" {
+  for_each = toset(var.task_role_policy_arns)
+
+  role       = aws_iam_role.task.name
+  policy_arn = each.value
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/outputs.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/outputs.tf
@@ -1,0 +1,9 @@
+output "alb_dns_name" {
+  description = "ALB DNS name"
+  value       = aws_lb.server.dns_name
+}
+
+output "webhook_url" {
+  description = "Payload URL to register in the GitHub webhook settings"
+  value       = var.route53_zone_id != "" ? "https://${var.domain_name}/events" : "https://${aws_lb.server.dns_name}/events"
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/providers.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      ManagedBy = "Terraform"
+      Project   = var.project_name
+    }
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/route53.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/route53.tf
@@ -1,0 +1,16 @@
+# Hosted zone은 콘솔에서 미리 만든 것을 참조한다. zone id가 비어 있으면
+# 레코드를 만들지 않고 ALB DNS 이름을 그대로 쓴다.
+
+resource "aws_route53_record" "server" {
+  count = var.route53_zone_id != "" ? 1 : 0
+
+  zone_id = var.route53_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.server.dns_name
+    zone_id                = aws_lb.server.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/security_group.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/security_group.tf
@@ -1,0 +1,69 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.project_name}-alb"
+  description = "ALB for akbun-terraform-apply-remote"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+# GitHub webhook 발신 IP 대역은 수시로 바뀌므로 전체 공개로 두고,
+# 요청 인증은 서버의 HMAC-SHA256 서명 검증에 맡긴다.
+resource "aws_vpc_security_group_ingress_rule" "alb_https" {
+  security_group_id = aws_security_group.alb.id
+  description       = "GitHub webhook deliveries"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http_redirect" {
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTP to HTTPS redirect"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_all" {
+  security_group_id = aws_security_group.alb.id
+  description       = "Forward to service tasks"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "service" {
+  name        = "${var.project_name}-service"
+  description = "akbun-terraform-apply-remote tasks"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "service_from_alb" {
+  security_group_id            = aws_security_group.service.id
+  description                  = "Webhook traffic from the ALB only"
+  from_port                    = var.server_port
+  to_port                      = var.server_port
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "service_all" {
+  security_group_id = aws_security_group.service.id
+  description       = "GitHub API, git clone, terraform providers, EFS"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "efs" {
+  name        = "${var.project_name}-efs"
+  description = "EFS for akbun-terraform-apply-remote state"
+  vpc_id      = data.aws_vpc.default.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "efs_from_service" {
+  security_group_id            = aws_security_group.efs.id
+  description                  = "NFS from service tasks only"
+  from_port                    = 2049
+  to_port                      = 2049
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.service.id
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/ssm.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/ssm.tf
@@ -1,0 +1,14 @@
+# 자격증명은 SSM SecureString으로만 전달하고 task definition에는
+# 파라미터 ARN만 남긴다. 값은 ECS가 컨테이너 기동 시 주입한다.
+
+resource "aws_ssm_parameter" "webhook_secret" {
+  name  = "/${var.project_name}/webhook-secret"
+  type  = "SecureString"
+  value = var.webhook_secret
+}
+
+resource "aws_ssm_parameter" "github_token" {
+  name  = "/${var.project_name}/github-token"
+  type  = "SecureString"
+  value = var.github_token
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/terraform.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.11"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/product/akbun-terraform-apply-remote/deploy/ecs/variables.tf
+++ b/product/akbun-terraform-apply-remote/deploy/ecs/variables.tf
@@ -1,0 +1,75 @@
+variable "project_name" {
+  description = "Tag and resource name prefix"
+  type        = string
+  default     = "akbun-terraform-apply-remote"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "image" {
+  description = "Container image (ECR URI with tag). Pushing a new tag and applying is a deployment; ECS rolls tasks with the old task draining gracefully."
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM certificate ARN for the ALB HTTPS listener. Created in the console beforehand."
+  type        = string
+}
+
+variable "route53_zone_id" {
+  description = "Route53 hosted zone id for the webhook domain. Empty string skips record creation."
+  type        = string
+  default     = ""
+}
+
+variable "domain_name" {
+  description = "Webhook domain name (e.g. atr.example.com). Used only when route53_zone_id is set."
+  type        = string
+  default     = ""
+}
+
+variable "webhook_secret" {
+  description = "GitHub webhook secret. Stored as an SSM SecureString parameter."
+  type        = string
+  sensitive   = true
+}
+
+variable "github_token" {
+  description = "GitHub API token for the server. Stored as an SSM SecureString parameter."
+  type        = string
+  sensitive   = true
+}
+
+variable "trigger_word" {
+  description = "Comment trigger word for plan/apply commands"
+  type        = string
+  default     = "akbun"
+}
+
+variable "server_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 4141
+}
+
+variable "task_cpu" {
+  description = "Fargate task CPU units"
+  type        = number
+  default     = 512
+}
+
+variable "task_memory" {
+  description = "Fargate task memory (MiB)"
+  type        = number
+  default     = 1024
+}
+
+variable "task_role_policy_arns" {
+  description = "IAM policies attached to the task role, granting the terraform runs inside the container their AWS permissions. Lab default is PowerUserAccess; narrow it in production."
+  type        = list(string)
+  default     = ["arn:aws:iam::aws:policy/PowerUserAccess"]
+}

--- a/product/akbun-terraform-apply-remote/docs/architecture.md
+++ b/product/akbun-terraform-apply-remote/docs/architecture.md
@@ -1,0 +1,181 @@
+# 아키텍처
+
+akbun-terraform-apply-remote의 구조와 핵심 흐름을 정리한다. 설계 의도는 세 가지다.
+
+1. PR이 생성되면 자동으로 plan하고 결과를 PR comment로 남긴다.
+2. PR comment로 plan을 다시 실행하고, apply와 import를 실행할 수 있다.
+3. 인증은 장기 PAT 또는 GitHub App의 임시 installation token 중 선택한다.
+
+## 전체 구성
+
+GitHub webhook을 받아 terraform을 실행하고 결과를 PR comment로 돌려주는 단일 바이너리 서버다.
+
+```mermaid
+flowchart LR
+  subgraph GitHub
+    PR[Pull Request]
+    WH[Webhook]
+    API[REST API]
+  end
+
+  subgraph Server[akbun-terraform-apply-remote]
+    SRV[server<br/>HTTP 수신, drain]
+    SIG[signature<br/>HMAC-SHA256 검증]
+    EVT[events<br/>payload 해석]
+    CMD[command<br/>comment 명령 파싱]
+    HDL[handler<br/>오케스트레이션]
+    LCK[locks<br/>프로젝트 lock]
+    ST[state<br/>state.json 영속화]
+    AUTH[auth<br/>PAT 또는 App token]
+    GH[github<br/>API 클라이언트]
+    WS[workspace<br/>PR checkout]
+    TF[terraform<br/>init/plan/apply/import]
+    FMT[format<br/>comment 렌더링]
+  end
+
+  DATA[(data 디렉터리<br/>checkout, plan 파일, state.json)]
+
+  WH -->|이벤트 전달| SRV
+  SRV --> SIG --> EVT --> HDL
+  HDL --> CMD
+  HDL --> LCK
+  HDL --> ST
+  HDL --> WS --> TF
+  HDL --> FMT --> GH
+  GH --> AUTH
+  WS --> AUTH
+  GH -->|comment 작성, PR 조회| API
+  WS --> DATA
+  ST --> DATA
+  API --> PR
+```
+
+- webhook은 서명 검증을 통과해야만 처리된다. 즉시 200으로 응답하고 실제 작업은 백그라운드 스레드에서 실행해 GitHub의 10초 timeout을 피한다.
+- 핵심 판단 로직(command, signature, project, format, locks, state, jobs, auth 선택)은 순수 함수/자료구조로 분리해 단위 테스트로 검증한다.
+
+## 흐름 1: PR 생성 시 자동 plan
+
+PR이 열리거나(head가 갱신되어도 동일) 변경 파일에 terraform 파일이 있으면 자동으로 plan하고 결과를 comment로 남긴다.
+
+```mermaid
+sequenceDiagram
+  participant U as 개발자
+  participant GH as GitHub
+  participant S as 서버
+  participant T as terraform
+
+  U->>GH: PR 생성 / push
+  GH->>S: webhook (pull_request: opened/synchronize)
+  S->>S: HMAC 서명 검증
+  S->>GH: 변경 파일 목록 조회
+  S->>S: terraform 프로젝트 디렉터리 탐지
+  S->>S: 프로젝트 lock 획득 (PR 단위)
+  S->>S: PR head checkout (pull/N/head)
+  S->>T: terraform init, plan -out .akbun.tfplan
+  T-->>S: plan 출력
+  S->>S: plan 파일 저장 + head SHA 기록
+  S->>GH: plan 결과를 PR comment로 작성
+  GH-->>U: comment 확인, 리뷰
+```
+
+## 흐름 2: comment로 plan / apply / import
+
+리뷰어는 PR comment로 서버를 조작한다. apply는 새로 plan하지 않고 **마지막 plan이 저장한 파일**을 그대로 적용한다.
+
+```mermaid
+sequenceDiagram
+  participant R as 리뷰어
+  participant GH as GitHub
+  participant S as 서버
+  participant T as terraform
+
+  R->>GH: comment "akbun apply"
+  GH->>S: webhook (issue_comment)
+  S->>S: 서명 검증, 명령 파싱
+  S->>S: plan 기록 확인
+  alt PR head가 plan 시점과 다름
+    S->>GH: comment "PR이 바뀌었다, 다시 plan하라"
+  else 저장된 plan이 유효
+    S->>T: terraform apply .akbun.tfplan
+    T-->>S: apply 출력
+    S->>S: lock 해제, plan 기록 삭제
+    S->>GH: apply 결과 comment
+  end
+
+  R->>GH: comment "akbun import aws_vpc.main vpc-123"
+  GH->>S: webhook (issue_comment)
+  S->>T: terraform import aws_vpc.main vpc-123
+  T-->>S: import 출력
+  S->>S: 저장된 plan 무효화 (state가 바뀌었으므로)
+  S->>GH: import 결과 + 재plan 안내 comment
+```
+
+명령 요약:
+
+| comment | 동작 |
+|---|---|
+| akbun plan [-d dir] | 변경된(또는 지정한) 프로젝트를 plan |
+| akbun apply [-d dir] | 저장된 plan 파일을 apply |
+| akbun import [-d dir] 주소 ID | 기존 리소스를 state로 import, 이후 재plan 요구 |
+| akbun unlock | 이 PR의 lock 전부 해제 |
+| akbun help | 사용법 안내 |
+
+## 동시성 제어: 프로젝트 lock과 저장된 plan
+
+- 프로젝트 디렉터리(예: aws/vpc)를 처음 plan한 PR이 lock을 잡는다. 다른 PR은 그 프로젝트를 apply 성공, PR close, unlock 전까지 건드릴 수 없다. 같은 state를 두 PR이 경쟁하는 것을 막는다.
+- apply는 저장된 plan 파일과 plan 시점의 head SHA를 검증한다. 리뷰한 내용과 적용되는 내용이 항상 일치한다.
+- plan이 실패하면 이전 plan 기록을 지워 오래된 plan이 apply되는 것을 막는다. lock은 유지된다(그 PR이 프로젝트를 점유 중).
+
+## 배포와 인수인계 (takeover)
+
+배포는 두 장치 위에서 무중단으로 동작한다. 상세는 [deploy-guide.md](./deploy-guide.md)를 본다.
+
+```mermaid
+flowchart TB
+  subgraph Old[기존 인스턴스]
+    O1[SIGTERM 수신] --> O2[새 webhook 수신 중단]
+    O2 --> O3[진행 중 terraform 실행 완료 대기<br/>drain 최대 30분]
+    O3 --> O4[종료]
+  end
+
+  subgraph Disk[data 디렉터리 EBS/EFS]
+    D1[state.json<br/>lock + plan 기록]
+    D2[PR checkout + plan 파일]
+  end
+
+  subgraph New[새 인스턴스]
+    N1[기동] --> N2[state.json 로드]
+    N2 --> N3[이전 lock과 plan을 이어받아 서비스 재개]
+  end
+
+  Old -.매 이벤트마다 저장.-> Disk
+  Disk -.기동 시 로드.-> New
+```
+
+- 모든 이벤트 처리 후 lock과 plan 기록을 state.json에 저장하므로, 새 인스턴스는 배포 직전 상태에서 이어서 동작한다.
+- EC2 배포는 systemd timer가 새 바이너리를 감지해 교체하는 self-deploy, ECS 배포는 rolling 교체(EFS 공유)로 같은 성질을 만든다.
+
+## 인증: PAT 또는 GitHub App 임시 토큰
+
+GitHub 접근 토큰은 두 방식 중 하나를 선택한다. 장기 토큰을 두고 싶지 않으면 GitHub App 방식을 쓴다.
+
+```mermaid
+flowchart LR
+  subgraph PAT[방식 1: PAT]
+    P1[ATR_GITHUB_TOKEN] --> P2[고정 토큰 그대로 사용]
+  end
+
+  subgraph App[방식 2: GitHub App]
+    A1[App private key로<br/>JWT 서명 RS256, 9분] --> A2[POST /app/installations/ID/access_tokens]
+    A2 --> A3[installation token 발급<br/>유효 1시간]
+    A3 --> A4[캐시, 만료 10분 전 자동 재발급]
+  end
+
+  P2 --> USE[GitHub API 호출과 git fetch에 사용]
+  A4 --> USE
+```
+
+- App 방식에서는 장기 자격증명이 런타임에 존재하지 않는다. private key는 디스크에만 있고, 실제로 쓰이는 토큰은 1시간짜리 installation token이다.
+- 토큰은 API 호출과 git fetch 시점마다 provider에서 꺼내 쓰므로, 긴 작업 중에도 만료 전에 자동 갱신된다.
+- git fetch는 토큰을 remote URL에 넣지 않고 Authorization 헤더로만 전달해 디스크에 토큰이 남지 않는다.
+- App 설정 절차는 [user-guide.md](./user-guide.md)의 인증 옵션 절을 따른다.

--- a/product/akbun-terraform-apply-remote/docs/deploy-guide.md
+++ b/product/akbun-terraform-apply-remote/docs/deploy-guide.md
@@ -1,0 +1,82 @@
+# 배포 가이드
+
+AWS에 서버를 배포하는 Terraform 코드(deploy/ec2, deploy/ecs)의 사용법과, 배포 중 작업이 끊기지 않는 이유를 정리한다. 기본 사용법은 [user-guide.md](./user-guide.md)를 먼저 본다.
+
+## 배포가 안전한 이유 (takeover 구조)
+
+서버는 재배포를 전제로 설계했다.
+
+- **graceful drain**: SIGTERM을 받으면 새 webhook 수신을 멈추고, 진행 중인 terraform plan/apply를 끝까지 마친 뒤 종료한다(최대 30분 대기). apply가 중간에 잘리는 최악의 상황을 배포가 만들지 않는다.
+- **상태 영속화**: 프로젝트 lock과 plan 기록(어느 commit에서 plan했는지)을 이벤트 처리 때마다 데이터 디렉터리의 state.json에 저장한다. 새 인스턴스는 기동 시 이 파일을 읽어 이전 인스턴스의 상태를 그대로 이어받는다. PR checkout과 저장된 plan 파일도 같은 디렉터리에 있으므로, 배포 전에 plan한 것을 배포 후에 apply할 수 있다.
+- **self-deploy**: EC2 배포는 새 바이너리를, ECS 배포는 새 이미지 태그를 감지해 스스로 교체한다. 아래 각 절에서 설명한다.
+
+## 공통 준비
+
+- GitHub token(대상 저장소 Contents read, Issues/PR write)과 webhook secret을 준비한다.
+- 두 스택 모두 secret을 SSM SecureString 파라미터로 만들어 전달하므로 코드나 user data에 평문이 남지 않는다.
+- 서버 안의 terraform이 AWS 리소스를 만들 때 쓰는 권한은 실습 기준 PowerUserAccess를 붙인다. 운영에서는 관리 대상에 맞게 좁힌다.
+
+## EC2 배포 (deploy/ec2)
+
+Graviton t4g.small 한 대에 systemd 서비스로 올리는 가장 저렴한 구성이다. default VPC를 쓰고, SSH 대신 SSM Session Manager로 접속한다.
+
+빌드 파이프라인이 올린 linux 바이너리를 아무 URL(S3 presigned 제외, 고정 URL 권장)에 올린 뒤 적용한다.
+
+```bash
+cd deploy/ec2
+terraform init
+terraform apply \
+  -var binary_url=https://<바이너리 URL> \
+  -var webhook_secret=<secret> \
+  -var github_token=<token>
+```
+
+출력된 webhook_url을 GitHub 저장소 webhook에 등록한다(Issue comments + Pull requests 이벤트, secret 동일하게).
+
+동작 구조:
+
+- user data가 terraform과 서버 바이너리를 설치하고 systemd 서비스(atr.service)로 띄운다. 서비스는 기동 시 SSM에서 secret을 읽어 환경변수로 주입한다.
+- **self-deploy**: atr-update.timer가 5분마다 binary_url을 받아 현재 바이너리와 비교하고, 바뀌었으면 교체 후 systemctl restart를 한다. systemd의 TimeoutStopSec이 30분이라 restart도 drain을 기다린다. 즉 binary_url에 새 바이너리를 올리는 것이 곧 배포다.
+- 상태는 인스턴스의 /opt/atr/data에 남는다. 재시작과 재배포에는 안전하지만 인스턴스를 교체하면 사라진다. 교체 후에는 PR에서 plan을 다시 실행한다.
+- webhook은 HTTP(포트 4141)로 받는다. HMAC 서명 검증이 인증을 담당하지만, TLS까지 원하면 ECS 배포(ALB + ACM)를 쓴다.
+
+## ECS 배포 (deploy/ecs)
+
+Fargate(ARM64) + ALB(HTTPS) + EFS 구성이다. HA 인수인계까지 필요하면 이쪽을 쓴다.
+
+이미지를 먼저 빌드해 ECR에 올린다.
+
+```bash
+docker buildx build --platform linux/arm64 -t <account>.dkr.ecr.ap-northeast-2.amazonaws.com/atr:v1 --push .
+```
+
+ACM 인증서(콘솔에서 미리 발급)와 함께 적용한다.
+
+```bash
+cd deploy/ecs
+terraform init
+terraform apply \
+  -var image=<ECR 이미지 URI> \
+  -var acm_certificate_arn=<인증서 ARN> \
+  -var route53_zone_id=<zone id, 선택> \
+  -var domain_name=<도메인, 선택> \
+  -var webhook_secret=<secret> \
+  -var github_token=<token>
+```
+
+동작 구조:
+
+- **takeover**: state.json, PR checkout, plan 파일이 모두 EFS(/data)에 있다. 배포 시 ECS가 새 task를 먼저 띄우고(healthy 확인) 이전 task를 내리는 rolling 교체를 하므로 다운타임이 없고, 새 task는 EFS에서 이전 상태를 이어받는다. 이전 task는 ALB에서 빠져 새 webhook을 받지 않는 상태로 진행 중인 실행을 마친다.
+- **self-deploy**: 새 이미지 태그를 push하고 image 변수만 바꿔 terraform apply하면 위의 rolling 교체가 일어난다.
+- **제약**: Fargate의 stopTimeout 상한이 120초라 SIGTERM 후 2분을 넘기는 apply는 잘릴 수 있다. 대신 상태가 EFS에 있으므로 새 task에서 plan을 다시 실행하면 된다. 2분 이상 걸리는 apply가 흔하면 EC2 배포를 권한다.
+- secret은 task definition의 secrets 필드로 SSM 파라미터 ARN만 참조하고, ECS가 기동 시 주입한다.
+
+## 두 구성 비교
+
+| | EC2 | ECS |
+|---|---|---|
+| 비용 | t4g.small 한 대 | Fargate + ALB + EFS |
+| TLS | 없음(HMAC만) | ALB + ACM |
+| 배포 방식 | binary_url 교체를 timer가 감지 | 이미지 태그 교체 후 apply |
+| drain 시간 | 최대 30분 | 최대 120초 (Fargate 상한) |
+| 인스턴스 교체 시 상태 | 사라짐 (재plan 필요) | EFS에 유지 |

--- a/product/akbun-terraform-apply-remote/docs/deploy-guide.md
+++ b/product/akbun-terraform-apply-remote/docs/deploy-guide.md
@@ -14,6 +14,7 @@ AWS에 서버를 배포하는 Terraform 코드(deploy/ec2, deploy/ecs)의 사용
 
 - GitHub token(대상 저장소 Contents read, Issues/PR write)과 webhook secret을 준비한다.
 - 두 스택 모두 secret을 SSM SecureString 파라미터로 만들어 전달하므로 코드나 user data에 평문이 남지 않는다.
+- 두 스택은 PAT 방식(`ATR_GITHUB_TOKEN`)을 기본으로 배선한다. GitHub App 임시 토큰 방식을 쓰려면 [user-guide.md](./user-guide.md)의 인증 옵션 절을 따라 `ATR_GITHUB_APP_*` 환경변수와 private key 파일을 대신 주입한다(EC2는 env 파일, ECS는 task definition 수정).
 - 서버 안의 terraform이 AWS 리소스를 만들 때 쓰는 권한은 실습 기준 PowerUserAccess를 붙인다. 운영에서는 관리 대상에 맞게 좁힌다.
 
 ## EC2 배포 (deploy/ec2)

--- a/product/akbun-terraform-apply-remote/docs/user-guide.md
+++ b/product/akbun-terraform-apply-remote/docs/user-guide.md
@@ -68,7 +68,9 @@ PR을 열면 변경된 terraform 디렉터리를 자동으로 plan하고 결과�
 - **apply는 저장된 plan만 적용한다.** plan 이후 PR에 push가 있으면 apply를 거부하고 재plan을 요구한다. 리뷰한 내용과 적용되는 내용이 항상 같다.
 - **프로젝트 lock**: 한 프로젝트 디렉터리를 먼저 plan한 PR이 lock을 잡는다. 다른 PR은 apply가 끝나거나 unlock될 때까지 그 프로젝트를 plan/apply할 수 없다. lock은 apply 성공, PR close, `akbun unlock` 시 해제된다.
 - **fork PR 지원**: PR head를 base 저장소의 `pull/N/head` ref에서 가져오므로 fork에서 온 PR도 동작한다.
-- 서버를 재시작하면 저장된 plan 기록이 사라진다. 이때는 `akbun plan`을 다시 실행한다.
+- **재시작/재배포에 안전**: lock과 plan 기록은 data 디렉터리의 state.json에 영속화되어 재시작한 서버가 이어받는다. SIGTERM을 받으면 진행 중인 terraform 실행을 마친 뒤 종료한다(graceful drain). data 디렉터리 자체를 잃은 경우에만 `akbun plan`을 다시 실행한다.
+
+AWS(EC2, ECS) 배포는 [deploy-guide.md](./deploy-guide.md)를 본다.
 
 ## 문제 해결
 

--- a/product/akbun-terraform-apply-remote/docs/user-guide.md
+++ b/product/akbun-terraform-apply-remote/docs/user-guide.md
@@ -1,0 +1,80 @@
+# 사용자 가이드
+
+akbun-terraform-apply-remote를 설치하고 GitHub 저장소에 연결하는 방법을 정리한다.
+
+## 요구사항
+
+- 서버에 terraform과 git이 설치되어 있어야 한다.
+- GitHub token: 대상 저장소의 Contents(read)와 Pull requests/Issues(write) 권한이 필요하다. fine-grained PAT 또는 GitHub App 설치 token을 사용한다.
+- 서버는 GitHub에서 접근 가능한 주소(도메인 또는 공인 IP)로 노출되어야 한다.
+
+## 빌드
+
+소스에서 릴리스 바이너리를 빌드한다. GitHub Actions 파이프라인(build-terraform-apply-remote)이 master 빌드마다 linux 바이너리 artifact를 올리므로 그것을 받아도 된다.
+
+```bash
+cargo build --release
+# 산출물: target/release/akbun-terraform-apply-remote
+```
+
+## 실행
+
+환경변수로 설정을 주입하고 실행한다.
+
+```bash
+export ATR_GITHUB_TOKEN=ghp_xxx        # 필수. GitHub API 토큰
+export ATR_WEBHOOK_SECRET=random-long  # 필수. webhook 서명 검증 secret
+export ATR_PORT=4141                   # 선택. 기본 4141
+export ATR_TRIGGER=akbun               # 선택. comment 명령 트리거 단어
+export ATR_TERRAFORM_BIN=terraform     # 선택. terraform 실행 파일 경로
+export ATR_DATA_DIR=./data             # 선택. PR checkout 저장 위치
+./akbun-terraform-apply-remote
+```
+
+terraform이 AWS 등 provider 자격증명을 요구하면 같은 프로세스 환경에 함께 주입한다(예: `AWS_PROFILE`, instance role).
+
+## Webhook 등록
+
+대상 저장소의 Settings > Webhooks에서 추가한다.
+
+- Payload URL: `https://<서버 주소>/events`
+- Content type: `application/json`
+- Secret: `ATR_WEBHOOK_SECRET`과 같은 값
+- 이벤트: "Let me select individual events"에서 **Issue comments**와 **Pull requests**를 선택
+
+등록 후 서버 헬스체크로 연결을 확인한다.
+
+```bash
+curl https://<서버 주소>/healthz
+```
+
+## 사용법
+
+PR을 열면 변경된 terraform 디렉터리를 자동으로 plan하고 결과를 comment로 남긴다. 이후는 PR comment로 조작한다.
+
+| 명령 | 동작 |
+|---|---|
+| `akbun plan` | 변경된 모든 terraform 프로젝트를 plan한다 |
+| `akbun plan -d <dir>` | 지정한 디렉터리만 plan한다 |
+| `akbun apply` | 저장된 plan을 모두 apply한다 |
+| `akbun apply -d <dir>` | 지정한 디렉터리의 plan만 apply한다 |
+| `akbun unlock` | 이 PR이 잡은 lock을 모두 해제한다 |
+| `akbun help` | 사용법을 comment로 남긴다 |
+
+트리거 단어(`akbun`)는 `ATR_TRIGGER`로 바꿀 수 있다. 명령은 comment의 한 줄이 트리거 단어로 시작할 때만 인식한다.
+
+## 동작 규칙
+
+- **apply는 저장된 plan만 적용한다.** plan 이후 PR에 push가 있으면 apply를 거부하고 재plan을 요구한다. 리뷰한 내용과 적용되는 내용이 항상 같다.
+- **프로젝트 lock**: 한 프로젝트 디렉터리를 먼저 plan한 PR이 lock을 잡는다. 다른 PR은 apply가 끝나거나 unlock될 때까지 그 프로젝트를 plan/apply할 수 없다. lock은 apply 성공, PR close, `akbun unlock` 시 해제된다.
+- **fork PR 지원**: PR head를 base 저장소의 `pull/N/head` ref에서 가져오므로 fork에서 온 PR도 동작한다.
+- 서버를 재시작하면 저장된 plan 기록이 사라진다. 이때는 `akbun plan`을 다시 실행한다.
+
+## 문제 해결
+
+| 증상 | 원인과 해결 |
+|---|---|
+| webhook이 401을 반환 | webhook Secret과 `ATR_WEBHOOK_SECRET` 불일치 |
+| comment에 반응이 없음 | 트리거 단어 불일치, 또는 comment가 트리거 단어로 시작하는 줄이 없음 |
+| plan은 되는데 apply가 거부됨 | plan 이후 PR head가 바뀜. 다시 plan한다 |
+| "locked by pull request #N" | 다른 PR이 같은 프로젝트를 작업 중. 그 PR을 apply하거나 unlock한다 |

--- a/product/akbun-terraform-apply-remote/docs/user-guide.md
+++ b/product/akbun-terraform-apply-remote/docs/user-guide.md
@@ -5,7 +5,7 @@ akbun-terraform-apply-remote를 설치하고 GitHub 저장소에 연결하는 �
 ## 요구사항
 
 - 서버에 terraform과 git이 설치되어 있어야 한다.
-- GitHub token: 대상 저장소의 Contents(read)와 Pull requests/Issues(write) 권한이 필요하다. fine-grained PAT 또는 GitHub App 설치 token을 사용한다.
+- GitHub 인증: 대상 저장소의 Contents(read)와 Pull requests/Issues(write) 권한이 필요하다. fine-grained PAT 또는 GitHub App 중 선택한다. 아래 인증 옵션 절을 본다.
 - 서버는 GitHub에서 접근 가능한 주소(도메인 또는 공인 IP)로 노출되어야 한다.
 
 ## 빌드
@@ -19,10 +19,10 @@ cargo build --release
 
 ## 실행
 
-환경변수로 설정을 주입하고 실행한다.
+환경변수로 설정을 주입하고 실행한다. 인증은 PAT(`ATR_GITHUB_TOKEN`) 또는 GitHub App(`ATR_GITHUB_APP_*`) 중 하나만 설정한다.
 
 ```bash
-export ATR_GITHUB_TOKEN=ghp_xxx        # 필수. GitHub API 토큰
+export ATR_GITHUB_TOKEN=ghp_xxx        # 인증 방식 1: PAT
 export ATR_WEBHOOK_SECRET=random-long  # 필수. webhook 서명 검증 secret
 export ATR_PORT=4141                   # 선택. 기본 4141
 export ATR_TRIGGER=akbun               # 선택. comment 명령 트리거 단어
@@ -32,6 +32,30 @@ export ATR_DATA_DIR=./data             # 선택. PR checkout 저장 위치
 ```
 
 terraform이 AWS 등 provider 자격증명을 요구하면 같은 프로세스 환경에 함께 주입한다(예: `AWS_PROFILE`, instance role).
+
+## 인증 옵션
+
+두 방식 중 하나를 선택한다. 둘 다 설정하면 기동 시 에러로 종료한다.
+
+**방식 1 - fine-grained PAT (간단)**: `ATR_GITHUB_TOKEN`에 토큰을 넣는다. 대상 저장소에 Contents Read, Issues Read/Write, Pull requests Read/Write 권한을 준다. 장기 토큰이 서버에 존재하는 것이 단점이다.
+
+**방식 2 - GitHub App 임시 토큰 (권장)**: 장기 토큰 대신 1시간짜리 installation token을 서버가 스스로 발급받는다. private key만 디스크에 두면 되고, 유출 시 App 단위로 즉시 폐기할 수 있다. bot 이름으로 comment가 달려 사람 계정과 구분되는 것도 장점이다.
+
+GitHub App 설정 절차:
+
+1. GitHub Settings > Developer settings > GitHub Apps > New GitHub App으로 App을 만든다. Webhook은 비활성화해도 된다(저장소 webhook을 따로 쓴다).
+2. Repository permissions에서 Contents Read-only, Issues Read and write, Pull requests Read and write를 준다.
+3. 생성된 App의 App ID를 기록하고, Private keys에서 키를 생성해 pem 파일을 내려받는다.
+4. 대상 저장소(또는 조직)에 App을 Install하고, 설치 후 URL의 마지막 숫자(installation id)를 기록한다.
+5. 아래 환경변수를 설정하고 서버를 실행한다.
+
+```bash
+export ATR_GITHUB_APP_ID=123456
+export ATR_GITHUB_APP_PRIVATE_KEY_PATH=/opt/atr/app-private-key.pem
+export ATR_GITHUB_APP_INSTALLATION_ID=98765432
+```
+
+서버는 private key로 9분짜리 JWT를 서명해 installation token(유효 1시간)을 발급받고, 만료 10분 전에 자동으로 재발급한다. 토큰은 API 호출과 git fetch에만 쓰이고 디스크에 남지 않는다.
 
 ## Webhook 등록
 
@@ -58,6 +82,8 @@ PR을 열면 변경된 terraform 디렉터리를 자동으로 plan하고 결과�
 | `akbun plan -d <dir>` | 지정한 디렉터리만 plan한다 |
 | `akbun apply` | 저장된 plan을 모두 apply한다 |
 | `akbun apply -d <dir>` | 지정한 디렉터리의 plan만 apply한다 |
+| `akbun import <주소> <ID>` | 기존 리소스를 terraform state로 import한다. 예: `akbun import aws_vpc.main vpc-123` |
+| `akbun import -d <dir> <주소> <ID>` | 지정한 디렉터리에서 import한다. PR이 여러 프로젝트를 바꿨으면 -d가 필수다 |
 | `akbun unlock` | 이 PR이 잡은 lock을 모두 해제한다 |
 | `akbun help` | 사용법을 comment로 남긴다 |
 
@@ -67,6 +93,7 @@ PR을 열면 변경된 terraform 디렉터리를 자동으로 plan하고 결과�
 
 - **apply는 저장된 plan만 적용한다.** plan 이후 PR에 push가 있으면 apply를 거부하고 재plan을 요구한다. 리뷰한 내용과 적용되는 내용이 항상 같다.
 - **프로젝트 lock**: 한 프로젝트 디렉터리를 먼저 plan한 PR이 lock을 잡는다. 다른 PR은 apply가 끝나거나 unlock될 때까지 그 프로젝트를 plan/apply할 수 없다. lock은 apply 성공, PR close, `akbun unlock` 시 해제된다.
+- **import 후에는 재plan**: import는 state를 바꾸므로 저장된 plan을 무효화한다. import 결과 comment의 안내대로 plan을 다시 실행하고 리뷰한 뒤 apply한다.
 - **fork PR 지원**: PR head를 base 저장소의 `pull/N/head` ref에서 가져오므로 fork에서 온 PR도 동작한다.
 - **재시작/재배포에 안전**: lock과 plan 기록은 data 디렉터리의 state.json에 영속화되어 재시작한 서버가 이어받는다. SIGTERM을 받으면 진행 중인 terraform 실행을 마친 뒤 종료한다(graceful drain). data 디렉터리 자체를 잃은 경우에만 `akbun plan`을 다시 실행한다.
 

--- a/product/akbun-terraform-apply-remote/src/auth.rs
+++ b/product/akbun-terraform-apply-remote/src/auth.rs
@@ -1,0 +1,243 @@
+use serde::Deserialize;
+use serde_json::json;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// How the server authenticates against the GitHub API and git.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthSettings {
+  /// A long-lived personal access token from ATR_GITHUB_TOKEN.
+  StaticToken(String),
+  /// A GitHub App that mints short-lived installation tokens.
+  App { app_id: String, private_key_path: String, installation_id: String },
+}
+
+/// Picks the auth mode from the environment values. Exactly one of the two
+/// modes must be configured; mixing or partial App settings is an error so
+/// misconfiguration fails at boot, not on the first webhook.
+pub fn select_auth(
+  token: Option<String>,
+  app_id: Option<String>,
+  private_key_path: Option<String>,
+  installation_id: Option<String>,
+) -> Result<AuthSettings, String> {
+  let app_vars = [&app_id, &private_key_path, &installation_id];
+  let app_set = app_vars.iter().filter(|v| v.is_some()).count();
+  match (token, app_set) {
+    (Some(_), n) if n > 0 => Err(
+      "set either ATR_GITHUB_TOKEN or the ATR_GITHUB_APP_* variables, not both".to_string(),
+    ),
+    (Some(token), _) => Ok(AuthSettings::StaticToken(token)),
+    (None, 3) => Ok(AuthSettings::App {
+      app_id: app_id.unwrap(),
+      private_key_path: private_key_path.unwrap(),
+      installation_id: installation_id.unwrap(),
+    }),
+    (None, 0) => Err(
+      "no GitHub credentials: set ATR_GITHUB_TOKEN, or ATR_GITHUB_APP_ID + \
+       ATR_GITHUB_APP_PRIVATE_KEY_PATH + ATR_GITHUB_APP_INSTALLATION_ID"
+        .to_string(),
+    ),
+    (None, _) => Err(
+      "incomplete GitHub App settings: ATR_GITHUB_APP_ID, ATR_GITHUB_APP_PRIVATE_KEY_PATH \
+       and ATR_GITHUB_APP_INSTALLATION_ID must all be set"
+        .to_string(),
+    ),
+  }
+}
+
+/// Hands out a GitHub token on demand. In App mode the token is a cached
+/// short-lived installation token, re-minted before it expires, so no
+/// long-lived credential exists anywhere at runtime.
+pub struct TokenProvider {
+  mode: ProviderMode,
+}
+
+enum ProviderMode {
+  Static(String),
+  App {
+    app_id: String,
+    private_key_pem: Vec<u8>,
+    installation_id: String,
+    api_base: String,
+    cache: Mutex<Option<CachedToken>>,
+  },
+}
+
+struct CachedToken {
+  token: String,
+  expires_at_epoch: u64,
+}
+
+/// Installation tokens live one hour; treat them as expiring earlier so a
+/// long terraform run started near the boundary still holds a valid token.
+const TOKEN_LIFETIME_SECS: u64 = 3600;
+const REFRESH_MARGIN_SECS: u64 = 600;
+
+/// True when the cached token is close enough to expiry to re-mint.
+/// Pure so the boundary is testable.
+pub fn needs_refresh(expires_at_epoch: u64, now_epoch: u64) -> bool {
+  now_epoch + REFRESH_MARGIN_SECS >= expires_at_epoch
+}
+
+impl TokenProvider {
+  /// Builds the provider, reading the App private key at boot so a bad
+  /// path fails immediately.
+  pub fn new(settings: &AuthSettings, api_base: &str) -> Result<TokenProvider, String> {
+    let mode = match settings {
+      AuthSettings::StaticToken(token) => ProviderMode::Static(token.clone()),
+      AuthSettings::App { app_id, private_key_path, installation_id } => {
+        let private_key_pem = std::fs::read(private_key_path)
+          .map_err(|e| format!("cannot read App private key {private_key_path}: {e}"))?;
+        jsonwebtoken::EncodingKey::from_rsa_pem(&private_key_pem)
+          .map_err(|e| format!("App private key is not a valid RSA PEM: {e}"))?;
+        ProviderMode::App {
+          app_id: app_id.clone(),
+          private_key_pem,
+          installation_id: installation_id.clone(),
+          api_base: api_base.trim_end_matches('/').to_string(),
+          cache: Mutex::new(None),
+        }
+      }
+    };
+    Ok(TokenProvider { mode })
+  }
+
+  pub fn token(&self) -> Result<String, String> {
+    match &self.mode {
+      ProviderMode::Static(token) => Ok(token.clone()),
+      ProviderMode::App { app_id, private_key_pem, installation_id, api_base, cache } => {
+        let now = epoch_now();
+        let mut cache = cache.lock().unwrap();
+        if let Some(cached) = cache.as_ref() {
+          if !needs_refresh(cached.expires_at_epoch, now) {
+            return Ok(cached.token.clone());
+          }
+        }
+        let token = mint_installation_token(app_id, private_key_pem, installation_id, api_base, now)?;
+        *cache = Some(CachedToken {
+          token: token.clone(),
+          expires_at_epoch: now + TOKEN_LIFETIME_SECS,
+        });
+        Ok(token)
+      }
+    }
+  }
+}
+
+#[derive(Deserialize)]
+struct InstallationTokenResponse {
+  token: String,
+}
+
+/// Signs a short-lived App JWT (RS256) and exchanges it for an
+/// installation access token.
+fn mint_installation_token(
+  app_id: &str,
+  private_key_pem: &[u8],
+  installation_id: &str,
+  api_base: &str,
+  now: u64,
+) -> Result<String, String> {
+  // GitHub rejects JWTs whose iat is in the future; backdate 60s to absorb
+  // clock skew. Max allowed exp is 10 minutes; use 9.
+  let claims = json!({ "iat": now - 60, "exp": now + 540, "iss": app_id });
+  let key = jsonwebtoken::EncodingKey::from_rsa_pem(private_key_pem)
+    .map_err(|e| format!("invalid App private key: {e}"))?;
+  let jwt = jsonwebtoken::encode(
+    &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+    &claims,
+    &key,
+  )
+  .map_err(|e| format!("failed to sign App JWT: {e}"))?;
+
+  let url = format!("{api_base}/app/installations/{installation_id}/access_tokens");
+  let response: InstallationTokenResponse = ureq::post(&url)
+    .set("Authorization", &format!("Bearer {jwt}"))
+    .set("Accept", "application/vnd.github+json")
+    .set("User-Agent", "akbun-terraform-apply-remote")
+    .call()
+    .map_err(|e| format!("POST {url} failed: {e}"))?
+    .into_json()
+    .map_err(|e| format!("installation token response invalid: {e}"))?;
+  Ok(response.token)
+}
+
+fn epoch_now() -> u64 {
+  SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn some(s: &str) -> Option<String> {
+    Some(s.to_string())
+  }
+
+  #[test]
+  fn static_token_is_selected() {
+    let auth = select_auth(some("tok"), None, None, None).unwrap();
+    assert_eq!(auth, AuthSettings::StaticToken("tok".to_string()));
+  }
+
+  #[test]
+  fn complete_app_settings_are_selected() {
+    let auth = select_auth(None, some("123"), some("/key.pem"), some("456")).unwrap();
+    assert_eq!(
+      auth,
+      AuthSettings::App {
+        app_id: "123".to_string(),
+        private_key_path: "/key.pem".to_string(),
+        installation_id: "456".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn no_credentials_is_an_error() {
+    assert!(select_auth(None, None, None, None).is_err());
+  }
+
+  #[test]
+  fn partial_app_settings_are_an_error() {
+    assert!(select_auth(None, some("123"), None, None).is_err());
+    assert!(select_auth(None, some("123"), some("/key.pem"), None).is_err());
+  }
+
+  #[test]
+  fn mixing_token_and_app_is_an_error() {
+    assert!(select_auth(some("tok"), some("123"), some("/key.pem"), some("456")).is_err());
+  }
+
+  #[test]
+  fn refresh_happens_before_expiry_margin() {
+    let expires = 10_000;
+    assert!(!needs_refresh(expires, expires - REFRESH_MARGIN_SECS - 1));
+    assert!(needs_refresh(expires, expires - REFRESH_MARGIN_SECS));
+    assert!(needs_refresh(expires, expires + 1));
+  }
+
+  #[test]
+  fn static_provider_returns_the_token_verbatim() {
+    let provider =
+      TokenProvider::new(&AuthSettings::StaticToken("tok".to_string()), "https://api.github.com")
+        .unwrap();
+    assert_eq!(provider.token().unwrap(), "tok");
+  }
+
+  #[test]
+  fn app_provider_rejects_a_bad_key_at_boot() {
+    let dir = std::env::temp_dir().join(format!("atr-auth-test-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let key_path = dir.join("bad.pem");
+    std::fs::write(&key_path, "not a pem").unwrap();
+    let settings = AuthSettings::App {
+      app_id: "1".to_string(),
+      private_key_path: key_path.to_string_lossy().to_string(),
+      installation_id: "2".to_string(),
+    };
+    assert!(TokenProvider::new(&settings, "https://api.github.com").is_err());
+    let _ = std::fs::remove_dir_all(dir);
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/command.rs
+++ b/product/akbun-terraform-apply-remote/src/command.rs
@@ -1,0 +1,146 @@
+/// A command extracted from a pull request comment.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Command {
+  /// Run terraform plan. `dir` narrows the run to one project directory.
+  Plan { dir: Option<String> },
+  /// Apply the saved plan. `dir` narrows the run to one project directory.
+  Apply { dir: Option<String> },
+  /// Release every lock this pull request holds.
+  Unlock,
+  /// Post usage help.
+  Help,
+}
+
+/// Why a comment did not produce a runnable command.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ParseError {
+  /// No line in the comment started with the trigger word.
+  NotACommand,
+  /// The trigger word was present but the rest was not understood.
+  Unrecognized(String),
+}
+
+/// Parses a pull request comment body into a command.
+///
+/// A command is a line whose first word is the trigger word, e.g.
+/// "akbun plan -d aws/vpc". Only the first trigger line is honored.
+pub fn parse(trigger: &str, comment_body: &str) -> Result<Command, ParseError> {
+  for line in comment_body.lines() {
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    match tokens.first() {
+      Some(first) if first.eq_ignore_ascii_case(trigger) => return parse_tokens(&tokens[1..]),
+      _ => continue,
+    }
+  }
+  Err(ParseError::NotACommand)
+}
+
+fn parse_tokens(tokens: &[&str]) -> Result<Command, ParseError> {
+  match tokens.first() {
+    Some(&"plan") => Ok(Command::Plan { dir: parse_dir_flag(&tokens[1..])? }),
+    Some(&"apply") => Ok(Command::Apply { dir: parse_dir_flag(&tokens[1..])? }),
+    Some(&"unlock") => Ok(Command::Unlock),
+    Some(&"help") | None => Ok(Command::Help),
+    Some(other) => Err(ParseError::Unrecognized(format!("unknown subcommand: {other}"))),
+  }
+}
+
+fn parse_dir_flag(tokens: &[&str]) -> Result<Option<String>, ParseError> {
+  match tokens {
+    [] => Ok(None),
+    ["-d", dir] | ["--dir", dir] => Ok(Some(normalize_dir(dir))),
+    ["-d"] | ["--dir"] => Err(ParseError::Unrecognized("-d needs a directory".to_string())),
+    other => Err(ParseError::Unrecognized(format!("unexpected arguments: {}", other.join(" ")))),
+  }
+}
+
+/// Normalizes a user-supplied project directory: strips "./" and trailing "/".
+fn normalize_dir(dir: &str) -> String {
+  let dir = dir.strip_prefix("./").unwrap_or(dir);
+  let dir = dir.trim_end_matches('/');
+  if dir.is_empty() { ".".to_string() } else { dir.to_string() }
+}
+
+/// Usage text posted in reply to "help" or an unrecognized command.
+pub fn usage(trigger: &str) -> String {
+  format!(
+    "Usage:\n\
+     - {trigger} plan [-d <dir>]: run terraform plan for changed projects (or one directory)\n\
+     - {trigger} apply [-d <dir>]: apply the plan saved by the latest plan run\n\
+     - {trigger} unlock: release locks held by this pull request\n\
+     - {trigger} help: show this message"
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_plain_plan() {
+    assert_eq!(parse("akbun", "akbun plan"), Ok(Command::Plan { dir: None }));
+  }
+
+  #[test]
+  fn parses_apply_with_dir_flag() {
+    assert_eq!(
+      parse("akbun", "akbun apply -d aws/vpc"),
+      Ok(Command::Apply { dir: Some("aws/vpc".to_string()) })
+    );
+  }
+
+  #[test]
+  fn parses_long_dir_flag_and_normalizes() {
+    assert_eq!(
+      parse("akbun", "akbun plan --dir ./aws/vpc/"),
+      Ok(Command::Plan { dir: Some("aws/vpc".to_string()) })
+    );
+  }
+
+  #[test]
+  fn trigger_is_case_insensitive() {
+    assert_eq!(parse("akbun", "AKBUN plan"), Ok(Command::Plan { dir: None }));
+  }
+
+  #[test]
+  fn finds_command_on_later_line() {
+    let body = "LGTM overall.\n\nakbun apply";
+    assert_eq!(parse("akbun", body), Ok(Command::Apply { dir: None }));
+  }
+
+  #[test]
+  fn ignores_trigger_mentioned_mid_sentence() {
+    assert_eq!(parse("akbun", "please run akbun plan later"), Err(ParseError::NotACommand));
+  }
+
+  #[test]
+  fn plain_comment_is_not_a_command() {
+    assert_eq!(parse("akbun", "looks good to me"), Err(ParseError::NotACommand));
+  }
+
+  #[test]
+  fn bare_trigger_shows_help() {
+    assert_eq!(parse("akbun", "akbun"), Ok(Command::Help));
+  }
+
+  #[test]
+  fn parses_unlock() {
+    assert_eq!(parse("akbun", "akbun unlock"), Ok(Command::Unlock));
+  }
+
+  #[test]
+  fn unknown_subcommand_is_reported() {
+    assert!(matches!(parse("akbun", "akbun destroy"), Err(ParseError::Unrecognized(_))));
+  }
+
+  #[test]
+  fn dir_flag_without_value_is_reported() {
+    assert!(matches!(parse("akbun", "akbun plan -d"), Err(ParseError::Unrecognized(_))));
+  }
+
+  #[test]
+  fn custom_trigger_word_is_honored() {
+    assert_eq!(parse("terraform-bot", "terraform-bot plan"), Ok(Command::Plan { dir: None }));
+    assert_eq!(parse("terraform-bot", "akbun plan"), Err(ParseError::NotACommand));
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/command.rs
+++ b/product/akbun-terraform-apply-remote/src/command.rs
@@ -5,6 +5,8 @@ pub enum Command {
   Plan { dir: Option<String> },
   /// Apply the saved plan. `dir` narrows the run to one project directory.
   Apply { dir: Option<String> },
+  /// Import an existing resource into terraform state.
+  Import { dir: Option<String>, address: String, id: String },
   /// Release every lock this pull request holds.
   Unlock,
   /// Post usage help.
@@ -39,9 +41,36 @@ fn parse_tokens(tokens: &[&str]) -> Result<Command, ParseError> {
   match tokens.first() {
     Some(&"plan") => Ok(Command::Plan { dir: parse_dir_flag(&tokens[1..])? }),
     Some(&"apply") => Ok(Command::Apply { dir: parse_dir_flag(&tokens[1..])? }),
+    Some(&"import") => parse_import(&tokens[1..]),
     Some(&"unlock") => Ok(Command::Unlock),
     Some(&"help") | None => Ok(Command::Help),
     Some(other) => Err(ParseError::Unrecognized(format!("unknown subcommand: {other}"))),
+  }
+}
+
+/// Parses "import [-d <dir>] <address> <id>". The -d flag may appear
+/// before or after the two positional arguments.
+fn parse_import(tokens: &[&str]) -> Result<Command, ParseError> {
+  let mut dir = None;
+  let mut positional = Vec::new();
+  let mut iter = tokens.iter();
+  while let Some(token) = iter.next() {
+    if *token == "-d" || *token == "--dir" {
+      match iter.next() {
+        Some(value) => dir = Some(normalize_dir(value)),
+        None => return Err(ParseError::Unrecognized("-d needs a directory".to_string())),
+      }
+    } else {
+      positional.push(*token);
+    }
+  }
+  match positional.as_slice() {
+    [address, id] => {
+      Ok(Command::Import { dir, address: address.to_string(), id: id.to_string() })
+    }
+    _ => Err(ParseError::Unrecognized(
+      "import needs exactly two arguments: <resource address> <resource id>".to_string(),
+    )),
   }
 }
 
@@ -67,6 +96,7 @@ pub fn usage(trigger: &str) -> String {
     "Usage:\n\
      - {trigger} plan [-d <dir>]: run terraform plan for changed projects (or one directory)\n\
      - {trigger} apply [-d <dir>]: apply the plan saved by the latest plan run\n\
+     - {trigger} import [-d <dir>] <address> <id>: import an existing resource into state\n\
      - {trigger} unlock: release locks held by this pull request\n\
      - {trigger} help: show this message"
   )
@@ -136,6 +166,35 @@ mod tests {
   #[test]
   fn dir_flag_without_value_is_reported() {
     assert!(matches!(parse("akbun", "akbun plan -d"), Err(ParseError::Unrecognized(_))));
+  }
+
+  #[test]
+  fn parses_import_with_address_and_id() {
+    assert_eq!(
+      parse("akbun", "akbun import aws_instance.web i-1234567890abcdef0"),
+      Ok(Command::Import {
+        dir: None,
+        address: "aws_instance.web".to_string(),
+        id: "i-1234567890abcdef0".to_string(),
+      })
+    );
+  }
+
+  #[test]
+  fn parses_import_with_dir_flag_in_any_position() {
+    let expected = Ok(Command::Import {
+      dir: Some("aws/vpc".to_string()),
+      address: "aws_vpc.main".to_string(),
+      id: "vpc-123".to_string(),
+    });
+    assert_eq!(parse("akbun", "akbun import -d aws/vpc aws_vpc.main vpc-123"), expected);
+    assert_eq!(parse("akbun", "akbun import aws_vpc.main vpc-123 -d aws/vpc"), expected);
+  }
+
+  #[test]
+  fn import_with_wrong_arity_is_reported() {
+    assert!(matches!(parse("akbun", "akbun import aws_vpc.main"), Err(ParseError::Unrecognized(_))));
+    assert!(matches!(parse("akbun", "akbun import a b c"), Err(ParseError::Unrecognized(_))));
   }
 
   #[test]

--- a/product/akbun-terraform-apply-remote/src/config.rs
+++ b/product/akbun-terraform-apply-remote/src/config.rs
@@ -1,0 +1,36 @@
+use std::env;
+
+/// Runtime configuration loaded from environment variables.
+#[derive(Clone, Debug)]
+pub struct Config {
+  pub github_token: String,
+  pub webhook_secret: String,
+  pub port: u16,
+  pub trigger: String,
+  pub terraform_bin: String,
+  pub data_dir: String,
+  pub github_api: String,
+}
+
+impl Config {
+  pub fn from_env() -> Result<Config, String> {
+    let github_token =
+      env::var("ATR_GITHUB_TOKEN").map_err(|_| "ATR_GITHUB_TOKEN is required".to_string())?;
+    let webhook_secret =
+      env::var("ATR_WEBHOOK_SECRET").map_err(|_| "ATR_WEBHOOK_SECRET is required".to_string())?;
+    let port = env::var("ATR_PORT")
+      .unwrap_or_else(|_| "4141".to_string())
+      .parse::<u16>()
+      .map_err(|_| "ATR_PORT must be a port number".to_string())?;
+    Ok(Config {
+      github_token,
+      webhook_secret,
+      port,
+      trigger: env::var("ATR_TRIGGER").unwrap_or_else(|_| "akbun".to_string()),
+      terraform_bin: env::var("ATR_TERRAFORM_BIN").unwrap_or_else(|_| "terraform".to_string()),
+      data_dir: env::var("ATR_DATA_DIR").unwrap_or_else(|_| "./data".to_string()),
+      github_api: env::var("ATR_GITHUB_API")
+        .unwrap_or_else(|_| "https://api.github.com".to_string()),
+    })
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/config.rs
+++ b/product/akbun-terraform-apply-remote/src/config.rs
@@ -1,9 +1,10 @@
+use crate::auth::{select_auth, AuthSettings};
 use std::env;
 
 /// Runtime configuration loaded from environment variables.
 #[derive(Clone, Debug)]
 pub struct Config {
-  pub github_token: String,
+  pub auth: AuthSettings,
   pub webhook_secret: String,
   pub port: u16,
   pub trigger: String,
@@ -14,8 +15,12 @@ pub struct Config {
 
 impl Config {
   pub fn from_env() -> Result<Config, String> {
-    let github_token =
-      env::var("ATR_GITHUB_TOKEN").map_err(|_| "ATR_GITHUB_TOKEN is required".to_string())?;
+    let auth = select_auth(
+      env::var("ATR_GITHUB_TOKEN").ok(),
+      env::var("ATR_GITHUB_APP_ID").ok(),
+      env::var("ATR_GITHUB_APP_PRIVATE_KEY_PATH").ok(),
+      env::var("ATR_GITHUB_APP_INSTALLATION_ID").ok(),
+    )?;
     let webhook_secret =
       env::var("ATR_WEBHOOK_SECRET").map_err(|_| "ATR_WEBHOOK_SECRET is required".to_string())?;
     let port = env::var("ATR_PORT")
@@ -23,7 +28,7 @@ impl Config {
       .parse::<u16>()
       .map_err(|_| "ATR_PORT must be a port number".to_string())?;
     Ok(Config {
-      github_token,
+      auth,
       webhook_secret,
       port,
       trigger: env::var("ATR_TRIGGER").unwrap_or_else(|_| "akbun".to_string()),

--- a/product/akbun-terraform-apply-remote/src/events.rs
+++ b/product/akbun-terraform-apply-remote/src/events.rs
@@ -1,0 +1,149 @@
+use serde_json::Value;
+
+/// A webhook payload reduced to the cases this server acts on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Event {
+  /// A new comment on a pull request; the body may contain a command.
+  Comment { repo: RepoRef, pr_number: u64, body: String, author: String },
+  /// A pull request was opened or its head was updated; triggers autoplan.
+  PrUpdated { repo: RepoRef, pr_number: u64 },
+  /// A pull request was closed or merged; locks and workspace are cleaned up.
+  PrClosed { repo: RepoRef, pr_number: u64 },
+}
+
+/// "owner/name" pair identifying a GitHub repository.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RepoRef {
+  pub owner: String,
+  pub name: String,
+}
+
+impl RepoRef {
+  pub fn full_name(&self) -> String {
+    format!("{}/{}", self.owner, self.name)
+  }
+}
+
+/// Interprets a GitHub webhook (event name header + JSON payload) into an
+/// Event. Returns Err with a human-readable reason for payloads this server
+/// deliberately ignores, such as bot comments or unrelated event types.
+pub fn interpret(event_name: &str, payload: &Value) -> Result<Event, String> {
+  match event_name {
+    "issue_comment" => interpret_comment(payload),
+    "pull_request" => interpret_pull_request(payload),
+    other => Err(format!("ignoring event type: {other}")),
+  }
+}
+
+fn interpret_comment(payload: &Value) -> Result<Event, String> {
+  if payload["action"].as_str() != Some("created") {
+    return Err("ignoring non-created comment action".to_string());
+  }
+  if payload["issue"]["pull_request"].is_null() {
+    return Err("comment is on an issue, not a pull request".to_string());
+  }
+  if payload["comment"]["user"]["type"].as_str() == Some("Bot") {
+    return Err("ignoring bot comment".to_string());
+  }
+  Ok(Event::Comment {
+    repo: repo_ref(payload)?,
+    pr_number: payload["issue"]["number"].as_u64().ok_or("missing issue number")?,
+    body: payload["comment"]["body"].as_str().unwrap_or_default().to_string(),
+    author: payload["comment"]["user"]["login"].as_str().unwrap_or_default().to_string(),
+  })
+}
+
+fn interpret_pull_request(payload: &Value) -> Result<Event, String> {
+  let repo = repo_ref(payload)?;
+  let pr_number = payload["pull_request"]["number"].as_u64().ok_or("missing PR number")?;
+  match payload["action"].as_str() {
+    Some("opened") | Some("synchronize") | Some("reopened") => {
+      Ok(Event::PrUpdated { repo, pr_number })
+    }
+    Some("closed") => Ok(Event::PrClosed { repo, pr_number }),
+    other => Err(format!("ignoring pull_request action: {other:?}")),
+  }
+}
+
+fn repo_ref(payload: &Value) -> Result<RepoRef, String> {
+  let full_name =
+    payload["repository"]["full_name"].as_str().ok_or("missing repository.full_name")?;
+  let (owner, name) = full_name.split_once('/').ok_or("malformed repository.full_name")?;
+  Ok(RepoRef { owner: owner.to_string(), name: name.to_string() })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  fn comment_payload(action: &str, on_pr: bool, user_type: &str) -> Value {
+    let mut issue = json!({"number": 7});
+    if on_pr {
+      issue["pull_request"] = json!({"url": "https://api.github.com/repos/o/r/pulls/7"});
+    }
+    json!({
+      "action": action,
+      "issue": issue,
+      "comment": {"body": "akbun plan", "user": {"login": "alice", "type": user_type}},
+      "repository": {"full_name": "octo/infra"}
+    })
+  }
+
+  #[test]
+  fn interprets_pr_comment() {
+    let event = interpret("issue_comment", &comment_payload("created", true, "User")).unwrap();
+    assert_eq!(
+      event,
+      Event::Comment {
+        repo: RepoRef { owner: "octo".to_string(), name: "infra".to_string() },
+        pr_number: 7,
+        body: "akbun plan".to_string(),
+        author: "alice".to_string(),
+      }
+    );
+  }
+
+  #[test]
+  fn ignores_comment_on_plain_issue() {
+    assert!(interpret("issue_comment", &comment_payload("created", false, "User")).is_err());
+  }
+
+  #[test]
+  fn ignores_edited_comment() {
+    assert!(interpret("issue_comment", &comment_payload("edited", true, "User")).is_err());
+  }
+
+  #[test]
+  fn ignores_bot_comment_to_avoid_feedback_loop() {
+    assert!(interpret("issue_comment", &comment_payload("created", true, "Bot")).is_err());
+  }
+
+  fn pr_payload(action: &str) -> Value {
+    json!({
+      "action": action,
+      "pull_request": {"number": 12},
+      "repository": {"full_name": "octo/infra"}
+    })
+  }
+
+  #[test]
+  fn pr_open_and_synchronize_trigger_autoplan() {
+    for action in ["opened", "synchronize", "reopened"] {
+      let event = interpret("pull_request", &pr_payload(action)).unwrap();
+      assert!(matches!(event, Event::PrUpdated { pr_number: 12, .. }), "action: {action}");
+    }
+  }
+
+  #[test]
+  fn pr_close_triggers_cleanup() {
+    let event = interpret("pull_request", &pr_payload("closed")).unwrap();
+    assert!(matches!(event, Event::PrClosed { pr_number: 12, .. }));
+  }
+
+  #[test]
+  fn ignores_unrelated_event_types() {
+    assert!(interpret("push", &json!({})).is_err());
+    assert!(interpret("pull_request", &pr_payload("labeled")).is_err());
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/format.rs
+++ b/product/akbun-terraform-apply-remote/src/format.rs
@@ -1,0 +1,164 @@
+/// GitHub caps issue comments at 65536 characters. Keep headroom for the
+/// markdown scaffolding around the terraform output.
+const MAX_OUTPUT_CHARS: usize = 60_000;
+
+/// One project's plan or apply result, ready to be rendered into a comment.
+pub struct RunResult {
+  pub dir: String,
+  pub success: bool,
+  pub output: String,
+}
+
+/// Renders the results of a plan or apply run over one or more projects
+/// into a single pull request comment body.
+pub fn render_comment(command_name: &str, results: &[RunResult]) -> String {
+  let mut sections = Vec::new();
+  for result in results {
+    let status = if result.success { "success" } else { "failed" };
+    let summary = summarize(&result.output).unwrap_or_else(|| status.to_string());
+    sections.push(format!(
+      "### terraform {command_name}: {dir} ({status})\n\n\
+       {summary}\n\n\
+       <details><summary>Show output</summary>\n\n\
+       ```\n{output}\n```\n\n\
+       </details>",
+      dir = result.dir,
+      output = truncate_middle(result.output.trim(), MAX_OUTPUT_CHARS),
+    ));
+  }
+  sections.join("\n\n---\n\n")
+}
+
+/// Pulls the one-line result out of terraform output: the "Plan: ..." /
+/// "Apply complete! ..." / "No changes." line, or the first error line.
+pub fn summarize(output: &str) -> Option<String> {
+  for line in output.lines() {
+    let line = line.trim();
+    if line.starts_with("Plan:")
+      || line.starts_with("Apply complete!")
+      || line.starts_with("No changes.")
+      || line.starts_with("Error:")
+    {
+      return Some(line.to_string());
+    }
+  }
+  None
+}
+
+/// Truncates long output from the middle, keeping the head (resource diff
+/// starts) and the tail (summary and errors), which are the useful parts.
+pub fn truncate_middle(text: &str, max_chars: usize) -> String {
+  if text.chars().count() <= max_chars {
+    return text.to_string();
+  }
+  let keep = max_chars / 2;
+  let head: String = text.chars().take(keep).collect();
+  let tail_start = text.chars().count() - keep;
+  let tail: String = text.chars().skip(tail_start).collect();
+  format!("{head}\n\n... output truncated by akbun-terraform-apply-remote ...\n\n{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  const PLAN_OUTPUT: &str = "\
+Terraform will perform the following actions:
+
+  # aws_instance.web will be created
+  + resource \"aws_instance\" \"web\" {}
+
+Plan: 1 to add, 0 to change, 0 to destroy.";
+
+  #[test]
+  fn summarize_finds_plan_line() {
+    assert_eq!(summarize(PLAN_OUTPUT), Some("Plan: 1 to add, 0 to change, 0 to destroy.".into()));
+  }
+
+  #[test]
+  fn summarize_finds_apply_line() {
+    let output = "aws_instance.web: Creating...\nApply complete! Resources: 1 added, 0 changed, 0 destroyed.";
+    assert_eq!(
+      summarize(output),
+      Some("Apply complete! Resources: 1 added, 0 changed, 0 destroyed.".into())
+    );
+  }
+
+  #[test]
+  fn summarize_finds_no_changes_and_error() {
+    assert_eq!(
+      summarize("No changes. Your infrastructure matches the configuration."),
+      Some("No changes. Your infrastructure matches the configuration.".into())
+    );
+    assert_eq!(
+      summarize("something\nError: Invalid provider configuration"),
+      Some("Error: Invalid provider configuration".into())
+    );
+  }
+
+  #[test]
+  fn summarize_returns_none_without_known_lines() {
+    assert_eq!(summarize("Initializing the backend..."), None);
+  }
+
+  #[test]
+  fn render_includes_dir_status_summary_and_output() {
+    let comment = render_comment(
+      "plan",
+      &[RunResult { dir: "aws/vpc".into(), success: true, output: PLAN_OUTPUT.into() }],
+    );
+    assert!(comment.contains("### terraform plan: aws/vpc (success)"));
+    assert!(comment.contains("Plan: 1 to add, 0 to change, 0 to destroy."));
+    assert!(comment.contains("<details>"));
+    assert!(comment.contains("aws_instance"));
+  }
+
+  #[test]
+  fn render_marks_failures() {
+    let comment = render_comment(
+      "plan",
+      &[RunResult { dir: ".".into(), success: false, output: "Error: boom".into() }],
+    );
+    assert!(comment.contains("### terraform plan: . (failed)"));
+    assert!(comment.contains("Error: boom"));
+  }
+
+  #[test]
+  fn render_joins_multiple_projects() {
+    let comment = render_comment(
+      "plan",
+      &[
+        RunResult { dir: "aws/vpc".into(), success: true, output: PLAN_OUTPUT.into() },
+        RunResult { dir: "aws/rds".into(), success: true, output: PLAN_OUTPUT.into() },
+      ],
+    );
+    assert!(comment.contains("aws/vpc"));
+    assert!(comment.contains("aws/rds"));
+    assert!(comment.contains("\n\n---\n\n"));
+  }
+
+  #[test]
+  fn truncation_keeps_head_and_tail() {
+    let long = format!("HEAD_MARKER\n{}\nTAIL_MARKER", "x".repeat(100_000));
+    let truncated = truncate_middle(&long, 1000);
+    assert!(truncated.contains("HEAD_MARKER"));
+    assert!(truncated.contains("TAIL_MARKER"));
+    assert!(truncated.contains("output truncated"));
+    assert!(truncated.chars().count() < 1200);
+  }
+
+  #[test]
+  fn short_output_is_untouched() {
+    assert_eq!(truncate_middle("short", 1000), "short");
+  }
+
+  #[test]
+  fn rendered_comment_stays_under_github_limit() {
+    let huge = "x".repeat(200_000);
+    let comment = render_comment(
+      "plan",
+      &[RunResult { dir: "aws/vpc".into(), success: true, output: huge }],
+    );
+    assert!(comment.chars().count() < 65_536);
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/github.rs
+++ b/product/akbun-terraform-apply-remote/src/github.rs
@@ -1,10 +1,14 @@
+use crate::auth::TokenProvider;
 use crate::events::RepoRef;
 use serde_json::Value;
+use std::sync::Arc;
 
 /// Minimal GitHub REST API client for the endpoints this server needs.
+/// Tokens come from the provider per call, so short-lived App tokens are
+/// refreshed transparently.
 pub struct GithubClient {
   api_base: String,
-  token: String,
+  provider: Arc<TokenProvider>,
 }
 
 pub struct PrInfo {
@@ -12,8 +16,8 @@ pub struct PrInfo {
 }
 
 impl GithubClient {
-  pub fn new(api_base: &str, token: &str) -> GithubClient {
-    GithubClient { api_base: api_base.trim_end_matches('/').to_string(), token: token.to_string() }
+  pub fn new(api_base: &str, provider: Arc<TokenProvider>) -> GithubClient {
+    GithubClient { api_base: api_base.trim_end_matches('/').to_string(), provider }
   }
 
   pub fn get_pr(&self, repo: &RepoRef, pr_number: u64) -> Result<PrInfo, String> {
@@ -56,7 +60,7 @@ impl GithubClient {
     let url =
       format!("{}/repos/{}/issues/{}/comments", self.api_base, repo.full_name(), pr_number);
     ureq::post(&url)
-      .set("Authorization", &format!("Bearer {}", self.token))
+      .set("Authorization", &format!("Bearer {}", self.provider.token()?))
       .set("Accept", "application/vnd.github+json")
       .set("User-Agent", "akbun-terraform-apply-remote")
       .send_json(serde_json::json!({ "body": body }))
@@ -66,7 +70,7 @@ impl GithubClient {
 
   fn get(&self, url: &str) -> Result<Value, String> {
     ureq::get(url)
-      .set("Authorization", &format!("Bearer {}", self.token))
+      .set("Authorization", &format!("Bearer {}", self.provider.token()?))
       .set("Accept", "application/vnd.github+json")
       .set("User-Agent", "akbun-terraform-apply-remote")
       .call()

--- a/product/akbun-terraform-apply-remote/src/github.rs
+++ b/product/akbun-terraform-apply-remote/src/github.rs
@@ -1,0 +1,73 @@
+use crate::events::RepoRef;
+use serde_json::Value;
+
+/// Minimal GitHub REST API client for the endpoints this server needs.
+pub struct GithubClient {
+  api_base: String,
+  token: String,
+}
+
+pub struct PrInfo {
+  pub head_sha: String,
+}
+
+impl GithubClient {
+  pub fn new(api_base: &str, token: &str) -> GithubClient {
+    GithubClient { api_base: api_base.trim_end_matches('/').to_string(), token: token.to_string() }
+  }
+
+  pub fn get_pr(&self, repo: &RepoRef, pr_number: u64) -> Result<PrInfo, String> {
+    let url = format!("{}/repos/{}/pulls/{}", self.api_base, repo.full_name(), pr_number);
+    let body: Value = self.get(&url)?;
+    let head_sha = body["head"]["sha"].as_str().ok_or("PR response missing head.sha")?;
+    Ok(PrInfo { head_sha: head_sha.to_string() })
+  }
+
+  /// Lists every changed file path in the pull request, following pagination.
+  pub fn list_changed_files(&self, repo: &RepoRef, pr_number: u64) -> Result<Vec<String>, String> {
+    let mut files = Vec::new();
+    for page in 1..=30 {
+      let url = format!(
+        "{}/repos/{}/pulls/{}/files?per_page=100&page={}",
+        self.api_base,
+        repo.full_name(),
+        pr_number,
+        page
+      );
+      let body: Value = self.get(&url)?;
+      let items = body.as_array().ok_or("files response is not an array")?;
+      if items.is_empty() {
+        break;
+      }
+      for item in items {
+        if let Some(filename) = item["filename"].as_str() {
+          files.push(filename.to_string());
+        }
+      }
+    }
+    Ok(files)
+  }
+
+  pub fn post_comment(&self, repo: &RepoRef, pr_number: u64, body: &str) -> Result<(), String> {
+    let url =
+      format!("{}/repos/{}/issues/{}/comments", self.api_base, repo.full_name(), pr_number);
+    ureq::post(&url)
+      .set("Authorization", &format!("Bearer {}", self.token))
+      .set("Accept", "application/vnd.github+json")
+      .set("User-Agent", "akbun-terraform-apply-remote")
+      .send_json(serde_json::json!({ "body": body }))
+      .map_err(|e| format!("POST {url} failed: {e}"))?;
+    Ok(())
+  }
+
+  fn get(&self, url: &str) -> Result<Value, String> {
+    ureq::get(url)
+      .set("Authorization", &format!("Bearer {}", self.token))
+      .set("Accept", "application/vnd.github+json")
+      .set("User-Agent", "akbun-terraform-apply-remote")
+      .call()
+      .map_err(|e| format!("GET {url} failed: {e}"))?
+      .into_json::<Value>()
+      .map_err(|e| format!("GET {url} returned invalid JSON: {e}"))
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/github.rs
+++ b/product/akbun-terraform-apply-remote/src/github.rs
@@ -23,29 +23,33 @@ impl GithubClient {
     Ok(PrInfo { head_sha: head_sha.to_string() })
   }
 
-  /// Lists every changed file path in the pull request, following pagination.
+  /// Lists every changed file path in the pull request, following
+  /// pagination until the API returns a partial or empty page.
   pub fn list_changed_files(&self, repo: &RepoRef, pr_number: u64) -> Result<Vec<String>, String> {
+    const PER_PAGE: usize = 100;
     let mut files = Vec::new();
-    for page in 1..=30 {
+    let mut page = 1;
+    loop {
       let url = format!(
-        "{}/repos/{}/pulls/{}/files?per_page=100&page={}",
+        "{}/repos/{}/pulls/{}/files?per_page={}&page={}",
         self.api_base,
         repo.full_name(),
         pr_number,
+        PER_PAGE,
         page
       );
       let body: Value = self.get(&url)?;
       let items = body.as_array().ok_or("files response is not an array")?;
-      if items.is_empty() {
-        break;
-      }
       for item in items {
         if let Some(filename) = item["filename"].as_str() {
           files.push(filename.to_string());
         }
       }
+      if items.len() < PER_PAGE {
+        return Ok(files);
+      }
+      page += 1;
     }
-    Ok(files)
   }
 
   pub fn post_comment(&self, repo: &RepoRef, pr_number: u64, body: &str) -> Result<(), String> {

--- a/product/akbun-terraform-apply-remote/src/handler.rs
+++ b/product/akbun-terraform-apply-remote/src/handler.rs
@@ -1,3 +1,4 @@
+use crate::auth::TokenProvider;
 use crate::command::{self, Command, ParseError};
 use crate::config::Config;
 use crate::events::{Event, RepoRef};
@@ -6,7 +7,7 @@ use crate::github::GithubClient;
 use crate::locks::{LockManager, LockOutcome};
 use crate::{project, terraform, workspace};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 /// State shared across webhook deliveries: locks and the record of which
 /// head SHA each saved plan was produced from.
@@ -17,11 +18,13 @@ use std::sync::Mutex;
 pub struct AppState {
   pub cfg: Config,
   pub locks: LockManager,
+  pub provider: Arc<TokenProvider>,
   planned_shas: Mutex<HashMap<String, String>>,
 }
 
 impl AppState {
-  pub fn new(cfg: Config) -> AppState {
+  pub fn new(cfg: Config) -> Result<AppState, String> {
+    let provider = Arc::new(TokenProvider::new(&cfg.auth, &cfg.github_api)?);
     let persisted = crate::state::load(&crate::state::state_file(&cfg.data_dir));
     if !persisted.locks.is_empty() || !persisted.planned_shas.is_empty() {
       println!(
@@ -30,11 +33,12 @@ impl AppState {
         persisted.planned_shas.len()
       );
     }
-    AppState {
+    Ok(AppState {
       cfg,
       locks: LockManager::from_snapshot(persisted.locks),
+      provider,
       planned_shas: Mutex::new(persisted.planned_shas),
-    }
+    })
   }
 
   /// Writes the current locks and plan records to disk. Called after each
@@ -107,6 +111,9 @@ fn handle_comment(state: &AppState, repo: &RepoRef, pr_number: u64, body: &str) 
   match command::parse(&state.cfg.trigger, body) {
     Ok(Command::Plan { dir }) => run_plan(state, repo, pr_number, dir),
     Ok(Command::Apply { dir }) => run_apply(state, repo, pr_number, dir),
+    Ok(Command::Import { dir, address, id }) => {
+      run_import(state, repo, pr_number, dir, &address, &id)
+    }
     Ok(Command::Unlock) => {
       let released = state.locks.release_all(&repo.full_name(), pr_number);
       state.forget_pr(repo, pr_number);
@@ -158,7 +165,7 @@ fn run_plan(
     );
   }
 
-  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.cfg.github_token, repo, pr_number, &pr.head_sha)?;
+  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.provider.token()?, repo, pr_number, &pr.head_sha)?;
   let mut results = Vec::new();
   for dir in dirs {
     results.push(plan_one_project(state, repo, pr_number, &pr.head_sha, &ws, &dir));
@@ -238,7 +245,7 @@ fn run_apply(
     );
   }
 
-  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.cfg.github_token, repo, pr_number, &pr.head_sha)?;
+  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.provider.token()?, repo, pr_number, &pr.head_sha)?;
   let mut results = Vec::new();
   for dir in dirs {
     results.push(apply_one_project(state, repo, pr_number, &pr.head_sha, &ws, &dir));
@@ -295,6 +302,87 @@ fn apply_one_project(
   RunResult { dir: dir.to_string(), success: apply.success, output: apply.output }
 }
 
+/// Imports an existing resource into the project's terraform state. The
+/// target directory is taken from -d, or inferred when the pull request
+/// changed exactly one terraform project.
+fn run_import(
+  state: &AppState,
+  repo: &RepoRef,
+  pr_number: u64,
+  dir_override: Option<String>,
+  address: &str,
+  id: &str,
+) -> Result<(), String> {
+  let github = client(state);
+  let pr = github.get_pr(repo, pr_number)?;
+  let dir = match dir_override {
+    Some(dir) => dir,
+    None => {
+      let changed =
+        project::projects_from_changed_files(&github.list_changed_files(repo, pr_number)?);
+      match changed.as_slice() {
+        [only] => only.clone(),
+        _ => {
+          return github.post_comment(
+            repo,
+            pr_number,
+            "import needs -d <dir> when the pull request does not change \
+             exactly one terraform project.",
+          )
+        }
+      }
+    }
+  };
+
+  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.provider.token()?, repo, pr_number, &pr.head_sha)?;
+  let result = import_one_project(state, repo, pr_number, &ws, &dir, address, id);
+  let mut comment = render_comment("import", &[result]);
+  comment.push_str(&format!(
+    "\n\nState changed: run \"{} plan\" to review the diff before apply.",
+    state.cfg.trigger
+  ));
+  github.post_comment(repo, pr_number, &comment)
+}
+
+fn import_one_project(
+  state: &AppState,
+  repo: &RepoRef,
+  pr_number: u64,
+  ws: &workspace::Workspace,
+  dir: &str,
+  address: &str,
+  id: &str,
+) -> RunResult {
+  if let LockOutcome::HeldByOther { pr_number: holder } =
+    state.locks.try_lock(&repo.full_name(), dir, pr_number)
+  {
+    return RunResult {
+      dir: dir.to_string(),
+      success: false,
+      output: format!("This project is locked by pull request #{holder}."),
+    };
+  }
+  let project_dir = ws.dir.join(dir);
+  if !project_dir.is_dir() {
+    state.locks.unlock(&repo.full_name(), dir, pr_number);
+    return RunResult {
+      dir: dir.to_string(),
+      success: false,
+      output: format!("directory not found in the PR head: {dir}"),
+    };
+  }
+  let init = terraform::init(&state.cfg.terraform_bin, &project_dir);
+  if !init.success {
+    return RunResult { dir: dir.to_string(), success: false, output: init.output };
+  }
+  let import = terraform::import(&state.cfg.terraform_bin, &project_dir, address, id);
+  if import.success {
+    // The import mutated state, so any saved plan no longer matches it.
+    state.forget_plan(repo, pr_number, dir);
+  }
+  RunResult { dir: dir.to_string(), success: import.success, output: import.output }
+}
+
 fn cleanup_pr(state: &AppState, repo: &RepoRef, pr_number: u64) -> Result<(), String> {
   state.locks.release_all(&repo.full_name(), pr_number);
   state.forget_pr(repo, pr_number);
@@ -307,5 +395,5 @@ fn short(sha: &str) -> &str {
 }
 
 fn client(state: &AppState) -> GithubClient {
-  GithubClient::new(&state.cfg.github_api, &state.cfg.github_token)
+  GithubClient::new(&state.cfg.github_api, state.provider.clone())
 }

--- a/product/akbun-terraform-apply-remote/src/handler.rs
+++ b/product/akbun-terraform-apply-remote/src/handler.rs
@@ -10,6 +10,10 @@ use std::sync::Mutex;
 
 /// State shared across webhook deliveries: locks and the record of which
 /// head SHA each saved plan was produced from.
+///
+/// Both maps are persisted to state.json under the data directory after
+/// every handled event and reloaded at startup, so a restarted or
+/// redeployed instance takes over the previous instance's locks and plans.
 pub struct AppState {
   pub cfg: Config,
   pub locks: LockManager,
@@ -18,7 +22,31 @@ pub struct AppState {
 
 impl AppState {
   pub fn new(cfg: Config) -> AppState {
-    AppState { cfg, locks: LockManager::new(), planned_shas: Mutex::new(HashMap::new()) }
+    let persisted = crate::state::load(&crate::state::state_file(&cfg.data_dir));
+    if !persisted.locks.is_empty() || !persisted.planned_shas.is_empty() {
+      println!(
+        "restored state: {} lock(s), {} saved plan record(s)",
+        persisted.locks.len(),
+        persisted.planned_shas.len()
+      );
+    }
+    AppState {
+      cfg,
+      locks: LockManager::from_snapshot(persisted.locks),
+      planned_shas: Mutex::new(persisted.planned_shas),
+    }
+  }
+
+  /// Writes the current locks and plan records to disk. Called after each
+  /// handled event; failures are logged, not fatal.
+  pub fn persist(&self) {
+    let snapshot = crate::state::PersistedState {
+      locks: self.locks.snapshot(),
+      planned_shas: self.planned_shas.lock().unwrap().clone(),
+    };
+    if let Err(e) = crate::state::save(&crate::state::state_file(&self.cfg.data_dir), &snapshot) {
+      eprintln!("failed to persist state: {e}");
+    }
   }
 
   fn record_plan(&self, repo: &RepoRef, pr_number: u64, dir: &str, sha: &str) {
@@ -71,6 +99,7 @@ pub fn handle_event(state: &AppState, event: Event) {
   if let Err(e) = outcome {
     eprintln!("event handling failed: {e} (event: {event:?})");
   }
+  state.persist();
 }
 
 fn handle_comment(state: &AppState, repo: &RepoRef, pr_number: u64, body: &str) -> Result<(), String> {

--- a/product/akbun-terraform-apply-remote/src/handler.rs
+++ b/product/akbun-terraform-apply-remote/src/handler.rs
@@ -1,0 +1,271 @@
+use crate::command::{self, Command, ParseError};
+use crate::config::Config;
+use crate::events::{Event, RepoRef};
+use crate::format::{render_comment, RunResult};
+use crate::github::GithubClient;
+use crate::locks::{LockManager, LockOutcome};
+use crate::{project, terraform, workspace};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// State shared across webhook deliveries: locks and the record of which
+/// head SHA each saved plan was produced from.
+pub struct AppState {
+  pub cfg: Config,
+  pub locks: LockManager,
+  planned_shas: Mutex<HashMap<String, String>>,
+}
+
+impl AppState {
+  pub fn new(cfg: Config) -> AppState {
+    AppState { cfg, locks: LockManager::new(), planned_shas: Mutex::new(HashMap::new()) }
+  }
+
+  fn record_plan(&self, repo: &RepoRef, pr_number: u64, dir: &str, sha: &str) {
+    let key = plan_key(repo, pr_number, dir);
+    self.planned_shas.lock().unwrap().insert(key, sha.to_string());
+  }
+
+  fn planned_sha(&self, repo: &RepoRef, pr_number: u64, dir: &str) -> Option<String> {
+    self.planned_shas.lock().unwrap().get(&plan_key(repo, pr_number, dir)).cloned()
+  }
+
+  fn forget_plan(&self, repo: &RepoRef, pr_number: u64, dir: &str) {
+    self.planned_shas.lock().unwrap().remove(&plan_key(repo, pr_number, dir));
+  }
+
+  fn planned_dirs(&self, repo: &RepoRef, pr_number: u64) -> Vec<String> {
+    let prefix = format!("{}::{}::", repo.full_name(), pr_number);
+    let mut dirs: Vec<String> = self
+      .planned_shas
+      .lock()
+      .unwrap()
+      .keys()
+      .filter(|key| key.starts_with(&prefix))
+      .map(|key| key[prefix.len()..].to_string())
+      .collect();
+    dirs.sort();
+    dirs
+  }
+
+  fn forget_pr(&self, repo: &RepoRef, pr_number: u64) {
+    let prefix = format!("{}::{}::", repo.full_name(), pr_number);
+    self.planned_shas.lock().unwrap().retain(|key, _| !key.starts_with(&prefix));
+  }
+}
+
+fn plan_key(repo: &RepoRef, pr_number: u64, dir: &str) -> String {
+  format!("{}::{}::{}", repo.full_name(), pr_number, dir)
+}
+
+/// Entry point for one interpreted webhook event. Errors end up as PR
+/// comments where possible, otherwise on stderr.
+pub fn handle_event(state: &AppState, event: Event) {
+  let outcome = match &event {
+    Event::Comment { repo, pr_number, body, author: _ } => {
+      handle_comment(state, repo, *pr_number, body)
+    }
+    Event::PrUpdated { repo, pr_number } => autoplan(state, repo, *pr_number),
+    Event::PrClosed { repo, pr_number } => cleanup_pr(state, repo, *pr_number),
+  };
+  if let Err(e) = outcome {
+    eprintln!("event handling failed: {e} (event: {event:?})");
+  }
+}
+
+fn handle_comment(state: &AppState, repo: &RepoRef, pr_number: u64, body: &str) -> Result<(), String> {
+  let github = client(state);
+  match command::parse(&state.cfg.trigger, body) {
+    Ok(Command::Plan { dir }) => run_plan(state, repo, pr_number, dir),
+    Ok(Command::Apply { dir }) => run_apply(state, repo, pr_number, dir),
+    Ok(Command::Unlock) => {
+      let released = state.locks.release_all(&repo.full_name(), pr_number);
+      state.forget_pr(repo, pr_number);
+      let message = if released.is_empty() {
+        "This pull request holds no locks.".to_string()
+      } else {
+        format!("Released locks: {}", released.join(", "))
+      };
+      github.post_comment(repo, pr_number, &message)
+    }
+    Ok(Command::Help) => github.post_comment(repo, pr_number, &command::usage(&state.cfg.trigger)),
+    Err(ParseError::NotACommand) => Ok(()),
+    Err(ParseError::Unrecognized(reason)) => {
+      let message = format!("{reason}\n\n{}", command::usage(&state.cfg.trigger));
+      github.post_comment(repo, pr_number, &message)
+    }
+  }
+}
+
+/// Plans automatically when a PR opens or its head moves, mirroring
+/// Atlantis autoplan. Stays silent when no terraform project changed.
+fn autoplan(state: &AppState, repo: &RepoRef, pr_number: u64) -> Result<(), String> {
+  let github = client(state);
+  let changed = github.list_changed_files(repo, pr_number)?;
+  if project::projects_from_changed_files(&changed).is_empty() {
+    return Ok(());
+  }
+  run_plan(state, repo, pr_number, None)
+}
+
+fn run_plan(
+  state: &AppState,
+  repo: &RepoRef,
+  pr_number: u64,
+  dir_override: Option<String>,
+) -> Result<(), String> {
+  let github = client(state);
+  let pr = github.get_pr(repo, pr_number)?;
+  let dirs = match dir_override {
+    Some(dir) => vec![dir],
+    None => project::projects_from_changed_files(&github.list_changed_files(repo, pr_number)?),
+  };
+  if dirs.is_empty() {
+    return github.post_comment(
+      repo,
+      pr_number,
+      "No terraform projects changed in this pull request. \
+       Use -d <dir> to plan a specific directory.",
+    );
+  }
+
+  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.cfg.github_token, repo, pr_number, &pr.head_sha)?;
+  let mut results = Vec::new();
+  for dir in dirs {
+    results.push(plan_one_project(state, repo, pr_number, &pr.head_sha, &ws, &dir));
+  }
+  github.post_comment(repo, pr_number, &render_comment("plan", &results))
+}
+
+fn plan_one_project(
+  state: &AppState,
+  repo: &RepoRef,
+  pr_number: u64,
+  head_sha: &str,
+  ws: &workspace::Workspace,
+  dir: &str,
+) -> RunResult {
+  match state.locks.try_lock(&repo.full_name(), dir, pr_number) {
+    LockOutcome::HeldByOther { pr_number: holder } => {
+      return RunResult {
+        dir: dir.to_string(),
+        success: false,
+        output: format!(
+          "This project is locked by pull request #{holder}. \
+           Wait for it to apply or ask it to run unlock."
+        ),
+      };
+    }
+    LockOutcome::Acquired => {}
+  }
+
+  let project_dir = ws.dir.join(dir);
+  if !project_dir.is_dir() {
+    return RunResult {
+      dir: dir.to_string(),
+      success: false,
+      output: format!("directory not found in the PR head: {dir}"),
+    };
+  }
+  let init = terraform::init(&state.cfg.terraform_bin, &project_dir);
+  if !init.success {
+    return RunResult { dir: dir.to_string(), success: false, output: init.output };
+  }
+  let plan = terraform::plan(&state.cfg.terraform_bin, &project_dir);
+  if plan.success {
+    state.record_plan(repo, pr_number, dir, head_sha);
+  }
+  RunResult { dir: dir.to_string(), success: plan.success, output: plan.output }
+}
+
+fn run_apply(
+  state: &AppState,
+  repo: &RepoRef,
+  pr_number: u64,
+  dir_override: Option<String>,
+) -> Result<(), String> {
+  let github = client(state);
+  let pr = github.get_pr(repo, pr_number)?;
+  let dirs = match dir_override {
+    Some(dir) => vec![dir],
+    None => state.planned_dirs(repo, pr_number),
+  };
+  if dirs.is_empty() {
+    return github.post_comment(
+      repo,
+      pr_number,
+      &format!("Nothing to apply. Run \"{} plan\" first.", state.cfg.trigger),
+    );
+  }
+
+  let ws = workspace::checkout_pr(&state.cfg.data_dir, &state.cfg.github_token, repo, pr_number, &pr.head_sha)?;
+  let mut results = Vec::new();
+  for dir in dirs {
+    results.push(apply_one_project(state, repo, pr_number, &pr.head_sha, &ws, &dir));
+  }
+  github.post_comment(repo, pr_number, &render_comment("apply", &results))
+}
+
+fn apply_one_project(
+  state: &AppState,
+  repo: &RepoRef,
+  pr_number: u64,
+  head_sha: &str,
+  ws: &workspace::Workspace,
+  dir: &str,
+) -> RunResult {
+  let fail = |output: String| RunResult { dir: dir.to_string(), success: false, output };
+
+  match state.planned_sha(repo, pr_number, dir) {
+    None => {
+      return fail(format!(
+        "No saved plan for this directory. Run \"{} plan -d {dir}\" first.",
+        state.cfg.trigger
+      ))
+    }
+    Some(planned) if planned != head_sha => {
+      return fail(format!(
+        "The pull request changed after the last plan (planned {}, head is now {}). \
+         Run \"{} plan\" again and review the new plan.",
+        short(&planned),
+        short(head_sha),
+        state.cfg.trigger
+      ))
+    }
+    Some(_) => {}
+  }
+  if let LockOutcome::HeldByOther { pr_number: holder } =
+    state.locks.try_lock(&repo.full_name(), dir, pr_number)
+  {
+    return fail(format!("This project is locked by pull request #{holder}."));
+  }
+
+  let project_dir = ws.dir.join(dir);
+  if !project_dir.join(terraform::PLAN_FILE).exists() {
+    return fail(format!(
+      "The saved plan file is gone (server restarted?). Run \"{} plan -d {dir}\" again.",
+      state.cfg.trigger
+    ));
+  }
+  let apply = terraform::apply_saved_plan(&state.cfg.terraform_bin, &project_dir);
+  if apply.success {
+    state.forget_plan(repo, pr_number, dir);
+    state.locks.unlock(&repo.full_name(), dir, pr_number);
+  }
+  RunResult { dir: dir.to_string(), success: apply.success, output: apply.output }
+}
+
+fn cleanup_pr(state: &AppState, repo: &RepoRef, pr_number: u64) -> Result<(), String> {
+  state.locks.release_all(&repo.full_name(), pr_number);
+  state.forget_pr(repo, pr_number);
+  workspace::remove_pr_workspace(&state.cfg.data_dir, repo, pr_number);
+  Ok(())
+}
+
+fn short(sha: &str) -> &str {
+  &sha[..sha.len().min(7)]
+}
+
+fn client(state: &AppState) -> GithubClient {
+  GithubClient::new(&state.cfg.github_api, &state.cfg.github_token)
+}

--- a/product/akbun-terraform-apply-remote/src/handler.rs
+++ b/product/akbun-terraform-apply-remote/src/handler.rs
@@ -190,6 +190,10 @@ fn plan_one_project(
 
   let project_dir = ws.dir.join(dir);
   if !project_dir.is_dir() {
+    // Not a real project: give the lock back so a typo does not block
+    // other pull requests.
+    state.locks.unlock(&repo.full_name(), dir, pr_number);
+    state.forget_plan(repo, pr_number, dir);
     return RunResult {
       dir: dir.to_string(),
       success: false,
@@ -198,11 +202,18 @@ fn plan_one_project(
   }
   let init = terraform::init(&state.cfg.terraform_bin, &project_dir);
   if !init.success {
+    state.forget_plan(repo, pr_number, dir);
     return RunResult { dir: dir.to_string(), success: false, output: init.output };
   }
   let plan = terraform::plan(&state.cfg.terraform_bin, &project_dir);
   if plan.success {
     state.record_plan(repo, pr_number, dir, head_sha);
+  } else {
+    // A failed re-plan must not leave an older plan record behind, or
+    // apply could ship a plan nobody reviewed against the current run.
+    // The lock is kept on purpose: this PR still claims the project until
+    // apply, close, or unlock.
+    state.forget_plan(repo, pr_number, dir);
   }
   RunResult { dir: dir.to_string(), success: plan.success, output: plan.output }
 }

--- a/product/akbun-terraform-apply-remote/src/jobs.rs
+++ b/product/akbun-terraform-apply-remote/src/jobs.rs
@@ -1,0 +1,100 @@
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+/// Counts in-flight webhook jobs so shutdown can drain them.
+///
+/// A terraform apply killed halfway is the worst outcome a deploy can
+/// cause, so the server refuses to exit while a job is running (up to a
+/// drain timeout). Each job holds a JobGuard; dropping it decrements the
+/// counter and wakes waiters.
+pub struct JobTracker {
+  count: Mutex<usize>,
+  idle: Condvar,
+}
+
+pub struct JobGuard {
+  tracker: Arc<JobTracker>,
+}
+
+impl JobTracker {
+  pub fn new() -> JobTracker {
+    JobTracker { count: Mutex::new(0), idle: Condvar::new() }
+  }
+
+  pub fn begin(tracker: &Arc<JobTracker>) -> JobGuard {
+    *tracker.count.lock().unwrap() += 1;
+    JobGuard { tracker: tracker.clone() }
+  }
+
+  pub fn active(&self) -> usize {
+    *self.count.lock().unwrap()
+  }
+
+  /// Blocks until no job is running or the timeout passes.
+  /// Returns true when fully drained.
+  pub fn wait_idle(&self, timeout: Duration) -> bool {
+    let count = self.count.lock().unwrap();
+    let (count, _) = self.idle.wait_timeout_while(count, timeout, |c| *c > 0).unwrap();
+    *count == 0
+  }
+}
+
+impl Drop for JobGuard {
+  fn drop(&mut self) {
+    let mut count = self.tracker.count.lock().unwrap();
+    *count -= 1;
+    if *count == 0 {
+      self.tracker.idle.notify_all();
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::time::Instant;
+
+  #[test]
+  fn guard_counts_and_releases() {
+    let tracker = Arc::new(JobTracker::new());
+    assert_eq!(tracker.active(), 0);
+    let a = JobTracker::begin(&tracker);
+    let b = JobTracker::begin(&tracker);
+    assert_eq!(tracker.active(), 2);
+    drop(a);
+    assert_eq!(tracker.active(), 1);
+    drop(b);
+    assert_eq!(tracker.active(), 0);
+  }
+
+  #[test]
+  fn wait_idle_returns_immediately_when_idle() {
+    let tracker = Arc::new(JobTracker::new());
+    assert!(tracker.wait_idle(Duration::from_millis(1)));
+  }
+
+  #[test]
+  fn wait_idle_times_out_while_a_job_runs() {
+    let tracker = Arc::new(JobTracker::new());
+    let _guard = JobTracker::begin(&tracker);
+    let start = Instant::now();
+    assert!(!tracker.wait_idle(Duration::from_millis(50)));
+    assert!(start.elapsed() >= Duration::from_millis(50));
+  }
+
+  #[test]
+  fn wait_idle_wakes_when_the_last_job_finishes() {
+    let tracker = Arc::new(JobTracker::new());
+    let guard = JobTracker::begin(&tracker);
+    let worker = {
+      let tracker = tracker.clone();
+      std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(30));
+        drop(guard);
+        tracker.active()
+      })
+    };
+    assert!(tracker.wait_idle(Duration::from_secs(5)));
+    worker.join().unwrap();
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/locks.rs
+++ b/product/akbun-terraform-apply-remote/src/locks.rs
@@ -21,12 +21,8 @@ pub enum LockOutcome {
 }
 
 impl LockManager {
-  pub fn new() -> LockManager {
-    LockManager { locks: Mutex::new(HashMap::new()) }
-  }
-
-  /// Rebuilds the manager from a persisted snapshot, so locks survive a
-  /// server restart or redeploy.
+  /// Builds the manager from a persisted snapshot (empty on first boot),
+  /// so locks survive a server restart or redeploy.
   pub fn from_snapshot(snapshot: HashMap<String, u64>) -> LockManager {
     LockManager { locks: Mutex::new(snapshot) }
   }
@@ -84,41 +80,41 @@ mod tests {
 
   #[test]
   fn first_pr_acquires_lock() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     assert_eq!(locks.try_lock("o/r", "aws/vpc", 1), LockOutcome::Acquired);
   }
 
   #[test]
   fn lock_is_reentrant_for_same_pr() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     assert_eq!(locks.try_lock("o/r", "aws/vpc", 1), LockOutcome::Acquired);
   }
 
   #[test]
   fn second_pr_is_rejected_with_holder() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     assert_eq!(locks.try_lock("o/r", "aws/vpc", 2), LockOutcome::HeldByOther { pr_number: 1 });
   }
 
   #[test]
   fn different_projects_do_not_conflict() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     assert_eq!(locks.try_lock("o/r", "aws/rds", 2), LockOutcome::Acquired);
   }
 
   #[test]
   fn same_dir_in_different_repos_do_not_conflict() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r1", "aws/vpc", 1);
     assert_eq!(locks.try_lock("o/r2", "aws/vpc", 2), LockOutcome::Acquired);
   }
 
   #[test]
   fn unlock_frees_the_project_for_others() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     locks.unlock("o/r", "aws/vpc", 1);
     assert_eq!(locks.try_lock("o/r", "aws/vpc", 2), LockOutcome::Acquired);
@@ -126,7 +122,7 @@ mod tests {
 
   #[test]
   fn unlock_by_non_holder_is_a_no_op() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     locks.unlock("o/r", "aws/vpc", 2);
     assert_eq!(locks.try_lock("o/r", "aws/vpc", 3), LockOutcome::HeldByOther { pr_number: 1 });
@@ -134,7 +130,7 @@ mod tests {
 
   #[test]
   fn snapshot_round_trip_preserves_holders() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     locks.try_lock("o/r", "aws/rds", 2);
     let restored = LockManager::from_snapshot(locks.snapshot());
@@ -145,7 +141,7 @@ mod tests {
 
   #[test]
   fn release_all_frees_only_this_prs_locks() {
-    let locks = LockManager::new();
+    let locks = LockManager::from_snapshot(HashMap::new());
     locks.try_lock("o/r", "aws/vpc", 1);
     locks.try_lock("o/r", "aws/rds", 1);
     locks.try_lock("o/r", "aws/alb", 2);

--- a/product/akbun-terraform-apply-remote/src/locks.rs
+++ b/product/akbun-terraform-apply-remote/src/locks.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Serializes plan/apply per project directory across pull requests.
+///
+/// A lock key is "owner/repo" + project dir. The first pull request to plan
+/// a project holds its lock until apply succeeds, the PR closes, or the PR
+/// runs unlock. This prevents two PRs from applying conflicting plans to
+/// the same state.
+pub struct LockManager {
+  locks: Mutex<HashMap<String, u64>>,
+}
+
+/// Outcome of a lock attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LockOutcome {
+  /// The lock is now (or was already) held by this pull request.
+  Acquired,
+  /// Another pull request holds the lock.
+  HeldByOther { pr_number: u64 },
+}
+
+impl LockManager {
+  pub fn new() -> LockManager {
+    LockManager { locks: Mutex::new(HashMap::new()) }
+  }
+
+  pub fn try_lock(&self, repo_full_name: &str, dir: &str, pr_number: u64) -> LockOutcome {
+    let key = lock_key(repo_full_name, dir);
+    let mut locks = self.locks.lock().unwrap();
+    match locks.get(&key) {
+      Some(&holder) if holder != pr_number => LockOutcome::HeldByOther { pr_number: holder },
+      _ => {
+        locks.insert(key, pr_number);
+        LockOutcome::Acquired
+      }
+    }
+  }
+
+  /// Releases one project lock if held by this pull request.
+  pub fn unlock(&self, repo_full_name: &str, dir: &str, pr_number: u64) {
+    let key = lock_key(repo_full_name, dir);
+    let mut locks = self.locks.lock().unwrap();
+    if locks.get(&key) == Some(&pr_number) {
+      locks.remove(&key);
+    }
+  }
+
+  /// Releases every lock this pull request holds in the repository.
+  /// Returns the released project dirs.
+  pub fn release_all(&self, repo_full_name: &str, pr_number: u64) -> Vec<String> {
+    let prefix = format!("{repo_full_name}::");
+    let mut locks = self.locks.lock().unwrap();
+    let released: Vec<String> = locks
+      .iter()
+      .filter(|(key, &holder)| key.starts_with(&prefix) && holder == pr_number)
+      .map(|(key, _)| key[prefix.len()..].to_string())
+      .collect();
+    for dir in &released {
+      locks.remove(&lock_key(repo_full_name, dir));
+    }
+    released
+  }
+}
+
+fn lock_key(repo_full_name: &str, dir: &str) -> String {
+  format!("{repo_full_name}::{dir}")
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn first_pr_acquires_lock() {
+    let locks = LockManager::new();
+    assert_eq!(locks.try_lock("o/r", "aws/vpc", 1), LockOutcome::Acquired);
+  }
+
+  #[test]
+  fn lock_is_reentrant_for_same_pr() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    assert_eq!(locks.try_lock("o/r", "aws/vpc", 1), LockOutcome::Acquired);
+  }
+
+  #[test]
+  fn second_pr_is_rejected_with_holder() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    assert_eq!(locks.try_lock("o/r", "aws/vpc", 2), LockOutcome::HeldByOther { pr_number: 1 });
+  }
+
+  #[test]
+  fn different_projects_do_not_conflict() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    assert_eq!(locks.try_lock("o/r", "aws/rds", 2), LockOutcome::Acquired);
+  }
+
+  #[test]
+  fn same_dir_in_different_repos_do_not_conflict() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r1", "aws/vpc", 1);
+    assert_eq!(locks.try_lock("o/r2", "aws/vpc", 2), LockOutcome::Acquired);
+  }
+
+  #[test]
+  fn unlock_frees_the_project_for_others() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    locks.unlock("o/r", "aws/vpc", 1);
+    assert_eq!(locks.try_lock("o/r", "aws/vpc", 2), LockOutcome::Acquired);
+  }
+
+  #[test]
+  fn unlock_by_non_holder_is_a_no_op() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    locks.unlock("o/r", "aws/vpc", 2);
+    assert_eq!(locks.try_lock("o/r", "aws/vpc", 3), LockOutcome::HeldByOther { pr_number: 1 });
+  }
+
+  #[test]
+  fn release_all_frees_only_this_prs_locks() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    locks.try_lock("o/r", "aws/rds", 1);
+    locks.try_lock("o/r", "aws/alb", 2);
+    let mut released = locks.release_all("o/r", 1);
+    released.sort();
+    assert_eq!(released, vec!["aws/rds", "aws/vpc"]);
+    assert_eq!(locks.try_lock("o/r", "aws/alb", 3), LockOutcome::HeldByOther { pr_number: 2 });
+    assert_eq!(locks.try_lock("o/r", "aws/vpc", 3), LockOutcome::Acquired);
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/locks.rs
+++ b/product/akbun-terraform-apply-remote/src/locks.rs
@@ -25,6 +25,17 @@ impl LockManager {
     LockManager { locks: Mutex::new(HashMap::new()) }
   }
 
+  /// Rebuilds the manager from a persisted snapshot, so locks survive a
+  /// server restart or redeploy.
+  pub fn from_snapshot(snapshot: HashMap<String, u64>) -> LockManager {
+    LockManager { locks: Mutex::new(snapshot) }
+  }
+
+  /// Copies the current lock table for persistence.
+  pub fn snapshot(&self) -> HashMap<String, u64> {
+    self.locks.lock().unwrap().clone()
+  }
+
   pub fn try_lock(&self, repo_full_name: &str, dir: &str, pr_number: u64) -> LockOutcome {
     let key = lock_key(repo_full_name, dir);
     let mut locks = self.locks.lock().unwrap();
@@ -119,6 +130,17 @@ mod tests {
     locks.try_lock("o/r", "aws/vpc", 1);
     locks.unlock("o/r", "aws/vpc", 2);
     assert_eq!(locks.try_lock("o/r", "aws/vpc", 3), LockOutcome::HeldByOther { pr_number: 1 });
+  }
+
+  #[test]
+  fn snapshot_round_trip_preserves_holders() {
+    let locks = LockManager::new();
+    locks.try_lock("o/r", "aws/vpc", 1);
+    locks.try_lock("o/r", "aws/rds", 2);
+    let restored = LockManager::from_snapshot(locks.snapshot());
+    assert_eq!(restored.try_lock("o/r", "aws/vpc", 9), LockOutcome::HeldByOther { pr_number: 1 });
+    assert_eq!(restored.try_lock("o/r", "aws/rds", 9), LockOutcome::HeldByOther { pr_number: 2 });
+    assert_eq!(restored.try_lock("o/r", "aws/alb", 9), LockOutcome::Acquired);
   }
 
   #[test]

--- a/product/akbun-terraform-apply-remote/src/main.rs
+++ b/product/akbun-terraform-apply-remote/src/main.rs
@@ -1,0 +1,27 @@
+mod command;
+mod config;
+mod events;
+mod format;
+mod github;
+mod handler;
+mod locks;
+mod project;
+mod server;
+mod signature;
+mod terraform;
+mod workspace;
+
+fn main() {
+  let cfg = match config::Config::from_env() {
+    Ok(cfg) => cfg,
+    Err(e) => {
+      eprintln!("config error: {e}");
+      std::process::exit(1);
+    }
+  };
+  println!(
+    "akbun-terraform-apply-remote listening on 0.0.0.0:{} (trigger word: {})",
+    cfg.port, cfg.trigger
+  );
+  server::run(cfg);
+}

--- a/product/akbun-terraform-apply-remote/src/main.rs
+++ b/product/akbun-terraform-apply-remote/src/main.rs
@@ -4,10 +4,12 @@ mod events;
 mod format;
 mod github;
 mod handler;
+mod jobs;
 mod locks;
 mod project;
 mod server;
 mod signature;
+mod state;
 mod terraform;
 mod workspace;
 

--- a/product/akbun-terraform-apply-remote/src/main.rs
+++ b/product/akbun-terraform-apply-remote/src/main.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod command;
 mod config;
 mod events;
@@ -21,9 +22,16 @@ fn main() {
       std::process::exit(1);
     }
   };
+  let state = match handler::AppState::new(cfg) {
+    Ok(state) => state,
+    Err(e) => {
+      eprintln!("startup error: {e}");
+      std::process::exit(1);
+    }
+  };
   println!(
     "akbun-terraform-apply-remote listening on 0.0.0.0:{} (trigger word: {})",
-    cfg.port, cfg.trigger
+    state.cfg.port, state.cfg.trigger
   );
-  server::run(cfg);
+  server::run(state);
 }

--- a/product/akbun-terraform-apply-remote/src/project.rs
+++ b/product/akbun-terraform-apply-remote/src/project.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeSet;
+
+/// File extensions that mark a directory as a terraform project.
+const TERRAFORM_EXTENSIONS: [&str; 4] = [".tf", ".tfvars", ".tf.json", ".tfvars.json"];
+
+/// Derives the terraform project directories affected by a pull request
+/// from its changed file paths.
+///
+/// A project is the directory that directly contains a changed terraform
+/// file. Files under a ".terraform" cache directory are ignored. The result
+/// is deduplicated and sorted; the repository root becomes ".".
+pub fn projects_from_changed_files(changed_files: &[String]) -> Vec<String> {
+  let mut dirs = BTreeSet::new();
+  for path in changed_files {
+    if !is_terraform_file(path) || in_terraform_cache(path) {
+      continue;
+    }
+    dirs.insert(parent_dir(path));
+  }
+  dirs.into_iter().collect()
+}
+
+fn is_terraform_file(path: &str) -> bool {
+  TERRAFORM_EXTENSIONS.iter().any(|ext| path.ends_with(ext))
+}
+
+fn in_terraform_cache(path: &str) -> bool {
+  path.split('/').any(|segment| segment == ".terraform")
+}
+
+fn parent_dir(path: &str) -> String {
+  match path.rsplit_once('/') {
+    Some((dir, _file)) => dir.to_string(),
+    None => ".".to_string(),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn strings(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| s.to_string()).collect()
+  }
+
+  #[test]
+  fn maps_changed_files_to_their_directories() {
+    let files = strings(&["aws/vpc/vpc.tf", "aws/vpc/variables.tf", "aws/rds/rds.tf"]);
+    assert_eq!(projects_from_changed_files(&files), vec!["aws/rds", "aws/vpc"]);
+  }
+
+  #[test]
+  fn ignores_non_terraform_files() {
+    let files = strings(&["aws/vpc/README.md", "docs/guide.md", "src/main.rs"]);
+    assert!(projects_from_changed_files(&files).is_empty());
+  }
+
+  #[test]
+  fn includes_tfvars_and_json_variants() {
+    let files = strings(&["envs/prod/prod.tfvars", "envs/dev/config.tf.json"]);
+    assert_eq!(projects_from_changed_files(&files), vec!["envs/dev", "envs/prod"]);
+  }
+
+  #[test]
+  fn repository_root_becomes_dot() {
+    let files = strings(&["main.tf"]);
+    assert_eq!(projects_from_changed_files(&files), vec!["."]);
+  }
+
+  #[test]
+  fn skips_terraform_cache_directories() {
+    let files = strings(&["aws/vpc/.terraform/modules/vpc/main.tf"]);
+    assert!(projects_from_changed_files(&files).is_empty());
+  }
+
+  #[test]
+  fn deduplicates_projects() {
+    let files = strings(&["aws/vpc/a.tf", "aws/vpc/b.tf", "aws/vpc/c.tfvars"]);
+    assert_eq!(projects_from_changed_files(&files), vec!["aws/vpc"]);
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/server.rs
+++ b/product/akbun-terraform-apply-remote/src/server.rs
@@ -1,0 +1,64 @@
+use crate::config::Config;
+use crate::handler::{self, AppState};
+use crate::{events, signature};
+use std::io::Read;
+use std::sync::Arc;
+use tiny_http::{Method, Request, Response, Server};
+
+/// Webhook bodies larger than this are rejected outright.
+const MAX_BODY_BYTES: usize = 5 * 1024 * 1024;
+
+/// Runs the webhook server forever. Each valid delivery is acknowledged
+/// immediately and processed on a background thread so GitHub's 10-second
+/// webhook timeout never hits a long terraform run.
+pub fn run(cfg: Config) {
+  let server = Server::http(("0.0.0.0", cfg.port)).expect("failed to bind server port");
+  let state = Arc::new(AppState::new(cfg));
+
+  for request in server.incoming_requests() {
+    match (request.method(), request.url()) {
+      (Method::Get, "/healthz") => respond(request, 200, "ok"),
+      (Method::Post, "/events") => handle_delivery(state.clone(), request),
+      _ => respond(request, 404, "not found"),
+    }
+  }
+}
+
+fn handle_delivery(state: Arc<AppState>, mut request: Request) {
+  let event_name = header(&request, "X-GitHub-Event").unwrap_or_default();
+  let signature_header = header(&request, "X-Hub-Signature-256").unwrap_or_default();
+
+  let mut body = Vec::new();
+  if request.as_reader().take(MAX_BODY_BYTES as u64 + 1).read_to_end(&mut body).is_err()
+    || body.len() > MAX_BODY_BYTES
+  {
+    return respond(request, 400, "body too large or unreadable");
+  }
+  if !signature::verify(&state.cfg.webhook_secret, &body, &signature_header) {
+    return respond(request, 401, "signature mismatch");
+  }
+  let payload: serde_json::Value = match serde_json::from_slice(&body) {
+    Ok(payload) => payload,
+    Err(_) => return respond(request, 400, "invalid JSON"),
+  };
+
+  match events::interpret(&event_name, &payload) {
+    Ok(event) => {
+      std::thread::spawn(move || handler::handle_event(&state, event));
+      respond(request, 200, "accepted");
+    }
+    Err(reason) => respond(request, 200, &format!("ignored: {reason}")),
+  }
+}
+
+fn header(request: &Request, name: &str) -> Option<String> {
+  request
+    .headers()
+    .iter()
+    .find(|h| h.field.as_str().as_str().eq_ignore_ascii_case(name))
+    .map(|h| h.value.as_str().to_string())
+}
+
+fn respond(request: Request, status: u16, message: &str) {
+  let _ = request.respond(Response::from_string(message).with_status_code(status));
+}

--- a/product/akbun-terraform-apply-remote/src/server.rs
+++ b/product/akbun-terraform-apply-remote/src/server.rs
@@ -1,4 +1,3 @@
-use crate::config::Config;
 use crate::handler::{self, AppState};
 use crate::jobs::JobTracker;
 use crate::{events, signature};
@@ -24,9 +23,10 @@ const DRAIN_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 /// /healthz starts failing because the port closes) and the server drains:
 /// it waits for running plan/apply jobs to finish before exiting. State is
 /// persisted after every event, so the next instance takes over from disk.
-pub fn run(cfg: Config) {
-  let server = Arc::new(Server::http(("0.0.0.0", cfg.port)).expect("failed to bind server port"));
-  let state = Arc::new(AppState::new(cfg));
+pub fn run(state: AppState) {
+  let server =
+    Arc::new(Server::http(("0.0.0.0", state.cfg.port)).expect("failed to bind server port"));
+  let state = Arc::new(state);
   let jobs = Arc::new(JobTracker::new());
 
   spawn_signal_listener(server.clone());

--- a/product/akbun-terraform-apply-remote/src/server.rs
+++ b/product/akbun-terraform-apply-remote/src/server.rs
@@ -1,30 +1,67 @@
 use crate::config::Config;
 use crate::handler::{self, AppState};
+use crate::jobs::JobTracker;
 use crate::{events, signature};
+use signal_hook::consts::{SIGINT, SIGTERM};
+use signal_hook::iterator::Signals;
 use std::io::Read;
 use std::sync::Arc;
+use std::time::Duration;
 use tiny_http::{Method, Request, Response, Server};
 
 /// Webhook bodies larger than this are rejected outright.
 const MAX_BODY_BYTES: usize = 5 * 1024 * 1024;
 
-/// Runs the webhook server forever. Each valid delivery is acknowledged
-/// immediately and processed on a background thread so GitHub's 10-second
-/// webhook timeout never hits a long terraform run.
+/// How long shutdown waits for in-flight terraform runs before giving up.
+/// Long on purpose: killing an apply halfway is worse than a slow deploy.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Runs the webhook server until SIGTERM/SIGINT. Each valid delivery is
+/// acknowledged immediately and processed on a background thread so
+/// GitHub's 10-second webhook timeout never hits a long terraform run.
+///
+/// On SIGTERM the accept loop stops (a load balancer health check on
+/// /healthz starts failing because the port closes) and the server drains:
+/// it waits for running plan/apply jobs to finish before exiting. State is
+/// persisted after every event, so the next instance takes over from disk.
 pub fn run(cfg: Config) {
-  let server = Server::http(("0.0.0.0", cfg.port)).expect("failed to bind server port");
+  let server = Arc::new(Server::http(("0.0.0.0", cfg.port)).expect("failed to bind server port"));
   let state = Arc::new(AppState::new(cfg));
+  let jobs = Arc::new(JobTracker::new());
+
+  spawn_signal_listener(server.clone());
 
   for request in server.incoming_requests() {
     match (request.method(), request.url()) {
       (Method::Get, "/healthz") => respond(request, 200, "ok"),
-      (Method::Post, "/events") => handle_delivery(state.clone(), request),
+      (Method::Post, "/events") => handle_delivery(state.clone(), &jobs, request),
       _ => respond(request, 404, "not found"),
     }
   }
+
+  let active = jobs.active();
+  if active > 0 {
+    println!("shutdown requested: draining {active} in-flight job(s)");
+  }
+  if !jobs.wait_idle(DRAIN_TIMEOUT) {
+    eprintln!("drain timeout after {}s; exiting with jobs still running", DRAIN_TIMEOUT.as_secs());
+  }
+  println!("shutdown complete");
 }
 
-fn handle_delivery(state: Arc<AppState>, mut request: Request) {
+/// Unblocks the accept loop when SIGTERM/SIGINT arrives, which ends
+/// incoming_requests() and lets run() drain and exit.
+fn spawn_signal_listener(server: Arc<Server>) {
+  let mut signals = Signals::new([SIGTERM, SIGINT]).expect("failed to register signal handler");
+  std::thread::spawn(move || {
+    if signals.forever().next().is_some() {
+      println!("received shutdown signal");
+      server.unblock();
+    }
+  });
+}
+
+fn handle_delivery(state: Arc<AppState>, jobs: &Arc<JobTracker>, mut request: Request) {
   let event_name = header(&request, "X-GitHub-Event").unwrap_or_default();
   let signature_header = header(&request, "X-Hub-Signature-256").unwrap_or_default();
 
@@ -44,7 +81,11 @@ fn handle_delivery(state: Arc<AppState>, mut request: Request) {
 
   match events::interpret(&event_name, &payload) {
     Ok(event) => {
-      std::thread::spawn(move || handler::handle_event(&state, event));
+      let guard = JobTracker::begin(jobs);
+      std::thread::spawn(move || {
+        handler::handle_event(&state, event);
+        drop(guard);
+      });
       respond(request, 200, "accepted");
     }
     Err(reason) => respond(request, 200, &format!("ignored: {reason}")),

--- a/product/akbun-terraform-apply-remote/src/signature.rs
+++ b/product/akbun-terraform-apply-remote/src/signature.rs
@@ -1,0 +1,68 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Verifies a GitHub webhook signature header (X-Hub-Signature-256)
+/// against the raw request body using the shared webhook secret.
+///
+/// The header format is "sha256=<hex digest>". Comparison is constant-time.
+pub fn verify(secret: &str, body: &[u8], signature_header: &str) -> bool {
+  let hex_digest = match signature_header.strip_prefix("sha256=") {
+    Some(rest) => rest,
+    None => return false,
+  };
+  let expected = match hex::decode(hex_digest) {
+    Ok(bytes) => bytes,
+    Err(_) => return false,
+  };
+  let mut mac = match HmacSha256::new_from_slice(secret.as_bytes()) {
+    Ok(mac) => mac,
+    Err(_) => return false,
+  };
+  mac.update(body);
+  mac.verify_slice(&expected).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn sign(secret: &str, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+  }
+
+  #[test]
+  fn accepts_valid_signature() {
+    let body = br#"{"action":"created"}"#;
+    let header = sign("s3cret", body);
+    assert!(verify("s3cret", body, &header));
+  }
+
+  #[test]
+  fn rejects_wrong_secret() {
+    let body = br#"{"action":"created"}"#;
+    let header = sign("other-secret", body);
+    assert!(!verify("s3cret", body, &header));
+  }
+
+  #[test]
+  fn rejects_tampered_body() {
+    let header = sign("s3cret", b"original body");
+    assert!(!verify("s3cret", b"tampered body", &header));
+  }
+
+  #[test]
+  fn rejects_missing_prefix() {
+    let body = b"body";
+    let header = sign("s3cret", body).replace("sha256=", "");
+    assert!(!verify("s3cret", body, &header));
+  }
+
+  #[test]
+  fn rejects_non_hex_digest() {
+    assert!(!verify("s3cret", b"body", "sha256=not-hex-at-all"));
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/state.rs
+++ b/product/akbun-terraform-apply-remote/src/state.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Locks and planned head SHAs, persisted so a restarted or redeployed
+/// server instance takes over exactly where the previous one stopped.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PersistedState {
+  pub locks: HashMap<String, u64>,
+  pub planned_shas: HashMap<String, String>,
+}
+
+pub fn state_file(data_dir: &str) -> PathBuf {
+  Path::new(data_dir).join("state.json")
+}
+
+/// Writes the state atomically: to a temp file first, then rename, so a
+/// crash mid-write never leaves a truncated state file behind.
+pub fn save(path: &Path, state: &PersistedState) -> Result<(), String> {
+  if let Some(parent) = path.parent() {
+    std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {parent:?} failed: {e}"))?;
+  }
+  let json = serde_json::to_string_pretty(state).map_err(|e| format!("serialize failed: {e}"))?;
+  let tmp = path.with_extension("json.tmp");
+  std::fs::write(&tmp, json).map_err(|e| format!("write {tmp:?} failed: {e}"))?;
+  std::fs::rename(&tmp, path).map_err(|e| format!("rename to {path:?} failed: {e}"))
+}
+
+/// Loads the state file. A missing file is a normal first boot; an
+/// unreadable or corrupt file is reported and treated as empty rather
+/// than blocking startup.
+pub fn load(path: &Path) -> PersistedState {
+  let raw = match std::fs::read_to_string(path) {
+    Ok(raw) => raw,
+    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return PersistedState::default(),
+    Err(e) => {
+      eprintln!("state file {path:?} unreadable ({e}); starting with empty state");
+      return PersistedState::default();
+    }
+  };
+  match serde_json::from_str(&raw) {
+    Ok(state) => state,
+    Err(e) => {
+      eprintln!("state file {path:?} corrupt ({e}); starting with empty state");
+      PersistedState::default()
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn temp_path(name: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("atr-state-test-{name}-{}", std::process::id()))
+  }
+
+  fn sample_state() -> PersistedState {
+    let mut state = PersistedState::default();
+    state.locks.insert("o/r::aws/vpc".to_string(), 7);
+    state.planned_shas.insert("o/r::7::aws/vpc".to_string(), "abc1234".to_string());
+    state
+  }
+
+  #[test]
+  fn save_and_load_round_trip() {
+    let dir = temp_path("round-trip");
+    let path = dir.join("state.json");
+    let state = sample_state();
+    save(&path, &state).unwrap();
+    assert_eq!(load(&path), state);
+    let _ = std::fs::remove_dir_all(dir);
+  }
+
+  #[test]
+  fn missing_file_loads_empty_state() {
+    let path = temp_path("missing").join("state.json");
+    assert_eq!(load(&path), PersistedState::default());
+  }
+
+  #[test]
+  fn corrupt_file_loads_empty_state() {
+    let dir = temp_path("corrupt");
+    let path = dir.join("state.json");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(&path, "{not json").unwrap();
+    assert_eq!(load(&path), PersistedState::default());
+    let _ = std::fs::remove_dir_all(dir);
+  }
+
+  #[test]
+  fn save_overwrites_previous_state() {
+    let dir = temp_path("overwrite");
+    let path = dir.join("state.json");
+    save(&path, &sample_state()).unwrap();
+    let empty = PersistedState::default();
+    save(&path, &empty).unwrap();
+    assert_eq!(load(&path), empty);
+    let _ = std::fs::remove_dir_all(dir);
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/terraform.rs
+++ b/product/akbun-terraform-apply-remote/src/terraform.rs
@@ -1,0 +1,43 @@
+use std::path::Path;
+use std::process::Command;
+
+/// Result of one terraform invocation: success flag plus interleaved
+/// stdout/stderr text.
+pub struct TerraformOutput {
+  pub success: bool,
+  pub output: String,
+}
+
+/// File name of the saved plan inside a project directory. Applying this
+/// exact file guarantees what was reviewed is what gets applied.
+pub const PLAN_FILE: &str = ".akbun.tfplan";
+
+pub fn init(bin: &str, project_dir: &Path) -> TerraformOutput {
+  run(bin, project_dir, &["init", "-input=false", "-no-color"])
+}
+
+pub fn plan(bin: &str, project_dir: &Path) -> TerraformOutput {
+  run(bin, project_dir, &["plan", "-input=false", "-no-color", &format!("-out={PLAN_FILE}")])
+}
+
+pub fn apply_saved_plan(bin: &str, project_dir: &Path) -> TerraformOutput {
+  run(bin, project_dir, &["apply", "-input=false", "-no-color", PLAN_FILE])
+}
+
+fn run(bin: &str, project_dir: &Path, args: &[&str]) -> TerraformOutput {
+  match Command::new(bin).args(args).current_dir(project_dir).output() {
+    Ok(result) => {
+      let mut output = String::from_utf8_lossy(&result.stdout).to_string();
+      let stderr = String::from_utf8_lossy(&result.stderr);
+      if !stderr.trim().is_empty() {
+        output.push('\n');
+        output.push_str(&stderr);
+      }
+      TerraformOutput { success: result.status.success(), output }
+    }
+    Err(e) => TerraformOutput {
+      success: false,
+      output: format!("failed to execute {bin} {}: {e}", args.join(" ")),
+    },
+  }
+}

--- a/product/akbun-terraform-apply-remote/src/terraform.rs
+++ b/product/akbun-terraform-apply-remote/src/terraform.rs
@@ -24,6 +24,10 @@ pub fn apply_saved_plan(bin: &str, project_dir: &Path) -> TerraformOutput {
   run(bin, project_dir, &["apply", "-input=false", "-no-color", PLAN_FILE])
 }
 
+pub fn import(bin: &str, project_dir: &Path, address: &str, id: &str) -> TerraformOutput {
+  run(bin, project_dir, &["import", "-input=false", "-no-color", address, id])
+}
+
 fn run(bin: &str, project_dir: &Path, args: &[&str]) -> TerraformOutput {
   match Command::new(bin).args(args).current_dir(project_dir).output() {
     Ok(result) => {

--- a/product/akbun-terraform-apply-remote/src/workspace.rs
+++ b/product/akbun-terraform-apply-remote/src/workspace.rs
@@ -18,19 +18,23 @@ pub fn checkout_pr(
   head_sha: &str,
 ) -> Result<Workspace, String> {
   let dir = pr_dir(data_dir, repo, pr_number);
-  let clone_url = format!("https://x-access-token:{}@github.com/{}.git", token, repo.full_name());
-  // git prints remote URLs in its error output; keep the token out of
-  // anything that may end up in a PR comment.
+  // The remote URL stays token-free; credentials are passed per fetch via
+  // an HTTP header so the token never lands in .git/config (which persists
+  // on disk, including shared EFS volumes).
+  let clone_url = format!("https://github.com/{}.git", repo.full_name());
+  let auth_config = format!("http.extraheader=Authorization: Basic {}", basic_auth(token));
   let redact = |e: String| e.replace(token, "***");
 
   if !dir.join(".git").exists() {
     std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir failed: {e}"))?;
     git(&dir, &["init", "--quiet"])?;
-    git(&dir, &["remote", "add", "origin", &clone_url]).map_err(redact)?;
+    git(&dir, &["remote", "add", "origin", &clone_url])?;
   } else {
-    git(&dir, &["remote", "set-url", "origin", &clone_url]).map_err(redact)?;
+    // Also scrubs tokens that an older version left in the remote URL.
+    git(&dir, &["remote", "set-url", "origin", &clone_url])?;
   }
-  git(&dir, &["fetch", "--quiet", "origin", &format!("pull/{pr_number}/head")]).map_err(redact)?;
+  git(&dir, &["-c", &auth_config, "fetch", "--quiet", "origin", &format!("pull/{pr_number}/head")])
+    .map_err(redact)?;
   git(&dir, &["checkout", "--quiet", "--force", head_sha])?;
   // Drop leftovers from previous runs but keep terraform caches and saved
   // plans, which live in ignored paths the next plan run overwrites anyway.
@@ -41,6 +45,28 @@ pub fn checkout_pr(
 pub fn remove_pr_workspace(data_dir: &str, repo: &RepoRef, pr_number: u64) {
   let dir = pr_dir(data_dir, repo, pr_number);
   let _ = std::fs::remove_dir_all(dir);
+}
+
+/// Value for a "Authorization: Basic ..." header authenticating as the
+/// x-access-token pseudo-user, the same scheme actions/checkout uses.
+fn basic_auth(token: &str) -> String {
+  base64(format!("x-access-token:{token}").as_bytes())
+}
+
+/// Standard base64 (RFC 4648, with padding). Hand-rolled to keep the
+/// dependency tree small; verified against known vectors in tests.
+fn base64(input: &[u8]) -> String {
+  const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let mut out = String::new();
+  for chunk in input.chunks(3) {
+    let b = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
+    let n = u32::from(b[0]) << 16 | u32::from(b[1]) << 8 | u32::from(b[2]);
+    out.push(ALPHABET[(n >> 18) as usize & 63] as char);
+    out.push(ALPHABET[(n >> 12) as usize & 63] as char);
+    out.push(if chunk.len() > 1 { ALPHABET[(n >> 6) as usize & 63] as char } else { '=' });
+    out.push(if chunk.len() > 2 { ALPHABET[n as usize & 63] as char } else { '=' });
+  }
+  out
 }
 
 fn pr_dir(data_dir: &str, repo: &RepoRef, pr_number: u64) -> PathBuf {
@@ -56,7 +82,40 @@ fn git(dir: &Path, args: &[&str]) -> Result<(), String> {
   if result.status.success() {
     Ok(())
   } else {
-    // The clone URL embeds the token; never echo the command line back.
-    Err(format!("git {} failed: {}", args[0], String::from_utf8_lossy(&result.stderr).trim()))
+    // Only the subcommand name is echoed back, never the full arguments:
+    // a "-c" config value carries the auth header. Skip "-c <value>" pairs.
+    let mut iter = args.iter();
+    let mut subcommand = "git";
+    while let Some(arg) = iter.next() {
+      if *arg == "-c" {
+        iter.next();
+        continue;
+      }
+      if !arg.starts_with('-') {
+        subcommand = arg;
+        break;
+      }
+    }
+    Err(format!("git {} failed: {}", subcommand, String::from_utf8_lossy(&result.stderr).trim()))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn base64_matches_known_vectors() {
+    assert_eq!(base64(b""), "");
+    assert_eq!(base64(b"f"), "Zg==");
+    assert_eq!(base64(b"fo"), "Zm8=");
+    assert_eq!(base64(b"foo"), "Zm9v");
+    assert_eq!(base64(b"foobar"), "Zm9vYmFy");
+  }
+
+  #[test]
+  fn basic_auth_encodes_the_checkout_scheme() {
+    // echo -n "x-access-token:tok" | base64
+    assert_eq!(basic_auth("tok"), "eC1hY2Nlc3MtdG9rZW46dG9r");
   }
 }

--- a/product/akbun-terraform-apply-remote/src/workspace.rs
+++ b/product/akbun-terraform-apply-remote/src/workspace.rs
@@ -1,0 +1,62 @@
+use crate::events::RepoRef;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Per-PR checkout of the repository under the data directory.
+///
+/// The PR head is fetched from the base repository's "pull/N/head" ref, so
+/// pull requests from forks work without extra credentials.
+pub struct Workspace {
+  pub dir: PathBuf,
+}
+
+pub fn checkout_pr(
+  data_dir: &str,
+  token: &str,
+  repo: &RepoRef,
+  pr_number: u64,
+  head_sha: &str,
+) -> Result<Workspace, String> {
+  let dir = pr_dir(data_dir, repo, pr_number);
+  let clone_url = format!("https://x-access-token:{}@github.com/{}.git", token, repo.full_name());
+  // git prints remote URLs in its error output; keep the token out of
+  // anything that may end up in a PR comment.
+  let redact = |e: String| e.replace(token, "***");
+
+  if !dir.join(".git").exists() {
+    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir failed: {e}"))?;
+    git(&dir, &["init", "--quiet"])?;
+    git(&dir, &["remote", "add", "origin", &clone_url]).map_err(redact)?;
+  } else {
+    git(&dir, &["remote", "set-url", "origin", &clone_url]).map_err(redact)?;
+  }
+  git(&dir, &["fetch", "--quiet", "origin", &format!("pull/{pr_number}/head")]).map_err(redact)?;
+  git(&dir, &["checkout", "--quiet", "--force", head_sha])?;
+  // Drop leftovers from previous runs but keep terraform caches and saved
+  // plans, which live in ignored paths the next plan run overwrites anyway.
+  git(&dir, &["clean", "-fd", "--quiet", "--exclude=.terraform", "--exclude=*.tfplan"])?;
+  Ok(Workspace { dir })
+}
+
+pub fn remove_pr_workspace(data_dir: &str, repo: &RepoRef, pr_number: u64) {
+  let dir = pr_dir(data_dir, repo, pr_number);
+  let _ = std::fs::remove_dir_all(dir);
+}
+
+fn pr_dir(data_dir: &str, repo: &RepoRef, pr_number: u64) -> PathBuf {
+  Path::new(data_dir).join("repos").join(&repo.owner).join(&repo.name).join(format!("pr-{pr_number}"))
+}
+
+fn git(dir: &Path, args: &[&str]) -> Result<(), String> {
+  let result = Command::new("git")
+    .args(args)
+    .current_dir(dir)
+    .output()
+    .map_err(|e| format!("failed to execute git: {e}"))?;
+  if result.status.success() {
+    Ok(())
+  } else {
+    // The clone URL embeds the token; never echo the command line back.
+    Err(format!("git {} failed: {}", args[0], String::from_utf8_lossy(&result.stderr).trim()))
+  }
+}


### PR DESCRIPTION
## Goal

Add akbun-terraform-apply-remote, a self-hosted server that runs terraform plan, apply, and import from GitHub pull request comments, the way Atlantis does. Deployments of the server itself are zero-downtime: a new instance drains and takes over the previous instance's state.

## 어떻게 해결했는가

- Rust webhook server on a small synchronous stack (tiny_http, ureq) that verifies HMAC-SHA256 signatures and handles issue_comment and pull_request events
- Autoplan on PR open and synchronize posts the plan as a PR comment; comment commands plan, apply, import, unlock, and help, with an optional -d directory flag
- Apply runs only the tfplan file saved by the last plan and refuses when the PR head moved since that plan; import runs under the project lock and invalidates the saved plan
- Per-project-directory locks serialize plan and apply across pull requests
- Auth is either a fine-grained PAT or a GitHub App: the server mints one-hour installation tokens from an RS256 App JWT, caches them, and refreshes before expiry; git fetch passes the token via an Authorization header so it never persists on disk
- Deployment safety: on SIGTERM the server drains in-flight terraform runs (up to 30 minutes) before exiting, and locks plus plan records are persisted to state.json so the next instance takes over
- Terraform deploy stacks: deploy/ec2 (Graviton t4g.small, systemd, SSM SecureString secrets, self-update timer polling the binary URL) and deploy/ecs (Fargate ARM64 behind ALB and ACM, state on EFS, rolling task replacement) plus a Dockerfile
- 70 unit tests cover the core logic: command parsing, signature verification, project detection, comment formatting, locks, persisted state, job tracker, and auth selection/refresh
- Docs: architecture with mermaid diagrams, user guide with GitHub App setup, deploy guide; GitHub Actions pipeline runs tests on PRs and uploads a linux release binary on master pushes
- Four English decision records under knowledge/decisions with index and log updates

Issue #585