### PR TITLE
feat(akbun-makepresentation): 슬라이드 줌, 배경 전용 패널, 글자 서식

### DIFF
--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -35,7 +35,8 @@ Cmd on macOS, Ctrl on Windows and Linux.
 | Cmd+Shift+drag | Same, with the copy kept on one axis |
 | V R O L A P T | Select, rectangle, ellipse, line, arrow, pen, text |
 | Arrows | Nudge the selection by 1px, or 10px with Shift |
-| Delete | Delete the selection |
+| Delete, Backspace | Delete the selection. Inside a text box being edited they delete a character instead |
+| Double click on a text box | Edit its text |
 
 ## Directory layout
 

--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -10,7 +10,7 @@ Desktop slide deck editor for the slides actually used in blog posts and talks: 
 - Text boxes with font family, size, color, bold, italic, underline and alignment
 - Per-shape line color, width, style (solid/dashed/dotted) and fill
 - Zoom from 50% to 400%, from the control in the corner of the stage or the keyboard
-- Slide numbers, toggled from the № button
+- Slide numbers, toggled from the Numbers button
 - Undo and redo, copy and paste, duplicate
 - Open and save .pptx, export every slide as a .pdf
 - Presentation mode (fullscreen, arrow keys)

--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -5,9 +5,11 @@ Desktop slide deck editor for the slides actually used in blog posts and talks: 
 ## What it does
 
 - Slides: add, delete, duplicate, switch, thumbnail panel
+- Per-slide background color from its own panel card, with presets, a custom color and apply-to-all
 - Shapes: rectangle, ellipse, line, arrow, freehand pen
-- Text boxes with font family, size and color
+- Text boxes with font family, size, color, bold, italic, underline and alignment
 - Per-shape line color, width, style (solid/dashed/dotted) and fill
+- Zoom from 50% to 400%, from the control in the corner of the stage or the keyboard
 - Slide numbers, toggled from the № button
 - Undo and redo, copy and paste, duplicate
 - Open and save .pptx, export every slide as a .pdf
@@ -24,6 +26,9 @@ Cmd on macOS, Ctrl on Windows and Linux.
 | Cmd+C, Cmd+V | Copy the selected shape, paste it down and to the right |
 | Cmd+D | Duplicate the selected shape, or the whole slide when nothing is selected |
 | Cmd+S | Save |
+| Cmd+B, Cmd+I, Cmd+U | Bold, italic, underline the selected text box, or the style new ones start with |
+| Cmd++ / Cmd+- | Zoom in / out |
+| Cmd+0 | Fit the slide to the window |
 | Shift while drawing | Square or circle; lines and arrows snap to 45 degrees |
 | Shift while dragging | Move on one axis only |
 | Cmd+drag | Drag a copy and leave the original in place |

--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -9,8 +9,8 @@ Desktop slide deck editor for the slides actually used in blog posts and talks: 
 - Shapes: rectangle, ellipse, line, arrow, freehand pen
 - Text boxes with font family, size, color, bold, italic, underline and alignment
 - Per-shape line color, width, style (solid/dashed/dotted) and fill
-- Zoom from 50% to 400%, from the control in the corner of the stage or the keyboard
-- Slide numbers, toggled from the Numbers button
+- Zoom from 50% to 400%, from the status bar or the keyboard
+- Slide numbers, toggled from the status bar
 - Undo and redo, copy and paste, duplicate
 - Open and save .pptx, export every slide as a .pdf
 - Presentation mode (fullscreen, arrow keys)

--- a/product/akbun-makepresentation/adr/2026-08-background-is-a-slide-field.md
+++ b/product/akbun-makepresentation/adr/2026-08-background-is-a-slide-field.md
@@ -1,0 +1,13 @@
+# The slide background is a field on the slide, not a page-sized shape
+
+## Decision
+
+A slide carries its own `background` color, and the property panel edits it from its own card above the selection properties. Importing a .pptx lifts a solid slide, layout or master background onto that field instead of pushing a page-sized rect into the shape list. Saving writes it back as the slide's `p:bg` element, and only when it is not white. A background *picture* stays a shape, because a color field has nowhere to put image bytes.
+
+## Reason
+
+Before this, the only ways to get a colored slide were to draw a rectangle over the whole canvas or to import a file whose background arrived as one. Both put the background in the shape list, where it is one click away from being selected, dragged, resized or recolored — and where the panel that changes it is the same Fill row that changes the selected rectangle. People reached for that row to repaint the slide and repainted a shape, or repainted the default for the next shape they drew, which is worse because nothing on screen changes until the next drag.
+
+Making it a field settles all of that by construction. There is exactly one control that writes it, it writes nowhere else, and the background cannot be picked up by a pointer because it is not in the list the pointer searches. The pptx side gets simpler too: `p:bg` is where PowerPoint already looks, so a deck made here opens elsewhere with the background PowerPoint expects rather than a rectangle sitting on top of the slide.
+
+The cost is one more field to keep in step across the JS model, the serde model and both directions of the pptx code, plus an import that no longer round-trips a solid background as the same shape it came in as. That trade is worth it: the shape it came in as was never something anyone wanted to select.

--- a/product/akbun-makepresentation/adr/index.md
+++ b/product/akbun-makepresentation/adr/index.md
@@ -6,3 +6,4 @@
 | [2026-08-own-pptx-writer.md](./2026-08-own-pptx-writer.md) | Hand-written OOXML subset instead of a document library |
 | [2026-08-pdf-from-rasterized-slides.md](./2026-08-pdf-from-rasterized-slides.md) | The page rasterizes slides; Rust wraps JPEGs into the pdf |
 | [2026-08-updater-fixed-tag-endpoint.md](./2026-08-updater-fixed-tag-endpoint.md) | The updater polls a fixed per-product tag, not releases/latest |
+| [2026-08-background-is-a-slide-field.md](./2026-08-background-is-a-slide-field.md) | The slide background is a field on the slide, not a page-sized shape |

--- a/product/akbun-makepresentation/wiki/architecture.md
+++ b/product/akbun-makepresentation/wiki/architecture.md
@@ -12,15 +12,19 @@ Two sides, one JSON model between them.
 One JSON object, identical on both sides (serde mirrors it in Rust):
 
 ```json
-{ "slides": [ { "shapes": [ {
-  "kind": "rect | ellipse | line | arrow | pen | text",
+{ "slides": [ { "background": "#ffffff", "shapes": [ {
+  "kind": "rect | ellipse | line | arrow | pen | text | image",
   "x": 0, "y": 0, "w": 0, "h": 0,
   "points": [[0, 0]],
   "stroke": "#1a1a1a", "strokeWidth": 2, "dash": "solid | dash | dot",
   "fill": "none | #rrggbb",
-  "text": "", "fontSize": 24, "textColor": "#1a1a1a", "fontFamily": "Helvetica"
+  "text": "", "fontSize": 24, "textColor": "#1a1a1a", "fontFamily": "Helvetica",
+  "bold": false, "italic": false, "underline": false,
+  "textAlign": "left | center | right", "verticalAlign": "top | center | bottom"
 } ] } ] }
 ```
+
+`background` belongs to the slide rather than to a page-sized shape, so the one control that changes it cannot touch a shape and the background cannot be selected or dragged ([ADR](../adr/2026-08-background-is-a-slide-field.md)). A slide with no `background` is white, which is what a deck saved before the field existed deserializes to.
 
 `fontFamily` is one plain family name, not a CSS stack, so it maps straight onto the pptx `a:latin` typeface and survives a round trip unchanged. A generic fallback is appended when the SVG is drawn.
 
@@ -46,7 +50,7 @@ Three commands, each takes a path the page picked with a native dialog:
 
 **Save**: page hands the deck JSON to `save_deck`; the deck crate writes a zip with the OOXML parts (presentation, one master, one blank layout, one theme, one part per slide) from string templates.
 
-**Open**: the deck crate follows each slide's layout, master and theme relationships, then walks those parts with a pull parser. It keeps preset rects/ellipses/lines, custom-geometry paths (read back as pen), text boxes, pictures (read into the deck as data URLs), flattened groups, and visible master/layout artwork. Theme colors (schemeClr plus lumMod/lumOff/shade/tint) resolve through the matching theme and master clrMap. Placeholders inherit their box and text style from the layout, master and master text styles. A non-white slide/layout/master background becomes a page-sized rect, and foreign page sizes (4:3, portrait, custom) are scaled to fit the 1280x720 canvas. Picture crop and rotation plus basic text alignment and emphasis survive save/open round trips. Other presets become their bounding rectangle; unsupported tables are skipped.
+**Open**: the deck crate follows each slide's layout, master and theme relationships, then walks those parts with a pull parser. It keeps preset rects/ellipses/lines, custom-geometry paths (read back as pen), text boxes, pictures (read into the deck as data URLs), flattened groups, and visible master/layout artwork. Theme colors (schemeClr plus lumMod/lumOff/shade/tint) resolve through the matching theme and master clrMap. Placeholders inherit their box and text style from the layout, master and master text styles. A non-white solid slide/layout/master background becomes the slide's `background`, while a background picture stays a page-sized image shape, and foreign page sizes (4:3, portrait, custom) are scaled to fit the 1280x720 canvas. Picture crop and rotation plus text alignment and emphasis (bold, italic, underline) survive save/open round trips. Other presets become their bounding rectangle; unsupported tables are skipped.
 
 **PDF export**: the page rasterizes each slide (SVG string → blob URL → Image → 1920x1080 canvas → JPEG data URL) and `export_pdf` wraps the JPEGs into PDF pages by hand — JPEG is a native PDF filter, so no PDF library is involved.
 
@@ -61,6 +65,12 @@ Every mutation goes through the model and the page redraws from it (`renderAll`)
 `markDirty` is the one hook every mutation already passes through, so history hangs off it rather than off each call site. It pushes the deck as it stood at the previous commit onto a past stack and takes a fresh snapshot; undo and redo move whole-deck clones between the two stacks. Snapshots are `structuredClone` of the whole deck, which is cheap at this scale — a deck is a few hundred small objects.
 
 Opening a file or starting a new deck clears both stacks, because a history that reaches back across a different document has nothing sensible to restore.
+
+## Zoom
+
+Zoom is a view setting: it lives in `state`, not in the deck, and nothing about the model changes with it. The stage is a scroller wrapping the slide, and zoom is one CSS variable multiplying the fitted width, so the browser does the scaling and scrollbars appear on their own once the slide outgrows the window.
+
+Nothing else has to know. Pointer positions come from `getBoundingClientRect`, which already reports the zoomed box, so clicks map onto slide coordinates at any zoom. The one exception is the overlay textarea, placed in screen pixels: zooming while a text box is open would strand it, so a zoom commits the edit first.
 
 ## Slide numbers
 

--- a/product/akbun-makepresentation/wiki/architecture.md
+++ b/product/akbun-makepresentation/wiki/architecture.md
@@ -78,6 +78,8 @@ Opening a file or starting a new deck clears both stacks, because a history that
 
 Zoom is a view setting: it lives in `state`, not in the deck, and nothing about the model changes with it. The stage is a scroller wrapping the slide, and zoom is one CSS variable multiplying the fitted width, so the browser does the scaling and scrollbars appear on their own once the slide outgrows the window.
 
+Its control lives in the status bar along the bottom, next to the slide-number toggle. Both answer the same question — how the deck is shown, not what it contains — which is why they sit together and away from the toolbar.
+
 Nothing else has to know. Pointer positions come from `getBoundingClientRect`, which already reports the zoomed box, so clicks map onto slide coordinates at any zoom. The one exception is the overlay textarea, placed in screen pixels: zooming while a text box is open would strand it, so a zoom commits the edit first.
 
 ## Slide numbers

--- a/product/akbun-makepresentation/wiki/architecture.md
+++ b/product/akbun-makepresentation/wiki/architecture.md
@@ -56,6 +56,14 @@ Three commands, each takes a path the page picked with a native dialog:
 
 **Presentation mode**: a fullscreen overlay that renders the same slide SVG; arrow keys and clicks navigate, Escape leaves.
 
+## Text editing
+
+Editing runs in a textarea laid over the slide, styled to match the glyphs it hides. Two things about it are load-bearing.
+
+The press that opens it is detected in `pointerdown` — two presses on the same shape within 400 ms — and not from a `dblclick` event. The browser never reports one here: `pointerup` redraws the canvas from the model, so `mouseup` lands on a freshly built element rather than the one that took `mousedown`, and a click needs both. Relying on `dblclick` meant text boxes could not be reopened at all.
+
+That press also calls `preventDefault`, which is what keeps the focus the overlay is about to take. Without it the press hands focus back to the page, and then every keystroke reaches the global shortcuts: Backspace deletes the box being typed into, letters switch tools. The document handler carries the same rule as a backstop — while `editingIndex` is set, the keyboard belongs to the overlay — and `commitTextEdit` tolerates a shape that is already gone, since reading through it took the whole page down.
+
 ## Rendering rule
 
 Every mutation goes through the model and the page redraws from it (`renderAll`). Nothing merges partial updates into the DOM, so the canvas, thumbnails and property panel can never drift apart.

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
@@ -19,9 +19,28 @@ pub struct Deck {
     pub slides: Vec<Slide>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+/// One slide: its own background color plus the shapes drawn on it. The
+/// background is a field rather than a page-sized rect so recoloring it
+/// cannot touch a shape, and so it can never be selected or dragged.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Slide {
     pub shapes: Vec<Shape>,
+    #[serde(default = "default_background")]
+    pub background: String,
+}
+
+impl Default for Slide {
+    fn default() -> Self {
+        Slide {
+            shapes: Vec::new(),
+            background: default_background(),
+        }
+    }
+}
+
+pub fn default_background() -> String {
+    "#ffffff".into()
 }
 
 /// One drawable thing. `kind` is rect | ellipse | line | arrow | pen | text.
@@ -69,6 +88,8 @@ pub struct Shape {
     pub bold: bool,
     #[serde(default)]
     pub italic: bool,
+    #[serde(default)]
+    pub underline: bool,
     #[serde(default = "default_text_align")]
     pub text_align: String,
     #[serde(default = "default_vertical_align")]
@@ -132,6 +153,7 @@ impl Default for Shape {
             src: String::new(),
             bold: false,
             italic: false,
+            underline: false,
             text_align: default_text_align(),
             vertical_align: default_vertical_align(),
             crop_left: 0.0,

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
@@ -320,14 +320,32 @@ fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
     }
     let xml = format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
-<p:sld{NS}><p:cSld><p:spTree>{EMPTY_TREE_HEADER}{shapes}</p:spTree></p:cSld>\
-<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>"
+<p:sld{NS}><p:cSld>{}<p:spTree>{EMPTY_TREE_HEADER}{shapes}</p:spTree></p:cSld>\
+<p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sld>",
+        background_xml(&slide.background)
     );
     let rels = format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
 <Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">{rels}</Relationships>"
     );
     (xml, rels)
+}
+
+/// The slide's `p:bg` element, empty for white. The master this writer emits
+/// already resolves to white, so leaving the element out says the same thing
+/// in fewer bytes and keeps files written before backgrounds existed
+/// byte-identical.
+fn background_xml(background: &str) -> String {
+    if background.is_empty()
+        || background == "none"
+        || background.eq_ignore_ascii_case("#ffffff")
+    {
+        return String::new();
+    }
+    format!(
+        "<p:bg><p:bgPr><a:solidFill><a:srgbClr val=\"{}\"/></a:solidFill><a:effectLst/></p:bgPr></p:bg>",
+        hex(background)
+    )
 }
 
 fn pic_xml(shape: &Shape, id: u64, rid: u64) -> String {
@@ -412,6 +430,7 @@ fn text_body(shape: &Shape) -> String {
     );
     let bold = if shape.bold { " b=\"1\"" } else { "" };
     let italic = if shape.italic { " i=\"1\"" } else { "" };
+    let underline = if shape.underline { " u=\"sng\"" } else { "" };
     let align = match shape.text_align.as_str() {
         "center" => "ctr",
         "right" => "r",
@@ -425,7 +444,7 @@ fn text_body(shape: &Shape) -> String {
     let mut paragraphs = String::new();
     for line in shape.text.split('\n') {
         paragraphs.push_str(&format!(
-            "<a:p><a:pPr algn=\"{align}\"/><a:r><a:rPr lang=\"en-US\" sz=\"{size}\"{bold}{italic} dirty=\"0\"><a:solidFill><a:srgbClr val=\"{color}\"/></a:solidFill>{latin}</a:rPr><a:t>{}</a:t></a:r></a:p>",
+            "<a:p><a:pPr algn=\"{align}\"/><a:r><a:rPr lang=\"en-US\" sz=\"{size}\"{bold}{italic}{underline} dirty=\"0\"><a:solidFill><a:srgbClr val=\"{color}\"/></a:solidFill>{latin}</a:rPr><a:t>{}</a:t></a:r></a:p>",
             xml_escape(line)
         ));
     }
@@ -639,8 +658,15 @@ pub fn read<R: Read + Seek>(input: R) -> Result<Deck, String> {
                     .as_deref()
                     .and_then(|master| parse_background(master, &master_ctx, page_w, page_h))
             });
-        if let Some(background) = bg {
-            shapes.push(background);
+        // A solid background is the slide's own color. Only a picture has to
+        // stay a shape, since a slide holds one color and not an image.
+        let mut background = crate::default_background();
+        if let Some(shape) = bg {
+            if shape.kind == "image" {
+                shapes.push(shape);
+            } else {
+                background = shape.fill;
+            }
         }
         shapes.extend(master.visible);
         shapes.extend(layout.visible);
@@ -664,7 +690,7 @@ pub fn read<R: Read + Seek>(input: R) -> Result<Deck, String> {
                 i += 1;
             }
         }
-        deck.slides.push(Slide { shapes });
+        deck.slides.push(Slide { shapes, background });
     }
 
     // Other editors use other canvases: 4:3, Google Slides' smaller 16:9,
@@ -812,7 +838,8 @@ fn scheme_hex(
 }
 
 /// The background a slide, layout or master declares. Embedded pictures are
-/// kept as page-sized images; solid and scheme colors become a page-sized rect.
+/// kept as page-sized images; solid and scheme colors come back as a rect
+/// whose fill `read` lifts onto the slide's own background field.
 fn parse_background(
     xml: &str,
     ctx: &SlideCtx,
@@ -1034,6 +1061,7 @@ struct Pending {
     accept_explicit_text_style: bool,
     bold: Option<bool>,
     italic: Option<bool>,
+    underline: Option<bool>,
     text_align: Option<String>,
     vertical_align: Option<String>,
     blip: Option<String>,
@@ -1415,6 +1443,9 @@ fn read_text_properties(p: &mut Pending, e: &quick_xml::events::BytesStart) {
     if p.italic.is_none() {
         p.italic = attr(e, b"i").map(|value| value == "1");
     }
+    if p.underline.is_none() {
+        p.underline = attr(e, b"u").map(|value| value != "none");
+    }
 }
 
 fn overwrite_text_properties(p: &mut Pending, e: &quick_xml::events::BytesStart) {
@@ -1429,6 +1460,9 @@ fn overwrite_text_properties(p: &mut Pending, e: &quick_xml::events::BytesStart)
     }
     if let Some(value) = attr(e, b"i") {
         p.italic = Some(value == "1");
+    }
+    if let Some(value) = attr(e, b"u") {
+        p.underline = Some(value != "none");
     }
 }
 
@@ -1542,6 +1576,9 @@ fn apply_text_properties(shape: &mut Shape, p: &Pending) {
     if let Some(value) = p.italic {
         shape.italic = value;
     }
+    if let Some(value) = p.underline {
+        shape.underline = value;
+    }
     if let Some(value) = &p.text_align {
         shape.text_align = value.clone();
     }
@@ -1649,6 +1686,9 @@ fn finish(p: Pending, ctx: &SlideCtx, default: Option<&Shape>) -> Option<Shape> 
         if let Some(value) = p.italic {
             shape.italic = value;
         }
+        if let Some(value) = p.underline {
+            shape.underline = value;
+        }
         if let Some(value) = p.text_align {
             shape.text_align = value;
         }
@@ -1741,6 +1781,7 @@ mod tests {
                             font_family: "Times New Roman".into(),
                             bold: true,
                             italic: true,
+                            underline: true,
                             text_align: "center".into(),
                             vertical_align: "bottom".into(),
                             stroke: "none".into(),
@@ -1760,6 +1801,7 @@ mod tests {
                             ..Shape::default()
                         },
                     ],
+                    background: "#212022".into(),
                 },
                 Slide {
                     shapes: vec![Shape {
@@ -1770,6 +1812,7 @@ mod tests {
                         dash: "dot".into(),
                         ..Shape::default()
                     }],
+                    ..Slide::default()
                 },
             ],
         }
@@ -1787,6 +1830,7 @@ mod tests {
         let close = |a: f64, b: f64| (a - b).abs() < 0.5;
         for (slide_a, slide_b) in deck.slides.iter().zip(&back.slides) {
             assert_eq!(slide_a.shapes.len(), slide_b.shapes.len());
+            assert_eq!(slide_a.background, slide_b.background);
             for (a, b) in slide_a.shapes.iter().zip(&slide_b.shapes) {
                 assert_eq!(a.kind, b.kind);
                 assert_eq!(a.stroke, b.stroke);
@@ -1809,6 +1853,7 @@ mod tests {
                     assert_eq!(a.font_family, b.font_family);
                     assert_eq!(a.bold, b.bold);
                     assert_eq!(a.italic, b.italic);
+                    assert_eq!(a.underline, b.underline);
                     assert_eq!(a.text_align, b.text_align);
                     assert_eq!(a.vertical_align, b.vertical_align);
                 }
@@ -1925,24 +1970,23 @@ mod tests {
         let deck = read(buffer).unwrap();
         let shapes = &deck.slides[0].shapes;
 
-        // The empty prompt placeholder is gone. Background, master artwork,
-        // layout logo and slide-owned shapes keep their layer order.
-        assert_eq!(shapes.len(), 6);
+        // The layout's solid background is the slide's color, not a shape on
+        // top of it.
+        assert_eq!(deck.slides[0].background, "#212022");
 
-        let bg = &shapes[0];
-        assert_eq!(bg.kind, "rect");
-        assert_eq!(bg.fill, "#212022");
-        assert!((bg.w - 1280.0).abs() < 0.5 && (bg.h - 720.0).abs() < 0.5);
+        // The empty prompt placeholder is gone. Master artwork, layout logo
+        // and slide-owned shapes keep their layer order.
+        assert_eq!(shapes.len(), 5);
 
-        let master_band = &shapes[1];
+        let master_band = &shapes[0];
         assert_eq!(master_band.kind, "rect");
         assert_eq!(master_band.fill, "#037f0c");
 
-        let layout_logo = &shapes[2];
+        let layout_logo = &shapes[1];
         assert_eq!(layout_logo.kind, "image");
         assert_eq!(layout_logo.src, TINY_PNG);
 
-        let title = &shapes[3];
+        let title = &shapes[2];
         assert_eq!(title.kind, "text");
         // 952500 EMU = 100 px: the box came from the layout.
         assert!((title.x - 100.0).abs() < 0.5 && (title.y - 50.0).abs() < 0.5);
@@ -1953,12 +1997,12 @@ mod tests {
         assert!(title.bold);
         assert_eq!(title.text_align, "center");
 
-        let band = &shapes[4];
+        let band = &shapes[3];
         assert_eq!(band.kind, "rect");
         // accent1 ED7100 shaded to 50%.
         assert_eq!(band.fill, "#773900");
 
-        let pic = &shapes[5];
+        let pic = &shapes[4];
         assert_eq!(pic.kind, "image");
         assert_eq!(pic.src, TINY_PNG);
         assert!((pic.x - 100.0).abs() < 0.5 && (pic.w - 100.0).abs() < 0.5);
@@ -1987,6 +2031,23 @@ mod tests {
         assert_eq!(background.kind, "image");
         assert_eq!(background.src, "ppt/media/background.png");
         assert_eq!((background.w, background.h), (1280.0, 720.0));
+    }
+
+    /// A slide part carries its background before its shape tree, and a white
+    /// slide writes no background element at all.
+    #[test]
+    fn background_is_written_only_when_it_is_not_white() {
+        let mut buffer = Cursor::new(Vec::new());
+        write(&sample_deck(), &mut buffer).unwrap();
+        buffer.set_position(0);
+        let mut archive = zip::ZipArchive::new(buffer).unwrap();
+
+        let colored = part(&mut archive, "ppt/slides/slide1.xml").unwrap();
+        assert!(colored.contains("<p:bg><p:bgPr><a:solidFill><a:srgbClr val=\"212022\"/>"));
+        assert!(colored.find("<p:bg>").unwrap() < colored.find("<p:spTree>").unwrap());
+
+        let white = part(&mut archive, "ppt/slides/slide2.xml").unwrap();
+        assert!(!white.contains("<p:bg>"));
     }
 
     #[test]

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -7,6 +7,10 @@
 const SLIDE_W = 1280;
 const SLIDE_H = 720;
 
+// Paper white. A slide keeps its own background so changing it touches that
+// one field and nothing else on the slide.
+const DEFAULT_BACKGROUND = '#ffffff';
+
 const DEFAULT_STYLE = {
   stroke: '#1a1a1a',
   strokeWidth: 2,
@@ -19,6 +23,11 @@ const DEFAULT_STYLE = {
   // offer lives in the markup of #prop-font-family, which is also where the
   // display labels belong; anything outside it still opens and renders.
   fontFamily: 'Helvetica',
+  bold: false,
+  italic: false,
+  underline: false,
+  textAlign: 'left',
+  verticalAlign: 'top',
 };
 
 const BOXY = new Set(['rect', 'ellipse', 'text', 'image']);
@@ -28,7 +37,14 @@ function createDeck() {
 }
 
 function createSlide() {
-  return { shapes: [] };
+  return { shapes: [], background: DEFAULT_BACKGROUND };
+}
+
+// A deck saved before slides carried a background, or a slide read from a
+// pptx that declares none, has no field here. Both mean paper white.
+function slideBackground(slide) {
+  const color = slide && slide.background;
+  return color && color !== 'none' ? color : DEFAULT_BACKGROUND;
 }
 
 function createShape(kind, x, y, style) {
@@ -49,10 +65,11 @@ function createShape(kind, x, y, style) {
     textColor: s.textColor,
     fontFamily: s.fontFamily,
     src: '',
-    bold: false,
-    italic: false,
-    textAlign: 'left',
-    verticalAlign: 'top',
+    bold: s.bold,
+    italic: s.italic,
+    underline: s.underline,
+    textAlign: s.textAlign,
+    verticalAlign: s.verticalAlign,
     cropLeft: 0,
     cropTop: 0,
     cropRight: 0,
@@ -328,7 +345,8 @@ function renderShapeSvg(shape, options) {
             `<tspan x="${x}" dy="${i === 0 ? 0 : '1.3em'}">${escapeXml(line) || ' '}</tspan>`
         )
         .join('');
-      const markup = `<text x="${x}" y="${y}" font-size="${shape.fontSize}" fill="${shape.textColor}" text-anchor="${anchor}" font-weight="${shape.bold ? '700' : '400'}" font-style="${shape.italic ? 'italic' : 'normal'}" ${fontAttr(shape)}>${spans}</text>`;
+      const decoration = shape.underline ? ' text-decoration="underline"' : '';
+      const markup = `<text x="${x}" y="${y}" font-size="${shape.fontSize}" fill="${shape.textColor}" text-anchor="${anchor}" font-weight="${shape.bold ? '700' : '400'}" font-style="${shape.italic ? 'italic' : 'normal'}"${decoration} ${fontAttr(shape)}>${spans}</text>`;
       return rotateSvg(shape, markup);
     }
     case 'image': {
@@ -391,16 +409,40 @@ function renderSlideSvg(slide, options) {
   }
   return (
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SLIDE_W} ${SLIDE_H}">` +
-    `<rect width="${SLIDE_W}" height="${SLIDE_H}" fill="#ffffff"/>${shapes}</svg>`
+    `<rect width="${SLIDE_W}" height="${SLIDE_H}" fill="${slideBackground(slide)}"/>${shapes}</svg>`
   );
+}
+
+// --- zoom ---------------------------------------------------------------------
+//
+// Fixed steps rather than a free factor: every stop is a round number the
+// label can show, and repeated presses land on the same places every time.
+// 1 is the slide fitted to the stage, which is where the editor starts.
+
+const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2, 3, 4];
+const ZOOM_FIT = 1;
+
+function zoomIn(zoom) {
+  return ZOOM_STEPS.find((step) => step > zoom + 0.001) || ZOOM_STEPS[ZOOM_STEPS.length - 1];
+}
+
+function zoomOut(zoom) {
+  const smaller = ZOOM_STEPS.filter((step) => step < zoom - 0.001);
+  return smaller.length ? smaller[smaller.length - 1] : ZOOM_STEPS[0];
 }
 
 const exported = {
   SLIDE_W,
   SLIDE_H,
   DEFAULT_STYLE,
+  DEFAULT_BACKGROUND,
+  ZOOM_STEPS,
+  ZOOM_FIT,
+  zoomIn,
+  zoomOut,
   createDeck,
   createSlide,
+  slideBackground,
   createShape,
   dragShape,
   isDegenerate,

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -25,7 +25,6 @@
       <button data-tool="text" title="Text (T)">T</button>
     </div>
     <div class="group">
-      <button id="btn-numbers" title="Show a slide number on every slide">Numbers</button>
       <button id="btn-present" title="Start the presentation from the current slide">▶ Present</button>
       <button id="btn-update" title="Check for a newer version">Updates</button>
     </div>
@@ -46,11 +45,6 @@
           <svg id="canvas" viewBox="0 0 1280 720"></svg>
           <textarea id="text-editor" hidden spellcheck="false"></textarea>
         </div>
-      </div>
-      <div id="zoom">
-        <button id="btn-zoom-out" title="Zoom out (Cmd+-)">−</button>
-        <button id="btn-zoom-level" title="Fit the slide to the window (Cmd+0)">100%</button>
-        <button id="btn-zoom-in" title="Zoom in (Cmd++)">+</button>
       </div>
     </section>
 
@@ -165,6 +159,22 @@
       <button id="btn-delete-shape">Delete shape</button>
     </aside>
   </main>
+
+  <!-- The view controls: what the deck looks like on screen, not what it
+       contains. They sit together at the bottom, away from the tools that
+       change the slide. -->
+  <footer id="statusbar">
+    <button id="btn-numbers" title="Show a slide number on every slide">№ Slide numbers</button>
+    <div id="zoom">
+      <button id="btn-zoom-out" title="Zoom out (Cmd+-)">
+        <svg viewBox="0 0 14 14" class="icon"><circle cx="6" cy="6" r="4.2" /><path d="M9.2 9.2 12.6 12.6M4 6h4" /></svg>
+      </button>
+      <button id="btn-zoom-level" title="Fit the slide to the window (Cmd+0)">100%</button>
+      <button id="btn-zoom-in" title="Zoom in (Cmd++)">
+        <svg viewBox="0 0 14 14" class="icon"><circle cx="6" cy="6" r="4.2" /><path d="M9.2 9.2 12.6 12.6M4 6h4M6 4v4" /></svg>
+      </button>
+    </div>
+  </footer>
 
   <div id="present" hidden></div>
 

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -25,7 +25,7 @@
       <button data-tool="text" title="Text (T)">T</button>
     </div>
     <div class="group">
-      <button id="btn-numbers" title="Show a slide number on every slide">№</button>
+      <button id="btn-numbers" title="Show a slide number on every slide">Numbers</button>
       <button id="btn-present" title="Start the presentation from the current slide">▶ Present</button>
       <button id="btn-update" title="Check for a newer version">Updates</button>
     </div>

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -130,13 +130,13 @@
         <div class="prop-row">
           <label>Align</label>
           <span class="btn-set" id="prop-align">
-            <button data-align="left" title="Align left">
+            <button data-align="left" title="Align left" aria-label="Align left">
               <svg viewBox="0 0 14 14" class="icon"><path d="M2 3h10M2 7h6M2 11h10" /></svg>
             </button>
-            <button data-align="center" title="Align center">
+            <button data-align="center" title="Align center" aria-label="Align center">
               <svg viewBox="0 0 14 14" class="icon"><path d="M2 3h10M4 7h6M2 11h10" /></svg>
             </button>
-            <button data-align="right" title="Align right">
+            <button data-align="right" title="Align right" aria-label="Align right">
               <svg viewBox="0 0 14 14" class="icon"><path d="M2 3h10M6 7h6M2 11h10" /></svg>
             </button>
           </span>
@@ -144,13 +144,13 @@
         <div class="prop-row">
           <label>Anchor</label>
           <span class="btn-set" id="prop-vertical-align">
-            <button data-valign="top" title="Anchor to the top of the box">
+            <button data-valign="top" title="Anchor to the top of the box" aria-label="Anchor to the top of the box">
               <svg viewBox="0 0 14 14" class="icon box"><rect x="2" y="1.5" width="10" height="11" /><path d="M4 4h6" /></svg>
             </button>
-            <button data-valign="center" title="Anchor to the middle of the box">
+            <button data-valign="center" title="Anchor to the middle of the box" aria-label="Anchor to the middle of the box">
               <svg viewBox="0 0 14 14" class="icon box"><rect x="2" y="1.5" width="10" height="11" /><path d="M4 7h6" /></svg>
             </button>
-            <button data-valign="bottom" title="Anchor to the bottom of the box">
+            <button data-valign="bottom" title="Anchor to the bottom of the box" aria-label="Anchor to the bottom of the box">
               <svg viewBox="0 0 14 14" class="icon box"><rect x="2" y="1.5" width="10" height="11" /><path d="M4 10h6" /></svg>
             </button>
           </span>
@@ -166,11 +166,11 @@
   <footer id="statusbar">
     <button id="btn-numbers" title="Show a slide number on every slide">№ Slide numbers</button>
     <div id="zoom">
-      <button id="btn-zoom-out" title="Zoom out (Cmd+-)">
+      <button id="btn-zoom-out" title="Zoom out (Cmd+-)" aria-label="Zoom out (Cmd+-)">
         <svg viewBox="0 0 14 14" class="icon"><circle cx="6" cy="6" r="4.2" /><path d="M9.2 9.2 12.6 12.6M4 6h4" /></svg>
       </button>
       <button id="btn-zoom-level" title="Fit the slide to the window (Cmd+0)">100%</button>
-      <button id="btn-zoom-in" title="Zoom in (Cmd++)">
+      <button id="btn-zoom-in" title="Zoom in (Cmd++)" aria-label="Zoom in (Cmd++)">
         <svg viewBox="0 0 14 14" class="icon"><circle cx="6" cy="6" r="4.2" /><path d="M9.2 9.2 12.6 12.6M4 6h4M6 4v4" /></svg>
       </button>
     </div>

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -41,16 +41,46 @@
     </aside>
 
     <section id="stage">
-      <div id="stage-inner">
-        <svg id="canvas" viewBox="0 0 1280 720"></svg>
-        <textarea id="text-editor" hidden spellcheck="false"></textarea>
+      <div id="stage-scroll">
+        <div id="stage-inner">
+          <svg id="canvas" viewBox="0 0 1280 720"></svg>
+          <textarea id="text-editor" hidden spellcheck="false"></textarea>
+        </div>
+      </div>
+      <div id="zoom">
+        <button id="btn-zoom-out" title="Zoom out (Cmd+-)">−</button>
+        <button id="btn-zoom-level" title="Fit the slide to the window (Cmd+0)">100%</button>
+        <button id="btn-zoom-in" title="Zoom in (Cmd++)">+</button>
       </div>
     </section>
 
     <aside id="props">
+      <!-- The background belongs to the slide, not to any shape, so it sits
+           in its own card above the selection properties. Sharing the Fill
+           row with shapes is what made people recolor a rectangle while
+           trying to recolor the slide. -->
+      <section id="props-background">
+        <h2>Slide background</h2>
+        <div class="swatches" id="bg-swatches">
+          <button class="swatch" data-bg="#ffffff" title="White" style="--swatch: #ffffff"></button>
+          <button class="swatch" data-bg="#f8f9fa" title="Paper" style="--swatch: #f8f9fa"></button>
+          <button class="swatch" data-bg="#fff9db" title="Cream" style="--swatch: #fff9db"></button>
+          <button class="swatch" data-bg="#e7f5ff" title="Sky" style="--swatch: #e7f5ff"></button>
+          <button class="swatch" data-bg="#e6fcf5" title="Mint" style="--swatch: #e6fcf5"></button>
+          <button class="swatch" data-bg="#f3f0ff" title="Lilac" style="--swatch: #f3f0ff"></button>
+          <button class="swatch" data-bg="#343a40" title="Charcoal" style="--swatch: #343a40"></button>
+          <button class="swatch" data-bg="#212022" title="Ink" style="--swatch: #212022"></button>
+        </div>
+        <div class="prop-row">
+          <label for="prop-background">Custom</label>
+          <input type="color" id="prop-background" />
+        </div>
+        <button id="btn-bg-all" title="Give every slide this background">Apply to all slides</button>
+      </section>
+
       <p id="props-hint"></p>
       <div id="props-fill" class="prop-row">
-        <label>Fill</label>
+        <label>Shape fill</label>
         <span><input type="checkbox" id="prop-fill-none" /> none</span>
         <input type="color" id="prop-fill" />
       </div>
@@ -94,6 +124,42 @@
         <div class="prop-row">
           <label>Text color</label>
           <input type="color" id="prop-text-color" />
+        </div>
+        <div class="prop-row">
+          <label>Style</label>
+          <span class="btn-set">
+            <button id="prop-bold" class="glyph" title="Bold (Cmd+B)"><b>B</b></button>
+            <button id="prop-italic" class="glyph" title="Italic (Cmd+I)"><i>I</i></button>
+            <button id="prop-underline" class="glyph" title="Underline (Cmd+U)"><u>U</u></button>
+          </span>
+        </div>
+        <div class="prop-row">
+          <label>Align</label>
+          <span class="btn-set" id="prop-align">
+            <button data-align="left" title="Align left">
+              <svg viewBox="0 0 14 14" class="icon"><path d="M2 3h10M2 7h6M2 11h10" /></svg>
+            </button>
+            <button data-align="center" title="Align center">
+              <svg viewBox="0 0 14 14" class="icon"><path d="M2 3h10M4 7h6M2 11h10" /></svg>
+            </button>
+            <button data-align="right" title="Align right">
+              <svg viewBox="0 0 14 14" class="icon"><path d="M2 3h10M6 7h6M2 11h10" /></svg>
+            </button>
+          </span>
+        </div>
+        <div class="prop-row">
+          <label>Anchor</label>
+          <span class="btn-set" id="prop-vertical-align">
+            <button data-valign="top" title="Anchor to the top of the box">
+              <svg viewBox="0 0 14 14" class="icon box"><rect x="2" y="1.5" width="10" height="11" /><path d="M4 4h6" /></svg>
+            </button>
+            <button data-valign="center" title="Anchor to the middle of the box">
+              <svg viewBox="0 0 14 14" class="icon box"><rect x="2" y="1.5" width="10" height="11" /><path d="M4 7h6" /></svg>
+            </button>
+            <button data-valign="bottom" title="Anchor to the bottom of the box">
+              <svg viewBox="0 0 14 14" class="icon box"><rect x="2" y="1.5" width="10" height="11" /><path d="M4 10h6" /></svg>
+            </button>
+          </span>
         </div>
       </div>
       <button id="btn-delete-shape">Delete shape</button>

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -19,6 +19,7 @@ const state = {
   presentIndex: 0,
   showNumbers: false,
   clipboard: null,
+  zoom: L.ZOOM_FIT,
 };
 
 const $ = (id) => document.getElementById(id);
@@ -79,6 +80,9 @@ function slideNumberSvg(index) {
 }
 
 function renderCanvas() {
+  // The slide's own color, not the app theme: what the editor shows here is
+  // what the pdf and the projector show.
+  canvas.style.background = L.slideBackground(slide());
   const shapes = slide()
     .shapes.map(
       (shape, i) =>
@@ -130,6 +134,18 @@ function renderProps() {
   $('prop-dash').value = source.dash;
   $('prop-font-size').value = source.fontSize;
   $('prop-text-color').value = source.textColor;
+  $('prop-bold').classList.toggle('active', !!source.bold);
+  $('prop-italic').classList.toggle('active', !!source.italic);
+  $('prop-underline').classList.toggle('active', !!source.underline);
+  for (const button of document.querySelectorAll('[data-align]')) {
+    button.classList.toggle('active', button.dataset.align === (source.textAlign || 'left'));
+  }
+  for (const button of document.querySelectorAll('[data-valign]')) {
+    button.classList.toggle(
+      'active',
+      button.dataset.valign === (source.verticalAlign || 'top')
+    );
+  }
 
   // A pptx from another editor can name a font this list does not offer.
   // Adding it keeps the select honest instead of silently showing the wrong
@@ -140,6 +156,14 @@ function renderProps() {
     fonts.add(new Option(family, family));
   }
   fonts.value = family;
+}
+
+function renderBackground() {
+  const color = L.slideBackground(slide());
+  $('prop-background').value = color;
+  for (const button of document.querySelectorAll('[data-bg]')) {
+    button.classList.toggle('active', button.dataset.bg.toLowerCase() === color.toLowerCase());
+  }
 }
 
 function updateTitle() {
@@ -153,6 +177,7 @@ function renderAll() {
   renderCanvas();
   renderThumbs();
   renderProps();
+  renderBackground();
   updateTitle();
 }
 
@@ -363,14 +388,11 @@ canvas.addEventListener('dblclick', (event) => {
 
 // --- text editing -----------------------------------------------------------------
 
-function startTextEdit(index) {
-  const shape = slide().shapes[index];
-  state.editingIndex = index;
-  renderCanvas();
-
+// The overlay has to look like the glyphs it hides, or every text box jumps
+// the moment editing starts or ends.
+function styleTextEditor(shape) {
   const scale = canvas.getBoundingClientRect().width / L.SLIDE_W;
   const lines = (shape.text || '').split('\n').length;
-  textEditor.value = shape.text;
   textEditor.style.left = `${shape.x * scale}px`;
   textEditor.style.top = `${shape.y * scale}px`;
   textEditor.style.width = `${Math.max(shape.w, 120) * scale}px`;
@@ -378,6 +400,19 @@ function startTextEdit(index) {
   textEditor.style.fontSize = `${shape.fontSize * scale}px`;
   textEditor.style.fontFamily = `${shape.fontFamily || 'Helvetica'}, sans-serif`;
   textEditor.style.color = shape.textColor;
+  textEditor.style.fontWeight = shape.bold ? '700' : '400';
+  textEditor.style.fontStyle = shape.italic ? 'italic' : 'normal';
+  textEditor.style.textDecoration = shape.underline ? 'underline' : 'none';
+  textEditor.style.textAlign = shape.textAlign || 'left';
+}
+
+function startTextEdit(index) {
+  const shape = slide().shapes[index];
+  state.editingIndex = index;
+  renderCanvas();
+
+  textEditor.value = shape.text;
+  styleTextEditor(shape);
   textEditor.hidden = false;
   // Deferred so it wins over whatever focus change the triggering click
   // still has queued.
@@ -409,8 +444,22 @@ function commitTextEdit() {
 
 textEditor.addEventListener('blur', commitTextEdit);
 textEditor.addEventListener('keydown', (event) => {
+  // The document handler must not see plain typing: every letter is a tool
+  // shortcut out there. Formatting and zoom are the exceptions, handled here
+  // so Cmd+B works mid-sentence like it does in any other editor.
   event.stopPropagation();
-  if (event.key === 'Escape') textEditor.blur();
+  if (event.key === 'Escape') {
+    textEditor.blur();
+    return;
+  }
+  if (!(event.metaKey || event.ctrlKey)) return;
+  const style = TEXT_STYLE_KEYS[event.key.toLowerCase()];
+  if (style) {
+    toggleTextStyle(style);
+    event.preventDefault();
+  } else if (handleZoomKey(event.key)) {
+    event.preventDefault();
+  }
 });
 
 // --- keyboard ------------------------------------------------------------------------
@@ -422,6 +471,13 @@ document.addEventListener('keydown', (event) => {
     if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'PageDown') presentStep(1);
     else if (event.key === 'ArrowLeft' || event.key === 'PageUp') presentStep(-1);
     else if (event.key === 'Escape') exitPresent();
+    event.preventDefault();
+    return;
+  }
+
+  // Zoom answers even while a field has focus: it is about the view, not
+  // about whatever is being typed into.
+  if ((event.metaKey || event.ctrlKey) && handleZoomKey(event.key)) {
     event.preventDefault();
     return;
   }
@@ -442,6 +498,7 @@ document.addEventListener('keydown', (event) => {
     else if (key === 'c') copyShape();
     else if (key === 'v') pasteShape();
     else if (key === 'd') duplicateSelection();
+    else if (TEXT_STYLE_KEYS[key]) toggleTextStyle(TEXT_STYLE_KEYS[key]);
     else return;
     event.preventDefault();
     return;
@@ -536,6 +593,56 @@ function applyProp(patch) {
   renderProps();
 }
 
+// --- slide background --------------------------------------------------------
+//
+// Deliberately not part of applyProp: it writes to the slide, never to a
+// shape or to the defaults for new shapes, whatever happens to be selected.
+
+function setBackground(color, allSlides) {
+  const targets = allSlides ? state.deck.slides : [slide()];
+  for (const target of targets) target.background = color;
+  markDirty();
+  renderCanvas();
+  renderThumbs();
+  renderBackground();
+}
+
+$('bg-swatches').addEventListener('click', (event) => {
+  const swatch = event.target.closest('[data-bg]');
+  if (swatch) setBackground(swatch.dataset.bg, false);
+});
+$('prop-background').addEventListener('input', (e) => setBackground(e.target.value, false));
+$('btn-bg-all').addEventListener('click', () =>
+  setBackground(L.slideBackground(slide()), true)
+);
+
+// --- zoom ---------------------------------------------------------------------
+
+function setZoom(zoom) {
+  state.zoom = zoom;
+  stageInner.style.setProperty('--zoom', String(zoom));
+  $('btn-zoom-level').textContent = `${Math.round(zoom * 100)}%`;
+  // The overlay textarea is placed in screen pixels, so a zoom while a text
+  // box is open would leave it behind the glyphs it is meant to cover.
+  if (state.editingIndex >= 0) textEditor.blur();
+}
+
+$('btn-zoom-in').addEventListener('click', () => setZoom(L.zoomIn(state.zoom)));
+$('btn-zoom-out').addEventListener('click', () => setZoom(L.zoomOut(state.zoom)));
+$('btn-zoom-level').addEventListener('click', () => setZoom(L.ZOOM_FIT));
+
+// True when the key was a zoom command, so the caller can swallow it. Cmd+=
+// rather than Cmd+Shift+= for zooming in, which is the habit everywhere else.
+function handleZoomKey(key) {
+  if (key === '=' || key === '+') setZoom(L.zoomIn(state.zoom));
+  else if (key === '-' || key === '_') setZoom(L.zoomOut(state.zoom));
+  else if (key === '0') setZoom(L.ZOOM_FIT);
+  else return false;
+  return true;
+}
+
+// --- shape properties ------------------------------------------------------
+
 $('prop-fill-none').addEventListener('change', (e) =>
   applyProp({ fill: e.target.checked ? 'none' : $('prop-fill').value })
 );
@@ -553,6 +660,43 @@ $('prop-font-family').addEventListener('change', (e) =>
   applyProp({ fontFamily: e.target.value })
 );
 $('btn-delete-shape').addEventListener('click', deleteSelectedShape);
+
+// --- text formatting -----------------------------------------------------------
+//
+// Formatting is a property of the whole text box, not of a run inside it, so
+// these apply to the selected box, or to the style new boxes start with when
+// nothing is selected.
+
+function textStyleTarget() {
+  const shape = selectedShape();
+  if (shape) return shape.kind === 'text' ? shape : null;
+  return state.defaults;
+}
+
+function toggleTextStyle(name) {
+  const target = textStyleTarget();
+  if (!target) return;
+  applyProp({ [name]: !target[name] });
+  // A box open for editing shows its glyphs in the textarea, not on the
+  // canvas, so the overlay has to be restyled too.
+  if (state.editingIndex >= 0) styleTextEditor(slide().shapes[state.editingIndex]);
+}
+
+$('prop-bold').addEventListener('click', () => toggleTextStyle('bold'));
+$('prop-italic').addEventListener('click', () => toggleTextStyle('italic'));
+$('prop-underline').addEventListener('click', () => toggleTextStyle('underline'));
+
+$('prop-align').addEventListener('click', (event) => {
+  const button = event.target.closest('[data-align]');
+  if (button) applyProp({ textAlign: button.dataset.align });
+});
+
+$('prop-vertical-align').addEventListener('click', (event) => {
+  const button = event.target.closest('[data-valign]');
+  if (button) applyProp({ verticalAlign: button.dataset.valign });
+});
+
+const TEXT_STYLE_KEYS = { b: 'bold', i: 'italic', u: 'underline' };
 
 // --- slide panel ------------------------------------------------------------------------
 
@@ -756,4 +900,5 @@ for (const button of document.querySelectorAll('[data-tool]')) {
 }
 
 setTool('select');
+setZoom(state.zoom);
 renderAll();

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -244,6 +244,19 @@ function setTool(tool) {
 
 // --- pointer interaction --------------------------------------------------------
 
+// Two presses on the same shape inside this window are a double click. The
+// value is the platform default a double click is judged by; longer and an
+// ordinary pair of clicks starts opening text boxes.
+const DOUBLE_PRESS_MS = 400;
+let lastPress = { index: -1, time: -Infinity };
+
+function isSecondPress(index) {
+  const now = performance.now();
+  const again = index === lastPress.index && now - lastPress.time < DOUBLE_PRESS_MS;
+  lastPress = { index, time: now };
+  return again;
+}
+
 function toPoint(event) {
   const rect = canvas.getBoundingClientRect();
   return {
@@ -296,6 +309,24 @@ canvas.addEventListener('pointerdown', (event) => {
   const group = event.target.closest('g[data-i]');
   if (group) {
     let index = Number(group.dataset.i);
+
+    // Opening a text box for editing is decided here rather than from a
+    // dblclick event, because the browser never reports one: pointerup
+    // redraws the canvas, so mouseup lands on a freshly built element and
+    // not the one that took mousedown, and a click needs both.
+    //
+    // preventDefault keeps the focus the overlay is about to take. Without
+    // it the press moves focus back to the page, and from there Backspace
+    // deletes the box being typed into instead of a character.
+    if (isSecondPress(index) && slide().shapes[index].kind === 'text') {
+      event.preventDefault();
+      state.selected = index;
+      renderCanvas();
+      renderProps();
+      startTextEdit(index);
+      return;
+    }
+
     const clicked = index;
     // Cmd/Ctrl+drag drags a copy and leaves the original where it was, the
     // way PowerPoint does. Add Shift and the copy travels on one axis.
@@ -375,16 +406,6 @@ canvas.addEventListener('pointerup', () => {
   renderAll();
 });
 
-canvas.addEventListener('dblclick', (event) => {
-  const group = event.target.closest('g[data-i]');
-  if (!group) return;
-  const index = Number(group.dataset.i);
-  if (slide().shapes[index].kind === 'text') {
-    state.selected = index;
-    renderCanvas();
-    startTextEdit(index);
-  }
-});
 
 // --- text editing -----------------------------------------------------------------
 
@@ -429,6 +450,15 @@ function commitTextEdit() {
   state.editingIndex = -1;
   textEditor.hidden = true;
 
+  // The shape can be gone by now: an undo, or a delete that reached the page
+  // while the overlay was open. There is nothing to commit into, and reading
+  // through it would take the whole page down.
+  if (!shape) {
+    state.selected = -1;
+    renderAll();
+    return;
+  }
+
   const text = textEditor.value.replace(/\s+$/, '');
   if (text === '') {
     slide().shapes.splice(index, 1);
@@ -471,6 +501,16 @@ document.addEventListener('keydown', (event) => {
     if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'PageDown') presentStep(1);
     else if (event.key === 'ArrowLeft' || event.key === 'PageUp') presentStep(-1);
     else if (event.key === 'Escape') exitPresent();
+    event.preventDefault();
+    return;
+  }
+
+  // A text box open for editing owns the keyboard, and its own handler below
+  // deals with every key it should answer. Reaching here at all means focus
+  // slipped off the overlay; without this the shortcuts would run against the
+  // box being typed into — Backspace deleting it, a letter switching tools.
+  if (state.editingIndex >= 0 && event.target !== textEditor) {
+    textEditor.focus();
     event.preventDefault();
     return;
   }

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -253,7 +253,10 @@ let lastPress = { index: -1, time: -Infinity };
 function isSecondPress(index) {
   const now = performance.now();
   const again = index === lastPress.index && now - lastPress.time < DOUBLE_PRESS_MS;
-  lastPress = { index, time: now };
+  // A consumed pair ends the sequence, the way a triple click is not two
+  // double clicks. Without the reset the press after one counts as a second
+  // press again, and a plain click keeps reopening the box just closed.
+  lastPress = { index: again ? -1 : index, time: now };
   return again;
 }
 

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -413,8 +413,10 @@ canvas.addEventListener('pointerup', () => {
 // --- text editing -----------------------------------------------------------------
 
 // The overlay has to look like the glyphs it hides, or every text box jumps
-// the moment editing starts or ends.
+// the moment editing starts or ends. A missing shape means the box being
+// edited is already gone, the same case commitTextEdit guards against.
 function styleTextEditor(shape) {
+  if (!shape) return;
   const scale = canvas.getBoundingClientRect().width / L.SLIDE_W;
   const lines = (shape.text || '').split('\n').length;
   textEditor.style.left = `${shape.x * scale}px`;
@@ -462,16 +464,22 @@ function commitTextEdit() {
     return;
   }
 
+  // Both answers are needed before the shape is touched. Asking afterwards
+  // compares the new text with itself, which is never a change, and then an
+  // edit reaches neither the undo history nor the dirty marker.
   const text = textEditor.value.replace(/\s+$/, '');
-  if (text === '') {
+  const removed = text === '';
+  const changed = !removed && text !== shape.text;
+
+  if (removed) {
     slide().shapes.splice(index, 1);
     state.selected = -1;
-  } else if (text !== shape.text) {
+  } else if (changed) {
     shape.text = text;
     const lines = text.split('\n').length;
     shape.h = Math.max(shape.h, lines * shape.fontSize * 1.35);
   }
-  if (text !== shape.text || text === '') markDirty();
+  if (removed || changed) markDirty();
   renderAll();
 }
 

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -154,13 +154,10 @@ main {
 
 /* --- stage --- */
 
-/* The stage holds the scroller and the zoom control. Only the scroller
-   scrolls, so the control stays pinned to the corner at any zoom. */
 #stage {
   flex: 1;
   min-width: 0;
   display: flex;
-  position: relative;
   background: var(--stage);
 }
 
@@ -173,41 +170,49 @@ main {
 }
 
 /* Centred with auto margins rather than justify-content, which puts the
-   overflowing top-left of a zoomed-in slide out of the scroll range. */
+   overflowing top-left of a zoomed-in slide out of the scroll range.
+
+   The subtracted 176px is everything the slide does not get: the toolbar,
+   the status bar, the stage padding, and breathing room around the slide.
+   Change either bar's height and this changes with it. */
 #stage-inner {
   position: relative;
   margin: auto;
   flex: none;
-  width: calc(min(100%, (100vh - 140px) * 16 / 9) * var(--zoom, 1));
+  width: calc(min(100%, (100vh - 176px) * 16 / 9) * var(--zoom, 1));
 }
 
-/* --- zoom control --- */
+/* --- status bar --- */
+
+#statusbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  background: var(--panel);
+  border-top: 1px solid var(--border);
+}
+
+#statusbar button {
+  padding: 3px 8px;
+}
 
 #zoom {
-  position: absolute;
-  right: 16px;
-  bottom: 16px;
   display: flex;
+  align-items: center;
   gap: 2px;
-  padding: 3px;
-  border-radius: 7px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.18);
 }
 
 #zoom button {
-  border: none;
-  padding: 3px 8px;
-  background: transparent;
-}
-
-#zoom button:hover {
-  background: var(--accent-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
 }
 
 #btn-zoom-level {
-  min-width: 52px;
+  min-width: 54px;
   font-variant-numeric: tabular-nums;
   color: var(--muted);
 }
@@ -273,6 +278,14 @@ main {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  /* A short window would otherwise cut the last rows off with no way to
+     reach them. */
+  overflow-y: auto;
+}
+
+/* Rows must keep their height when the panel scrolls, not be squeezed. */
+#props > * {
+  flex: none;
 }
 
 #props-hint {
@@ -341,7 +354,7 @@ main {
   justify-content: center;
 }
 
-.btn-set .icon {
+.icon {
   width: 14px;
   height: 14px;
   stroke: currentColor;
@@ -351,7 +364,7 @@ main {
 }
 
 /* The frame is scaffolding for the bar that carries the meaning. */
-.btn-set .icon.box rect {
+.icon.box rect {
   opacity: 0.35;
 }
 

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -174,7 +174,8 @@ main {
 
    The subtracted 176px is everything the slide does not get: the toolbar,
    the status bar, the stage padding, and breathing room around the slide.
-   Change either bar's height and this changes with it. */
+   It is a hand-measured constant, so changing either bar's height means
+   changing this number too. */
 #stage-inner {
   position: relative;
   margin: auto;

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -1,6 +1,7 @@
 /* Colors only through variables. Light is the base; dark overrides via the
    media query, which is all it takes to follow the system setting. The slide
-   itself stays white in both themes, like paper. */
+   itself ignores the theme: it shows the background the deck stores, so the
+   editor and the projector agree. */
 
 :root {
   --bg: #f1f3f5;
@@ -153,27 +154,73 @@ main {
 
 /* --- stage --- */
 
+/* The stage holds the scroller and the zoom control. Only the scroller
+   scrolls, so the control stays pinned to the corner at any zoom. */
 #stage {
   flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--stage);
-  padding: 20px;
   min-width: 0;
+  display: flex;
+  position: relative;
+  background: var(--stage);
 }
 
+#stage-scroll {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  overflow: auto;
+  padding: 20px;
+}
+
+/* Centred with auto margins rather than justify-content, which puts the
+   overflowing top-left of a zoomed-in slide out of the scroll range. */
 #stage-inner {
   position: relative;
-  width: min(100%, calc((100vh - 140px) * 16 / 9));
+  margin: auto;
+  flex: none;
+  width: calc(min(100%, (100vh - 140px) * 16 / 9) * var(--zoom, 1));
 }
 
+/* --- zoom control --- */
+
+#zoom {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  gap: 2px;
+  padding: 3px;
+  border-radius: 7px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.18);
+}
+
+#zoom button {
+  border: none;
+  padding: 3px 8px;
+  background: transparent;
+}
+
+#zoom button:hover {
+  background: var(--accent-soft);
+}
+
+#btn-zoom-level {
+  min-width: 52px;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+}
+
+/* The background is the slide's own, set inline from the deck. The hairline
+   in the shadow is what keeps the slide edge visible when a dark background
+   meets the dark stage. */
 #canvas {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 9;
   background: #ffffff;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 0 0 1px var(--border), 0 2px 12px rgba(0, 0, 0, 0.25);
 }
 
 #canvas[data-tool='rect'],
@@ -231,6 +278,86 @@ main {
 #props-hint {
   margin: 0;
   color: var(--muted);
+}
+
+/* --- slide background card --- */
+
+/* Its own card, because a control that repaints the whole slide should not
+   look like the one that repaints the selected rectangle. */
+#props-background {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+}
+
+#props-background h2 {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.swatches {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.swatch {
+  height: 26px;
+  padding: 0;
+  border-radius: 5px;
+  background: var(--swatch);
+  /* The swatch is the color, so its own border must not read as part of it. */
+  border: 1px solid var(--border);
+}
+
+.swatch.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+#btn-bg-all {
+  padding: 5px;
+}
+
+/* --- button sets --- */
+
+.btn-set {
+  display: flex;
+  gap: 3px;
+}
+
+.btn-set button {
+  min-width: 28px;
+  padding: 3px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-set .icon {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  fill: none;
+}
+
+/* The frame is scaffolding for the bar that carries the meaning. */
+.btn-set .icon.box rect {
+  opacity: 0.35;
+}
+
+.glyph {
+  font-size: 13px;
+  line-height: 1;
 }
 
 #props-stroke,

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -291,3 +291,52 @@ test('renderSlideSvg is a standalone svg with a white background', () => {
   assert.ok(svg.startsWith('<svg xmlns='));
   assert.ok(svg.includes('fill="#ffffff"'));
 });
+
+test('renderSlideSvg paints the slide background and leaves shapes alone', () => {
+  const slide = L.createSlide();
+  const shape = L.createShape('rect', 10, 10, { fill: '#ffd43b' });
+  L.dragShape(shape, 10, 10, 100, 100);
+  slide.shapes.push(shape);
+  slide.background = '#212022';
+
+  const svg = L.renderSlideSvg(slide);
+  assert.ok(svg.includes(`<rect width="1280" height="720" fill="#212022"/>`));
+  assert.ok(svg.includes('fill="#ffd43b"'));
+});
+
+test('slideBackground falls back to white for a slide saved without one', () => {
+  assert.strictEqual(L.slideBackground({ shapes: [] }), '#ffffff');
+  assert.strictEqual(L.slideBackground({ shapes: [], background: 'none' }), '#ffffff');
+  assert.strictEqual(L.slideBackground({ shapes: [], background: '#212022' }), '#212022');
+});
+
+test('createShape carries the text style defaults it is handed', () => {
+  const shape = L.createShape('text', 0, 0, { bold: true, underline: true, textAlign: 'center' });
+  assert.deepStrictEqual(
+    { bold: shape.bold, italic: shape.italic, underline: shape.underline, align: shape.textAlign },
+    { bold: true, italic: false, underline: true, align: 'center' }
+  );
+});
+
+test('renderShapeSvg marks up bold, italic and underlined text', () => {
+  const shape = L.createShape('text', 0, 0, { bold: true, italic: true, underline: true });
+  shape.text = 'hi';
+  const svg = L.renderShapeSvg(shape);
+  assert.ok(svg.includes('font-weight="700"'));
+  assert.ok(svg.includes('font-style="italic"'));
+  assert.ok(svg.includes('text-decoration="underline"'));
+
+  const plain = L.createShape('text', 0, 0, {});
+  plain.text = 'hi';
+  assert.ok(!L.renderShapeSvg(plain).includes('text-decoration'));
+});
+
+test('zoomIn and zoomOut walk the steps and stop at the ends', () => {
+  assert.strictEqual(L.zoomIn(1), 1.25);
+  assert.strictEqual(L.zoomOut(1), 0.75);
+  assert.strictEqual(L.zoomIn(L.ZOOM_STEPS[L.ZOOM_STEPS.length - 1]), 4);
+  assert.strictEqual(L.zoomOut(L.ZOOM_STEPS[0]), 0.5);
+  // A factor between two steps snaps to the neighbour in that direction.
+  assert.strictEqual(L.zoomIn(1.1), 1.25);
+  assert.strictEqual(L.zoomOut(1.1), 1);
+});


### PR DESCRIPTION
# 구현

슬라이드 줌인아웃, 배경 전용 패널, 글자 서식 추가와 하단 상태바 신설
- node 33개와 cargo 10개 통과, 줌 200퍼센트에서 클릭 좌표와 편집 오버레이 정렬을 브라우저로 확인

# 어려웠던 점

텍스트 재편집이 열리지 않던 원인이 dblclick 이벤트 자체의 부재였음
- pointerup의 renderAll이 canvas를 다시 그려 mousedown 대상이 사라지므로 브라우저가 click과 dblclick을 만들지 않음

# 리스크

solid 배경 import 결과가 도형에서 slide 필드로 바뀜
- 배경 이미지는 그대로 shape이라 색 배경만 해당, 되돌릴 곳은 read의 parse_background 반환값 처리 한 곳

Issue #653
