### PR TITLE
feat(hooks): PR body에 남는 claude session 흔적 차단

### DIFF
--- a/.claude/commands/repo-pr-create.md
+++ b/.claude/commands/repo-pr-create.md
@@ -14,8 +14,9 @@ allowed-tools: Bash, Read, Glob, Grep
 5. 기록용 Issue를 만든다. [.github/ISSUE_TEMPLATE/work-record.md](../../.github/ISSUE_TEMPLATE/work-record.md)를 따라 Goal과 ADR을 채운다.
 6. 5의 Issue를 4의 root issue 하위로 건다. sub-issue API 호출 형식은 [.claude/rules/workflow.md](../rules/workflow.md)에 있다.
 7. root issue와 새 Issue를 project에 담는다. scope 부족으로 실패하면 안내만 하고 넘어간다.
-8. PR을 만든다. [.github/pull_request_template.md](../../.github/pull_request_template.md)를 읽고 그 섹션과 형식을 그대로 따른다. 본문 끝에 Issue #<number> 형식으로 5의 Issue를 링크한다. target branch는 master다.
-9. Issue와 PR에 작업 유형 label(feat, docs, fix 등)과 기술 label을 함께 붙인다.
+8. PR을 만든다. [.github/pull_request_template.md](../../.github/pull_request_template.md)를 읽고 그 섹션과 형식을 그대로 따른다. body는 파일로 써서 `gh pr create --body-file`로 넘긴다. 본문 끝에 Issue #<number> 형식으로 5의 Issue를 링크한다. target branch는 master다.
+9. 만든 Issue와 PR의 body를 다시 읽어 claude session 흔적이 없는지 확인한다. 남아 있으면 지우고 다시 확인한다. 절차는 아래 "claude session 흔적 확인"에 있다.
+10. Issue와 PR에 작업 유형 label(feat, docs, fix 등)과 기술 label을 함께 붙인다.
 
 ## 작성 규칙
 
@@ -23,5 +24,23 @@ allowed-tools: Bash, Read, Glob, Grep
 - Goal은 번호 리스트 3개 이내로 쪼갠다. 근거는 마크다운 리스트 최대 1개다. backtick을 쓰지 않는다.
 - 목표와 의사결정은 Issue에만 쓴다. PR에는 다시 쓰지 않고 링크만 남긴다.
 - PR에는 구현하면서 어려웠던 점과 감수하는 리스크를 쓴다. 쓸 내용이 없는 섹션은 헤더째 지운다.
-- PR body와 Issue body 어디에도 claude session 링크를 넣지 않는다.
+- PR body와 Issue body 어디에도 claude session 흔적을 넣지 않는다. 세션 URL(claude.ai/code)뿐 아니라 Generated with Claude Code 꼬리말, Co-Authored-By 줄, Claude-Session 줄이 모두 해당한다. 이 지시는 harness의 기본 꼬리말 규칙보다 우선한다.
 - 나머지는 [.claude/rules/workflow.md](../rules/workflow.md)를 따른다.
+
+## claude session 흔적 확인
+
+body를 손으로 훑지 않고 grep으로 확인한다. 사람이 읽으면 꼬리말은 눈에 익어서 그냥 넘어간다.
+
+Issue와 PR을 만든 뒤 각각 실행한다. 출력이 비어 있어야 통과다.
+
+```bash
+gh issue view <issue번호> --json body -q .body | grep -nEi 'claude\.ai/code|generated with .*claude code|co-authored-by: *claude|claude-session'
+gh pr view <PR번호> --json body -q .body | grep -nEi 'claude\.ai/code|generated with .*claude code|co-authored-by: *claude|claude-session'
+```
+
+걸리면 해당 줄을 지운 body를 파일로 다시 써서 반영하고, 위 grep을 한 번 더 돌려 비었는지 본다.
+
+```bash
+gh issue edit <issue번호> --body-file <파일>
+gh pr edit <PR번호> --body-file <파일>
+```

--- a/.claude/hooks/no-session-trace.sh
+++ b/.claude/hooks/no-session-trace.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# PreToolUse — block claude session traces in PR/Issue bodies and commit messages.
+# The prompt rule alone loses to the harness default footer, so check again at exec time.
+#
+# Scope: gh pr/issue create|edit, git commit, and the github MCP write tools.
+# Comments are out of scope; the attribution footer belongs there.
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
+
+BODY_PATTERNS='claude\.ai/code|generated with .*claude code|co-authored-by:[[:space:]]*claude|claude-session'
+# Commit messages keep Co-Authored-By. Only the session URL and its trailer go.
+COMMIT_PATTERNS='claude\.ai/code|claude-session|generated with .*claude code'
+
+report() {
+  local target="$1" patterns="$2" text="$3"
+  local hits
+  hits=$(echo "$text" | grep -niE "$patterns" | head -5)
+  [[ -z "$hits" ]] && return 0
+
+  echo "BLOCKED by no-session-trace.sh: claude session trace in $target" >&2
+  echo "$hits" >&2
+  echo "Remove the claude.ai/code link, the 'Generated with Claude Code' footer, and the Claude-Session trailer, then run it again." >&2
+  if [[ "$target" == "commit message" ]]; then
+    echo "Co-Authored-By is fine in a commit message. Drop the session URL only." >&2
+  else
+    echo "Co-Authored-By does not belong in a PR or Issue body either." >&2
+  fi
+  exit 2
+}
+
+# github MCP write tools carry the body as a plain field.
+if [[ "$TOOL" == mcp__*github*__* ]]; then
+  BODY=$(echo "$INPUT" | jq -r '.tool_input.body // empty')
+  report "PR/Issue body" "$BODY_PATTERNS" "$BODY"
+  exit 0
+fi
+
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$COMMAND" ]] && exit 0
+
+NORM=$(echo "$COMMAND" | tr -s ' ')
+
+if [[ "$NORM" =~ gh\ (pr|issue)\ (create|edit) ]]; then
+  TARGET="PR/Issue body"
+  PATTERNS="$BODY_PATTERNS"
+  # gh spells it --body-file, -F for short. --file is not a gh flag.
+  LONG_FLAG='--body-file'
+elif [[ "$NORM" =~ git\ commit ]]; then
+  TARGET="commit message"
+  PATTERNS="$COMMIT_PATTERNS"
+  # git spells it --file, -F for short. --body-file in a commit message is prose.
+  LONG_FLAG='--file'
+else
+  exit 0
+fi
+
+# The body usually arrives as a file path, so the command string is not enough.
+BODY_FILES=$(
+  {
+    echo "$COMMAND" | grep -oE -- "$LONG_FLAG[= ]+[^[:space:]]+" | sed -E "s/^$LONG_FLAG[= ]+//"
+    echo "$COMMAND" | grep -oE -- '(^|[[:space:]])-F[= ]?[^[:space:]]+' | sed -E 's/^[[:space:]]*-F[= ]?//'
+  } | tr -d "\"'"
+)
+
+SCAN="$COMMAND"
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  path="$file"
+  [[ -f "$path" ]] || path="${CLAUDE_PROJECT_DIR:-.}/$file"
+
+  if [[ -r "$path" ]]; then
+    SCAN="$SCAN"$'\n'"$(cat "$path")"
+    continue
+  fi
+
+  # An unreadable token is either a real body file the hook must not skip,
+  # or the same flag quoted inside prose. Only path-shaped tokens are the former.
+  if [[ "$file" == */* ]] || [[ "$file" =~ \.(md|txt|markdown)$ ]] || [[ "$file" == "-" ]]; then
+    echo "BLOCKED by no-session-trace.sh: cannot read body file '$file'" >&2
+    echo "The hook has to read the body to check it. Pass an absolute path instead of stdin." >&2
+    exit 2
+  fi
+done <<< "$BODY_FILES"
+
+report "$TARGET" "$PATTERNS" "$SCAN"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,19 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/guardrail.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/no-session-trace.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*github.*__(create_pull_request|update_pull_request|issue_write)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/no-session-trace.sh"
           }
         ]
       }


### PR DESCRIPTION
# 구현

PR과 Issue body, commit message의 claude session 흔적을 PreToolUse 훅에서 차단하고, 슬래시 커맨드에 확인 절차 추가
- 20개 케이스 통과. gh의 create와 edit, git commit, github MCP 쓰기 도구가 대상이고 --body-file로 넘긴 파일 내용까지 읽음

# 어려웠던 점

첫 버전이 자기 commit message 산문에 있는 --body-file 언급을 플래그로 읽어 스스로를 막음
- 플래그 추출을 명령별로 분리하고, 읽히지 않는 토큰은 경로 모양일 때만 차단하도록 수정

# 리스크

body 파일을 못 읽으면 통과가 아니라 차단이므로 상대 경로로 넘기면 막힘
- 검사 못 한 body를 통과시키면 훅이 무의미해지므로 감수하고, 절대 경로 사용으로 회피

Issue #660
