### PR TITLE
fix(akbun-makepresentation): set the real updater pubkey

### DIFF
--- a/product/akbun-makepresentation/workspace/src-tauri/tauri.conf.json
+++ b/product/akbun-makepresentation/workspace/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "endpoints": [
         "https://github.com/choisungwook/portfolio/releases/download/akbun-makepresentation-updater/latest.json"
       ],
-      "pubkey": "REPLACE_WITH_UPDATER_PUBKEY"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEM1ODAzMUJEOUNDNjMwQjYKUldTMk1NYWN2VEdBeGFpQUlKSVQrUk95MjJPaDZKZGhxU0ZsbUp6QUNzU1pYaE9yWTFMeHpuenQK"
     }
   }
 }


### PR DESCRIPTION
# Goal

The akbun-makepresentation release workflow failed on master and no release was ever created. The updater public key in tauri.conf.json was still the placeholder REPLACE_WITH_UPDATER_PUBKEY. This PR puts the real minisign public key in its place.

# Decisions

We commit the public key value into tauri.conf.json.
- A minisign public key is not a secret. Only the private key is, and that stays in the repository secrets.
- The pubkey field takes the key contents, not a path to a key file.

We keep the version at 0.1.0.
- The build died before tauri-action created anything, so no akbun-makepresentation tag exists yet.
- Bumping would skip the version the app was written as. The first release should be v0.1.0.

# Implementation

One line in product/akbun-makepresentation/workspace/src-tauri/tauri.conf.json.
- The key comes from the pair whose private half is already stored as TAURI_SIGNING_PRIVATE_KEY_MAKEPRESENTATION.
- After merge, confirm with gh release list that akbun-makepresentation-v0.1.0 actually shipped.

# Challenges

The failure looked like a missing secret, but both secrets were present.
- The build log ends with: failed to decode base64 pubkey: Invalid symbol 95, offset 7.
- Symbol 95 is an underscore and offset 7 is the one in REPLACE_. That pointed at the config, not at the secrets.
- The signing key has no password, and an empty TAURI_SIGNING_PRIVATE_KEY_PASSWORD is accepted, so that was not the cause either.

Issue #633