### PR TITLE
fix(akbun-folderview): thumbnail cache CORS, persistent tree, folder-grouped filter results

### DIFF
--- a/knowledge/decisions/2026-08-thumbnails-in-the-webview.md
+++ b/knowledge/decisions/2026-08-thumbnails-in-the-webview.md
@@ -21,6 +21,6 @@ akbun-folderview의 썸네일 캐시는 webview가 만든다. 카드의 img가 o
 
 ## 지뢰: canvas에 그릴 asset은 crossOrigin이 필수다
 
-첫 출시 버전은 썸네일이 하나도 만들어지지 않았다. asset protocol(Windows는 <http://asset.localhost)은> 페이지(<http://tauri.localhost)와> 다른 origin이라, crossOrigin 없이 로드한 img/video를 canvas에 그리면 canvas가 taint되어 toBlob이 실패한다. 에러는 카드마다 "no preview"로만 보이고 콘솔의 SecurityError는 릴리스 빌드에서 아무도 보지 않는다. Tauri v2의 asset protocol은 Access-Control-Allow-Origin을 window origin으로 응답하므로, 생성용 img/video 엘리먼트에 crossOrigin = 'anonymous'를 주면 끝난다. 표시만 하는 엘리먼트에는 필요 없다.
+첫 출시 버전은 썸네일이 하나도 만들어지지 않았다. asset protocol(Windows에서는 asset.localhost 호스트)은 페이지(tauri.localhost)와 다른 origin이라, crossOrigin 없이 로드한 img/video를 canvas에 그리면 canvas가 taint되어 toBlob이 실패한다. 에러는 카드마다 "no preview"로만 보이고 콘솔의 SecurityError는 릴리스 빌드에서 아무도 보지 않는다. Tauri v2의 asset protocol은 Access-Control-Allow-Origin을 window origin으로 응답하므로, 생성용 img/video 엘리먼트에 crossOrigin = 'anonymous'를 주면 끝난다. 표시만 하는 엘리먼트에는 필요 없다.
 
 관련: [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](2026-07-unsigned-desktop-app-self-update.md)

--- a/knowledge/decisions/2026-08-thumbnails-in-the-webview.md
+++ b/knowledge/decisions/2026-08-thumbnails-in-the-webview.md
@@ -19,4 +19,8 @@ akbun-folderview의 썸네일 캐시는 webview가 만든다. 카드의 img가 o
 
 같은 상황의 다른 Tauri product에도 이 구성을 기본으로 한다. 단, blob URL로 갓 만든 썸네일을 보여주므로 CSP img-src에 blob:이 필요하고, 생성용 video 엘리먼트 때문에 media-src도 유지해야 한다.
 
+## 지뢰: canvas에 그릴 asset은 crossOrigin이 필수다
+
+첫 출시 버전은 썸네일이 하나도 만들어지지 않았다. asset protocol(Windows는 <http://asset.localhost)은> 페이지(<http://tauri.localhost)와> 다른 origin이라, crossOrigin 없이 로드한 img/video를 canvas에 그리면 canvas가 taint되어 toBlob이 실패한다. 에러는 카드마다 "no preview"로만 보이고 콘솔의 SecurityError는 릴리스 빌드에서 아무도 보지 않는다. Tauri v2의 asset protocol은 Access-Control-Allow-Origin을 window origin으로 응답하므로, 생성용 img/video 엘리먼트에 crossOrigin = 'anonymous'를 주면 끝난다. 표시만 하는 엘리먼트에는 필요 없다.
+
 관련: [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](2026-07-unsigned-desktop-app-self-update.md)

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-02
+
+* **Update**: [Tauri 앱의 썸네일은 webview가 그리고 Rust는 바이트만 저장한다](decisions/2026-08-thumbnails-in-the-webview.md)에 canvas taint 지뢰를 추가했다. asset protocol은 다른 origin이라 crossOrigin 없이 그리면 toBlob이 실패하고, 첫 출시 버전의 썸네일 캐시가 이것 때문에 통째로 동작하지 않았다.
+
 ## 2026-08-01
 
 * **Creation**: [Tauri 앱의 썸네일은 webview가 그리고 Rust는 바이트만 저장한다](decisions/2026-08-thumbnails-in-the-webview.md) 결정 기록. akbun-folderview에 썸네일 캐시를 넣어 외장하드 시작 멈춤을 고치면서 남긴다.

--- a/product/akbun-folderview/workspace/package.json
+++ b/product/akbun-folderview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-folderview",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Windows desktop browser for a hand-picked photo and video library with tags, ratings and instant search",
   "author": "akbun",

--- a/product/akbun-folderview/workspace/src/renderer.js
+++ b/product/akbun-folderview/workspace/src/renderer.js
@@ -83,6 +83,19 @@ function toggleToken(token) {
 // once per library change instead of once per keystroke.
 let derived = null;
 
+// Which folders are open, by path. Selecting a folder calls render(), which
+// rebuilds the tree from scratch; without this map that rebuild would close
+// every folder the user had opened. Roots default open, everything else closed.
+const expandedFolders = new Map();
+
+function folderIcon(open) {
+  return open ? '📂' : '📁';
+}
+
+function fileIcon(entry) {
+  return entry.kind === 'video' ? '🎬' : '🖼️';
+}
+
 function derive() {
   if (!derived) {
     derived = {
@@ -127,6 +140,7 @@ function fileRow(entry) {
 
   const twisty = document.createElement('span');
   twisty.className = 'twisty';
+  twisty.textContent = fileIcon(entry);
   row.append(twisty);
 
   const label = document.createElement('span');
@@ -149,9 +163,10 @@ function folderNode(node, isRoot) {
   if (state.folder === node.path) row.classList.add('selected');
 
   const hasChildren = node.folders.length > 0 || node.files.length > 0;
+  const open = expandedFolders.get(node.path) ?? isRoot;
   const twisty = document.createElement('span');
   twisty.className = 'twisty';
-  twisty.textContent = hasChildren ? (isRoot ? '▾' : '▸') : '';
+  twisty.textContent = folderIcon(open && hasChildren);
   row.append(twisty);
 
   const label = document.createElement('span');
@@ -169,7 +184,7 @@ function folderNode(node, isRoot) {
   // thousands of rows in the page before anyone asked to see them.
   const children = document.createElement('div');
   children.className = 'node';
-  children.hidden = !isRoot;
+  children.hidden = !open;
   let built = false;
   const build = () => {
     if (built) return;
@@ -177,22 +192,27 @@ function folderNode(node, isRoot) {
     for (const child of node.folders) children.append(folderNode(child, false));
     for (const file of node.files) children.append(fileRow(file));
   };
-  if (isRoot) build();
+  if (open) build();
 
   row.addEventListener('click', () => {
-    state.folder = state.folder === node.path ? null : node.path;
+    const selecting = state.folder !== node.path;
+    state.folder = selecting ? node.path : null;
+    // Selecting a folder also opens it, so the first click shows its contents
+    // in both panels instead of appearing to close the tree.
+    if (selecting) expandedFolders.set(node.path, true);
     state.shown = PAGE;
     render();
   });
 
-  // The twisty is the one part of the row that opens the folder instead of
-  // selecting it.
+  // The folder icon is the one part of the row that opens the folder instead
+  // of selecting it.
   twisty.addEventListener('click', (event) => {
     event.stopPropagation();
     if (!hasChildren) return;
     build();
     children.hidden = !children.hidden;
-    twisty.textContent = children.hidden ? '▸' : '▾';
+    expandedFolders.set(node.path, !children.hidden);
+    twisty.textContent = folderIcon(!children.hidden);
   });
 
   // A root folder can be dropped from the library. Its files stay on disk.
@@ -308,6 +328,10 @@ function drawThumb(source, width, height) {
 function loadPhoto(path) {
   return new Promise((resolve, reject) => {
     const image = new Image();
+    // The asset protocol is a different origin from the page. Without a CORS
+    // load the canvas is tainted and toBlob fails, so nothing ever reaches the
+    // cache. Tauri answers with Access-Control-Allow-Origin for exactly this.
+    image.crossOrigin = 'anonymous';
     image.onload = () => resolve(image);
     image.onerror = () => reject(new Error(`cannot read ${path}`));
     image.src = fileUrl(path);
@@ -318,6 +342,9 @@ function loadVideoFrame(path) {
   return new Promise((resolve, reject) => {
     const video = document.createElement('video');
     video.muted = true;
+    // Same as loadPhoto: a non-CORS load taints the canvas and the poster
+    // frame can never be drawn out of it.
+    video.crossOrigin = 'anonymous';
     // metadata is enough: the seek itself pulls the range around the target
     // frame, and auto would read far more of the file than a poster needs.
     video.preload = 'metadata';
@@ -454,14 +481,30 @@ function syncViews() {
 }
 
 function renderGrid() {
-  const matches = visibleEntries();
+  let matches = visibleEntries();
+  // Filter results come from anywhere in the library, so a flat list loses
+  // where each file lives. Sorting by folder and putting a folder header over
+  // each run keeps the tree visible in the results.
+  const grouped = state.query.trim() !== '';
+  if (grouped) {
+    matches = [...matches].sort(
+      (a, b) => a.dir.localeCompare(b.dir) || a.name.localeCompare(b.name)
+    );
+  }
   const page = matches.slice(0, state.shown);
   const listMode = state.settings.view === 'list';
 
   const grid = $('grid');
   grid.textContent = '';
   grid.classList.toggle('list', listMode);
-  for (const entry of page) grid.append(listMode ? listRow(entry) : card(entry));
+  let lastDir = null;
+  for (const entry of page) {
+    if (grouped && entry.dir !== lastDir) {
+      lastDir = entry.dir;
+      grid.append(groupTitle(`📂 ${entry.dir}`));
+    }
+    grid.append(listMode ? listRow(entry) : card(entry));
+  }
   syncViews();
 
   const where = state.folder ? ` in ${state.folder}` : '';

--- a/product/akbun-folderview/workspace/src/style.css
+++ b/product/akbun-folderview/workspace/src/style.css
@@ -5,10 +5,11 @@
 :root {
   --bg: #f6f6f7;
   --panel: #ffffff;
+  --sidebar: #eceef3;
   --fg: #1a1a1c;
   --muted: #6b6b70;
   --border: #dedee1;
-  --hover: #eeeef0;
+  --hover: #e2e4ea;
   --accent: #3b6ef5;
   --accent-fg: #ffffff;
   --star: #e2a03f;
@@ -19,10 +20,11 @@
   :root {
     --bg: #1b1b1d;
     --panel: #232326;
+    --sidebar: #26262c;
     --fg: #e9e9ea;
     --muted: #9a9aa0;
     --border: #343438;
-    --hover: #2d2d31;
+    --hover: #323238;
     --accent: #5b86f7;
     --accent-fg: #ffffff;
     --star: #f0b95c;
@@ -32,10 +34,11 @@
 :root[data-theme='light'] {
   --bg: #f6f6f7;
   --panel: #ffffff;
+  --sidebar: #eceef3;
   --fg: #1a1a1c;
   --muted: #6b6b70;
   --border: #dedee1;
-  --hover: #eeeef0;
+  --hover: #e2e4ea;
   --accent: #3b6ef5;
   --star: #e2a03f;
 }
@@ -43,10 +46,11 @@
 :root[data-theme='dark'] {
   --bg: #1b1b1d;
   --panel: #232326;
+  --sidebar: #26262c;
   --fg: #e9e9ea;
   --muted: #9a9aa0;
   --border: #343438;
-  --hover: #2d2d31;
+  --hover: #323238;
   --accent: #5b86f7;
   --star: #f0b95c;
 }
@@ -75,7 +79,8 @@ select {
 
 .app {
   display: grid;
-  grid-template-columns: 260px 1fr;
+  /* The sidebar owns 30% of the window and the grid the remaining 70%. */
+  grid-template-columns: 30% 1fr;
   height: 100vh;
 }
 
@@ -83,7 +88,8 @@ select {
   display: grid;
   grid-template-rows: 1fr 1fr auto;
   border-right: 1px solid var(--border);
-  background: var(--panel);
+  /* Its own tint, so the two panels read as two panels. */
+  background: var(--sidebar);
   min-height: 0;
   /* Nothing in the sidebar may paint over the grid, whatever the panels do. */
   overflow: hidden;
@@ -106,7 +112,7 @@ select {
   flex-direction: column;
   min-height: 0;
   /* Without this a long file name widens the sidebar's inner track past its
-     260px column and the tree paints over the grid. Held to the column, the
+     30% column and the tree paints over the grid. Held to the column, the
      wide rows overflow the panel body instead, which scrolls sideways. */
   min-width: 0;
   border-bottom: 1px solid var(--border);
@@ -212,7 +218,9 @@ button.primary {
 }
 
 .twisty {
-  width: 12px;
+  /* Wide enough for the folder and file emoji icons. */
+  width: 18px;
+  flex-shrink: 0;
   color: var(--muted);
 }
 
@@ -383,6 +391,17 @@ button.primary {
 
 .show-more {
   margin: 0 14px 14px;
+}
+
+/* Folder headers over filter results. A path is not a label, so the sidebar's
+   uppercase transform is turned back off, and in grid mode the header takes
+   the whole row. */
+.grid .group-title {
+  grid-column: 1 / -1;
+  text-transform: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ------------------------------------------------------------ list view */


### PR DESCRIPTION
# Goal

The thumbnail cache shipped in 0.3.0 never cached anything, and clicking a folder in the tree collapsed every open folder. This PR fixes both and improves the layout: a tinted 30% sidebar, folder and file icons in the tree, and filter results grouped under the folder they live in.

# Decisions

**[Important]** Thumbnail builds load the source img and video with crossOrigin set to anonymous.
- The asset protocol is a different origin from the page, so a non-CORS load taints the canvas and toBlob fails. Every build failed, nothing reached the cache, and each card fell back to no preview.
- Tauri v2 answers asset requests with Access-Control-Allow-Origin for the window origin, verified in the tauri 2.11.5 source, so the CORS load is all that was missing.
- Only the offscreen build elements need it. Display-only elements never touch a canvas.

Tree expansion state lives in a map instead of the DOM.
- Selecting a folder calls render, which rebuilds the tree from scratch. State that lived only in the DOM was lost on every click, which is the reported collapse.
- Selecting a folder now also opens it, so the first click shows contents instead of appearing to close the tree.

Filter results are sorted by folder with a path header over each run.
- Matches come from anywhere in the library. A flat list loses where each file lives; sorting plus headers keeps the tree visible inside the results, in both grid and list view.

The folder icon replaces the twisty arrow.
- One icon carries the folder-versus-file distinction and the expand affordance at once. Files show a photo or video icon in the same slot.

# Implementation

The sidebar takes a 30% column with its own background tint.
- The tint is a new CSS variable declared in all four theme blocks; hover was darkened one step so rows stay visible on the tint.
- Version bumped to 0.4.0. The canvas taint mine is recorded in the existing thumbnails knowledge decision.

All 12 node tests pass and the three page scripts pass a syntax check.
- The CORS fix needs a check on a Windows install, since the taint only reproduces inside the packaged webview.

Issue #625