### PR TITLE
feat(akbun-folderview): thumbnail cache, split rescan and refresh, list view

### DIFF
--- a/knowledge/decisions/2026-08-thumbnails-in-the-webview.md
+++ b/knowledge/decisions/2026-08-thumbnails-in-the-webview.md
@@ -1,0 +1,22 @@
+---
+type: Decision
+title: Tauri 앱의 썸네일은 webview가 그리고 Rust는 바이트만 저장한다
+description: akbun-folderview의 썸네일 캐시를 Rust 이미지 라이브러리 없이 canvas로 생성하기로 한 결정.
+tags: [tauri, desktop, performance]
+timestamp: 2026-08-01T00:00:00Z
+---
+
+## 결정
+
+akbun-folderview의 썸네일 캐시는 webview가 만든다. 카드의 img가 onerror를 내면 페이지가 원본을 asset protocol로 한 번 읽어 canvas로 축소하고, JPEG 바이트를 save_thumb 명령으로 넘긴다. Rust는 이름을 검증하고 파일로 쓸 뿐 이미지 라이브러리를 갖지 않는다. 파일명은 경로+mtime+size의 FNV-1a 해시라서 파일이 바뀌면 새 썸네일이 되고, 갱신을 추적할 상태가 없다.
+
+## 이유
+
+- Rust에서 image crate로 디코딩하면 heic와 동영상은 어차피 못 다룬다. webview의 Chromium 코덱을 쓰면 화면에 표시되는 포맷과 썸네일이 되는 포맷이 정확히 일치한다. 동영상 포스터 프레임도 video 엘리먼트 seek로 같은 경로로 얻는다.
+- image crate는 빌드 시간과 CI 캐시를 키운다. tauri 앱 crate는 이미 무겁고, 순수 모델 crate 분리로 얻은 CI 이점을 지키고 싶었다.
+- 생성이 페이지에 있으면 loading="lazy"의 onerror가 자연스러운 생성 큐 창이 된다. 뷰포트 근처 카드만 생성을 요청하므로 우선순위 로직이 공짜다.
+- 느린 디스크 보호(동시 2개, 30초 타임아웃)도 페이지의 큐 하나로 끝난다. Rust 쪽 스레드 풀 관리가 필요 없다.
+
+같은 상황의 다른 Tauri product에도 이 구성을 기본으로 한다. 단, blob URL로 갓 만든 썸네일을 보여주므로 CSP img-src에 blob:이 필요하고, 생성용 video 엘리먼트 때문에 media-src도 유지해야 한다.
+
+관련: [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](2026-07-unsigned-desktop-app-self-update.md)

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -18,3 +18,4 @@
 * [GitHub App installation tokens as the recommended auth for the terraform bot](2026-07-github-app-tokens-for-terraform-bot.md) - 장기 PAT 대신 1시간짜리 App installation token을 권장 인증으로 두는 결정.
 * [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](2026-07-unsigned-desktop-app-self-update.md) - electron-updater가 막힌 상황에서 dmg 교체 방식을 모든 데스크톱 product의 기본으로 두는 결정.
 * [PR body 형식의 기준은 pull request template 하나다](2026-07-pr-body-format-in-template.md) - PR body를 Decisions와 Implementation으로 바꾸고 형식을 template 한 곳에만 두는 결정.
+* [Tauri 앱의 썸네일은 webview가 그리고 Rust는 바이트만 저장한다](2026-08-thumbnails-in-the-webview.md) - akbun-folderview의 썸네일 캐시를 Rust 이미지 라이브러리 없이 canvas로 생성하기로 한 결정.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-01
+
+* **Creation**: [Tauri 앱의 썸네일은 webview가 그리고 Rust는 바이트만 저장한다](decisions/2026-08-thumbnails-in-the-webview.md) 결정 기록. akbun-folderview에 썸네일 캐시를 넣어 외장하드 시작 멈춤을 고치면서 남긴다.
+
 ## 2026-07-31
 
 * **Creation**: [PR body 형식의 기준은 pull request template 하나다](decisions/2026-07-pr-body-format-in-template.md) 결정 기록. PR body를 Decisions와 Implementation으로 바꾸면서 형식이 네 파일에 흩어져 있던 문제를 함께 정리한다.

--- a/product/akbun-folderview/wiki/architecture.md
+++ b/product/akbun-folderview/wiki/architecture.md
@@ -127,20 +127,20 @@ pub fn allow_asset_dir(app: &AppHandle, path: &str) {
 The CSP has to name both `img-src` and `media-src` for the asset protocol. Tauri does not add them, and with `img-src` alone every video thumbnail is blocked. The policy in `tauri.conf.json`:
 
 ```
-default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' asset: http://asset.localhost https://asset.localhost data:; media-src 'self' asset: http://asset.localhost https://asset.localhost
+default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost
 ```
 
-Both schemes are listed because the URL `convertFileSrc` produces differs by platform.
+Both schemes are listed because the URL `convertFileSrc` produces differs by platform. `blob:` in `img-src` is for a freshly generated thumbnail, which is shown from the blob that was just drawn rather than re-requested from the cache URL the browser has already remembered a 404 for. `media-src` stays even though the grid no longer holds `<video>` elements, because thumbnail generation still reads the video through one.
 
 ## Thumbnails
 
-A photo is an `<img loading="lazy">` pointed at the asset URL. A video is a `<video>` with `preload="metadata"` and a `#t=0.5` fragment:
+A card is an `<img loading="lazy">` pointed at a cached thumbnail under the app config directory (`thumbs/`), not at the original file. That is what keeps a start from touching the added folders' disk at all: the first version pointed every card at the original, and two hundred concurrent reads against a spinning external drive froze the first paint.
 
-```html
-<video src="asset://.../clip.mp4#t=0.5" preload="metadata" muted></video>
-```
+The cache fills lazily in the page. When a card's thumbnail is missing the `<img>` fires `onerror`, the original is read once through the asset protocol, drawn small on a canvas, and the JPEG bytes go to the `save_thumb` command. Rust needs no image library this way, and the formats that thumbnail are exactly the formats the webview can display. For a video the frame at `0.5s` is drawn from a `<video>` element, and Settings can turn video thumbnails off entirely, because a poster frame costs a read of the video file itself. `loading="lazy"` means only cards near the viewport fire `onerror`, and the queue runs two reads at a time so a slow disk stays responsive.
 
-The engine seeks to that second and paints the frame, which is a poster image without decoding the file ourselves. It works because the asset protocol answers Range requests and a video element always sends one; `preload="metadata"` then pulls the header and just enough around the seek point instead of the whole file.
+The thumbnail file name is an FNV-1a hash of path, mtime and size (`thumbName` in `library.js`), so an edited file gets a fresh thumbnail and the stale one is simply never asked for again. A read that fails — the drive is unplugged — is remembered for the session and the card shows "no preview" instead of retrying on every render.
+
+Refresh Thumbs in the sidebar is deliberately a separate button from Rescan Disk: Rescan walks the roots for new and removed files, Refresh throws the `thumbs/` folder away (`clear_thumbs`) so thumbnails rebuild from the originals. Dropping the whole folder is also what cleans up thumbnails orphaned by renames and deletes.
 
 File names are escaped before they reach `innerHTML`. A name is data from the disk, and without escaping a file called `<img onerror=...>.jpg` would run its own script inside the window.
 

--- a/product/akbun-folderview/workspace/package.json
+++ b/product/akbun-folderview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-folderview",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Windows desktop browser for a hand-picked photo and video library with tags, ratings and instant search",
   "author": "akbun",

--- a/product/akbun-folderview/workspace/src-tauri/crates/library/src/lib.rs
+++ b/product/akbun-folderview/workspace/src-tauri/crates/library/src/lib.rs
@@ -55,6 +55,11 @@ pub struct Settings {
     /// here too. Single click is offered because this window is a viewer.
     pub open_on_single_click: bool,
     pub card_size: u32,
+    /// "grid" is thumbnail cards, "list" is detail rows like the file explorer.
+    pub view: String,
+    /// A video poster frame costs a read of the video file itself, so it can
+    /// be turned off for a slow disk.
+    pub show_video_thumbs: bool,
 }
 
 impl Default for Settings {
@@ -63,6 +68,8 @@ impl Default for Settings {
             theme: "system".to_string(),
             open_on_single_click: false,
             card_size: 180,
+            view: "grid".to_string(),
+            show_video_thumbs: true,
         }
     }
 }
@@ -209,5 +216,7 @@ mod tests {
         assert_eq!(parsed.theme, "dark");
         assert_eq!(parsed.card_size, 180);
         assert!(!parsed.open_on_single_click);
+        assert_eq!(parsed.view, "grid");
+        assert!(parsed.show_video_thumbs);
     }
 }

--- a/product/akbun-folderview/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-folderview/workspace/src-tauri/src/commands.rs
@@ -29,6 +29,7 @@ pub struct Snapshot {
     pub settings: Settings,
     pub version: String,
     pub data_dir: String,
+    pub thumbs_dir: String,
 }
 
 /// Let the webview read this folder through the asset protocol.
@@ -55,6 +56,9 @@ fn snapshot(app: &AppHandle, state: &State<AppState>) -> Snapshot {
         settings: state.settings.lock().unwrap().clone(),
         version: app.package_info().version.to_string(),
         data_dir: store::data_dir(app),
+        thumbs_dir: store::thumbs_dir(app)
+            .map(|dir| dir.to_string_lossy().to_string())
+            .unwrap_or_default(),
     }
 }
 
@@ -280,6 +284,29 @@ pub fn open_data_dir(app: AppHandle) -> Result<(), String> {
     app.opener()
         .open_path(dir, None::<&str>)
         .map_err(|error| error.to_string())
+}
+
+/// The page generates thumbnails with its own codecs and hands the JPEG bytes
+/// here, so Rust needs no image library and the formats that display are
+/// exactly the formats that thumbnail.
+#[tauri::command]
+pub fn save_thumb(app: AppHandle, name: String, bytes: Vec<u8>) -> Result<(), String> {
+    // The name is computed in the page. Reject anything that could step out
+    // of the thumbs folder.
+    if name.is_empty() || name.contains(['/', '\\']) || name.contains("..") {
+        return Err("bad thumbnail name".into());
+    }
+    let dir = store::thumbs_dir(&app)?;
+    std::fs::write(dir.join(&name), bytes).map_err(|error| error.to_string())
+}
+
+/// Refresh Thumbnails in the page. Dropping the whole folder is also what
+/// cleans up thumbnails orphaned by renames and deletes.
+#[tauri::command]
+pub fn clear_thumbs(app: AppHandle) -> Result<(), String> {
+    let dir = store::thumbs_dir(&app)?;
+    std::fs::remove_dir_all(&dir).map_err(|error| error.to_string())?;
+    std::fs::create_dir_all(&dir).map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/product/akbun-folderview/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-folderview/workspace/src-tauri/src/commands.rs
@@ -291,10 +291,17 @@ pub fn open_data_dir(app: AppHandle) -> Result<(), String> {
 /// exactly the formats that thumbnail.
 #[tauri::command]
 pub fn save_thumb(app: AppHandle, name: String, bytes: Vec<u8>) -> Result<(), String> {
-    // The name is computed in the page. Reject anything that could step out
-    // of the thumbs folder.
-    if name.is_empty() || name.contains(['/', '\\']) || name.contains("..") {
+    // The name comes from the page, so it is held to exactly what thumbName
+    // produces: sixteen hex digits and .jpg. Nothing else can land in the
+    // thumbs folder, and nothing can step out of it.
+    let hex = name.strip_suffix(".jpg").unwrap_or_default();
+    if hex.len() != 16 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err("bad thumbnail name".into());
+    }
+    // A 512px JPEG is tens of kilobytes; anything near this cap is a bug, not
+    // a thumbnail.
+    if bytes.len() > 2 * 1024 * 1024 {
+        return Err("thumbnail too large".into());
     }
     let dir = store::thumbs_dir(&app)?;
     std::fs::write(dir.join(&name), bytes).map_err(|error| error.to_string())

--- a/product/akbun-folderview/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-folderview/workspace/src-tauri/src/lib.rs
@@ -59,6 +59,11 @@ pub fn run() {
             for entry in &library.entries {
                 commands::allow_asset_file(handle, &entry.path);
             }
+            // The grid reads cached thumbnails instead of the originals, so
+            // this local folder is the only thing a normal start touches.
+            if let Ok(thumbs) = store::thumbs_dir(handle) {
+                commands::allow_asset_dir(handle, &thumbs.to_string_lossy());
+            }
 
             app.manage(AppState {
                 library: Mutex::new(library),
@@ -80,6 +85,8 @@ pub fn run() {
             commands::copy_path,
             commands::open_data_dir,
             commands::save_settings,
+            commands::save_thumb,
+            commands::clear_thumbs,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/product/akbun-folderview/workspace/src-tauri/src/store.rs
+++ b/product/akbun-folderview/workspace/src-tauri/src/store.rs
@@ -54,6 +54,18 @@ pub fn save_library(app: &AppHandle, library: &Library) -> Result<(), String> {
     write_json(app, "library.json", library)
 }
 
+/// Where cached thumbnails live. Created on demand, so clearing the cache is
+/// just removing the folder.
+pub fn thumbs_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|error| format!("no config directory: {error}"))?
+        .join("thumbs");
+    std::fs::create_dir_all(&dir).map_err(|error| format!("cannot create {dir:?}: {error}"))?;
+    Ok(dir)
+}
+
 pub fn load_settings(app: &AppHandle) -> Settings {
     read_json(app, "settings.json")
 }

--- a/product/akbun-folderview/workspace/src-tauri/tauri.conf.json
+++ b/product/akbun-folderview/workspace/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' asset: http://asset.localhost https://asset.localhost data:; media-src 'self' asset: http://asset.localhost https://asset.localhost",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' asset: http://asset.localhost https://asset.localhost data: blob:; media-src 'self' asset: http://asset.localhost https://asset.localhost",
       "assetProtocol": {
         "enable": true,
         "scope": []

--- a/product/akbun-folderview/workspace/src/api.js
+++ b/product/akbun-folderview/workspace/src/api.js
@@ -151,12 +151,17 @@ window.api = {
   // this throws away the cached thumbnails so they are rebuilt from originals.
   refreshThumbs: async () => {
     const confirmed = await ask(
-      'Throw away all cached thumbnails and rebuild them from the original files?\n\nThe originals must be reachable to rebuild.',
+      'Throw away all cached thumbnails?\n\nThey are rebuilt from the original files as cards come into view, so the originals must be reachable.',
       { title: 'Refresh Thumbnails' }
     );
     if (!confirmed) return false;
-    await invoke('clear_thumbs');
-    return true;
+    try {
+      await invoke('clear_thumbs');
+      return true;
+    } catch (error) {
+      await message(String(error), { title: 'Refresh failed', kind: 'error' });
+      return false;
+    }
   },
 
   saveSettings: (settings) => invoke('save_settings', { settings }),

--- a/product/akbun-folderview/workspace/src/api.js
+++ b/product/akbun-folderview/workspace/src/api.js
@@ -144,6 +144,21 @@ window.api = {
     await menu.popup();
   },
 
+  // The page draws the thumbnail on a canvas and hands the JPEG bytes over.
+  saveThumb: (name, bytes) => invoke('save_thumb', { name, bytes }),
+
+  // Distinct from Rescan on purpose: Rescan walks the disk for file changes,
+  // this throws away the cached thumbnails so they are rebuilt from originals.
+  refreshThumbs: async () => {
+    const confirmed = await ask(
+      'Throw away all cached thumbnails and rebuild them from the original files?\n\nThe originals must be reachable to rebuild.',
+      { title: 'Refresh Thumbnails' }
+    );
+    if (!confirmed) return false;
+    await invoke('clear_thumbs');
+    return true;
+  },
+
   saveSettings: (settings) => invoke('save_settings', { settings }),
   checkUpdate,
 };

--- a/product/akbun-folderview/workspace/src/index.html
+++ b/product/akbun-folderview/workspace/src/index.html
@@ -27,13 +27,18 @@
         <section class="panel">
           <header class="panel-head">
             <h2>Catalog</h2>
-            <div class="panel-actions">
-              <button id="rescan" title="Look for new and removed files">Rescan</button>
-              <button id="open-settings" title="Settings and updates">Settings</button>
-            </div>
           </header>
           <div class="panel-body" id="catalog"></div>
         </section>
+
+        <!-- App-wide actions, pinned so a long catalog cannot push them away.
+             Rescan and Refresh Thumbs are deliberately two buttons: one walks
+             the disk for file changes, the other rebuilds the thumbnail cache. -->
+        <footer class="sidebar-foot">
+          <button id="rescan" title="Walk the added folders for new and removed files">Rescan Disk</button>
+          <button id="refresh-thumbs" title="Throw away cached thumbnails and rebuild them">Refresh Thumbs</button>
+          <button id="open-settings" title="Settings and updates">Settings</button>
+        </footer>
       </aside>
 
       <main class="main">
@@ -52,6 +57,10 @@
             <button data-token="type:video">Videos</button>
             <button data-token="fav">Favorites</button>
             <button data-token="rating:>=4">4 stars and up</button>
+          </div>
+          <div class="filters" id="views">
+            <button id="view-grid" title="Thumbnail cards">Grid</button>
+            <button id="view-list" title="Details like the file explorer">List</button>
           </div>
         </div>
 
@@ -92,6 +101,9 @@
         </label>
         <label class="inline">
           <input id="set-single-click" type="checkbox" /> Open a file with a single click
+        </label>
+        <label class="inline">
+          <input id="set-video-thumbs" type="checkbox" /> Show video thumbnails
         </label>
         <label>Card size<input id="set-card-size" type="range" min="120" max="320" step="20" /></label>
         <dl class="facts">

--- a/product/akbun-folderview/workspace/src/library.js
+++ b/product/akbun-folderview/workspace/src/library.js
@@ -158,6 +158,19 @@ function buildTree(roots, entries) {
   });
 }
 
+// The thumbnail file name for an entry. Path, mtime and size together, so an
+// edited or replaced file gets a fresh thumbnail and the stale one is simply
+// never asked for again. FNV-1a, 64 bits so a large library will not collide.
+function thumbName(filePath, mtime, size) {
+  const text = `${filePath}|${mtime}|${size}`;
+  let hash = 0xcbf29ce484222325n;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= BigInt(text.charCodeAt(i));
+    hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+  }
+  return `${hash.toString(16).padStart(16, '0')}.jpg`;
+}
+
 function formatSize(bytes) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   let value = bytes;
@@ -181,6 +194,7 @@ const exported = {
   ratingCounts,
   searchEntries,
   tagCounts,
+  thumbName,
 };
 
 // Loaded two ways on purpose. The tests require it; the page takes it as a

--- a/product/akbun-folderview/workspace/src/renderer.js
+++ b/product/akbun-folderview/workspace/src/renderer.js
@@ -251,22 +251,150 @@ function renderCatalog() {
     .join('');
 }
 
-function thumb(entry) {
-  if (entry.kind === 'video') {
-    // The #t fragment makes Chromium seek to that second and paint the frame,
-    // which is a poster image without decoding the file ourselves.
-    return `<video src="${fileUrl(entry.path)}#t=0.5" preload="metadata" muted></video>
-            <span class="badge">VIDEO</span>`;
+/* ------------------------------------------------------------- thumbnails */
+
+// A card reads a small cached JPEG instead of the original file, so a normal
+// start never touches the added folders' disk — the reason a slow external
+// drive froze the first paint. The cache fills lazily: when a card's
+// thumbnail is missing, the original is read once, drawn small on a canvas,
+// and the JPEG bytes are handed to Rust to keep for every later run.
+const THUMB_EDGE = 512;
+// ponytail: 2 concurrent reads keeps a spinning external disk responsive.
+// Make it a setting if a fast NAS ever needs more.
+const THUMB_JOBS = 2;
+const thumbQueue = [];
+const thumbQueued = new Set();
+// A drive that is unplugged fails every read. Remembered for the session so a
+// dead disk is asked once per file, not once per render.
+const thumbFailed = new Set();
+const thumbWaiting = new Map();
+let thumbActive = 0;
+
+function thumbUrl(entry) {
+  return fileUrl(`${state.thumbsDir}/${lib.thumbName(entry.path, entry.mtime, entry.size)}`);
+}
+
+function markMissing(img) {
+  const host = img.closest('.thumb');
+  if (host) host.classList.add('missing');
+  img.remove();
+}
+
+// A read from a dying disk can hang rather than fail, and it would pin one of
+// the queue slots forever.
+function withTimeout(promise, seconds) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('timed out')), seconds * 1000);
+    promise.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}
+
+function drawThumb(source, width, height) {
+  const scale = Math.min(1, THUMB_EDGE / Math.max(width, height, 1));
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(width * scale));
+  canvas.height = Math.max(1, Math.round(height * scale));
+  canvas.getContext('2d').drawImage(source, 0, 0, canvas.width, canvas.height);
+  return new Promise((resolve, reject) =>
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('cannot draw'))), 'image/jpeg', 0.82)
+  );
+}
+
+function loadPhoto(path) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error(`cannot read ${path}`));
+    image.src = fileUrl(path);
+  }).then((image) => drawThumb(image, image.naturalWidth, image.naturalHeight));
+}
+
+function loadVideoFrame(path) {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video');
+    video.muted = true;
+    video.preload = 'auto';
+    // Clearing src releases the file handle, or a later rename or delete of
+    // the video would fail while this element is still holding it.
+    const done = (blob, error) => {
+      video.removeAttribute('src');
+      video.load();
+      if (error) reject(error);
+      else resolve(blob);
+    };
+    video.onerror = () => done(null, new Error(`cannot read ${path}`));
+    video.onloadedmetadata = () => {
+      video.currentTime = Math.min(0.5, video.duration || 0);
+    };
+    video.onseeked = () =>
+      drawThumb(video, video.videoWidth, video.videoHeight).then(done, (error) => done(null, error));
+    video.src = fileUrl(path);
+  });
+}
+
+async function makeThumb(entry) {
+  const blob =
+    entry.kind === 'video' ? await loadVideoFrame(entry.path) : await loadPhoto(entry.path);
+  const bytes = Array.from(new Uint8Array(await blob.arrayBuffer()));
+  await window.api.saveThumb(lib.thumbName(entry.path, entry.mtime, entry.size), bytes);
+  return blob;
+}
+
+function showThumb(path, blob) {
+  const img = thumbWaiting.get(path);
+  if (!img || !img.isConnected) return;
+  // The blob that was just drawn is shown directly; the saved file serves the
+  // next run. Re-pointing at the cache here could hit the 404 the browser
+  // already remembers for this URL.
+  img.onerror = () => markMissing(img);
+  img.onload = () => URL.revokeObjectURL(img.src);
+  img.src = URL.createObjectURL(blob);
+}
+
+function pumpThumbs() {
+  while (thumbActive < THUMB_JOBS && thumbQueue.length > 0) {
+    const entry = thumbQueue.shift();
+    thumbActive += 1;
+    withTimeout(makeThumb(entry), 30)
+      .then((blob) => showThumb(entry.path, blob))
+      .catch(() => {
+        thumbFailed.add(entry.path);
+        const img = thumbWaiting.get(entry.path);
+        if (img && img.isConnected) markMissing(img);
+      })
+      .finally(() => {
+        thumbQueued.delete(entry.path);
+        thumbWaiting.delete(entry.path);
+        thumbActive -= 1;
+        pumpThumbs();
+      });
   }
-  return `<img src="${fileUrl(entry.path)}" loading="lazy" alt="" />`;
+}
+
+function requestThumb(entry, img) {
+  if (thumbFailed.has(entry.path)) return markMissing(img);
+  if (!thumbQueued.has(entry.path)) {
+    thumbQueued.add(entry.path);
+    thumbQueue.push(entry);
+  }
+  // The latest rendered card wins; an older one is disconnected by now.
+  thumbWaiting.set(entry.path, img);
+  pumpThumbs();
+}
+
+function thumb(entry) {
+  const badge = entry.kind === 'video' ? '<span class="badge">VIDEO</span>' : '';
+  if (entry.kind === 'video' && !state.settings.showVideoThumbs) return badge;
+  return `<img src="${thumbUrl(entry)}" loading="lazy" alt="" />${badge}`;
 }
 
 function card(entry) {
   const element = document.createElement('div');
   element.className = 'card';
   element.dataset.path = entry.path;
+  const videoOff = entry.kind === 'video' && !state.settings.showVideoThumbs;
   element.innerHTML = `
-    <div class="thumb">${thumb(entry)}</div>
+    <div class="thumb${videoOff ? ' off' : ''}">${thumb(entry)}</div>
     <div class="card-body">
       <div class="card-name" title="${escapeHtml(entry.path)}">${escapeHtml(entry.name)}</div>
       <div class="card-meta">
@@ -275,6 +403,26 @@ function card(entry) {
       </div>
       <div>${entry.tags.map((tag) => `<span class="tag-chip">${escapeHtml(tag)}</span>`).join('')}</div>
     </div>`;
+  // A missing thumbnail is the signal to build one. loading="lazy" means only
+  // cards near the viewport fire this, which is the queue's natural window.
+  const img = element.querySelector('.thumb img');
+  if (img) img.onerror = () => requestThumb(entry, img);
+  return element;
+}
+
+// Detail rows like the file explorer. No images at all, which also makes it
+// the fast view for a disk with no thumbnails yet.
+function listRow(entry) {
+  const element = document.createElement('div');
+  element.className = 'list-item';
+  element.dataset.path = entry.path;
+  element.innerHTML = `
+    <span class="list-name" title="${escapeHtml(entry.path)}">${escapeHtml(entry.name)}</span>
+    ${entry.kind === 'video' ? '<span class="badge">VIDEO</span>' : ''}
+    <span class="stars">${starsHtml(entry.rating)}</span>
+    <span class="fav ${entry.favorite ? 'on' : ''}" data-fav="1">${entry.favorite ? '♥' : '♡'}</span>
+    <span class="list-size">${lib.formatSize(entry.size)}</span>
+    <span class="list-date">${entry.mtime ? new Date(entry.mtime).toLocaleDateString() : ''}</span>`;
   return element;
 }
 
@@ -291,13 +439,22 @@ function syncTokens() {
   }
 }
 
+function syncViews() {
+  const listMode = state.settings.view === 'list';
+  $('view-grid').classList.toggle('on', !listMode);
+  $('view-list').classList.toggle('on', listMode);
+}
+
 function renderGrid() {
   const matches = visibleEntries();
   const page = matches.slice(0, state.shown);
+  const listMode = state.settings.view === 'list';
 
   const grid = $('grid');
   grid.textContent = '';
-  for (const entry of page) grid.append(card(entry));
+  grid.classList.toggle('list', listMode);
+  for (const entry of page) grid.append(listMode ? listRow(entry) : card(entry));
+  syncViews();
 
   const where = state.folder ? ` in ${state.folder}` : '';
   $('status').textContent =
@@ -319,7 +476,7 @@ function render() {
 /* ------------------------------------------------------------ file actions */
 
 function entryAt(element) {
-  const host = element.closest('.card');
+  const host = element.closest('.card, .list-item');
   return host ? state.entries.find((entry) => entry.path === host.dataset.path) : null;
 }
 
@@ -386,6 +543,7 @@ async function saveProperties() {
 function openSettings() {
   $('set-theme').value = state.settings.theme;
   $('set-single-click').checked = state.settings.openOnSingleClick;
+  $('set-video-thumbs').checked = state.settings.showVideoThumbs;
   $('set-card-size').value = state.settings.cardSize;
   $('set-data-dir').textContent = state.dataDir;
   $('set-version').textContent = state.version;
@@ -393,12 +551,18 @@ function openSettings() {
 }
 
 async function saveCurrentSettings() {
+  // Spread first: the view mode lives in settings but is set from the
+  // toolbar, and rebuilding from the dialog alone would drop it.
   state.settings = {
+    ...state.settings,
     theme: $('set-theme').value,
     openOnSingleClick: $('set-single-click').checked,
+    showVideoThumbs: $('set-video-thumbs').checked,
     cardSize: Number($('set-card-size').value),
   };
   applySettings();
+  // Toggling video thumbnails changes what the cards show.
+  renderGrid();
   await window.api.saveSettings(state.settings);
 }
 
@@ -411,9 +575,46 @@ function applySettings() {
 
 /* ------------------------------------------------------------------- wiring */
 
-$('add-folder').addEventListener('click', () => window.api.addFolder());
+// A walk of a big or slow disk takes a while. The command runs off the main
+// thread, so the window stays alive; this makes the wait visible instead of
+// looking like a dead button.
+async function busy(button, label, task) {
+  const original = button.textContent;
+  button.disabled = true;
+  button.textContent = label;
+  try {
+    return await task();
+  } finally {
+    button.disabled = false;
+    button.textContent = original;
+  }
+}
+
+$('add-folder').addEventListener('click', () =>
+  busy($('add-folder'), 'Scanning…', () => window.api.addFolder())
+);
 $('add-files').addEventListener('click', () => window.api.addFiles());
-$('rescan').addEventListener('click', () => window.api.rescan());
+$('rescan').addEventListener('click', () =>
+  busy($('rescan'), 'Rescanning…', () => window.api.rescan())
+);
+$('refresh-thumbs').addEventListener('click', () =>
+  busy($('refresh-thumbs'), 'Clearing…', async () => {
+    if (!(await window.api.refreshThumbs())) return;
+    // Forget this session's failures too, so a re-plugged drive gets retried.
+    thumbFailed.clear();
+    renderGrid();
+  })
+);
+
+async function setView(view) {
+  if (state.settings.view === view) return;
+  state.settings.view = view;
+  renderGrid();
+  await window.api.saveSettings(state.settings);
+}
+
+$('view-grid').addEventListener('click', () => void setView('grid'));
+$('view-list').addEventListener('click', () => void setView('list'));
 $('show-more').addEventListener('click', () => {
   state.shown += PAGE;
   renderGrid();

--- a/product/akbun-folderview/workspace/src/renderer.js
+++ b/product/akbun-folderview/workspace/src/renderer.js
@@ -267,11 +267,16 @@ const thumbQueued = new Set();
 // A drive that is unplugged fails every read. Remembered for the session so a
 // dead disk is asked once per file, not once per render.
 const thumbFailed = new Set();
+// Thumbnails built this session. Their cache URL 404ed once before the build,
+// so a re-render asks with a changed URL rather than trusting the webview not
+// to have remembered that 404.
+const thumbBuilt = new Set();
 const thumbWaiting = new Map();
 let thumbActive = 0;
 
 function thumbUrl(entry) {
-  return fileUrl(`${state.thumbsDir}/${lib.thumbName(entry.path, entry.mtime, entry.size)}`);
+  const url = fileUrl(`${state.thumbsDir}/${lib.thumbName(entry.path, entry.mtime, entry.size)}`);
+  return thumbBuilt.has(entry.path) ? `${url}?fresh` : url;
 }
 
 function markMissing(img) {
@@ -313,7 +318,9 @@ function loadVideoFrame(path) {
   return new Promise((resolve, reject) => {
     const video = document.createElement('video');
     video.muted = true;
-    video.preload = 'auto';
+    // metadata is enough: the seek itself pulls the range around the target
+    // frame, and auto would read far more of the file than a poster needs.
+    video.preload = 'metadata';
     // Clearing src releases the file handle, or a later rename or delete of
     // the video would fail while this element is still holding it.
     const done = (blob, error) => {
@@ -341,6 +348,7 @@ async function makeThumb(entry) {
 }
 
 function showThumb(path, blob) {
+  thumbBuilt.add(path);
   const img = thumbWaiting.get(path);
   if (!img || !img.isConnected) return;
   // The blob that was just drawn is shown directly; the saved file serves the
@@ -602,6 +610,7 @@ $('refresh-thumbs').addEventListener('click', () =>
     if (!(await window.api.refreshThumbs())) return;
     // Forget this session's failures too, so a re-plugged drive gets retried.
     thumbFailed.clear();
+    thumbBuilt.clear();
     renderGrid();
   })
 );
@@ -673,6 +682,7 @@ $('prop-save').addEventListener('click', () => void saveProperties());
 
 $('set-theme').addEventListener('change', () => void saveCurrentSettings());
 $('set-single-click').addEventListener('change', () => void saveCurrentSettings());
+$('set-video-thumbs').addEventListener('change', () => void saveCurrentSettings());
 $('set-card-size').addEventListener('input', () => void saveCurrentSettings());
 $('set-open-dir').addEventListener('click', () => window.api.openDataDir());
 $('set-update').addEventListener('click', () => window.api.checkUpdate());

--- a/product/akbun-folderview/workspace/src/style.css
+++ b/product/akbun-folderview/workspace/src/style.css
@@ -81,10 +81,22 @@ select {
 
 .sidebar {
   display: grid;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 1fr 1fr auto;
   border-right: 1px solid var(--border);
   background: var(--panel);
   min-height: 0;
+}
+
+/* Pinned below both panels, so rescan and settings never scroll away. */
+.sidebar-foot {
+  display: flex;
+  gap: 4px;
+  padding: 8px 10px;
+}
+
+.sidebar-foot button {
+  flex: 1;
+  white-space: nowrap;
 }
 
 .panel {
@@ -167,6 +179,11 @@ button.primary {
   border-radius: 5px;
   cursor: pointer;
   white-space: nowrap;
+  /* A long name widens the row instead of painting past it, so the panel's
+     own overflow turns into a horizontal scrollbar rather than text bleeding
+     into the grid. min-width keeps short rows hoverable edge to edge. */
+  width: max-content;
+  min-width: 100%;
 }
 
 .row-item:hover {
@@ -282,6 +299,20 @@ button.primary {
   object-fit: cover;
 }
 
+/* The original could not be read (drive unplugged, file gone), or video
+   thumbnails are turned off. The card stays useful without an image. */
+.thumb.missing::after {
+  content: 'no preview';
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.thumb.off::after {
+  content: '▶';
+  color: var(--muted);
+  font-size: 22px;
+}
+
 .badge {
   position: absolute;
   top: 6px;
@@ -346,6 +377,54 @@ button.primary {
 
 .show-more {
   margin: 0 14px 14px;
+}
+
+/* ------------------------------------------------------------ list view */
+
+/* Same container, different layout: detail rows like the file explorer. No
+   thumbnails at all, which also makes it the fast view for a slow disk. */
+.grid.list {
+  display: block;
+}
+
+.list-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.list-item:hover {
+  background: var(--hover);
+}
+
+.list-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.list-item .badge {
+  position: static;
+}
+
+.list-size,
+.list-date {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.list-size {
+  width: 70px;
+  text-align: right;
+}
+
+.list-date {
+  width: 130px;
 }
 
 /* ------------------------------------------------------------------ dialog */

--- a/product/akbun-folderview/workspace/test/library.test.js
+++ b/product/akbun-folderview/workspace/test/library.test.js
@@ -18,6 +18,7 @@ const {
   ratingCounts,
   searchEntries,
   tagCounts,
+  thumbName,
 } = require('../src/library');
 
 // The shape Rust serialises. Written out here rather than built by a helper
@@ -136,6 +137,16 @@ test('tag counts are ordered by use', () => {
     { tag: 'summer', count: 2 },
   ]);
   assert.deepStrictEqual(ratingCounts(LIBRARY), [1, 0, 0, 1, 1, 1]);
+});
+
+// The name is the cache key: stable for the same file, different the moment
+// the file changes, safe to hand to the file system.
+test('thumbName is stable and changes with the file', () => {
+  const name = thumbName('C:\\photos\\여행\\a.jpg', 100, 5);
+  assert.strictEqual(name, thumbName('C:\\photos\\여행\\a.jpg', 100, 5));
+  assert.match(name, /^[0-9a-f]{16}\.jpg$/);
+  assert.notStrictEqual(name, thumbName('C:\\photos\\여행\\a.jpg', 101, 5));
+  assert.notStrictEqual(name, thumbName('C:\\photos\\여행\\b.jpg', 100, 5));
 });
 
 test('formatSize picks the unit', () => {


### PR DESCRIPTION
# Goal

On a slow or unplugged external drive the app froze at first paint, because every grid card read its original file. This PR adds a local thumbnail cache so a normal start never touches the added folders' disk, splits Rescan Disk and Refresh Thumbs into two distinct actions, and adds a list view and a video thumbnail switch for slow disks.

# Decisions

**[Important]** The library cache has no TTL; Rescan Disk stays manual.
- With the external drive unplugged, an automatic rescan would show every file as gone. The cache surviving a disconnected drive is the point of having one.

**[Important]** Thumbnails are drawn by the webview; Rust only validates a name and writes bytes.
- The Chromium codecs already decide what displays, so the formats that display and the formats that thumbnail are exactly the same set, videos included.
- No image crate: the app crate stays light and the CI cache benefit of the separate model crate is preserved.

The thumbnail file name is an FNV-1a hash of path, mtime and size.
- An edited file gets a new name and therefore a fresh thumbnail. No invalidation state exists.

Rescan Disk and Refresh Thumbs are separate buttons in a pinned sidebar footer.
- Walking the disk for file changes and rebuilding the thumbnail cache are different jobs; one button cannot say which is running. Refresh drops the thumbs folder, which is also the orphan cleanup.

# Implementation

Cards read a cached JPEG from app data; the cache fills lazily from the page.
- A missing thumbnail fires onerror on the lazy img, the original is read once, drawn to at most 512px on a canvas, and saved through the save_thumb command.
- Two reads run at a time with a 30 second timeout, so a spinning disk stays responsive and a hung read cannot pin a queue slot.
- A failed read (drive unplugged) is remembered for the session and the card shows no preview instead of retrying every render.
- Video posters come from a video element seek at half a second; Settings can turn video thumbnails off so no video file is opened at all.

List view renders explorer-style rows with name, size, date and rating, and loads no images. Grid and List are toolbar buttons persisted in settings.

Long names in the sidebar now widen the row instead of painting across the grid, so the panel scrolls horizontally.

Verified: 12 node tests and 4 Rust tests pass, cargo check clean. Version bumped to 0.2.0.

# Challenges

Pointing the card back at the cache URL after generating showed a broken image.
- The browser had already remembered the 404 for that URL. The freshly drawn blob is shown directly via a blob URL instead, which needed blob: in img-src; the saved file serves the next run.

media-src looks removable now that the grid holds no video elements, but is not.
- Poster generation still reads the video through a video element, so dropping it breaks every video thumbnail quietly.

Issue #621