### PR TITLE
docs: make the pull request template the single source of the PR body format

### DIFF
--- a/.claude/commands/repo-pr-create.md
+++ b/.claude/commands/repo-pr-create.md
@@ -11,13 +11,13 @@ allowed-tools: Bash, Read, Glob, Grep
 2. commit할 변경이 남아 있으면 commit한다. commit message에 claude session 링크(claude.ai/code 링크, Co-Authored-By 아래 붙는 세션 URL)가 있으면 제거한다.
 3. push한다.
 4. 기록용 Issue를 만든다. [.github/ISSUE_TEMPLATE/work-record.md](../../.github/ISSUE_TEMPLATE/work-record.md)를 따라 Goal과 ADR을 채운다.
-5. PR을 만든다. [.github/pull_request_template.md](../../.github/pull_request_template.md)를 따르고 본문 끝에 Issue #<number> 형식으로 4의 Issue를 링크한다. target branch는 master다.
+5. PR을 만든다. [.github/pull_request_template.md](../../.github/pull_request_template.md)를 읽고 그 섹션과 항목 형식을 그대로 따른다. 본문 끝에 Issue #<number> 형식으로 4의 Issue를 링크한다. target branch는 master다.
 6. Issue와 PR에 작업 유형 label(feat, docs, fix 등)과 기술 label을 함께 붙인다.
 
 ## 작성 규칙
 
 - commit message와 PR body는 영어로 쓴다.
 - 간단명료하게 쓴다. backtick을 쓰지 않는다.
-- Goal은 3문장 미만, 해결 과정은 항목으로 쓴다.
+- Issue의 Goal은 2문장 미만으로 쓴다. PR body의 섹션과 형식은 pull request template을 기준으로 한다.
 - PR body와 Issue body 어디에도 claude session 링크를 넣지 않는다.
 - 나머지는 [.claude/rules/workflow.md](../rules/workflow.md)를 따른다.

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -44,9 +44,9 @@ PR을 생성할 때 기록용 GitHub Issue를 함께 만들고 PR body에서 링
 
 ## PR 작성 규칙
 
-- 템플릿: [.github/pull_request_template.md](../../.github/pull_request_template.md)를 따른다.
-- **Goal**: 해결하려는 문제 또는 공부하려는 주제를 3문장 미만으로 작성한다.
-- **How I solved it**: 해결 과정 또는 정리한 내용을 항목으로 작성한다.
+body 형식의 기준은 [.github/pull_request_template.md](../../.github/pull_request_template.md) 하나다. 섹션 구성과 항목 형식은 이 규칙 파일에 중복해 적지 않고 템플릿에서 읽는다.
+
+- PR을 쓰기 전에 템플릿을 읽고 그 섹션과 형식을 그대로 따른다.
 - 본문 끝에 기록용 issue를 `Issue #<number>` 형식으로 링크한다.
 - target branch는 `master`로 설정한다.
 - 사용자가 요청하면 git diff를 다시 읽고 PR body를 재작성한다. Issue 번호는 유지한다.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,36 @@
-<!-- 문어체로 간단명료하게 작성하고 backtick을 사용하지 않는다. -->
+<!--
+이 파일이 PR body 형식의 기준이다. slash command와 rules는 이 파일을 참조한다.
+여기는 형식만 정한다. 문체와 label 같은 공통 작성 규칙은 .claude/rules/workflow.md를 따른다.
 
-## Goal
+아래 H1 두 개가 PR body의 전체 구조다. PR body는 .claude/rules/markdown.md의 헤더 규칙 대상이 아니므로 H1을 그대로 쓴다.
+항목은 요약 한 줄과 그 아래 근거 항목들로 구성한다.
+앞으로의 작업에도 영향을 주는 항목은 요약 줄 앞에 **[Important]** 를 붙이고 섹션 위로 올린다.
+-->
 
-<!-- 이 PR이 해결하려는 문제 또는 공부하려는 주제를 3문장 미만으로 작성한다. -->
+# Decisions
 
-## How I solved it
+<!--
+작업 중 내린 의사결정을 쓴다. 요약 줄은 무엇을 정했는지, 아래 항목은 왜 그렇게 정했는지다.
 
-<!-- 해결 과정 또는 정리한 내용을 항목으로 작성한다. -->
+예시:
+**[Important]** We hide icons with two spacer status items made of spaces.
+- macOS has no hide API. Widening one item is the only way to push others off screen.
+- Electron only exposes setTitle. So we express width as long runs of spaces.
+
+We let macOS own which section an icon belongs to.
+- Icon order is system state. Only a Command drag changes it.
+-->
+
+# Implementation
+
+<!--
+실제로 구현한 것과 검증 결과를 쓴다. 수치와 측정값이 있으면 항목으로 남긴다.
+
+예시:
+**[Important]** The item scan runs one short call per process, in a pool of eight.
+- The process list is fetched once, then reused.
+- A full scan takes about 10 seconds and finds all 19 real items.
+-->
 
 <!-- 아래에 기록용 issue를 링크한다. 예: Issue #123 -->
 Issue #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,20 @@
 이 파일이 PR body 형식의 기준이다. slash command와 rules는 이 파일을 참조한다.
 여기는 형식만 정한다. 문체와 label 같은 공통 작성 규칙은 .claude/rules/workflow.md를 따른다.
 
-아래 H1 두 개가 PR body의 전체 구조다. PR body는 .claude/rules/markdown.md의 헤더 규칙 대상이 아니므로 H1을 그대로 쓴다.
-항목은 요약 한 줄과 그 아래 근거 항목들로 구성한다.
+아래 H1 네 개가 PR body의 전체 구조다. PR body는 .claude/rules/markdown.md의 헤더 규칙 대상이 아니므로 H1을 그대로 쓴다.
+Goal은 산문으로 쓰고, 나머지 세 섹션은 요약 한 줄과 그 아래 근거 항목들로 구성한다.
 앞으로의 작업에도 영향을 주는 항목은 요약 줄 앞에 **[Important]** 를 붙이고 섹션 위로 올린다.
+남길 내용이 없는 섹션은 헤더째 지운다. Goal은 항상 쓴다.
+-->
+
+# Goal
+
+<!--
+무엇이 문제였고 이 PR이 무엇을 더하는지 3문장 이내로 쓴다. 항목으로 나누지 않는다.
+
+예시:
+A crowded macOS menu bar hides icons past the screen edge. You cannot click them.
+This PR adds akbun-mactaskbar. It splits the bar into three sections and pages through them with one click.
 -->
 
 # Decisions
@@ -30,6 +41,20 @@ We let macOS own which section an icon belongs to.
 **[Important]** The item scan runs one short call per process, in a pool of eight.
 - The process list is fetched once, then reused.
 - A full scan takes about 10 seconds and finds all 19 real items.
+-->
+
+# Challenges
+
+<!--
+막혔던 지점과 시도했다가 버린 방법을 쓴다. 왜 버렸는지 판단 근거가 된 수치를 남긴다.
+
+예시:
+One osascript walking every process was far too slow.
+- Measured 2m34s for the full walk. One named process took 150ms.
+- So we split it into one short call per process.
+
+A pool of sixteen was faster but lost data.
+- Item count dropped from 19 to 13. We kept the pool at eight.
 -->
 
 <!-- 아래에 기록용 issue를 링크한다. 예: Issue #123 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,5 @@
 ## 작업 흐름
 
 **git commit, push, PR 생성, Issue 생성은 사용자가 명시적으로 지시할 때만 실행한다.** agent는 구현과 검증까지만 하고 멈춘 뒤 변경 요약을 보고한다. plan 승인이나 이 문서의 표준 흐름은 실행 허가가 아니다.
+
+PR body 형식의 기준은 [.github/pull_request_template.md](./.github/pull_request_template.md) 하나다. PR을 쓰기 전에 이 파일을 읽고 그 섹션과 항목 형식을 그대로 따른다. 형식을 이 문서나 `.claude/rules/`에 중복해 적지 않는다.

--- a/knowledge/decisions/2026-07-pr-body-format-in-template.md
+++ b/knowledge/decisions/2026-07-pr-body-format-in-template.md
@@ -1,0 +1,22 @@
+---
+type: Decision
+title: PR body 형식의 기준은 pull request template 하나다
+description: 섹션 구성과 항목 형식을 template에만 두고 AGENTS.md와 rules와 slash command는 참조만 한다.
+tags: [workflow, github]
+timestamp: 2026-07-31T00:00:00Z
+---
+
+## 결정
+
+PR body의 섹션은 Decisions와 Implementation 둘이다. 각 항목은 요약 한 줄과 그 아래 근거 항목들로 쓰고, 앞으로의 작업에도 영향을 주는 항목은 앞에 [Important]를 붙여 위로 올린다.
+
+이 형식은 [.github/pull_request_template.md](../../.github/pull_request_template.md)에만 적는다. AGENTS.md, `.claude/rules/workflow.md`, `.claude/commands/repo-pr-create.md`는 template을 읽으라고만 하고 섹션 이름과 항목 형식을 옮겨 적지 않는다.
+
+## 이유
+
+- 형식이 네 곳에 흩어져 있으면 한 곳만 고쳐도 나머지가 낡은 지시로 남는다. 실제로 rules와 command에 남아 있던 Goal 3문장 규칙이 template과 어긋나 있었다.
+- Goal과 How I solved it은 무엇을 했는지만 남기고 왜 그렇게 했는지는 남기지 않았다. Decisions를 앞에 두면 판단 근거가 PR의 첫 화면에 온다.
+- 형식 예시는 template의 주석 안에 둔다. 주석 밖에 두면 GitHub compose box에 채워져 실제 PR body에 그대로 남는다.
+- PR body는 H1 두 개를 쓰므로 `.claude/rules/markdown.md`의 헤더 규칙과 충돌한다. 예외를 template 안에 명시해 agent가 헤더를 H2로 되돌리지 않게 한다.
+
+관련 결정은 [규칙 문서는 도구 중립으로 쓰고 상시 로드 비용으로 정리한다](2026-07-agents-md-tool-neutral.md)를 참조한다.

--- a/knowledge/decisions/2026-07-pr-body-format-in-template.md
+++ b/knowledge/decisions/2026-07-pr-body-format-in-template.md
@@ -8,14 +8,15 @@ timestamp: 2026-07-31T00:00:00Z
 
 ## 결정
 
-PR body의 섹션은 Decisions와 Implementation 둘이다. 각 항목은 요약 한 줄과 그 아래 근거 항목들로 쓰고, 앞으로의 작업에도 영향을 주는 항목은 앞에 [Important]를 붙여 위로 올린다.
+PR body의 섹션은 Goal, Decisions, Implementation, Challenges 넷이다. Goal은 산문으로 쓰고 나머지는 요약 한 줄과 그 아래 근거 항목들로 쓴다. 앞으로의 작업에도 영향을 주는 항목은 앞에 [Important]를 붙여 위로 올린다.
 
 이 형식은 [.github/pull_request_template.md](../../.github/pull_request_template.md)에만 적는다. AGENTS.md, `.claude/rules/workflow.md`, `.claude/commands/repo-pr-create.md`는 template을 읽으라고만 하고 섹션 이름과 항목 형식을 옮겨 적지 않는다.
 
 ## 이유
 
 - 형식이 네 곳에 흩어져 있으면 한 곳만 고쳐도 나머지가 낡은 지시로 남는다. 실제로 rules와 command에 남아 있던 Goal 3문장 규칙이 template과 어긋나 있었다.
-- Goal과 How I solved it은 무엇을 했는지만 남기고 왜 그렇게 했는지는 남기지 않았다. Decisions를 앞에 두면 판단 근거가 PR의 첫 화면에 온다.
+- How I solved it은 무엇을 했는지만 남기고 왜 그렇게 했는지는 남기지 않았다. Decisions와 Challenges로 나누면 채택한 이유와 버린 방법이 둘 다 남는다.
+- Challenges에는 버린 방법의 측정값을 남긴다. 같은 방법을 다음 작업에서 다시 시도하는 것을 막는다.
 - 형식 예시는 template의 주석 안에 둔다. 주석 밖에 두면 GitHub compose box에 채워져 실제 PR body에 그대로 남는다.
 - PR body는 H1 두 개를 쓰므로 `.claude/rules/markdown.md`의 헤더 규칙과 충돌한다. 예외를 template 안에 명시해 agent가 헤더를 H2로 되돌리지 않게 한다.
 

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -17,3 +17,4 @@
 * [Deploys drain in-flight runs and hand state over via disk](2026-07-deploy-drain-and-persisted-takeover.md) - 멀티 노드 HA 대신 SIGTERM drain과 state.json 영속화로 배포 중 인수인계를 해결하는 결정.
 * [GitHub App installation tokens as the recommended auth for the terraform bot](2026-07-github-app-tokens-for-terraform-bot.md) - 장기 PAT 대신 1시간짜리 App installation token을 권장 인증으로 두는 결정.
 * [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](2026-07-unsigned-desktop-app-self-update.md) - electron-updater가 막힌 상황에서 dmg 교체 방식을 모든 데스크톱 product의 기본으로 두는 결정.
+* [PR body 형식의 기준은 pull request template 하나다](2026-07-pr-body-format-in-template.md) - PR body를 Decisions와 Implementation으로 바꾸고 형식을 template 한 곳에만 두는 결정.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-07-31
 
+* **Creation**: [PR body 형식의 기준은 pull request template 하나다](decisions/2026-07-pr-body-format-in-template.md) 결정 기록. PR body를 Decisions와 Implementation으로 바꾸면서 형식이 네 파일에 흩어져 있던 문제를 함께 정리한다.
 * **Creation**: [Electron 메뉴바 앱은 창 정리와 메뉴바 공간에서 조용히 실패한다](topics/electron-menubar-silent-failures.md) topic 기록. akbun-screenshot의 프리뷰 창이 화면 밖으로 밀려나던 버그를 고치면서 남긴다.
 * **Creation**: [macOS 메뉴바 status item은 넓은 자리 차지로만 가릴 수 있고, 목록은 프로세스 단위로만 읽을 수 있다](topics/macos-menubar-status-items.md) topic 작성. akbun-mactaskbar를 만들며 실측한 제약과 우회 방법을 남긴다.
 * **Creation**: [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](decisions/2026-07-unsigned-desktop-app-self-update.md) 결정 기록. 세 번째 제품에 같은 구현을 포팅하면서 제품 생성 규칙으로 옮긴다.


### PR DESCRIPTION
# Goal

The PR body format was spread over four files and recorded what was done but not why.
This PR moves the format into .github/pull_request_template.md alone and changes the body to Goal, Decisions, Implementation, and Challenges.

# Decisions

**[Important]** The PR body format lives only in .github/pull_request_template.md.
- AGENTS.md, the workflow rule, and the repo-pr-create command now say to read the template, and no longer restate the sections.
- Editing one of four copies left the other three as stale instructions.
- The rule file and the command still carried a Goal under three sentences rule that the template no longer matched.

**[Important]** The body is Goal, Decisions, Implementation, and Challenges.
- How I solved it recorded what was done but not why. Decisions and Challenges keep both the reasons we accepted and the approaches we dropped.
- Challenges carries the measurements behind a dropped approach, so the next PR does not retry it.
- Items that shape future work get an [Important] marker and move to the top of their section.

We keep the format examples inside HTML comments.
- Anything outside a comment is prefilled into the GitHub compose box and ends up in the real PR body.
- An agent cannot tell a placeholder from a skeleton to fill.

We declare the PR body an exception to the markdown header rule.
- .claude/rules/markdown.md allows one H1 at the top of a file, and the body uses four.
- Without the exception written in the template, an agent reading the rule reverts the headers to H2.

# Implementation

The template is the only file that gained content. Every other change removes text.
- The workflow rule and the command lost their copies of the section list.
- AGENTS.md gained one pointer line and a note not to restate the format.

Each section carries a worked example rather than X and Y placeholders.
- The examples come from a real PR body, which carries the intended voice better than a sentence describing it.
- Sections with nothing to say are deleted header and all. Goal is always written.

A decision was recorded in knowledge.
- It names the four sections and the reason the format sits in one file.

# Challenges

The first draft put the examples outside the comments.
- GitHub prefills the template into the compose box, so the placeholder text would have shipped inside real PR bodies.
- Moving every example into a comment leaves only the four headers and the issue link visible.

The first draft also left the writing rules in two places.
- The template repeated 문어체, backtick, and English rules that workflow.md already owns.
- The template now holds format only, and workflow.md holds style.

Issue #601