### PR TITLE
feat(akbun-screenshot): add update check and in place bundle swap

### DIFF
--- a/product/akbun-screenshot/README.md
+++ b/product/akbun-screenshot/README.md
@@ -1,6 +1,6 @@
 # akbun-screenshot
 
-macOS menu bar app for area screenshots. Drag to select, the capture lands on the clipboard, and a floating preview in the bottom-left corner lets you save it as png or discard it.
+macOS menu bar app for area screenshots. Drag to select, the capture lands on the clipboard, and a floating preview in the bottom-left corner lets you save it as png or discard it. The menu bar icon also carries Check for Updates, which pulls the newest dmg from GitHub Releases and replaces the app in place.
 
 ## Directory layout
 

--- a/product/akbun-screenshot/adr/2026-07-update-download-and-swap.md
+++ b/product/akbun-screenshot/adr/2026-07-update-download-and-swap.md
@@ -1,0 +1,31 @@
+---
+type: Decision
+title: 업데이트는 dmg 직접 내려받기와 번들 교체로 구현
+description: 메뉴바 아이콘 메뉴의 Check for Updates가 GitHub Release를 조회하고, 새 버전이면 dmg를 받아 .app 번들을 교체한다.
+tags: [electron, update]
+timestamp: 2026-07-31T00:00:00Z
+---
+
+## 결정
+
+메뉴바 아이콘을 누르면 나오는 메뉴에 Check for Updates 항목을 두었다. 이 항목이 GitHub Release API에서 akbun-screenshot-v 태그의 최신 버전을 찾아 현재 버전과 비교한다. 새 버전이면 dmg를 임시 디렉터리에 받아 교체 스크립트를 분리 프로세스로 띄우고 앱을 종료하며, 스크립트가 .app 번들을 통째로 바꾸고 재실행한다. 같은 저장소의 akbun-k8supgradeview 구현을 plain JavaScript로 옮겼다.
+
+디스크 누수 방지를 핵심 요구사항으로 두고 정리 지점을 세 곳에 두었다.
+
+1. downloadDmg가 내려받기 실패 시 만든 임시 디렉터리를 지운다.
+2. 교체 스크립트의 trap이 어느 단계에서 실패해도 작업 디렉터리와 mount를 지운다.
+3. 앱 시작 때 cleanupTempDirs가 강제 종료로 남은 임시 디렉터리를 지운다.
+
+세 지점은 workspace/test/update.test.js가 검증하며 release workflow의 verify job에서 실행된다.
+
+## 이유
+
+- dmg가 무서명이라 Squirrel.Mac 기반 자동 업데이트(electron-updater)를 쓸 수 없다. 앱이 fetch로 받은 파일에는 quarantine 속성이 붙지 않아 Gatekeeper를 거치지 않고 교체할 수 있다.
+- 이 앱은 메뉴바 전용이라 상단 애플리케이션 메뉴가 없다. 사용자가 앱과 만나는 지점이 tray 메뉴 하나뿐이므로 업데이트 항목도 같은 메뉴에 둔다. 현재 버전도 같은 메뉴에 비활성 항목으로 보여 업데이트 여부를 판단할 근거를 남긴다.
+- 저장소의 기존 구현이 이미 같은 릴리즈 구조(태그 형식, arm64 dmg)에서 동작하고 있어 검증된 코드를 재사용했다.
+- dmg는 용량이 커서 정리가 한 군데라도 빠지면 실패할 때마다 디스크가 찬다. 정리 지점이 세 곳으로 흩어져 있어 수동 확인이 어렵고, 회귀를 막으려면 테스트가 필요하다.
+
+## Citations
+
+1. product/akbun-k8supgradeview/workspace/src/main/update.ts
+2. product/akbun-k8supgradeview/workspace/test/update-disk-leak.test.js

--- a/product/akbun-screenshot/adr/index.md
+++ b/product/akbun-screenshot/adr/index.md
@@ -6,3 +6,4 @@ Decision records for akbun-screenshot in "decision - reason" form. Filenames fol
 
 * [Electron with native screencapture](2026-07-electron-native-screencapture.md) - Chose Electron over Rust and delegated capture to the macOS screencapture binary.
 * [Release from package.json version](2026-07-release-workflow.md) - The version field drives the tag and an unsigned arm64 dmg ships with an xattr note.
+* [Update by dmg download and bundle swap](2026-07-update-download-and-swap.md) - The tray menu checks GitHub Releases and swaps the .app bundle, with three temp file cleanup points.

--- a/product/akbun-screenshot/wiki/architecture.md
+++ b/product/akbun-screenshot/wiki/architecture.md
@@ -7,6 +7,7 @@ Electron app in plain JavaScript with no build step. It lives in the menu bar on
 - `workspace/src/main.js`: app bootstrap. Tray icon, tray menu, global shortcut registration, IPC handlers, settings window.
 - `workspace/src/capture.js`: capture flow. Runs the native screencapture binary, writes the result to the clipboard, and opens preview windows.
 - `workspace/src/settings.js`: reads and writes settings.json under the Electron userData path.
+- `workspace/src/update.js`: update check against GitHub Releases, dmg download, and the bundle swap script.
 - `workspace/src/lib.js`: pure helpers (filename, settings merge, preview position). No electron imports so tests run with plain node.
 - `workspace/src/preload.js`: exposes `window.api` to renderers via contextBridge.
 - `workspace/src/renderer/`: two small pages. `settings.html` has a General tab (shortcut, save directory) and a Permissions tab; `preview.html` shows one captured image with Save and Delete buttons.
@@ -38,6 +39,20 @@ Save copies the temp file into the configured save directory as `akbun-screensho
 | `permissions:open-screen-settings` | Open macOS System Settings at the Screen Recording pane |
 | `preview:save` | Move the temp png to the save directory and close the preview |
 | `preview:delete` | Remove the temp png and close the preview |
+
+## Update
+
+The tray menu has Check for Updates. It reads the GitHub Releases API, finds the newest `akbun-screenshot-v` tag, and compares it with `app.getVersion()`. On a newer version the dialog offers Update Now, which downloads the arm64 dmg into a temp directory, writes a swap script, spawns it detached, and quits. The script waits for the app to exit, mounts the dmg, replaces the `.app` bundle with `ditto`, and relaunches. If `ditto` fails it restores the bundle it moved aside.
+
+The dmg is unsigned, so Squirrel.Mac auto update is not an option. A file the app downloads itself carries no quarantine attribute, which is what makes the in-place swap work.
+
+Temp cleanup happens in three places, and `workspace/test/update.test.js` checks all three:
+
+- `downloadDmg` removes its temp directory when the download fails.
+- The swap script's `trap` removes the mount point and work directory on any exit.
+- `cleanupTempDirs` on app start removes directories left by a killed process.
+
+Update Now is hidden when the app is not packaged, because in development the bundle would be Electron.app. That case shows Open Release instead.
 
 ## Settings
 

--- a/product/akbun-screenshot/wiki/development.md
+++ b/product/akbun-screenshot/wiki/development.md
@@ -12,7 +12,7 @@ npm install
 npm start
 ```
 
-Run the tests (pure functions only, no Electron binary needed):
+Run the tests (pure functions and the update temp file cleanup, no Electron binary needed):
 
 ```bash
 npm test

--- a/product/akbun-screenshot/workspace/src/main.js
+++ b/product/akbun-screenshot/workspace/src/main.js
@@ -53,8 +53,11 @@ async function installUpdate(dmgUrl) {
     await spawnSwap(appBundlePath(), dmgPath);
     app.quit();
   } catch (error) {
-    if (dmgPath) await fs.rm(path.dirname(dmgPath), { recursive: true, force: true });
+    // Clear the flag first. A throwing rm must not leave the menu item dead.
     updating = false;
+    if (dmgPath) {
+      await fs.rm(path.dirname(dmgPath), { recursive: true, force: true }).catch(() => {});
+    }
     await dialog.showMessageBox({
       type: 'error',
       message: 'Update failed',

--- a/product/akbun-screenshot/workspace/src/main.js
+++ b/product/akbun-screenshot/workspace/src/main.js
@@ -13,9 +13,11 @@ const {
   shell,
   systemPreferences,
 } = require('electron');
+const fs = require('node:fs/promises');
 const path = require('path');
 const { loadSettings, saveSettings } = require('./settings');
 const { captureArea, savePreview, deletePreview } = require('./capture');
+const { checkUpdate, cleanupTempDirs, downloadDmg, spawnSwap } = require('./update');
 
 let settings = loadSettings();
 let tray = null;
@@ -34,12 +36,87 @@ function registerShortcut(shortcut) {
   }
 }
 
+// Running .app bundle path. exe is <app>.app/Contents/MacOS/<binary>.
+function appBundlePath() {
+  return path.resolve(app.getPath('exe'), '../../..');
+}
+
+// Guard so a second click cannot start an overlapping download.
+let updating = false;
+
+// Download the dmg, start the swap script, quit. The script relaunches the app.
+async function installUpdate(dmgUrl) {
+  updating = true;
+  let dmgPath = null;
+  try {
+    dmgPath = await downloadDmg(dmgUrl);
+    await spawnSwap(appBundlePath(), dmgPath);
+    app.quit();
+  } catch (error) {
+    if (dmgPath) await fs.rm(path.dirname(dmgPath), { recursive: true, force: true });
+    updating = false;
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Update failed',
+      detail: String(error),
+    });
+  }
+}
+
+async function runUpdateCheck() {
+  if (updating) return;
+  try {
+    const result = await checkUpdate(app.getVersion());
+    if (!result.hasUpdate) {
+      await dialog.showMessageBox({
+        type: 'info',
+        message: 'You are on the latest version',
+        detail: `Current version ${result.current}`,
+      });
+      return;
+    }
+
+    // In development the bundle is Electron.app, so installing is blocked.
+    const canInstall = app.isPackaged && result.dmgUrl !== null;
+    const buttons = canInstall
+      ? ['Update Now', 'Open Release', 'Close']
+      : ['Open Release', 'Close'];
+    const detail = canInstall
+      ? `Current version ${result.current}. Update Now downloads the dmg, replaces the app, and relaunches it.`
+      : `Current version ${result.current}. Download the dmg from the release page.`;
+
+    const answer = await dialog.showMessageBox({
+      type: 'info',
+      message: `Version ${result.latest} is available`,
+      detail,
+      buttons,
+      defaultId: 0,
+      cancelId: buttons.length - 1,
+    });
+
+    if (canInstall && answer.response === 0) {
+      await installUpdate(result.dmgUrl);
+      return;
+    }
+    const openIndex = canInstall ? 1 : 0;
+    if (answer.response === openIndex && result.url) await shell.openExternal(result.url);
+  } catch (error) {
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Cannot check for updates',
+      detail: String(error),
+    });
+  }
+}
+
 function buildTrayMenu() {
   tray.setContextMenu(
     Menu.buildFromTemplate([
       { label: 'Capture Area', accelerator: settings.shortcut, click: capture },
       { label: 'Settings…', click: openSettingsWindow },
+      { label: 'Check for Updates…', click: () => void runUpdateCheck() },
       { type: 'separator' },
+      { label: `Version ${app.getVersion()}`, enabled: false },
       { label: 'Quit', role: 'quit' },
     ])
   );
@@ -104,6 +181,9 @@ ipcMain.handle('preview:save', (event) => savePreview(event.sender.id));
 ipcMain.handle('preview:delete', (event) => deletePreview(event.sender.id));
 
 app.whenReady().then(() => {
+  // Drop update temp dirs left by a killed process. Failure is harmless.
+  void cleanupTempDirs().catch(() => {});
+
   // menu bar app: no dock icon, no main window
   if (app.dock) app.dock.hide();
 

--- a/product/akbun-screenshot/workspace/src/update.js
+++ b/product/akbun-screenshot/workspace/src/update.js
@@ -17,7 +17,10 @@ const path = require('node:path');
 const { Readable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 
-const RELEASES_API = 'https://api.github.com/repos/choisungwook/portfolio/releases';
+// This repository releases several products, so one page of 30 would push this
+// app's newest release out of reach as releases pile up. 100 is the API maximum.
+const RELEASES_API =
+  'https://api.github.com/repos/choisungwook/portfolio/releases?per_page=100';
 const TAG_PREFIX = 'akbun-screenshot-v';
 const TEMP_PREFIX = 'akbun-screenshot-update-';
 

--- a/product/akbun-screenshot/workspace/src/update.js
+++ b/product/akbun-screenshot/workspace/src/update.js
@@ -1,0 +1,160 @@
+'use strict';
+
+// Checks GitHub Releases for a newer version and, if asked, downloads the dmg
+// and swaps the .app bundle in place. Same approach as akbun-k8supgradeview:
+// the app is unsigned, so Squirrel.Mac auto update is out. Files fetched by the
+// app itself get no quarantine attribute, so Gatekeeper does not block them.
+//
+// Temp files are the risk. Three cleanup points: downloadDmg on failure, the
+// swap script's trap, and cleanupTempDirs on app start for anything left by a
+// kill -9.
+
+const { spawn } = require('node:child_process');
+const { createWriteStream } = require('node:fs');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+const { Readable } = require('node:stream');
+const { pipeline } = require('node:stream/promises');
+
+const RELEASES_API = 'https://api.github.com/repos/choisungwook/portfolio/releases';
+const TAG_PREFIX = 'akbun-screenshot-v';
+const TEMP_PREFIX = 'akbun-screenshot-update-';
+
+// Neither fetch can be left without a deadline. A stalled connection would hang
+// the check, and hang the download with the install already marked in progress,
+// so the menu item stays dead until the app restarts. The download deadline
+// covers the streamed body, so it is generous rather than tuned to a fast link.
+const CHECK_TIMEOUT_MS = 15_000;
+const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+
+// Compare "0.2.0" strings. Positive when a is newer.
+function compareVersion(a, b) {
+  const left = a.split('.').map(Number);
+  const right = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((left[i] ?? 0) !== (right[i] ?? 0)) return (left[i] ?? 0) - (right[i] ?? 0);
+  }
+  return 0;
+}
+
+// Pick the dmg matching this arch. electron-builder suffixes arm64 only.
+function pickDmg(assets) {
+  const dmgs = assets.filter((asset) => asset.name.endsWith('.dmg'));
+  const wantArm = process.arch === 'arm64';
+  const match = dmgs.find((asset) => asset.name.includes('-arm64.') === wantArm);
+  return match?.browser_download_url ?? null;
+}
+
+async function checkUpdate(currentVersion) {
+  const response = await fetch(RELEASES_API, {
+    headers: { Accept: 'application/vnd.github+json' },
+    signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`GitHub API error: ${response.status}`);
+
+  const releases = await response.json();
+  const release = releases.find((entry) => entry.tag_name.startsWith(TAG_PREFIX));
+  if (!release) {
+    return { current: currentVersion, latest: null, url: null, dmgUrl: null, hasUpdate: false };
+  }
+
+  const latest = release.tag_name.slice(TAG_PREFIX.length);
+  return {
+    current: currentVersion,
+    latest,
+    url: release.html_url,
+    dmgUrl: pickDmg(release.assets),
+    hasUpdate: compareVersion(latest, currentVersion) > 0,
+  };
+}
+
+// Stream the dmg into a temp dir and return its path. Removes the dir on failure.
+async function downloadDmg(dmgUrl) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX));
+  try {
+    const response = await fetch(dmgUrl, {
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
+    if (!response.ok) throw new Error(`dmg download failed: ${response.status}`);
+    if (!response.body) throw new Error('empty dmg response body');
+    const dmgPath = path.join(dir, path.basename(new URL(dmgUrl).pathname));
+    await pipeline(Readable.fromWeb(response.body), createWriteStream(dmgPath));
+    return dmgPath;
+  } catch (error) {
+    await fs.rm(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+// Remove temp dirs left behind when the app or the swap script was killed.
+async function cleanupTempDirs() {
+  const tmpDir = os.tmpdir();
+  const names = await fs.readdir(tmpDir);
+  await Promise.all(
+    names
+      .filter((name) => name.startsWith(TEMP_PREFIX))
+      .map((name) => fs.rm(path.join(tmpDir, name), { recursive: true, force: true }))
+  );
+}
+
+// Waits for the app to quit, replaces the .app bundle, relaunches. Must run
+// outside the app because a running bundle cannot overwrite itself. Restores
+// the old bundle if ditto fails; the trap removes the mount and work dir.
+const SWAP_SCRIPT = `#!/bin/bash
+set -u
+APP="$1"; DMG="$2"; PID="$3"
+WORK=$(dirname "$DMG")
+MOUNT=""
+
+cleanup() {
+  if [ -n "$MOUNT" ]; then
+    hdiutil detach "$MOUNT" -quiet 2>/dev/null || hdiutil detach "$MOUNT" -force -quiet 2>/dev/null
+    rmdir "$MOUNT" 2>/dev/null
+  fi
+  # This script lives in WORK too. Already open, so removing it is fine.
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+while kill -0 "$PID" 2>/dev/null; do sleep 0.3; done
+
+MOUNT=$(mktemp -d) || exit 1
+hdiutil attach "$DMG" -nobrowse -quiet -mountpoint "$MOUNT" || exit 1
+NEW=$(find "$MOUNT" -maxdepth 1 -name '*.app' | head -1)
+[ -n "$NEW" ] || exit 1
+
+rm -rf "$APP.old"
+mv "$APP" "$APP.old" || exit 1
+if ditto "$NEW" "$APP"; then
+  rm -rf "$APP.old"
+else
+  rm -rf "$APP"
+  mv "$APP.old" "$APP"
+  exit 1
+fi
+
+xattr -cr "$APP"
+open "$APP"
+`;
+
+// Start the swap script detached. The caller must app.quit() right after.
+async function spawnSwap(appPath, dmgPath) {
+  const scriptPath = path.join(path.dirname(dmgPath), 'swap.sh');
+  await fs.writeFile(scriptPath, SWAP_SCRIPT, { mode: 0o755 });
+  const child = spawn('/bin/bash', [scriptPath, appPath, dmgPath, String(process.pid)], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  child.unref();
+}
+
+module.exports = {
+  checkUpdate,
+  cleanupTempDirs,
+  compareVersion,
+  downloadDmg,
+  pickDmg,
+  spawnSwap,
+  SWAP_SCRIPT,
+};

--- a/product/akbun-screenshot/workspace/test/update.test.js
+++ b/product/akbun-screenshot/workspace/test/update.test.js
@@ -91,6 +91,18 @@ test('the swap script leaves no work dir when it fails', () => {
   assert.ok(!fs.existsSync(work), 'the failed swap left its work dir behind');
 });
 
+// Both fetches need a deadline. Without one a stalled connection hangs the
+// check with no way back, and hangs the download with the install already
+// marked in progress, which kills the menu item until the app restarts.
+// Waiting out a real timeout is not worth the test time, so the wiring is what
+// gets checked.
+test('both fetch calls carry a timeout', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../src/update.js'), 'utf-8');
+  const signals = source.match(/signal: AbortSignal\.timeout\(/g) || [];
+
+  assert.strictEqual(signals.length, 2, 'a fetch lost its deadline');
+});
+
 test('all three cleanup points are still wired up', () => {
   const mainSource = fs.readFileSync(path.join(__dirname, '../src/main.js'), 'utf-8');
 

--- a/product/akbun-screenshot/workspace/test/update.test.js
+++ b/product/akbun-screenshot/workspace/test/update.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+// The update path downloads a large dmg into a temp dir. Miss one cleanup point
+// and every failed attempt fills the disk, so all three are checked here:
+// downloadDmg on failure, the swap script's trap, and cleanupTempDirs on start.
+// The swap script test also runs where hdiutil is absent — the attach failure is
+// exactly the path under test.
+
+const assert = require('node:assert');
+const { test } = require('node:test');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  cleanupTempDirs,
+  compareVersion,
+  downloadDmg,
+  pickDmg,
+  SWAP_SCRIPT,
+} = require('../src/update');
+
+const TEMP_PREFIX = 'akbun-screenshot-update-';
+
+function countTempDirs() {
+  return fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith(TEMP_PREFIX)).length;
+}
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), TEMP_PREFIX));
+}
+
+test('compareVersion orders releases by number, not string', () => {
+  assert.ok(compareVersion('0.10.0', '0.9.0') > 0);
+  assert.ok(compareVersion('0.1.0', '0.1.1') < 0);
+  assert.strictEqual(compareVersion('1.0.0', '1.0.0'), 0);
+});
+
+test('pickDmg matches the running architecture', () => {
+  const assets = [
+    { name: 'akbun-screenshot-0.2.0-arm64.dmg', browser_download_url: 'arm' },
+    { name: 'akbun-screenshot-0.2.0.dmg', browser_download_url: 'x64' },
+    { name: 'akbun-screenshot-0.2.0.zip', browser_download_url: 'zip' },
+  ];
+  assert.strictEqual(pickDmg(assets), process.arch === 'arm64' ? 'arm' : 'x64');
+  assert.strictEqual(pickDmg([{ name: 'notes.txt', browser_download_url: 'x' }]), null);
+});
+
+test('cleanupTempDirs removes only update temp dirs', async () => {
+  const stale = makeTempDir();
+  fs.writeFileSync(path.join(stale, 'leftover.dmg'), 'x'.repeat(1024));
+  const unrelated = fs.mkdtempSync(path.join(os.tmpdir(), 'unrelated-'));
+
+  try {
+    assert.ok(countTempDirs() > 0, 'the dir this test created should be visible');
+    await cleanupTempDirs();
+
+    assert.strictEqual(countTempDirs(), 0, 'an update temp dir was left behind');
+    assert.ok(fs.existsSync(unrelated), 'unrelated dirs must survive');
+  } finally {
+    fs.rmSync(unrelated, { recursive: true, force: true });
+  }
+});
+
+test('downloadDmg removes its temp dir when the download fails', async () => {
+  await cleanupTempDirs();
+
+  // Connection refused, so this fails immediately without network access.
+  await assert.rejects(() => downloadDmg('http://127.0.0.1:1/akbun-screenshot.dmg'));
+
+  assert.strictEqual(countTempDirs(), 0, 'a failed download left its dir behind');
+});
+
+test('the swap script leaves no work dir when it fails', () => {
+  const work = makeTempDir();
+  const scriptPath = path.join(work, 'swap.sh');
+  const dmgPath = path.join(work, 'fake.dmg');
+  fs.writeFileSync(scriptPath, SWAP_SCRIPT, { mode: 0o755 });
+  fs.writeFileSync(dmgPath, 'not a dmg, so attach fails');
+
+  // A finished process id makes the wait loop exit right away.
+  const deadPid = spawnSync('/usr/bin/true').pid;
+  const appPath = path.join(work, 'nonexistent.app');
+
+  const result = spawnSync('/bin/bash', [scriptPath, appPath, dmgPath, String(deadPid)], {
+    stdio: 'ignore',
+    timeout: 30_000,
+  });
+
+  assert.notStrictEqual(result.status, 0, 'a bogus dmg must not succeed');
+  assert.ok(!fs.existsSync(work), 'the failed swap left its work dir behind');
+});
+
+test('all three cleanup points are still wired up', () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, '../src/main.js'), 'utf-8');
+
+  assert.match(SWAP_SCRIPT, /trap cleanup EXIT/, 'the swap script trap is gone');
+  assert.match(mainSource, /cleanupTempDirs/, 'app start does not clean leftovers');
+  assert.match(mainSource, /fs\.rm\(/, 'a failed install does not remove the dmg');
+});


### PR DESCRIPTION
# Goal

Updating akbun-screenshot meant finding the release page and downloading the dmg by hand. This PR adds Check for Updates to the menu bar icon. It compares the running version with the newest release and replaces the app in place.

# Decisions

The update entry point lives in the tray menu, next to the current version.
- The app hides its dock icon and has no main window, so there is no application menu to put it in. The tray menu is the only place the user meets the app.
- The version sits in the same menu as a disabled row, so the user can tell whether an update is worth checking.

**[Important]** We download the dmg ourselves and swap the .app bundle instead of using electron-updater.
- The dmg is unsigned, so Squirrel.Mac auto update is not available.
- A file the app downloads itself carries no quarantine attribute, so Gatekeeper does not inspect the replacement.

We ported akbun-mactaskbar update.js rather than writing a new one.
- It already works against the same release shape: the akbun-screenshot-v tag prefix and an arm64 dmg.

# Implementation

Check for Updates reads the GitHub Releases API, picks the dmg matching the running architecture, and hands the swap to a detached bash script.
- The script waits for the app to exit, mounts the dmg, replaces the bundle with ditto, and relaunches. A failed ditto restores the bundle it moved aside.
- Update Now is hidden when the app is not packaged, because the bundle would be Electron.app in development. That case offers Open Release instead.

**[Important]** Both fetches carry a deadline: 15s for the check, 10m for the download.
- Without one a stalled connection hangs the check, and hangs the download with the in progress flag still set, leaving the menu item dead until the app restarts.

Temp file cleanup happens in three places and test/update.test.js covers all three.
- downloadDmg removes its temp directory when the download fails, the swap script traps EXIT, and cleanupTempDirs sweeps leftovers at app start.
- 10 tests pass with plain node, so the ubuntu verify job still runs them without the Electron binary.

Issue #605