### PR TITLE
feat(akbun-folderview): tag context menu, keep sidebar inside its column

### DIFF
--- a/product/akbun-folderview/workspace/package.json
+++ b/product/akbun-folderview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-folderview",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Windows desktop browser for a hand-picked photo and video library with tags, ratings and instant search",
   "author": "akbun",

--- a/product/akbun-folderview/workspace/src/api.js
+++ b/product/akbun-folderview/workspace/src/api.js
@@ -127,13 +127,31 @@ window.api = {
   // A real system menu. Each item runs the handler directly rather than the
   // menu resolving a promise, because there is no dismissed event to settle a
   // promise with when the user clicks away.
-  entryMenu: async (run) => {
+  //
+  // tags is [{ tag, on }]: every tag in the library, checked when this file
+  // has it. Clicking one toggles it; New Tag… is for a tag that does not
+  // exist yet, which needs typing and therefore the Properties dialog.
+  entryMenu: async (run, tags = []) => {
     const item = (id, text) => ({ id, text, action: () => run(id) });
+    const tagItems = tags.map(({ tag, on }) => ({
+      text: tag,
+      checked: on,
+      action: () => run(`tag:${tag}`),
+    }));
     const menu = await Menu.new({
       items: [
         item('open', 'Open'),
         item('rename', 'Rename…'),
         item('delete', 'Delete'),
+        { item: 'Separator' },
+        {
+          text: 'Tags',
+          items: [
+            ...tagItems,
+            ...(tagItems.length > 0 ? [{ item: 'Separator' }] : []),
+            item('newTag', 'New Tag…'),
+          ],
+        },
         { item: 'Separator' },
         item('copyPath', 'Copy Path'),
         item('reveal', 'Show in Folder'),

--- a/product/akbun-folderview/workspace/src/renderer.js
+++ b/product/akbun-folderview/workspace/src/renderer.js
@@ -137,7 +137,7 @@ function fileRow(entry) {
   row.addEventListener('click', () => window.api.openEntry(entry.path));
   row.addEventListener('contextmenu', async (event) => {
     event.preventDefault();
-    await window.api.entryMenu((action) => void runAction(action, entry));
+    await window.api.entryMenu((action) => void runAction(action, entry), tagMenu(entry));
   });
   return row;
 }
@@ -502,9 +502,28 @@ async function runAction(action, entry) {
   if (action === 'copyPath') return window.api.copyPath(entry.path);
   if (action === 'delete') return window.api.deleteEntry(entry.path);
   // Rename shares the Properties dialog, so there is one place that edits a
-  // file's name, tags and rating.
-  if (action === 'rename') return openProperties(entry, true);
-  if (action === 'properties') return openProperties(entry, false);
+  // file's name, tags and rating. A brand-new tag lands there too, because it
+  // needs typing and a native menu cannot take text.
+  if (action === 'rename') return openProperties(entry, 'name');
+  if (action === 'newTag') return openProperties(entry, 'tags');
+  if (action === 'properties') return openProperties(entry);
+  if (action.startsWith('tag:')) {
+    const tag = action.slice(4);
+    const tags = entry.tags.includes(tag)
+      ? entry.tags.filter((existing) => existing !== tag)
+      : [...entry.tags, tag];
+    return patch(entry, { tags });
+  }
+}
+
+// Every tag in the library, checked when this file already has it, so the
+// context menu can toggle tags without opening a dialog.
+function tagMenu(entry) {
+  const known = derive().tags.map(({ tag }) => tag);
+  return [...new Set([...known, ...entry.tags])].map((tag) => ({
+    tag,
+    on: entry.tags.includes(tag),
+  }));
 }
 
 /* ---------------------------------------------------------------- dialogs */
@@ -512,7 +531,9 @@ async function runAction(action, entry) {
 let propertyTarget = null;
 let propertyRating = 0;
 
-function openProperties(entry, focusName) {
+// focus names the field the user came for: 'name' from Rename, 'tags' from
+// New Tag…, nothing from Properties itself.
+function openProperties(entry, focus) {
   propertyTarget = entry;
   propertyRating = entry.rating;
 
@@ -530,7 +551,8 @@ function openProperties(entry, focusName) {
     <dt>Location</dt><dd>${escapeHtml(entry.dir)}</dd>`;
 
   $('properties').hidden = false;
-  if (focusName) $('prop-name').select();
+  if (focus === 'name') $('prop-name').select();
+  if (focus === 'tags') $('prop-tags').focus();
 }
 
 async function saveProperties() {
@@ -665,7 +687,7 @@ $('grid').addEventListener('contextmenu', async (event) => {
   const entry = entryAt(event.target);
   if (!entry) return;
   event.preventDefault();
-  await window.api.entryMenu((action) => void runAction(action, entry));
+  await window.api.entryMenu((action) => void runAction(action, entry), tagMenu(entry));
 });
 
 $('prop-stars').addEventListener('click', (event) => {

--- a/product/akbun-folderview/workspace/src/style.css
+++ b/product/akbun-folderview/workspace/src/style.css
@@ -85,6 +85,8 @@ select {
   border-right: 1px solid var(--border);
   background: var(--panel);
   min-height: 0;
+  /* Nothing in the sidebar may paint over the grid, whatever the panels do. */
+  overflow: hidden;
 }
 
 /* Pinned below both panels, so rescan and settings never scroll away. */
@@ -103,6 +105,10 @@ select {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Without this a long file name widens the sidebar's inner track past its
+     260px column and the tree paints over the grid. Held to the column, the
+     wide rows overflow the panel body instead, which scrolls sideways. */
+  min-width: 0;
   border-bottom: 1px solid var(--border);
 }
 


### PR DESCRIPTION
# Goal

The sidebar tree painted over the file grid when a file name was long, and tags could only be edited through the Properties dialog nobody found. This PR keeps the sidebar inside its column with a horizontal scrollbar and adds a Tags submenu to the file context menu. Version goes to 0.3.0 so the release workflow ships it.

# Decisions

**[Important]** The sidebar fix is min-width 0 on the panel, not a clip on the text.
- The root cause was the sidebar's inner auto grid track growing to the min-content width of a long file name, past its fixed 260px column, so the tree painted over the grid.
- Held to the column, wide rows hit the panel body's existing overflow auto and scroll sideways instead. An overflow hidden on the sidebar backstops anything else.

New tags go through the Properties dialog; the menu only toggles known ones.
- A native menu cannot take text input, so the New Tag item opens Properties focused on the tags field, keeping one place that edits tags.

Update safety needed no change.
- Settings, library and thumbnails already live under APPDATA, separate from the install folder the updater replaces. Recorded in the existing settings-in-appdata ADR.

# Implementation

The context menu gains a Tags submenu on cards, list rows and tree file rows.
- Every tag in the library appears as a check item, checked when the file has it; clicking toggles it through the existing update_entry command.
- No new capabilities: core menu default already covers submenus and check items.

Verified with node --test: all library tests pass, no failures.

Issue #623