### PR TITLE
docs: remove Atlantis references from product docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 86. LiteLLM AI gateway 3시간 학습과 폐쇄망 Bedrock 실습 (26.7.11) - [링크](./computer_science/ai/litellm/)
 87. Bifrost AI gateway 학습(LiteLLM 비교) (26.7.11) - [링크](./computer_science/ai/bifrost/)
 88. Java heap dump 자동 수집과 분석 핸즈온 (OOM 증거 남기기) (26.7.18) - [링크](./computer_science/java/heapdump/)
-89. git credential helper 원리와 CodeBuild connection 학습지 (26.7.26) - [링크](./computer_science/git/git_credential_helper/)
+89. git credential helper 원리와 CodeBuild connection 핸즈온 (26.7.26) - [링크](./computer_science/git/git_credential_helper/)
 
 ## 직접 만든 제품
 
@@ -111,7 +111,7 @@
 - [git graph 데스크톱 앱 (akbun-gitdesktop)](./product/akbun-gitdesktop/) (26.7.25)
 - [언어 공부용 구간 반복 오디오 플레이어 (akbun-shadowing-player)](./product/akbun-shadowing-player/) (26.7.25)
 - [EKS 업그레이드용 노드/파드 조회 데스크톱 앱 (akbun-k8supgradeview)](./product/akbun-k8supgradeview/) (26.7.26)
-- [GitHub PR에서 terraform plan/apply를 실행하는 Atlantis 방식 서버 (akbun-terraform-apply-remote)](./product/akbun-terraform-apply-remote/) (26.7.29)
+- [GitHub PR에서 terraform plan/apply를 실행하는 서버 (akbun-terraform-apply-remote)](./product/akbun-terraform-apply-remote/) (26.7.29)
 - [macOS 메뉴바 스크린샷 앱 (akbun-screenshot)](./product/akbun-screenshot/) (26.7.31)
 
 ## Dockerfile

--- a/product/README.md
+++ b/product/README.md
@@ -13,7 +13,7 @@
 | [akbun-k8supgradeview](./akbun-k8supgradeview/) | EKS 업그레이드 작업용 노드/파드 조회 Electron 데스크톱 앱 |
 | [akbun-screenshot](./akbun-screenshot/) | 영역 캡처, 클립보드 복사, 미리보기 저장을 지원하는 macOS 메뉴바 스크린샷 앱 |
 | [akbun-shadowing-player](./akbun-shadowing-player/) | 언어 공부(쉐도잉)용 구간 반복 오디오 플레이어 Electron 앱 |
-| [akbun-terraform-apply-remote](./akbun-terraform-apply-remote/) | GitHub PR comment로 terraform plan/apply를 실행하는 Atlantis 방식 자동화 서버 |
+| [akbun-terraform-apply-remote](./akbun-terraform-apply-remote/) | GitHub PR comment로 terraform plan/apply를 실행하는 자동화 서버 |
 | [slide-reference](./slide-reference/) | AI agent용 슬라이드 레이아웃 레퍼런스 |
 | [slo](./slo/) | SLO 가용성을 입력하면 허용 다운타임을 계산하는 웹 도구 |
 | [tistory-skin](./tistory-skin/) | Tistory 블로그 스킨 |

--- a/product/akbun-terraform-apply-remote/README.md
+++ b/product/akbun-terraform-apply-remote/README.md
@@ -1,6 +1,6 @@
 # akbun-terraform-apply-remote
 
-GitHub pull request에서 terraform plan/apply를 실행하는 셀프호스팅 자동화 서버다. Atlantis와 같은 방식으로 동작한다. PR이 열리면 변경된 terraform 프로젝트를 자동으로 plan하고, 리뷰어가 comment로 `akbun apply`를 남기면 리뷰한 plan 파일을 그대로 apply한다.
+GitHub pull request에서 terraform plan/apply를 실행하는 셀프호스팅 자동화 서버다. PR이 열리면 변경된 terraform 프로젝트를 자동으로 plan하고, 리뷰어가 comment로 `akbun apply`를 남기면 리뷰한 plan 파일을 그대로 apply한다.
 
 ## 동작 방식
 


### PR DESCRIPTION
## Goal

The akbun-terraform-apply-remote documentation described the product as an Atlantis-style server. The goal is to describe the product on its own terms without referring to Atlantis.

## How I solved it

- Removed the sentence stating the server works the same way as Atlantis from product/akbun-terraform-apply-remote/README.md.
- Removed the Atlantis wording from the root README product list entry.
- Removed the same wording from the product/README.md index entry, because the product rule requires both indexes to stay in sync.
- Changed 학습지 to 핸즈온 in the git credential helper entry of the root README hands-on list.
- Kept the Atlantis mention in knowledge/decisions/2026-07-terraform-apply-saved-plan.md, since that record explains why Atlantis was not adopted.

Issue #593