### PR TITLE
feat(k8supgradeview): add node instance type column and node describe panel

### DIFF
--- a/product/akbun-k8supgradeview/adr/2026-07-node-instance-type-and-describe.md
+++ b/product/akbun-k8supgradeview/adr/2026-07-node-instance-type-and-describe.md
@@ -1,0 +1,20 @@
+# 노드 Instance Type 칼럼과 노드 describe를 파드와 같은 사이드 패널에 둔다
+
+## 결정
+
+- Nodes 탭에 Instance Type 칼럼을 두고 `node.kubernetes.io/instance-type` label에서 읽는다. 그 label이 없으면 예전 이름인 `beta.kubernetes.io/instance-type`을 본다. 둘 다 없으면 `-`가 아니라 빈 칸으로 둔다.
+- 노드 이름을 누르면 `kubectl describe node`의 출력을 파드와 같은 `#pod-detail-panel`에 띄운다. 패널 상태는 `detailTarget`에 kind를 담아 노드와 파드를 함께 다룬다.
+- 파드 이름 칸에도 노드와 같은 복사 버튼을 둔다. 이름 칸을 만드는 함수를 `appendNameCell` 하나로 합친다.
+- 사이드 패널 너비를 `min(720px, 90vw)`에서 `min(1100px, 95vw)`로 넓힌다.
+
+## 이유
+
+instance type은 업그레이드 중에 노드를 고르는 기준이 된다. 같은 NodePool이 만든 노드라도 타입이 섞여 있어서, 어느 노드를 먼저 비울지 정하려면 `kubectl get nodes -o wide`를 따로 돌려야 했다. label에서 읽으므로 조회를 늘리지 않고 이미 받아 오는 노드 JSON에서 꺼낸다.
+
+값이 없을 때 `-`를 적지 않는 이유는 두 상황이 구분되어야 하기 때문이다. EC2가 아닌 노드에는 이 label이 애초에 없다. `-`는 다른 칼럼에서 "값을 못 읽었다"는 뜻으로 쓰고 있어서, 원래 없는 값에까지 쓰면 조회가 실패한 것처럼 읽힌다.
+
+노드 describe는 파드와 답하는 질문이 같다. 표의 칼럼으로는 taint, allocatable, condition의 자세한 사유가 보이지 않는다. 패널을 하나 더 만드는 대신 파드가 쓰던 패널을 그대로 쓰면, 여는 방법과 닫는 방법, focus 처리, 늦게 온 응답을 버리는 규칙이 한 벌로 남는다. 노드는 cluster scope라 namespace가 없어서 대상에 kind를 담아 명령만 가른다.
+
+파드 이름도 노드와 마찬가지로 `kubectl logs`나 `kubectl exec`에 그대로 붙여 쓰는 값이다. 노드에만 복사 버튼이 있을 이유가 없어서 이름 칸 함수를 하나로 합쳤다.
+
+패널이 넓어진 이유는 describe 출력의 한 줄이 길기 때문이다. 720px에서는 event message와 annotation이 여러 줄로 접혀 원문의 줄 단위가 무너졌다. 화면을 거의 덮지만 패널을 열었다는 것은 지금 그 대상을 읽겠다는 뜻이라 표를 함께 볼 필요가 적다.

--- a/product/akbun-k8supgradeview/adr/index.md
+++ b/product/akbun-k8supgradeview/adr/index.md
@@ -16,4 +16,5 @@ akbun-k8supgradeview 프로젝트의 의사결정을 "결정 - 이유" 구조로
 * [파드 describe는 이름 클릭으로 여는 오른쪽 사이드 패널에서 원문 그대로 보여준다](2026-07-pod-describe-side-panel.md) - describe 출력을 파싱하지 않고 겹치는 사이드 패널에 붙이기로 한 결정.
 * [Pods 탭에 Ready 칼럼을 두고 Ready 필터는 상태 필터와 따로 둔다](2026-07-pod-ready-column-and-filter.md) - Ready를 컨테이너 개수 표기로 보여주고 "Ready 아닌 파드만" 토글을 상태 필터와 분리하기로 한 결정.
 * [모든 표의 모든 칼럼을 정렬 가능하게 두고 칸의 종류로 견주는 방법을 정한다](2026-07-all-column-sort.md) - 정렬 대상을 네 칼럼에서 전체로 넓히고 칼럼마다 값의 종류를 붙여 비교 방법을 나누기로 한 결정.
+* [노드 Instance Type 칼럼과 노드 describe를 파드와 같은 사이드 패널에 둔다](2026-07-node-instance-type-and-describe.md) - instance type을 label에서 읽어 값이 없으면 빈 칸으로 두고, 노드 describe를 파드 패널에 합치며 이름 칸과 패널 너비를 함께 손보기로 한 결정.
 * [상단 탭 바를 왼쪽 고정 사이드메뉴로 바꾸고 테마를 CSS 변수로 옮긴다](2026-07-sidebar-navigation-ui.md) - 배치만 어두운 톤의 세로 사이드메뉴로 바꾸고 색을 CSS 변수로 옮겨 dark mode를 함께 지원하되 renderer 로직은 그대로 두기로 한 결정.

--- a/product/akbun-k8supgradeview/wiki/architecture.md
+++ b/product/akbun-k8supgradeview/wiki/architecture.md
@@ -12,7 +12,7 @@ Electron + TypeScript 데스크톱 앱이다. 클러스터 조회는 Kubernetes 
   - `preload.ts`: contextBridge로 renderer에 `window.api` 노출
 - `workspace/src/renderer/`: 화면. Nodes, Pods, Karpenter Event, NodePool / EC2NodeClass, Utilize, Settings 6개 탭과 테이블 렌더링. 프레임워크 없이 DOM API만 사용한다.
 
-renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:describe-pod`, `kubectl:set-node-cordon`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `kubectl:karpenter-versions`, `kubectl:namespaces`, `overprovision:build`, `clipboard:write`, `settings:get`, `settings:save`)로만 통신한다.
+renderer는 `nodeIntegration: false`, `contextIsolation: true`이며 main 프로세스와는 IPC(`kubectl:nodes`, `kubectl:pods`, `kubectl:describe-pod`, `kubectl:describe-node`, `kubectl:set-node-cordon`, `kubectl:karpenter-events`, `kubectl:karpenter-logs`, `kubectl:karpenter-resources`, `kubectl:karpenter-versions`, `kubectl:namespaces`, `overprovision:build`, `clipboard:write`, `settings:get`, `settings:save`)로만 통신한다.
 
 ## kubectl 실행 흐름
 
@@ -26,10 +26,11 @@ kubectl get pods --all-namespaces -o json
 kubectl get pods --all-namespaces -o json --field-selector spec.nodeName=<노드이름>
 ```
 
-파드 이름을 눌러 describe 사이드 패널을 열 때 사용하는 명령:
+이름을 눌러 describe 사이드 패널을 열 때 사용하는 명령. 노드는 cluster scope라 namespace를 붙이지 않는다:
 
 ```bash
 kubectl describe pod <파드이름> -n <namespace>
+kubectl describe node <노드이름>
 ```
 
 Utilize 탭이 manifest를 만들 대상 목록을 채울 때 사용하는 명령:
@@ -108,15 +109,15 @@ Pods 탭의 두 토글은 노드 필터와 같은 `.filter-button` 모양을 쓴
 
 Ready 칸도 상태처럼 색으로 먼저 읽히게 한다. 다만 상태와 달리 중간 단계를 두지 않고 모두 Ready면 초록, 아니면 빨강 두 가지만 쓴다. Ready는 개수가 다 찼는가 아닌가의 문제라 그 사이에 둘 단계가 없다.
 
-## 파드 describe 사이드 패널
+## describe 사이드 패널
 
-Pods 탭과 노드 상세의 파드 표에서 이름 칸만 버튼(`.pod-name-button`)이다. 누르면 화면 오른쪽에 `#pod-detail-panel`이 열리고 `kubectl describe pod`의 출력을 그대로 붙인다. 패널은 `position: fixed`로 표 위에 겹친다. 표를 밀어내면 칼럼이 접혀 어느 파드를 열었는지 보이지 않기 때문이다.
+Nodes 탭, Pods 탭, 노드 상세의 파드 표에서 이름 칸만 버튼(`.name-button`)이다. 누르면 화면 오른쪽에 `#pod-detail-panel`이 열리고 `kubectl describe`의 출력을 그대로 붙인다. 패널은 `position: fixed`로 표 위에 겹친다. 표를 밀어내면 칼럼이 접혀 어느 대상을 열었는지 보이지 않기 때문이다. 너비는 `min(1100px, 95vw)`다. describe는 한 줄이 길어 좁은 패널에서는 줄바꿈이 잦아 읽기 어렵다.
 
-describe 결과는 파싱하지 않는다. main은 `describePod(namespace, name)`이 문자열을 그대로 돌려주고, renderer는 error 낱말 하이라이트(`appendErrorHighlighted`)만 얹는다. 들여쓰기가 계층을 나타내는 출력이라 `white-space: pre-wrap`으로 원문 형태를 지키고, 조각은 `textContent`로만 넣어 클러스터가 준 문자열이 HTML로 해석되지 않게 한다.
+describe 결과는 파싱하지 않는다. main은 `describePod(namespace, name)`과 `describeNode(name)`이 문자열을 그대로 돌려주고, renderer는 error 낱말 하이라이트(`appendErrorHighlighted`)만 얹는다. 들여쓰기가 계층을 나타내는 출력이라 `white-space: pre-wrap`으로 원문 형태를 지키고, 조각은 `textContent`로만 넣어 클러스터가 준 문자열이 HTML로 해석되지 않게 한다.
 
 패널은 `role="dialog"`로 선언하고, 이름 버튼으로 열 때 닫기 버튼으로 focus를 옮긴다. 표에 focus가 남아 있으면 키보드만 쓰는 경우 열린 패널에 닿을 수 없다. 연 버튼은 `detailOpener`에 들고 있다가 닫을 때 그 자리로 focus를 되돌린다. 패널 안의 새로고침으로 다시 읽을 때는 이미 패널 안에 있으므로 focus를 건드리지 않는다.
 
-지금 보고 있는 파드는 `detailPod`에 들고 있다. 새로고침 버튼이 같은 대상을 다시 읽는 데 쓰고, 조회하는 동안 다른 파드를 눌렀을 때 늦게 온 응답이 화면을 덮지 않도록 응답의 대상과 비교하는 데도 쓴다. 조회 실패는 상단 배너가 아니라 패널 안에 적는다. 패널이 오른쪽을 덮고 있어 배너가 눈에 들어오지 않는다.
+지금 보고 있는 대상은 `detailTarget`(kind, namespace, name)에 들고 있다. 노드와 파드가 한 패널을 쓰므로 kind까지 담아야 새로고침이 어느 명령을 다시 돌릴지 정할 수 있다. 조회하는 동안 다른 대상을 눌렀을 때 늦게 온 응답이 화면을 덮지 않도록 응답의 대상과 비교하는 데도 쓴다. 조회 실패는 상단 배너가 아니라 패널 안에 적는다. 패널이 오른쪽을 덮고 있어 배너가 눈에 들어오지 않는다.
 
 이름 검증은 IPC 경계에서 노드와 같은 `assertResourceName`이 한다. shell을 거치지 않아 인젝션은 없지만 `-`로 시작하는 값은 kubectl이 이름이 아니라 옵션으로 읽는다. 배경은 [describe 사이드 패널 ADR](../adr/2026-07-pod-describe-side-panel.md)에 있다.
 
@@ -180,9 +181,9 @@ Nodes 탭 노드 행 끝 Action 칼럼에 버튼 하나를 두고, 글자를 `un
 
 subcommand를 반대로 넘기면 노드를 열려다 닫으므로 `test/node-cordon.test.js`가 실제 실행 경로에서 넘어간 인자를 확인한다.
 
-## 노드 이름 복사
+## 이름 복사
 
-Nodes 탭 Name 칼럼의 이름 오른쪽에 복사 버튼을 둔다. 클릭하면 renderer가 `clipboard:write` IPC로 이름을 넘기고 main이 electron `clipboard.writeText`로 복사한다. renderer의 `navigator.clipboard`를 쓰지 않는 이유는 focus와 권한 상태를 타서 조용히 실패하기 때문이며, 배경은 [이름 복사 ADR](../adr/2026-07-name-copy-and-error-highlight.md)에 있다.
+Nodes, Pods, 노드 상세의 파드 표 Name 칼럼에서 이름 오른쪽에 복사 버튼을 둔다. 세 표 모두 `appendNameCell` 하나를 쓴다. 클릭하면 renderer가 `clipboard:write` IPC로 이름을 넘기고 main이 electron `clipboard.writeText`로 복사한다. renderer의 `navigator.clipboard`를 쓰지 않는 이유는 focus와 권한 상태를 타서 조용히 실패하기 때문이며, 배경은 [이름 복사 ADR](../adr/2026-07-name-copy-and-error-highlight.md)에 있다.
 
 복사에 성공하면 버튼 글자를 1.5초 동안 "복사됨"으로 바꾼다. 행 클릭은 파드 조회에 쓰고 있으므로 cordon 버튼과 마찬가지로 `stopPropagation`으로 전파를 멈춘다. `td`를 직접 flex로 만들면 표 정렬이 깨지므로 칸 안에 감싸는 요소(`.name-box`)를 하나 두고 그것을 flex로 만든다.
 
@@ -193,6 +194,12 @@ Nodes 탭 Name 칼럼의 이름 오른쪽에 복사 버튼을 둔다. 클릭하�
 | Karpenter 노드 | `karpenter.sh/nodepool` 또는 구버전 `karpenter.sh/provisioner-name` label 존재 |
 | Managed NodeGroup 노드 | `eks.amazonaws.com/nodegroup` label 존재 |
 | Cordoned 노드 | `spec.unschedulable == true`, 상태에 SchedulingDisabled로 표시 |
+
+## Instance Type 칼럼
+
+Nodes 탭의 Instance Type 칼럼은 `node.kubernetes.io/instance-type` label에서 읽고, 그 label이 없으면 예전 이름인 `beta.kubernetes.io/instance-type`을 본다. 업그레이드 중에는 같은 NodePool에서도 노드마다 타입이 달라질 수 있어, 어느 노드를 먼저 비울지 정할 때 이 값을 본다.
+
+둘 다 없으면 빈 문자열로 두고 아무것도 적지 않는다. EC2가 아닌 노드에는 이 label이 없는데, `-`를 적으면 "타입을 못 읽었다"와 "값이 원래 없다"가 같은 모양이 된다. 값이 있고 없고는 `test/node-instance-type.test.js`가 확인한다.
 
 ## 업데이트 흐름
 

--- a/product/akbun-k8supgradeview/workspace/package-lock.json
+++ b/product/akbun-k8supgradeview/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-k8supgradeview",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-k8supgradeview",
-      "version": "0.10.0",
+      "version": "0.12.0",
       "license": "MIT",
       "devDependencies": {
         "electron": "^33.0.0",

--- a/product/akbun-k8supgradeview/workspace/package.json
+++ b/product/akbun-k8supgradeview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-k8supgradeview",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "EKS 업그레이드 작업 중 노드와 파드 상태를 확인하는 데스크톱 뷰어",
   "author": "akbun",
   "license": "MIT",

--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -4,6 +4,8 @@ import { loadSettings } from "./settings";
 export interface NodeInfo {
   name: string;
   internalIp: string;
+  // EC2 인스턴스 타입(t3.medium 등). label이 없는 노드도 있어 그때는 빈 문자열이다.
+  instanceType: string;
   version: string;
   status: string;
   creationTimestamp: string;
@@ -87,6 +89,8 @@ export interface KarpenterLogs {
 
 const KARPENTER_LABELS = ["karpenter.sh/nodepool", "karpenter.sh/provisioner-name"];
 const MANAGED_NODEGROUP_LABEL = "eks.amazonaws.com/nodegroup";
+// beta.는 예전 이름이다. 오래된 노드에도 값이 보이도록 둘 다 본다.
+const INSTANCE_TYPE_LABELS = ["node.kubernetes.io/instance-type", "beta.kubernetes.io/instance-type"];
 
 // 설정된 kubectl 명령("tsh kubectl" 등)을 공백으로 나눠 shell 없이 실행한다.
 function runKubectl(args: string[]): Promise<string> {
@@ -129,11 +133,20 @@ function nodeGroup(labels: Record<string, string>): string {
   return labels[MANAGED_NODEGROUP_LABEL] ?? "";
 }
 
+/** EC2가 아닌 노드에는 이 label이 없다. 없으면 빈 칸으로 두고 아무것도 적지 않는다. */
+function instanceType(labels: Record<string, string>): string {
+  for (const label of INSTANCE_TYPE_LABELS) {
+    if (labels[label]) return labels[label];
+  }
+  return "";
+}
+
 function toNodeInfo(node: any): NodeInfo {
   const labels: Record<string, string> = node.metadata?.labels ?? {};
   return {
     name: node.metadata?.name ?? "",
     internalIp: internalIp(node),
+    instanceType: instanceType(labels),
     version: node.status?.nodeInfo?.kubeletVersion ?? "",
     status: nodeStatus(node),
     creationTimestamp: node.metadata?.creationTimestamp ?? "",
@@ -216,6 +229,12 @@ export async function getPods(nodeName?: string): Promise<PodInfo[]> {
  */
 export async function describePod(namespace: string, name: string): Promise<string> {
   const stdout = await runKubectl(["describe", "pod", name, "-n", namespace]);
+  return stdout.trimEnd();
+}
+
+/** 노드도 같은 이유로 원문을 그대로 돌려준다. 노드는 cluster scope라 namespace가 없다. */
+export async function describeNode(name: string): Promise<string> {
+  const stdout = await runKubectl(["describe", "node", name]);
   return stdout.trimEnd();
 }
 

--- a/product/akbun-k8supgradeview/workspace/src/main/main.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/main.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import * as path from "path";
 import {
   describePod,
+  describeNode,
   getKarpenterEvents,
   getKarpenterLogs,
   getKarpenterResources,
@@ -81,6 +82,10 @@ function registerIpcHandlers(): void {
     assertResourceName(namespace, "namespace");
     assertResourceName(name, "파드 이름");
     return describePod(namespace, name);
+  });
+  ipcMain.handle("kubectl:describe-node", (_event, name: unknown) => {
+    assertResourceName(name, "노드 이름");
+    return describeNode(name);
   });
   ipcMain.handle("kubectl:namespaces", () => getNamespaces());
   /**

--- a/product/akbun-k8supgradeview/workspace/src/main/preload.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/preload.ts
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld("api", {
   getPods: (nodeName?: string) => ipcRenderer.invoke("kubectl:pods", nodeName),
   describePod: (namespace: string, name: string) =>
     ipcRenderer.invoke("kubectl:describe-pod", namespace, name),
+  describeNode: (name: string) => ipcRenderer.invoke("kubectl:describe-node", name),
   getNamespaces: () => ipcRenderer.invoke("kubectl:namespaces"),
   buildOverprovisionYaml: (options: unknown) => ipcRenderer.invoke("overprovision:build", options),
   setNodeCordon: (nodeName: string, cordon: boolean) =>

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -111,6 +111,9 @@
             <th class="sortable" data-sort-key="internalIp" tabindex="0" role="button" aria-sort="none">
               Internal IP<span class="sort-arrow"></span>
             </th>
+            <th class="sortable" data-sort-key="instanceType" tabindex="0" role="button" aria-sort="none">
+              Instance Type<span class="sort-arrow"></span>
+            </th>
             <th class="sortable" data-sort-key="version" tabindex="0" role="button" aria-sort="none">
               Version<span class="sort-arrow"></span>
             </th>
@@ -416,8 +419,8 @@
   </main>
   </div>
 
-  <!-- 파드 이름을 누르면 열리는 describe 사이드 패널. 표를 가리지 않도록 오른쪽에 붙는다. -->
-  <aside id="pod-detail-panel" class="hidden" role="dialog" aria-label="파드 describe">
+  <!-- 노드나 파드 이름을 누르면 열리는 describe 사이드 패널. 표를 가리지 않도록 오른쪽에 붙는다. -->
+  <aside id="pod-detail-panel" class="hidden" role="dialog" aria-label="describe">
     <div class="pod-detail-header">
       <h2 id="pod-detail-title"></h2>
       <div class="pod-detail-actions">

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -1,6 +1,7 @@
 interface NodeInfo {
   name: string;
   internalIp: string;
+  instanceType: string;
   version: string;
   status: string;
   creationTimestamp: string;
@@ -93,6 +94,7 @@ interface Api {
   getNodes(): Promise<NodeInfo[]>;
   getPods(nodeName?: string): Promise<PodInfo[]>;
   describePod(namespace: string, name: string): Promise<string>;
+  describeNode(name: string): Promise<string>;
   getNamespaces(): Promise<string[]>;
   buildOverprovisionYaml(options: OverprovisionOptions): Promise<string>;
   setNodeCordon(nodeName: string, cordon: boolean): Promise<boolean>;
@@ -254,6 +256,7 @@ const NODE_SORT: SortSpec<NodeInfo> = {
   columns: {
     name: { kind: "text", value: (node) => node.name },
     internalIp: { kind: "ip", value: (node) => node.internalIp },
+    instanceType: { kind: "text", value: (node) => node.instanceType },
     version: { kind: "natural", value: (node) => node.version },
     status: { kind: "text", value: (node) => node.status },
     age: { kind: "age", value: (node) => node.creationTimestamp },
@@ -420,88 +423,90 @@ async function copyToClipboard(text: string, button: HTMLButtonElement): Promise
   }
 }
 
-/** 노드 이름은 kubectl 명령에 그대로 붙여 쓰는 값이라 이름 옆에 복사 버튼을 둔다. */
-function appendNameCellWithCopy(row: HTMLTableRowElement, name: string): void {
+/**
+ * 이름 칸. 이름을 누르면 describe가 열리고, 옆의 버튼으로 이름만 복사한다.
+ * 이름은 kubectl 명령에 그대로 붙여 쓰는 값이라 노드와 파드 모두 복사가 필요하다.
+ */
+function appendNameCell(row: HTMLTableRowElement, name: string, open: () => void): void {
   const cell = row.insertCell();
   cell.className = "name-cell";
   const box = document.createElement("div");
   box.className = "name-box";
   cell.appendChild(box);
 
-  const label = document.createElement("span");
-  label.textContent = name;
-  box.appendChild(label);
-
-  const button = document.createElement("button");
-  button.className = "copy-button";
-  button.textContent = "복사";
-  button.title = `${name} 복사`;
-  // 행 클릭은 파드 조회다. 복사할 때 그 동작까지 함께 돌지 않게 막는다.
-  button.addEventListener("click", (event) => {
+  const nameButton = document.createElement("button");
+  nameButton.className = "name-button";
+  nameButton.textContent = name;
+  nameButton.title = `${name} describe 보기`;
+  // 행 클릭은 노드 선택(파드 조회)이다. 이름을 눌렀을 때 함께 돌지 않게 막는다.
+  nameButton.addEventListener("click", (event) => {
     event.stopPropagation();
-    void copyToClipboard(name, button);
+    open();
   });
-  box.appendChild(button);
-}
+  box.appendChild(nameButton);
 
-/** 사이드 패널이 보고 있는 파드. 새로고침 버튼이 같은 대상을 다시 읽는 데 쓴다. */
-let detailPod: { namespace: string; name: string } | null = null;
+  const copyButton = document.createElement("button");
+  copyButton.className = "copy-button";
+  copyButton.textContent = "복사";
+  copyButton.title = `${name} 복사`;
+  copyButton.addEventListener("click", (event) => {
+    event.stopPropagation();
+    void copyToClipboard(name, copyButton);
+  });
+  box.appendChild(copyButton);
+}
 
 /**
- * 파드 이름 칸을 눌러 describe를 여는 버튼으로 만든다. 표의 다른 칸은 그대로 두어
- * 어디를 눌러야 열리는지 한 곳으로 모은다.
+ * 사이드 패널이 보고 있는 대상. 새로고침 버튼이 같은 대상을 다시 읽는 데 쓴다.
+ * 노드는 cluster scope라 namespace가 빈 문자열이다.
  */
-function appendPodNameCell(row: HTMLTableRowElement, pod: PodInfo): void {
-  const cell = row.insertCell();
-  const button = document.createElement("button");
-  button.className = "pod-name-button";
-  button.textContent = pod.name;
-  button.title = `${pod.name} describe 보기`;
-  button.addEventListener("click", (event) => {
-    // 노드 탭의 파드 표는 행 클릭이 노드 선택이라 그 동작까지 함께 돌지 않게 막는다.
-    event.stopPropagation();
-    void openPodDetail(pod.namespace, pod.name);
-  });
-  cell.appendChild(button);
-}
+let detailTarget: { kind: "pod" | "node"; namespace: string; name: string } | null = null;
 
 /** 패널을 연 버튼. 닫을 때 그 자리로 focus를 되돌려 표에서 이어서 볼 수 있게 한다. */
 let detailOpener: HTMLElement | null = null;
 
 function closePodDetail(): void {
-  detailPod = null;
+  detailTarget = null;
   $("#pod-detail-panel").classList.add("hidden");
   detailOpener?.focus();
   detailOpener = null;
+}
+
+function isSameTarget(kind: string, namespace: string, name: string): boolean {
+  return (
+    detailTarget?.kind === kind &&
+    detailTarget.namespace === namespace &&
+    detailTarget.name === name
+  );
 }
 
 /**
  * describe는 한 번에 수십 줄이 나오고 클러스터가 멀면 몇 초가 걸린다.
  * 여는 즉시 대상과 조회 중임을 적어 두어 빈 화면을 보여주지 않는다.
  */
-async function openPodDetail(namespace: string, name: string): Promise<void> {
-  detailPod = { namespace, name };
+async function openDetail(kind: "pod" | "node", namespace: string, name: string): Promise<void> {
+  detailTarget = { kind, namespace, name };
   $("#pod-detail-panel").classList.remove("hidden");
   // 표에 focus가 남아 있으면 키보드만 쓰는 경우 열린 패널에 닿을 수 없다.
   // 패널 안의 새로고침으로 다시 읽을 때는 이미 패널에 있으므로 focus를 건드리지 않는다.
   const active = document.activeElement as HTMLElement | null;
-  if (active?.classList.contains("pod-name-button")) {
+  if (active?.classList.contains("name-button")) {
     detailOpener = active;
     ($("#close-pod-detail") as HTMLButtonElement).focus();
   }
-  $("#pod-detail-title").textContent = `${namespace} / ${name}`;
+  $("#pod-detail-title").textContent = kind === "pod" ? `${namespace} / ${name}` : `node / ${name}`;
   const body = $("#pod-detail-body");
   body.className = "";
   body.textContent = "조회 중...";
 
   try {
-    const text = await api.describePod(namespace, name);
-    // 조회하는 동안 다른 파드를 눌렀으면 늦게 온 결과가 화면을 덮지 않게 버린다.
-    if (detailPod?.namespace !== namespace || detailPod.name !== name) return;
+    const text = kind === "pod" ? await api.describePod(namespace, name) : await api.describeNode(name);
+    // 조회하는 동안 다른 대상을 눌렀으면 늦게 온 결과가 화면을 덮지 않게 버린다.
+    if (!isSameTarget(kind, namespace, name)) return;
     body.textContent = "";
     appendErrorHighlighted(body, text);
   } catch (error) {
-    if (detailPod?.namespace !== namespace || detailPod.name !== name) return;
+    if (!isSameTarget(kind, namespace, name)) return;
     // 상단 배너로 보내면 패널을 보는 동안 눈에 들어오지 않아 패널 안에 적는다.
     body.className = "detail-error";
     body.textContent = String(error instanceof Error ? error.message : error);
@@ -557,8 +562,9 @@ function renderNodes(): void {
     const row = tbody.insertRow();
     row.dataset.name = node.name;
     if (node.name === selectedNode) row.classList.add("selected");
-    appendNameCellWithCopy(row, node.name);
+    appendNameCell(row, node.name, () => void openDetail("node", "", node.name));
     appendCell(row, node.internalIp);
+    appendCell(row, node.instanceType);
     appendCell(row, node.version);
     appendCell(row, node.status, statusClass(node.status));
     appendCell(row, formatAge(node.creationTimestamp));
@@ -591,7 +597,7 @@ function renderNodePods(): void {
   for (const pod of nodePodSort.apply(nodePods)) {
     const row = tbody.insertRow();
     appendCell(row, pod.namespace);
-    appendPodNameCell(row, pod);
+    appendNameCell(row, pod.name, () => void openDetail("pod", pod.namespace, pod.name));
     appendCell(row, pod.status, statusClass(pod.status));
     appendCell(row, pod.ready, podReadyClass(pod));
     appendCell(row, formatAge(pod.creationTimestamp));
@@ -706,7 +712,7 @@ function renderPods(): void {
   for (const pod of pods) {
     const row = tbody.insertRow();
     appendCell(row, pod.namespace);
-    appendPodNameCell(row, pod);
+    appendNameCell(row, pod.name, () => void openDetail("pod", pod.namespace, pod.name));
     appendCell(row, pod.status, statusClass(pod.status));
     appendCell(row, pod.ready, podReadyClass(pod));
     appendCell(row, pod.nodeName);
@@ -1083,7 +1089,7 @@ function registerEventHandlers(): void {
   });
   $("#close-pod-detail").addEventListener("click", closePodDetail);
   $("#refresh-pod-detail").addEventListener("click", () => {
-    if (detailPod) void openPodDetail(detailPod.namespace, detailPod.name);
+    if (detailTarget) void openDetail(detailTarget.kind, detailTarget.namespace, detailTarget.name);
   });
   $("#copy-pod-detail").addEventListener("click", () => {
     const button = $("#copy-pod-detail") as HTMLButtonElement;
@@ -1091,7 +1097,7 @@ function registerEventHandlers(): void {
   });
   // 패널을 닫는 데 마우스를 쓰지 않아도 되게 Escape를 받는다.
   document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && detailPod) closePodDetail();
+    if (event.key === "Escape" && detailTarget) closePodDetail();
   });
   $("#save-settings").addEventListener("click", () => void submitSettings());
   $("#refresh-namespaces").addEventListener("click", () => void refreshNamespaces());

--- a/product/akbun-k8supgradeview/workspace/src/renderer/style.css
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/style.css
@@ -536,7 +536,7 @@ th.sortable.sorted {
 }
 
 /* 파드 이름은 눌러서 describe를 여는 자리라 링크처럼 보이게 한다. */
-.pod-name-button {
+.name-button {
   padding: 0;
   border: none;
   background: none;
@@ -546,7 +546,7 @@ th.sortable.sorted {
   cursor: pointer;
 }
 
-.pod-name-button:hover {
+.name-button:hover {
   text-decoration: underline;
 }
 
@@ -562,7 +562,8 @@ th.sortable.sorted {
   z-index: 10;
   display: flex;
   flex-direction: column;
-  width: min(720px, 90vw);
+  /* describe는 한 줄이 길다. 줄바꿈이 잦으면 읽기 어려워 화면 대부분을 준다. */
+  width: min(1100px, 95vw);
   background: var(--surface);
   border-left: 1px solid var(--border);
   box-shadow: -8px 0 24px var(--shadow);

--- a/product/akbun-k8supgradeview/workspace/test/node-instance-type.test.js
+++ b/product/akbun-k8supgradeview/workspace/test/node-instance-type.test.js
@@ -1,0 +1,109 @@
+/**
+ * 노드 표의 Instance Type 칸과 노드 describe가 실행하는 kubectl 명령을 확인한다.
+ *
+ * instance type은 label에서 읽는데, label 이름이 바뀐 적이 있고 EC2가 아닌 노드에는
+ * 아예 없다. 값이 없을 때 빈 칸이 되는지까지 봐야 잘못된 타입을 보고 판단하지 않는다.
+ *
+ * 실행: npm test (dist/를 읽으므로 build가 먼저 돈다)
+ */
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "akbun-k8supgradeview-instance-test-"));
+
+// settings는 electron의 app.getPath만 쓴다. 테스트 임시 디렉터리를 주어 실제 앱 설정을 건드리지 않는다.
+const Module = require("node:module");
+const resolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (request === "electron") return "electron-stub";
+  return resolveFilename.call(this, request, ...rest);
+};
+require.cache["electron-stub"] = {
+  id: "electron-stub",
+  filename: "electron-stub",
+  loaded: true,
+  exports: { app: { getPath: () => workDir } },
+};
+
+const { saveSettings } = require("../dist/main/settings.js");
+const { getNodes, describeNode } = require("../dist/main/kubectl.js");
+
+Module._resolveFilename = resolveFilename;
+delete require.cache["electron-stub"];
+
+const argsPath = path.join(workDir, "args.txt");
+
+const NODES_JSON = {
+  items: [
+    {
+      metadata: { name: "current-label", labels: { "node.kubernetes.io/instance-type": "t3.medium" } },
+      spec: {},
+      status: {},
+    },
+    {
+      metadata: { name: "legacy-label", labels: { "beta.kubernetes.io/instance-type": "m5.large" } },
+      spec: {},
+      status: {},
+    },
+    { metadata: { name: "no-label", labels: {} }, spec: {}, status: {} },
+  ],
+};
+
+/** 받은 인자를 기록하고 주어진 stdout을 내보내는 가짜 kubectl. */
+function useRecordingKubectl(stdout) {
+  const scriptPath = path.join(workDir, "fake-kubectl");
+  const script =
+    `#!/bin/bash\necho "$@" > ${JSON.stringify(argsPath)}\n` +
+    `cat ${JSON.stringify(path.join(workDir, "stdout.txt"))}\n`;
+  fs.writeFileSync(path.join(workDir, "stdout.txt"), stdout);
+  fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+  saveSettings({
+    kubectlCommand: scriptPath,
+    karpenterNamespace: "karpenter",
+    karpenterPodLabelSelector: "app.kubernetes.io/name=karpenter",
+    karpenterLogSinceMinutes: 15,
+  });
+}
+
+test.after(() => fs.rmSync(workDir, { recursive: true, force: true }));
+
+test("instance type은 현재 label을 읽고, 예전 label만 있어도 읽는다", async () => {
+  useRecordingKubectl(JSON.stringify(NODES_JSON));
+  const nodes = await getNodes();
+
+  assert.strictEqual(nodes[0].instanceType, "t3.medium");
+  assert.strictEqual(nodes[1].instanceType, "m5.large");
+});
+
+test("label이 없는 노드의 instance type은 빈 문자열이라 화면에 아무것도 적히지 않는다", async () => {
+  useRecordingKubectl(JSON.stringify(NODES_JSON));
+  const nodes = await getNodes();
+
+  assert.strictEqual(nodes[2].instanceType, "");
+});
+
+test("노드 describe는 kubectl describe node <이름>을 실행한다", async () => {
+  useRecordingKubectl("Name:  ip-10-0-0-1\n");
+  await describeNode("ip-10-0-0-1");
+
+  assert.strictEqual(fs.readFileSync(argsPath, "utf8").trim(), "describe node ip-10-0-0-1");
+});
+
+/**
+ * 이름 검증은 main.ts의 IPC 경계에 있다. 그 함수는 export하지 않으므로
+ * -로 시작하는 값을 막는 규칙이 노드에도 걸려 있는지 코드로 확인한다.
+ */
+test("describe-node IPC는 노드 이름을 검증한다", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "dist", "main", "main.js"), "utf8");
+  const start = source.indexOf('"kubectl:describe-node"');
+  assert.notStrictEqual(start, -1, "describe-node IPC 핸들러를 찾지 못했다");
+
+  const next = source.indexOf("ipcMain.handle(", start);
+  const handler = next === -1 ? source.slice(start) : source.slice(start, next);
+
+  assert.match(handler, /assertResourceName\(name/);
+});


### PR DESCRIPTION
# Goal

During an EKS upgrade you pick which node to drain next, and the instance type is part of that decision. The Nodes table did not show it, so you had to run kubectl get nodes -o wide in a terminal, and the taints and conditions behind a NotReady node needed another kubectl describe. This PR adds an Instance Type column and opens describe for a node in the side panel that pods already use.

# Decisions

The instance type is read from a label, not from a new query.
- node.kubernetes.io/instance-type is already in the node JSON the app fetches. Falling back to the older beta.kubernetes.io/instance-type keeps the value visible on long-lived nodes.

A node with no instance-type label gets a blank cell, not a dash.
- Other columns use a dash to mean the value could not be read. Non-EC2 nodes never have this label, so a dash would read as a failed lookup.

Node describe reuses the pod side panel instead of getting its own.
- Opening, closing, focus handling and dropping late responses stay in one place.
- The panel target now carries a kind, so refresh knows whether to run describe pod or describe node. Nodes are cluster scoped and pass an empty namespace.

The node and pod name cells are now one function.
- A pod name is pasted into kubectl logs and kubectl exec just like a node name, so it gets the same copy button.

# Implementation

**[Important]** Instance type is resolved in main and shipped as a NodeInfo field, so the renderer never parses labels.
- describeNode(name) runs kubectl describe node without a namespace flag, and the kubectl:describe-node IPC validates the name with the same assertResourceName guard as pods.
- appendNameCellWithCopy and appendPodNameCell collapsed into appendNameCell, which renders a name button plus a copy button. That single change gives pods a copy button and nodes a describe click.
- The side panel width went from min(720px, 90vw) to min(1100px, 95vw).

test/node-instance-type.test.js covers what is not visible on screen.
- Both label names, the blank case, the kubectl describe node arguments, and the IPC name validation.
- Full suite: 53 tests, 0 failures, build included.

# Challenges

The node name cell already had a click target, so the new one had to be scoped.
- A node row click loads that node's pods. The name button and the copy button both stopPropagation, otherwise pressing either would also reload the pod table.

Verification stopped at build and tests.
- The app was not run against a live cluster in this change, so the new column and panel were checked through the unit tests and the type build only.

Issue #603
