### PR TITLE
chore(k8supgradeview): bump version to 0.10.0 to fix release workflow failure

### DIFF
--- a/product/akbun-k8supgradeview/workspace/package-lock.json
+++ b/product/akbun-k8supgradeview/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-k8supgradeview",
-  "version": "0.4.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-k8supgradeview",
-      "version": "0.4.0",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "electron": "^33.0.0",

--- a/product/akbun-k8supgradeview/workspace/package.json
+++ b/product/akbun-k8supgradeview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-k8supgradeview",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "EKS 업그레이드 작업 중 노드와 파드 상태를 확인하는 데스크톱 뷰어",
   "author": "akbun",
   "license": "MIT",


### PR DESCRIPTION
## Goal

The release-k8supgradeview workflow failed on the last two master pushes because the tag akbun-k8supgradeview-v0.9.0 already exists. The workflow derives the tag from the package.json version, and two workspace changes were merged without a version bump. Bump the version so the next master push creates a new tag and release.

## 어떻게 해결했는가

- Bumped the version in product/akbun-k8supgradeview/workspace/package.json from 0.9.0 to 0.10.0, following the existing minor-bump convention (0.8.0 to 0.9.0).
- Synced the two stale root version fields in package-lock.json, which were left at 0.4.0, to 0.10.0.
- Left the workflow unchanged: the failure came from missing version bumps, not from a workflow defect, and silently skipping an existing tag would hide missed releases.

Issue #587

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg2R34VgGzrd3nVwUZEeKc)_