### PR TITLE
feat(akbun-gitdesktop): add GitHub issue, project board and sub-issue tree views

### DIFF
--- a/product/akbun-gitdesktop/README.md
+++ b/product/akbun-gitdesktop/README.md
@@ -1,6 +1,6 @@
 # akbun-gitdesktop
 
-로컬 git 저장소의 commit, branch, worktree, git graph, GitHub PR을 한 화면에서 보는 데스크톱 앱이다. Electron + TypeScript + React로 만들었고 macOS를 우선 지원하며 Windows, Linux 빌드도 제공한다.
+로컬 git 저장소의 commit, branch, worktree, git graph와 GitHub의 PR, issue, project를 한 화면에서 보는 데스크톱 앱이다. Electron + TypeScript + React로 만들었고 macOS를 우선 지원하며 Windows, Linux 빌드도 제공한다.
 
 UI 언어는 영어다.
 
@@ -9,8 +9,8 @@ UI 언어는 영어다.
 - 상단 바: git과 gh CLI 인식 상태 chip, Settings 버튼
 - 왼쪽 사이드바: 가져온 git 폴더 목록과 폴더 가져오기 버튼
 - 두 번째 열: 선택한 저장소의 worktree 목록. 각 worktree 옆에 "Open with"(VS Code, Finder, Terminal 등)가 있다
-- 나머지 화면: 선택한 worktree의 git graph, 브랜치 목록, GitHub PR 목록 탭
-- 오른쪽 drawer: commit이나 branch를 클릭하면 열리는 변경 파일 목록과 git diff
+- 나머지 화면: 선택한 worktree의 Graph, Branches, Pull requests, Issues, Projects 탭
+- 오른쪽 drawer: Graph와 Branches 탭에서는 변경 파일 목록과 git diff, GitHub 탭에서는 issue나 PR의 본문과 comment
 
 선택한 저장소와 worktree는 accent 색 배경과 왼쪽 세로 바로 표시한다.
 
@@ -22,7 +22,10 @@ UI 언어는 영어다.
 - branch를 클릭하면 기본 브랜치와의 3-dot diff 파일 목록과 diff를 표시
 - branch 보기, 생성, 삭제 (미병합 브랜치는 확인 후 강제 삭제)
 - worktree 보기, 생성(새 브랜치와 함께), 삭제
-- GitHub PR 목록 보기 (gh CLI 사용, 클릭하면 브라우저로 이동)
+- GitHub PR과 issue 목록 보기 (state, label, 작성자, 갱신일)
+- PR이나 issue를 클릭하면 본문과 comment 전체를 오른쪽 drawer에 표시. PR은 base ← head와 변경 파일 수, 추가/삭제 줄 수도 함께 표시
+- GitHub project를 Status 필드 기준 칸반으로 보기. 카드가 이 저장소의 issue나 PR이면 클릭해서 drawer로 열고, 다른 저장소의 카드나 draft issue는 브라우저로 연다
+- 목록의 ↗ 버튼이나 drawer의 "Open in browser"로 GitHub 원본 열기
 - worktree를 외부 앱으로 열기
 - dark/light 테마 전환, 기본값은 시스템 설정을 따르는 system
 - Settings에서 git, gh CLI의 인식 여부와 버전, 경로, gh 로그인 상태 확인과 재검사
@@ -33,9 +36,11 @@ Settings의 Appearance에서 System, Light, Dark 중 하나를 고른다. 기본
 
 ## 설계 원칙: git CLI + gh CLI
 
-git 라이브러리를 쓰지 않고 git command를 직접 실행한다. main 프로세스에서 execFile로 git을 호출하고 결과를 IPC로 renderer에 전달한다. gh CLI는 항상 쓰는 것이 아니라 GitHub PR 목록을 조회할 때만 실행한다. gh가 없어도 나머지 기능은 모두 동작하며, PR 보기만 사용할 수 없다.
+git 라이브러리를 쓰지 않고 git command를 직접 실행한다. main 프로세스에서 execFile로 git을 호출하고 결과를 IPC로 renderer에 전달한다. gh CLI는 항상 쓰는 것이 아니라 GitHub의 PR, issue, project를 조회할 때만 실행한다. gh가 없어도 나머지 기능은 모두 동작하며, GitHub 탭 세 개만 사용할 수 없다.
 
-앱을 켜면 상단 바가 git과 gh 설치 여부를 chip으로 보여 준다. git이 없으면 앱이 동작하지 않으므로 경고 배너로 강조하고, gh가 없거나 로그인이 안 되어 있으면 PR 보기만 사용할 수 없다고 알린다. Settings의 Command line tools에서 각 CLI의 버전과 경로, gh 로그인 상태를 확인하고 다시 검사할 수 있다.
+앱을 켜면 상단 바가 git과 gh 설치 여부를 chip으로 보여 준다. git이 없으면 앱이 동작하지 않으므로 경고 배너로 강조하고, gh가 없거나 로그인이 안 되어 있으면 GitHub 탭만 사용할 수 없다고 알린다. Settings의 Command line tools에서 각 CLI의 버전과 경로, gh 로그인 상태를 확인하고 다시 검사할 수 있다.
+
+main 프로세스의 코드도 이 경계를 따라 나뉜다. git command는 `src/main/git.ts`, gh command는 `src/main/github.ts`다. CLI 탐지만 `git.ts`에 함께 둔다.
 
 라이브러리 후보를 검토한 결과다.
 
@@ -45,6 +50,20 @@ git 라이브러리를 쓰지 않고 git command를 직접 실행한다. main �
 - PR 조회에 Octokit(REST API) 대신 gh CLI를 쓰는 이유: gh는 사용자가 이미 로그인한 인증을 그대로 재사용한다. Octokit을 쓰면 토큰 입력 UI와 안전한 저장(keytar 등)을 앱이 직접 구현해야 한다.
 
 개발자 머신에는 git이 이미 있고 이 앱의 사용자는 개발자이므로, git CLI 직접 실행이 가장 단순하고 유지보수하기 쉬운 선택이다.
+
+## GitHub project를 읽는 방법
+
+project는 저장소가 아니라 user나 organization이 소유한다. 그래서 `gh repo view`로 이 저장소의 owner를 먼저 구하고 그 owner의 project 목록을 조회한다. 저장소 owner와 project owner가 다르면(예: 개인 저장소를 organization project에 연결한 경우) 그 project는 목록에 나오지 않는다.
+
+칸반의 열은 Status 단일 선택 필드의 옵션 순서를 따른다. `gh project field-list`로 옵션을 읽어 비어 있는 열도 자리를 지키게 하고, 이 조회가 실패하면 항목이 도착한 순서로 열을 만든다. Status가 없는 항목은 마지막 "No status" 열로 모은다.
+
+project 조회는 `gh auth login`이 기본으로 주지 않는 scope를 요구한다. 권한이 없으면 Projects 탭이 다음 명령을 안내한다.
+
+```bash
+gh auth refresh -s read:project
+```
+
+issue와 PR의 본문은 GitHub Markdown이지만 렌더링하지 않고 원문 그대로 보여 준다. 렌더링하려면 Markdown parser와 sanitizer를 앱에 들여야 하고, 읽는 용도에는 원문으로 충분하다.
 
 ## 개발
 

--- a/product/akbun-gitdesktop/README.md
+++ b/product/akbun-gitdesktop/README.md
@@ -23,6 +23,7 @@ UI 언어는 영어다.
 - branch 보기, 생성, 삭제 (미병합 브랜치는 확인 후 강제 삭제)
 - worktree 보기, 생성(새 브랜치와 함께), 삭제
 - GitHub PR과 issue 목록 보기 (state, label, 작성자, 갱신일)
+- 하위 issue가 있으면 issue 목록을 트리로 표시. 부모 아래에 하위 issue를 들여쓰고 세로선으로 상하관계를 그리며, 부모 행에는 하위 개수를 ↳ 배지로 표시
 - PR이나 issue를 클릭하면 본문과 comment 전체를 오른쪽 drawer에 표시. PR은 base ← head와 변경 파일 수, 추가/삭제 줄 수도 함께 표시
 - GitHub project를 Status 필드 기준 칸반으로 보기. 카드가 이 저장소의 issue나 PR이면 클릭해서 drawer로 열고, 다른 저장소의 카드나 draft issue는 브라우저로 연다
 - 목록의 ↗ 버튼이나 drawer의 "Open in browser"로 GitHub 원본 열기
@@ -62,6 +63,22 @@ project 조회는 `gh auth login`이 기본으로 주지 않는 scope를 요구�
 ```bash
 gh auth refresh -s read:project
 ```
+
+## 하위 issue 트리를 만드는 방법
+
+`gh issue list --json`에는 하위 issue 관계가 없다. 그래서 목록은 그대로 `gh issue list`로 받고, 부모 번호만 GraphQL 한 번으로 따로 받아 합친다. GraphQL은 목록보다 넓은 범위를 같은 정렬(생성 역순)로 조회하므로 목록에 있는 issue는 모두 부모 조회 범위 안에 들어온다.
+
+```bash
+gh api graphql -f query='query($owner:String!,$name:String!,$limit:Int!){repository(owner:$owner,name:$name){issues(first:$limit,orderBy:{field:CREATED_AT,direction:DESC}){nodes{number parent{number}}}}}'
+```
+
+이 조회가 실패하면 트리 없이 평평한 목록을 보여 준다. 하위 issue 필드를 모르는 GitHub Enterprise나 오래된 gh에서도 issue 목록 자체는 보이는 편이 낫기 때문이다.
+
+트리를 그릴 때 지키는 것 세 가지다.
+
+- 부모가 목록 범위 밖이면 그 issue를 최상위에 두고 `↰ #번호`로 부모를 표시한다. 목록은 최근 issue만 담는 창이라 부모가 밖에 있을 수 있다.
+- 부모 관계가 순환하면 도달하지 못한 issue를 최상위로 올린다. 화면에서 issue가 사라지는 것보다 낫다.
+- 세로선은 행 안이 아니라 행 전체 높이에 절대 위치로 그린다. 행 안에 두면 padding에서 선이 끊긴다.
 
 issue와 PR의 본문은 GitHub Markdown이지만 렌더링하지 않고 원문 그대로 보여 준다. 렌더링하려면 Markdown parser와 sanitizer를 앱에 들여야 하고, 읽는 용도에는 원문으로 충분하다.
 

--- a/product/akbun-gitdesktop/package-lock.json
+++ b/product/akbun-gitdesktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-gitdesktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-gitdesktop",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.8",

--- a/product/akbun-gitdesktop/package.json
+++ b/product/akbun-gitdesktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-gitdesktop",
   "productName": "akbun-gitdesktop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Git graph desktop viewer for local repositories and worktrees",
   "main": "out/main/index.js",
   "author": "akbun",

--- a/product/akbun-gitdesktop/src/main/git.ts
+++ b/product/akbun-gitdesktop/src/main/git.ts
@@ -5,7 +5,6 @@ import type {
   CliToolStatus,
   CommitInfo,
   FileChange,
-  PullRequestInfo,
   WorktreeInfo
 } from '../shared/types'
 
@@ -16,18 +15,6 @@ const DEFAULT_BRANCH_CANDIDATES = ['main', 'master', 'develop']
 export function runGit(cwd: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile('git', args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error(stderr.trim() || error.message))
-        return
-      }
-      resolve(stdout)
-    })
-  })
-}
-
-function runGh(cwd: string, args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile('gh', args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (error, stdout, stderr) => {
       if (error) {
         reject(new Error(stderr.trim() || error.message))
         return
@@ -287,35 +274,4 @@ export async function getRangeDiff(
   filePath: string
 ): Promise<string> {
   return runGit(repoPath, ['diff', '--no-color', `${base}...${head}`, '--', filePath])
-}
-
-export async function getPullRequests(repoPath: string): Promise<PullRequestInfo[]> {
-  const out = await runGh(repoPath, [
-    'pr',
-    'list',
-    '--state',
-    'all',
-    '--limit',
-    '50',
-    '--json',
-    'number,title,state,author,headRefName,url,updatedAt'
-  ])
-  const rows = JSON.parse(out) as Array<{
-    number: number
-    title: string
-    state: string
-    author: { login: string }
-    headRefName: string
-    url: string
-    updatedAt: string
-  }>
-  return rows.map((row) => ({
-    number: row.number,
-    title: row.title,
-    state: row.state,
-    author: row.author?.login ?? '',
-    headRefName: row.headRefName,
-    url: row.url,
-    updatedAt: row.updatedAt
-  }))
 }

--- a/product/akbun-gitdesktop/src/main/github.ts
+++ b/product/akbun-gitdesktop/src/main/github.ts
@@ -12,6 +12,8 @@ import type {
 } from '../shared/types'
 
 const LIST_LIMIT = 50
+/** Wider than the issue list so every listed issue has its parent looked up. */
+const PARENT_LOOKUP_LIMIT = 100
 const BOARD_ITEM_LIMIT = 200
 const FIELD_LIMIT = 50
 /** Column for project items whose Status field is empty. */
@@ -80,10 +82,16 @@ interface GhRepo {
   nameWithOwner?: string
 }
 
-async function getRepoIdentity(repoPath: string): Promise<{ owner: string; nameWithOwner: string }> {
+async function getRepoIdentity(
+  repoPath: string
+): Promise<{ owner: string; name: string; nameWithOwner: string }> {
   const out = await runGh(repoPath, ['repo', 'view', '--json', 'owner,name,nameWithOwner'])
   const repo = JSON.parse(out) as GhRepo
-  return { owner: repo.owner?.login ?? '', nameWithOwner: repo.nameWithOwner ?? '' }
+  return {
+    owner: repo.owner?.login ?? '',
+    name: repo.name ?? '',
+    nameWithOwner: repo.nameWithOwner ?? ''
+  }
 }
 
 interface GhPullRequest {
@@ -131,6 +139,49 @@ interface GhIssue {
   labels?: GhLabel[]
 }
 
+/**
+ * Reads the sub-issue parent of every issue, keyed by issue number.
+ *
+ * gh issue list does not carry the sub-issue link, so it takes a GraphQL query
+ * of its own. The window is wider than the list and is ordered the same way, so
+ * every listed issue is covered. A repository or a gh old enough to not know the
+ * field still has to show its issues, so a failure here means a flat list.
+ */
+async function readIssueParents(repoPath: string): Promise<Map<number, number>> {
+  const query = `query($owner: String!, $name: String!, $limit: Int!) {
+    repository(owner: $owner, name: $name) {
+      issues(first: $limit, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes { number parent { number } }
+      }
+    }
+  }`
+  const parents = new Map<number, number>()
+  try {
+    const identity = await getRepoIdentity(repoPath)
+    const out = await runGh(repoPath, [
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-f',
+      `owner=${identity.owner}`,
+      '-f',
+      `name=${identity.name}`,
+      '-F',
+      `limit=${PARENT_LOOKUP_LIMIT}`
+    ])
+    const parsed = JSON.parse(out) as {
+      data?: { repository?: { issues?: { nodes?: Array<{ number: number; parent?: { number: number } | null }> } } }
+    }
+    for (const node of parsed.data?.repository?.issues?.nodes ?? []) {
+      if (node.parent?.number) parents.set(node.number, node.parent.number)
+    }
+  } catch {
+    // The issue list is worth more than the tree, so keep the list and drop the tree.
+  }
+  return parents
+}
+
 export async function getIssues(repoPath: string): Promise<IssueInfo[]> {
   const out = await runGh(repoPath, [
     'issue',
@@ -143,6 +194,7 @@ export async function getIssues(repoPath: string): Promise<IssueInfo[]> {
     ISSUE_LIST_FIELDS
   ])
   const rows = JSON.parse(out) as GhIssue[]
+  const parents = await readIssueParents(repoPath)
   return rows.map((row) => ({
     number: row.number,
     title: row.title,
@@ -150,7 +202,8 @@ export async function getIssues(repoPath: string): Promise<IssueInfo[]> {
     author: row.author?.login ?? '',
     url: row.url,
     updatedAt: row.updatedAt,
-    labels: labelNames(row.labels)
+    labels: labelNames(row.labels),
+    parent: parents.get(row.number) ?? 0
   }))
 }
 

--- a/product/akbun-gitdesktop/src/main/github.ts
+++ b/product/akbun-gitdesktop/src/main/github.ts
@@ -1,0 +1,342 @@
+import { execFile } from 'node:child_process'
+import type {
+  IssueInfo,
+  ProjectBoard,
+  ProjectColumn,
+  ProjectInfo,
+  ProjectItem,
+  ProjectListResult,
+  PullRequestInfo,
+  ThreadComment,
+  ThreadDetail
+} from '../shared/types'
+
+const LIST_LIMIT = 50
+const BOARD_ITEM_LIMIT = 200
+const FIELD_LIMIT = 50
+/** Column for project items whose Status field is empty. */
+const NO_STATUS = 'No status'
+
+const PR_LIST_FIELDS = 'number,title,state,author,headRefName,url,updatedAt,labels'
+const PR_DETAIL_FIELDS =
+  'number,title,state,author,url,createdAt,updatedAt,labels,assignees,body,comments,baseRefName,headRefName,additions,deletions,changedFiles'
+const ISSUE_LIST_FIELDS = 'number,title,state,author,url,updatedAt,labels'
+const ISSUE_DETAIL_FIELDS =
+  'number,title,state,author,url,createdAt,updatedAt,labels,assignees,body,comments'
+
+function runGh(cwd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('gh', args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr.trim() || error.message))
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+interface GhActor {
+  login?: string
+}
+
+interface GhLabel {
+  name?: string
+}
+
+interface GhComment {
+  author?: GhActor
+  createdAt?: string
+  body?: string
+}
+
+function labelNames(labels: GhLabel[] | undefined): string[] {
+  return (labels ?? []).map((label) => label.name ?? '').filter(Boolean)
+}
+
+function logins(actors: GhActor[] | undefined): string[] {
+  return (actors ?? []).map((actor) => actor.login ?? '').filter(Boolean)
+}
+
+function toComments(comments: GhComment[] | undefined): ThreadComment[] {
+  return (comments ?? []).map((comment) => ({
+    author: comment.author?.login ?? '',
+    createdAt: comment.createdAt ?? '',
+    body: comment.body ?? ''
+  }))
+}
+
+/** gh takes a number as a command line argument, so reject anything that is not one. */
+function numberArg(value: number): string {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Not a valid number: ${value}`)
+  }
+  return String(value)
+}
+
+interface GhRepo {
+  owner?: GhActor
+  name?: string
+  nameWithOwner?: string
+}
+
+async function getRepoIdentity(repoPath: string): Promise<{ owner: string; nameWithOwner: string }> {
+  const out = await runGh(repoPath, ['repo', 'view', '--json', 'owner,name,nameWithOwner'])
+  const repo = JSON.parse(out) as GhRepo
+  return { owner: repo.owner?.login ?? '', nameWithOwner: repo.nameWithOwner ?? '' }
+}
+
+interface GhPullRequest {
+  number: number
+  title: string
+  state: string
+  author?: GhActor
+  headRefName?: string
+  url: string
+  updatedAt: string
+  labels?: GhLabel[]
+}
+
+export async function getPullRequests(repoPath: string): Promise<PullRequestInfo[]> {
+  const out = await runGh(repoPath, [
+    'pr',
+    'list',
+    '--state',
+    'all',
+    '--limit',
+    String(LIST_LIMIT),
+    '--json',
+    PR_LIST_FIELDS
+  ])
+  const rows = JSON.parse(out) as GhPullRequest[]
+  return rows.map((row) => ({
+    number: row.number,
+    title: row.title,
+    state: row.state,
+    author: row.author?.login ?? '',
+    headRefName: row.headRefName ?? '',
+    url: row.url,
+    updatedAt: row.updatedAt,
+    labels: labelNames(row.labels)
+  }))
+}
+
+interface GhIssue {
+  number: number
+  title: string
+  state: string
+  author?: GhActor
+  url: string
+  updatedAt: string
+  labels?: GhLabel[]
+}
+
+export async function getIssues(repoPath: string): Promise<IssueInfo[]> {
+  const out = await runGh(repoPath, [
+    'issue',
+    'list',
+    '--state',
+    'all',
+    '--limit',
+    String(LIST_LIMIT),
+    '--json',
+    ISSUE_LIST_FIELDS
+  ])
+  const rows = JSON.parse(out) as GhIssue[]
+  return rows.map((row) => ({
+    number: row.number,
+    title: row.title,
+    state: row.state,
+    author: row.author?.login ?? '',
+    url: row.url,
+    updatedAt: row.updatedAt,
+    labels: labelNames(row.labels)
+  }))
+}
+
+interface GhThread {
+  number: number
+  title: string
+  state: string
+  author?: GhActor
+  url: string
+  createdAt: string
+  updatedAt: string
+  labels?: GhLabel[]
+  assignees?: GhActor[]
+  body?: string
+  comments?: GhComment[]
+  baseRefName?: string
+  headRefName?: string
+  additions?: number
+  deletions?: number
+  changedFiles?: number
+}
+
+function toThreadDetail(kind: ThreadDetail['kind'], raw: GhThread): ThreadDetail {
+  return {
+    kind,
+    number: raw.number,
+    title: raw.title,
+    state: raw.state,
+    author: raw.author?.login ?? '',
+    url: raw.url,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    labels: labelNames(raw.labels),
+    assignees: logins(raw.assignees),
+    body: raw.body ?? '',
+    comments: toComments(raw.comments),
+    baseRefName: raw.baseRefName ?? '',
+    headRefName: raw.headRefName ?? '',
+    additions: raw.additions ?? 0,
+    deletions: raw.deletions ?? 0,
+    changedFiles: raw.changedFiles ?? 0
+  }
+}
+
+export async function getPullRequestDetail(repoPath: string, number: number): Promise<ThreadDetail> {
+  const out = await runGh(repoPath, ['pr', 'view', numberArg(number), '--json', PR_DETAIL_FIELDS])
+  return toThreadDetail('pr', JSON.parse(out) as GhThread)
+}
+
+export async function getIssueDetail(repoPath: string, number: number): Promise<ThreadDetail> {
+  const out = await runGh(repoPath, ['issue', 'view', numberArg(number), '--json', ISSUE_DETAIL_FIELDS])
+  return toThreadDetail('issue', JSON.parse(out) as GhThread)
+}
+
+interface GhProject {
+  number: number
+  title?: string
+  url?: string
+  closed?: boolean
+  items?: { totalCount?: number }
+}
+
+/**
+ * Lists the projects of the owner of this repository.
+ * A project belongs to a user or an organization rather than to a repository,
+ * so the owner is resolved first and returned for the board lookup that follows.
+ */
+export async function getProjects(repoPath: string): Promise<ProjectListResult> {
+  const identity = await getRepoIdentity(repoPath)
+  const out = await runGh(repoPath, [
+    'project',
+    'list',
+    '--owner',
+    identity.owner,
+    '--limit',
+    String(LIST_LIMIT),
+    '--format',
+    'json'
+  ])
+  const parsed = JSON.parse(out) as { projects?: GhProject[] }
+  const projects: ProjectInfo[] = (parsed.projects ?? []).map((project) => ({
+    number: project.number,
+    title: project.title ?? '',
+    url: project.url ?? '',
+    closed: project.closed ?? false,
+    itemCount: project.items?.totalCount ?? 0
+  }))
+  return { owner: identity.owner, nameWithOwner: identity.nameWithOwner, projects }
+}
+
+/**
+ * One row of gh project item-list.
+ * The item carries its content plus one key per project field, so a single
+ * select field named Status arrives as a plain string under `status`.
+ */
+interface GhProjectItem {
+  id?: string
+  title?: string
+  type?: string
+  url?: string
+  status?: string
+  assignees?: string[]
+  labels?: string[]
+  content?: {
+    type?: string
+    title?: string
+    number?: number
+    url?: string
+    repository?: string
+  }
+}
+
+function toProjectItem(raw: GhProjectItem, index: number): ProjectItem {
+  const content = raw.content ?? {}
+  return {
+    id: raw.id || `item-${index}`,
+    title: raw.title || content.title || '(untitled)',
+    status: raw.status?.trim() || NO_STATUS,
+    type: content.type || raw.type || '',
+    url: content.url || raw.url || '',
+    number: content.number ?? 0,
+    repository: content.repository ?? '',
+    assignees: raw.assignees ?? [],
+    labels: raw.labels ?? []
+  }
+}
+
+/**
+ * Reads the options of the Status field to order the board columns.
+ * Only the order comes from here, so a failure is not worth surfacing.
+ */
+async function readStatusOptions(repoPath: string, owner: string, number: number): Promise<string[]> {
+  try {
+    const out = await runGh(repoPath, [
+      'project',
+      'field-list',
+      numberArg(number),
+      '--owner',
+      owner,
+      '--limit',
+      String(FIELD_LIMIT),
+      '--format',
+      'json'
+    ])
+    const parsed = JSON.parse(out) as {
+      fields?: Array<{ name?: string; options?: Array<{ name?: string }> }>
+    }
+    const status = (parsed.fields ?? []).find((field) => field.name?.toLowerCase() === 'status')
+    return (status?.options ?? []).map((option) => option.name ?? '').filter(Boolean)
+  } catch {
+    // The columns then follow the order the items arrive in.
+    return []
+  }
+}
+
+function buildColumns(items: ProjectItem[], statusOrder: string[]): ProjectColumn[] {
+  const names = statusOrder.filter((name) => name !== NO_STATUS)
+  for (const item of items) {
+    if (item.status !== NO_STATUS && !names.includes(item.status)) names.push(item.status)
+  }
+  // Items without a status are not a real column, so they go last.
+  if (items.some((item) => item.status === NO_STATUS)) names.push(NO_STATUS)
+  return names.map((name) => ({
+    name,
+    items: items.filter((item) => item.status === name)
+  }))
+}
+
+export async function getProjectBoard(
+  repoPath: string,
+  owner: string,
+  number: number
+): Promise<ProjectBoard> {
+  const out = await runGh(repoPath, [
+    'project',
+    'item-list',
+    numberArg(number),
+    '--owner',
+    owner,
+    '--limit',
+    String(BOARD_ITEM_LIMIT),
+    '--format',
+    'json'
+  ])
+  const parsed = JSON.parse(out) as { items?: GhProjectItem[] }
+  const items = (parsed.items ?? []).map(toProjectItem)
+  const statusOrder = await readStatusOptions(repoPath, owner, number)
+  return { columns: buildColumns(items, statusOrder) }
+}

--- a/product/akbun-gitdesktop/src/main/index.ts
+++ b/product/akbun-gitdesktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, ipcMain, nativeTheme, shell } from 'electro
 import path from 'node:path'
 import type { GitResult, ThemePreference } from '../shared/types'
 import * as git from './git'
+import * as github from './github'
 import { openInApp, listOpenerApps } from './openWith'
 import { addRepo, loadRepos, removeRepo } from './repoStore'
 import { loadSettings, saveTheme } from './settingsStore'
@@ -102,7 +103,20 @@ function registerIpcHandlers(): void {
       wrap(() => git.getRangeDiff(repoPath, base, head, filePath))
   )
 
-  ipcMain.handle('gh:pullRequests', (_event, repoPath: string) => wrap(() => git.getPullRequests(repoPath)))
+  ipcMain.handle('gh:pullRequests', (_event, repoPath: string) =>
+    wrap(() => github.getPullRequests(repoPath))
+  )
+  ipcMain.handle('gh:pullRequestDetail', (_event, repoPath: string, number: number) =>
+    wrap(() => github.getPullRequestDetail(repoPath, number))
+  )
+  ipcMain.handle('gh:issues', (_event, repoPath: string) => wrap(() => github.getIssues(repoPath)))
+  ipcMain.handle('gh:issueDetail', (_event, repoPath: string, number: number) =>
+    wrap(() => github.getIssueDetail(repoPath, number))
+  )
+  ipcMain.handle('gh:projects', (_event, repoPath: string) => wrap(() => github.getProjects(repoPath)))
+  ipcMain.handle('gh:projectBoard', (_event, repoPath: string, owner: string, number: number) =>
+    wrap(() => github.getProjectBoard(repoPath, owner, number))
+  )
 
   ipcMain.handle('open:external', (_event, url: string) => wrap(() => shell.openExternal(url)))
   ipcMain.handle('open:apps', () => wrap(async () => listOpenerApps()))

--- a/product/akbun-gitdesktop/src/preload/index.d.ts
+++ b/product/akbun-gitdesktop/src/preload/index.d.ts
@@ -5,10 +5,14 @@ import type {
   CommitInfo,
   FileChange,
   GitResult,
+  IssueInfo,
   OpenerApp,
+  ProjectBoard,
+  ProjectListResult,
   PullRequestInfo,
   RepoEntry,
   ThemePreference,
+  ThreadDetail,
   WorktreeInfo
 } from '../shared/types'
 
@@ -47,6 +51,11 @@ export interface GitDesktopApi {
   ) => Promise<GitResult<string>>
 
   getPullRequests: (repoPath: string) => Promise<GitResult<PullRequestInfo[]>>
+  getPullRequestDetail: (repoPath: string, number: number) => Promise<GitResult<ThreadDetail>>
+  getIssues: (repoPath: string) => Promise<GitResult<IssueInfo[]>>
+  getIssueDetail: (repoPath: string, number: number) => Promise<GitResult<ThreadDetail>>
+  getProjects: (repoPath: string) => Promise<GitResult<ProjectListResult>>
+  getProjectBoard: (repoPath: string, owner: string, number: number) => Promise<GitResult<ProjectBoard>>
 
   openExternal: (url: string) => Promise<GitResult<void>>
   listOpenerApps: () => Promise<GitResult<OpenerApp[]>>

--- a/product/akbun-gitdesktop/src/preload/index.ts
+++ b/product/akbun-gitdesktop/src/preload/index.ts
@@ -33,6 +33,14 @@ const api = {
     ipcRenderer.invoke('git:rangeDiff', repoPath, base, head, filePath),
 
   getPullRequests: (repoPath: string) => ipcRenderer.invoke('gh:pullRequests', repoPath),
+  getPullRequestDetail: (repoPath: string, number: number) =>
+    ipcRenderer.invoke('gh:pullRequestDetail', repoPath, number),
+  getIssues: (repoPath: string) => ipcRenderer.invoke('gh:issues', repoPath),
+  getIssueDetail: (repoPath: string, number: number) =>
+    ipcRenderer.invoke('gh:issueDetail', repoPath, number),
+  getProjects: (repoPath: string) => ipcRenderer.invoke('gh:projects', repoPath),
+  getProjectBoard: (repoPath: string, owner: string, number: number) =>
+    ipcRenderer.invoke('gh:projectBoard', repoPath, owner, number),
 
   openExternal: (url: string) => ipcRenderer.invoke('open:external', url),
   listOpenerApps: () => ipcRenderer.invoke('open:apps'),

--- a/product/akbun-gitdesktop/src/renderer/src/App.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/App.tsx
@@ -3,15 +3,31 @@ import type { BranchInfo, CommitInfo, OpenerApp, RepoEntry, WorktreeInfo } from 
 import BranchPanel from './components/BranchPanel'
 import DiffDrawer, { type DiffSource } from './components/DiffDrawer'
 import GraphView from './components/GraphView'
+import IssuePanel from './components/IssuePanel'
 import PrPanel from './components/PrPanel'
+import ProjectPanel from './components/ProjectPanel'
 import RepoSidebar from './components/RepoSidebar'
 import SettingsDialog from './components/SettingsDialog'
+import ThreadDrawer, { type ThreadRef } from './components/ThreadDrawer'
 import TopBar from './components/TopBar'
 import WorktreePanel from './components/WorktreePanel'
 import { useCliStatus } from './lib/useCliStatus'
 import { useTheme } from './lib/useTheme'
 
-type Tab = 'graph' | 'branches' | 'prs'
+type Tab = 'graph' | 'branches' | 'prs' | 'issues' | 'projects'
+
+const TAB_LABELS: Array<[Tab, string]> = [
+  ['graph', 'Graph'],
+  ['branches', 'Branches'],
+  ['prs', 'Pull requests'],
+  ['issues', 'Issues'],
+  ['projects', 'Projects']
+]
+
+/** The git tabs show a diff on the right, the GitHub tabs show an issue or a pull request. */
+function isGitTab(tab: Tab): boolean {
+  return tab === 'graph' || tab === 'branches'
+}
 
 export default function App(): JSX.Element {
   const [repos, setRepos] = useState<RepoEntry[]>([])
@@ -24,6 +40,7 @@ export default function App(): JSX.Element {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [defaultBranch, setDefaultBranch] = useState('HEAD')
   const [diffSource, setDiffSource] = useState<DiffSource | null>(null)
+  const [thread, setThread] = useState<ThreadRef | null>(null)
   const theme = useTheme()
   const cli = useCliStatus()
   // The repository whose default branch lookup is still allowed to win.
@@ -56,6 +73,7 @@ export default function App(): JSX.Element {
       setSelectedRepo(repo)
       setTab('graph')
       setDiffSource(null)
+      setThread(null)
       refreshWorktrees(repo)
       pendingRepoPath.current = repo.path
       setDefaultBranch('HEAD')
@@ -89,6 +107,7 @@ export default function App(): JSX.Element {
           setWorktrees([])
           setSelectedWorktree(null)
           setDiffSource(null)
+          setThread(null)
         }
       } else {
         setError(result.error)
@@ -126,18 +145,28 @@ export default function App(): JSX.Element {
     [targetPath, defaultBranch]
   )
 
+  const showThread = useCallback(
+    (kind: 'issue' | 'pr', number: number, title: string) => {
+      setThread({ kind, repoPath: targetPath, number, title })
+    },
+    [targetPath]
+  )
+
   const selectWorktree = useCallback((worktree: WorktreeInfo) => {
     setSelectedWorktree(worktree)
     setDiffSource(null)
+    setThread(null)
   }, [])
 
   const selectTab = useCallback((next: Tab) => {
     setTab(next)
     setDiffSource(null)
+    setThread(null)
   }, [])
 
   const selectedHash = diffSource?.kind === 'commit' ? diffSource.hash : ''
   const selectedBranch = diffSource?.kind === 'range' ? diffSource.head : ''
+  const selectedThreadNumber = thread?.number ?? 0
 
   return (
     <div className="app-shell">
@@ -163,15 +192,15 @@ export default function App(): JSX.Element {
             />
             <main className="main-view">
               <nav className="tabs">
-                <button className={tab === 'graph' ? 'active' : ''} onClick={() => selectTab('graph')}>
-                  Graph
-                </button>
-                <button className={tab === 'branches' ? 'active' : ''} onClick={() => selectTab('branches')}>
-                  Branches
-                </button>
-                <button className={tab === 'prs' ? 'active' : ''} onClick={() => selectTab('prs')}>
-                  Pull requests
-                </button>
+                {TAB_LABELS.map(([id, label]) => (
+                  <button
+                    key={id}
+                    className={tab === id ? 'active' : ''}
+                    onClick={() => selectTab(id)}
+                  >
+                    {label}
+                  </button>
+                ))}
                 <span className="target-path">{targetPath}</span>
               </nav>
               {error && <div className="error-banner">{error}</div>}
@@ -192,10 +221,33 @@ export default function App(): JSX.Element {
                       onSelectBranch={showBranchDiff}
                     />
                   )}
-                  {tab === 'prs' && targetPath && <PrPanel repoPath={targetPath} />}
+                  {tab === 'prs' && targetPath && (
+                    <PrPanel
+                      repoPath={targetPath}
+                      selectedNumber={selectedThreadNumber}
+                      onSelect={(pr) => showThread('pr', pr.number, pr.title)}
+                    />
+                  )}
+                  {tab === 'issues' && targetPath && (
+                    <IssuePanel
+                      repoPath={targetPath}
+                      selectedNumber={selectedThreadNumber}
+                      onSelect={(issue) => showThread('issue', issue.number, issue.title)}
+                    />
+                  )}
+                  {tab === 'projects' && targetPath && (
+                    <ProjectPanel
+                      repoPath={targetPath}
+                      selectedNumber={selectedThreadNumber}
+                      onSelectThread={showThread}
+                    />
+                  )}
                 </div>
-                {diffSource && tab !== 'prs' && (
+                {isGitTab(tab) && diffSource && (
                   <DiffDrawer source={diffSource} onClose={() => setDiffSource(null)} />
+                )}
+                {!isGitTab(tab) && thread && (
+                  <ThreadDrawer thread={thread} onClose={() => setThread(null)} />
                 )}
               </div>
             </main>

--- a/product/akbun-gitdesktop/src/renderer/src/components/IssuePanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/IssuePanel.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useState, type JSX } from 'react'
-import type { PullRequestInfo } from '../../../shared/types'
+import type { IssueInfo } from '../../../shared/types'
 import { clickable } from '../lib/clickable'
 import { ghErrorMessage, shortDate, stateClass } from '../lib/github'
 
 interface Props {
   repoPath: string
   selectedNumber: number
-  onSelect: (pr: PullRequestInfo) => void
+  onSelect: (issue: IssueInfo) => void
 }
 
-export default function PrPanel({ repoPath, selectedNumber, onSelect }: Props): JSX.Element {
-  const [prs, setPrs] = useState<PullRequestInfo[]>([])
+export default function IssuePanel({ repoPath, selectedNumber, onSelect }: Props): JSX.Element {
+  const [issues, setIssues] = useState<IssueInfo[]>([])
   const [loadError, setLoadError] = useState('')
   const [loading, setLoading] = useState(true)
 
@@ -18,13 +18,13 @@ export default function PrPanel({ repoPath, selectedNumber, onSelect }: Props): 
     let cancelled = false
     setLoading(true)
     setLoadError('')
-    window.gitdesktop.getPullRequests(repoPath).then((result) => {
+    window.gitdesktop.getIssues(repoPath).then((result) => {
       if (cancelled) return
       setLoading(false)
       if (result.ok) {
-        setPrs(result.data)
+        setIssues(result.data)
       } else {
-        setLoadError(ghErrorMessage('pull requests', result.error))
+        setLoadError(ghErrorMessage('issues', result.error))
       }
     })
     return () => {
@@ -32,44 +32,44 @@ export default function PrPanel({ repoPath, selectedNumber, onSelect }: Props): 
     }
   }, [repoPath])
 
-  if (loading) return <p className="placeholder">Loading pull requests...</p>
+  if (loading) return <p className="placeholder">Loading issues...</p>
   if (loadError) return <div className="error-banner">{loadError}</div>
 
   return (
     <ul className="pr-list">
-      {prs.map((pr) => (
+      {issues.map((issue) => (
         <li
-          key={pr.number}
-          className={pr.number === selectedNumber ? 'selected' : ''}
-          {...clickable(() => onSelect(pr))}
-          title={`Show pull request #${pr.number}`}
+          key={issue.number}
+          className={issue.number === selectedNumber ? 'selected' : ''}
+          {...clickable(() => onSelect(issue))}
+          title={`Show issue #${issue.number}`}
         >
-          <span className={stateClass(pr.state)}>{pr.state}</span>
+          <span className={stateClass(issue.state)}>{issue.state}</span>
           <span className="pr-title">
-            #{pr.number} {pr.title}
+            #{issue.number} {issue.title}
           </span>
-          {pr.labels.map((label) => (
+          {issue.labels.map((label) => (
             <span key={label} className="label-chip">
               {label}
             </span>
           ))}
           <span className="pr-meta">
-            {pr.author} · {pr.headRefName} · {shortDate(pr.updatedAt)}
+            {issue.author} · {shortDate(issue.updatedAt)}
           </span>
           <button
             className="icon-button"
             title="Open on GitHub"
-            aria-label={`Open pull request ${pr.number} on GitHub`}
+            aria-label={`Open issue ${issue.number} on GitHub`}
             onClick={(event) => {
               event.stopPropagation()
-              window.gitdesktop.openExternal(pr.url)
+              window.gitdesktop.openExternal(issue.url)
             }}
           >
             ↗
           </button>
         </li>
       ))}
-      {prs.length === 0 && <li className="placeholder">No pull requests.</li>}
+      {issues.length === 0 && <li className="placeholder">No issues.</li>}
     </ul>
   )
 }

--- a/product/akbun-gitdesktop/src/renderer/src/components/IssuePanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/IssuePanel.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState, type JSX } from 'react'
+import { useEffect, useMemo, useState, type JSX } from 'react'
 import type { IssueInfo } from '../../../shared/types'
 import { clickable } from '../lib/clickable'
-import { ghErrorMessage, shortDate, stateClass } from '../lib/github'
+import { buildIssueTree, ghErrorMessage, shortDate, stateClass } from '../lib/github'
+
+/** Indent per tree level, wide enough for the connector to read as a corner. */
+const INDENT_PX = 22
 
 interface Props {
   repoPath: string
@@ -32,44 +35,65 @@ export default function IssuePanel({ repoPath, selectedNumber, onSelect }: Props
     }
   }, [repoPath])
 
+  const rows = useMemo(() => buildIssueTree(issues), [issues])
+
   if (loading) return <p className="placeholder">Loading issues...</p>
   if (loadError) return <div className="error-banner">{loadError}</div>
 
   return (
-    <ul className="pr-list">
-      {issues.map((issue) => (
+    <ul className="pr-list issue-tree">
+      {rows.map((row) => (
         <li
-          key={issue.number}
-          className={issue.number === selectedNumber ? 'selected' : ''}
-          {...clickable(() => onSelect(issue))}
-          title={`Show issue #${issue.number}`}
+          key={row.issue.number}
+          className={row.issue.number === selectedNumber ? 'selected' : ''}
+          style={{ paddingLeft: 6 + row.depth * INDENT_PX }}
+          {...clickable(() => onSelect(row.issue))}
+          title={`Show issue #${row.issue.number}`}
         >
-          <span className={stateClass(issue.state)}>{issue.state}</span>
+          {row.depth > 0 && (
+            <span className="issue-rails" aria-hidden="true">
+              {row.guides.map((keepsGoing, level) => (
+                <span key={level} className={keepsGoing ? 'issue-rail through' : 'issue-rail'} />
+              ))}
+              <span className={row.isLast ? 'issue-rail elbow last' : 'issue-rail elbow'} />
+            </span>
+          )}
+          <span className={stateClass(row.issue.state)}>{row.issue.state}</span>
           <span className="pr-title">
-            #{issue.number} {issue.title}
+            #{row.issue.number} {row.issue.title}
           </span>
-          {issue.labels.map((label) => (
+          {row.childCount > 0 && (
+            <span className="issue-sub-count" title={`${row.childCount} sub-issues`}>
+              ↳ {row.childCount}
+            </span>
+          )}
+          {row.detachedParent > 0 && (
+            <span className="pr-meta" title="The parent issue is outside this list">
+              ↰ #{row.detachedParent}
+            </span>
+          )}
+          {row.issue.labels.map((label) => (
             <span key={label} className="label-chip">
               {label}
             </span>
           ))}
           <span className="pr-meta">
-            {issue.author} · {shortDate(issue.updatedAt)}
+            {row.issue.author} · {shortDate(row.issue.updatedAt)}
           </span>
           <button
             className="icon-button"
             title="Open on GitHub"
-            aria-label={`Open issue ${issue.number} on GitHub`}
+            aria-label={`Open issue ${row.issue.number} on GitHub`}
             onClick={(event) => {
               event.stopPropagation()
-              window.gitdesktop.openExternal(issue.url)
+              window.gitdesktop.openExternal(row.issue.url)
             }}
           >
             ↗
           </button>
         </li>
       ))}
-      {issues.length === 0 && <li className="placeholder">No issues.</li>}
+      {rows.length === 0 && <li className="placeholder">No issues.</li>}
     </ul>
   )
 }

--- a/product/akbun-gitdesktop/src/renderer/src/components/ProjectPanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/ProjectPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type JSX } from 'react'
+import { useCallback, useEffect, useRef, useState, type JSX } from 'react'
 import type { ProjectBoard, ProjectInfo, ProjectItem } from '../../../shared/types'
 import { clickable } from '../lib/clickable'
 import { ghErrorMessage, PROJECT_SCOPE_HINT } from '../lib/github'
@@ -11,6 +11,20 @@ interface Props {
 
 const EMPTY_BOARD: ProjectBoard = { columns: [] }
 
+/**
+ * The projects of one repository, tagged with the repository they were read from.
+ * They travel together because an owner only means anything next to the path it
+ * came from: a board loaded with the previous repository's owner is the wrong board.
+ */
+interface ProjectSource {
+  repoPath: string
+  owner: string
+  nameWithOwner: string
+  projects: ProjectInfo[]
+}
+
+const EMPTY_SOURCE: ProjectSource = { repoPath: '', owner: '', nameWithOwner: '', projects: [] }
+
 function itemKind(item: ProjectItem): 'issue' | 'pr' | null {
   if (item.type === 'Issue') return 'issue'
   if (item.type === 'PullRequest') return 'pr'
@@ -22,30 +36,36 @@ function itemKind(item: ProjectItem): 'issue' | 'pr' | null {
  * Columns come from the Status field, which is what the board on GitHub groups by.
  */
 export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread }: Props): JSX.Element {
-  const [projects, setProjects] = useState<ProjectInfo[]>([])
-  const [owner, setOwner] = useState('')
-  const [nameWithOwner, setNameWithOwner] = useState('')
+  const [source, setSource] = useState<ProjectSource>(EMPTY_SOURCE)
   const [selected, setSelected] = useState(0)
   const [board, setBoard] = useState<ProjectBoard>(EMPTY_BOARD)
   const [loadError, setLoadError] = useState('')
   const [loading, setLoading] = useState(true)
+  // Only the newest board request may write state. An older one landing late
+  // would put another repository's board on screen.
+  const boardRequest = useRef(0)
 
   useEffect(() => {
     let cancelled = false
+    boardRequest.current += 1
     setLoading(true)
     setLoadError('')
     setBoard(EMPTY_BOARD)
+    setSource(EMPTY_SOURCE)
+    setSelected(0)
     window.gitdesktop.getProjects(repoPath).then((result) => {
       if (cancelled) return
       setLoading(false)
       if (!result.ok) {
-        setProjects([])
         setLoadError(ghErrorMessage('projects', result.error, PROJECT_SCOPE_HINT))
         return
       }
-      setOwner(result.data.owner)
-      setNameWithOwner(result.data.nameWithOwner)
-      setProjects(result.data.projects)
+      setSource({
+        repoPath,
+        owner: result.data.owner,
+        nameWithOwner: result.data.nameWithOwner,
+        projects: result.data.projects
+      })
       const open = result.data.projects.find((project) => !project.closed)
       setSelected(open?.number ?? result.data.projects[0]?.number ?? 0)
     })
@@ -55,9 +75,13 @@ export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread 
   }, [repoPath])
 
   const loadBoard = useCallback(async () => {
-    if (!owner || !selected) return
+    // A repository change re-runs this before the new owner has arrived, and the
+    // stale owner would ask for a project the new repository does not own.
+    if (source.repoPath !== repoPath || !source.owner || !selected) return
+    const request = ++boardRequest.current
     setLoading(true)
-    const result = await window.gitdesktop.getProjectBoard(repoPath, owner, selected)
+    const result = await window.gitdesktop.getProjectBoard(repoPath, source.owner, selected)
+    if (request !== boardRequest.current) return
     setLoading(false)
     if (result.ok) {
       setBoard(result.data)
@@ -66,7 +90,7 @@ export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread 
       setBoard(EMPTY_BOARD)
       setLoadError(ghErrorMessage('this project board', result.error, PROJECT_SCOPE_HINT))
     }
-  }, [repoPath, owner, selected])
+  }, [repoPath, source, selected])
 
   useEffect(() => {
     loadBoard()
@@ -76,14 +100,14 @@ export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread 
     const kind = itemKind(item)
     // A card from another repository cannot be read with gh in this working copy,
     // and a draft issue has no number at all, so both fall back to the browser.
-    if (kind && item.number > 0 && item.repository === nameWithOwner) {
+    if (kind && item.number > 0 && item.repository === source.nameWithOwner) {
       onSelectThread(kind, item.number, item.title)
       return
     }
     if (item.url) window.gitdesktop.openExternal(item.url)
   }
 
-  const project = projects.find((entry) => entry.number === selected) ?? null
+  const project = source.projects.find((entry) => entry.number === selected) ?? null
 
   return (
     <div className="project-panel">
@@ -93,8 +117,8 @@ export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread 
           onChange={(event) => setSelected(Number(event.target.value))}
           aria-label="Project"
         >
-          {projects.length === 0 && <option value={0}>No project</option>}
-          {projects.map((entry) => (
+          {source.projects.length === 0 && <option value={0}>No project</option>}
+          {source.projects.map((entry) => (
             <option key={entry.number} value={entry.number}>
               #{entry.number} {entry.title}
               {entry.closed ? ' (closed)' : ''}
@@ -109,12 +133,12 @@ export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread 
             Open in browser
           </button>
         )}
-        {owner && <span className="pr-meta">owner {owner}</span>}
+        {source.owner && <span className="pr-meta">owner {source.owner}</span>}
       </div>
 
       {loadError && <div className="error-banner">{loadError}</div>}
       {loading && <p className="placeholder">Loading project...</p>}
-      {!loading && !loadError && projects.length === 0 && (
+      {!loading && !loadError && source.projects.length === 0 && (
         <p className="placeholder">This owner has no project.</p>
       )}
 
@@ -136,7 +160,7 @@ export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread 
                   <span className="project-card-title">{item.title}</span>
                   <span className="project-card-meta">
                     {item.number > 0 ? `#${item.number}` : 'draft'}
-                    {item.repository && item.repository !== nameWithOwner ? ` · ${item.repository}` : ''}
+                    {item.repository && item.repository !== source.nameWithOwner ? ` · ${item.repository}` : ''}
                     {item.assignees.length > 0 ? ` · ${item.assignees.join(', ')}` : ''}
                   </span>
                   {item.labels.length > 0 && (

--- a/product/akbun-gitdesktop/src/renderer/src/components/ProjectPanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/ProjectPanel.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useState, type JSX } from 'react'
+import type { ProjectBoard, ProjectInfo, ProjectItem } from '../../../shared/types'
+import { clickable } from '../lib/clickable'
+import { ghErrorMessage, PROJECT_SCOPE_HINT } from '../lib/github'
+
+interface Props {
+  repoPath: string
+  selectedNumber: number
+  onSelectThread: (kind: 'issue' | 'pr', number: number, title: string) => void
+}
+
+const EMPTY_BOARD: ProjectBoard = { columns: [] }
+
+function itemKind(item: ProjectItem): 'issue' | 'pr' | null {
+  if (item.type === 'Issue') return 'issue'
+  if (item.type === 'PullRequest') return 'pr'
+  return null
+}
+
+/**
+ * Kanban view of the projects owned by the owner of this repository.
+ * Columns come from the Status field, which is what the board on GitHub groups by.
+ */
+export default function ProjectPanel({ repoPath, selectedNumber, onSelectThread }: Props): JSX.Element {
+  const [projects, setProjects] = useState<ProjectInfo[]>([])
+  const [owner, setOwner] = useState('')
+  const [nameWithOwner, setNameWithOwner] = useState('')
+  const [selected, setSelected] = useState(0)
+  const [board, setBoard] = useState<ProjectBoard>(EMPTY_BOARD)
+  const [loadError, setLoadError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setLoadError('')
+    setBoard(EMPTY_BOARD)
+    window.gitdesktop.getProjects(repoPath).then((result) => {
+      if (cancelled) return
+      setLoading(false)
+      if (!result.ok) {
+        setProjects([])
+        setLoadError(ghErrorMessage('projects', result.error, PROJECT_SCOPE_HINT))
+        return
+      }
+      setOwner(result.data.owner)
+      setNameWithOwner(result.data.nameWithOwner)
+      setProjects(result.data.projects)
+      const open = result.data.projects.find((project) => !project.closed)
+      setSelected(open?.number ?? result.data.projects[0]?.number ?? 0)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [repoPath])
+
+  const loadBoard = useCallback(async () => {
+    if (!owner || !selected) return
+    setLoading(true)
+    const result = await window.gitdesktop.getProjectBoard(repoPath, owner, selected)
+    setLoading(false)
+    if (result.ok) {
+      setBoard(result.data)
+      setLoadError('')
+    } else {
+      setBoard(EMPTY_BOARD)
+      setLoadError(ghErrorMessage('this project board', result.error, PROJECT_SCOPE_HINT))
+    }
+  }, [repoPath, owner, selected])
+
+  useEffect(() => {
+    loadBoard()
+  }, [loadBoard])
+
+  const openItem = (item: ProjectItem): void => {
+    const kind = itemKind(item)
+    // A card from another repository cannot be read with gh in this working copy,
+    // and a draft issue has no number at all, so both fall back to the browser.
+    if (kind && item.number > 0 && item.repository === nameWithOwner) {
+      onSelectThread(kind, item.number, item.title)
+      return
+    }
+    if (item.url) window.gitdesktop.openExternal(item.url)
+  }
+
+  const project = projects.find((entry) => entry.number === selected) ?? null
+
+  return (
+    <div className="project-panel">
+      <div className="project-toolbar">
+        <select
+          value={selected}
+          onChange={(event) => setSelected(Number(event.target.value))}
+          aria-label="Project"
+        >
+          {projects.length === 0 && <option value={0}>No project</option>}
+          {projects.map((entry) => (
+            <option key={entry.number} value={entry.number}>
+              #{entry.number} {entry.title}
+              {entry.closed ? ' (closed)' : ''}
+            </option>
+          ))}
+        </select>
+        <button onClick={loadBoard} title="Reload this board">
+          Refresh
+        </button>
+        {project && (
+          <button onClick={() => window.gitdesktop.openExternal(project.url)} title="Open on GitHub">
+            Open in browser
+          </button>
+        )}
+        {owner && <span className="pr-meta">owner {owner}</span>}
+      </div>
+
+      {loadError && <div className="error-banner">{loadError}</div>}
+      {loading && <p className="placeholder">Loading project...</p>}
+      {!loading && !loadError && projects.length === 0 && (
+        <p className="placeholder">This owner has no project.</p>
+      )}
+
+      <div className="project-board">
+        {board.columns.map((column) => (
+          <section className="project-column" key={column.name}>
+            <h3>
+              {column.name}
+              <span className="project-count">{column.items.length}</span>
+            </h3>
+            <ul>
+              {column.items.map((item) => (
+                <li
+                  key={item.id}
+                  className={item.number === selectedNumber && item.number > 0 ? 'selected' : ''}
+                  {...clickable(() => openItem(item))}
+                  title={item.title}
+                >
+                  <span className="project-card-title">{item.title}</span>
+                  <span className="project-card-meta">
+                    {item.number > 0 ? `#${item.number}` : 'draft'}
+                    {item.repository && item.repository !== nameWithOwner ? ` · ${item.repository}` : ''}
+                    {item.assignees.length > 0 ? ` · ${item.assignees.join(', ')}` : ''}
+                  </span>
+                  {item.labels.length > 0 && (
+                    <span className="label-row">
+                      {item.labels.map((label) => (
+                        <span key={label} className="label-chip">
+                          {label}
+                        </span>
+                      ))}
+                    </span>
+                  )}
+                </li>
+              ))}
+              {column.items.length === 0 && <li className="placeholder">Empty</li>}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/product/akbun-gitdesktop/src/renderer/src/components/ThreadDrawer.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/ThreadDrawer.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState, type JSX } from 'react'
+import type { ThreadDetail } from '../../../shared/types'
+import { ghErrorMessage, shortDate, stateClass } from '../lib/github'
+
+/** Which issue or pull request the drawer is showing. */
+export interface ThreadRef {
+  kind: 'issue' | 'pr'
+  repoPath: string
+  number: number
+  title: string
+}
+
+interface Props {
+  thread: ThreadRef
+  onClose: () => void
+}
+
+function loadThread(thread: ThreadRef): ReturnType<typeof window.gitdesktop.getIssueDetail> {
+  return thread.kind === 'pr'
+    ? window.gitdesktop.getPullRequestDetail(thread.repoPath, thread.number)
+    : window.gitdesktop.getIssueDetail(thread.repoPath, thread.number)
+}
+
+function Labels({ labels }: { labels: string[] }): JSX.Element | null {
+  if (labels.length === 0) return null
+  return (
+    <span className="label-row">
+      {labels.map((label) => (
+        <span key={label} className="label-chip">
+          {label}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+/**
+ * Side panel that shows one issue or pull request: its body, its labels and its
+ * comments. Bodies are GitHub Markdown and are shown as the plain text they are,
+ * because rendering them would mean pulling a Markdown parser into the app.
+ */
+export default function ThreadDrawer({ thread, onClose }: Props): JSX.Element {
+  const [detail, setDetail] = useState<ThreadDetail | null>(null)
+  const [loadError, setLoadError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const key = `${thread.kind}:${thread.repoPath}:${thread.number}`
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setLoadError('')
+    setDetail(null)
+    loadThread(thread).then((result) => {
+      if (cancelled) return
+      setLoading(false)
+      if (result.ok) {
+        setDetail(result.data)
+      } else {
+        setLoadError(ghErrorMessage(thread.kind === 'pr' ? 'this pull request' : 'this issue', result.error))
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+    // The thread object is rebuilt on every render, so depend on its identity key.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  const url = detail?.url ?? ''
+
+  return (
+    <aside className="diff-drawer">
+      <div className="diff-drawer-header">
+        <div className="diff-drawer-title">
+          <strong title={detail?.title ?? thread.title}>{detail?.title ?? thread.title}</strong>
+          <span className="diff-drawer-subtitle">
+            {thread.kind === 'pr' ? 'pull request' : 'issue'} #{thread.number}
+          </span>
+        </div>
+        {url && (
+          <button onClick={() => window.gitdesktop.openExternal(url)} title="Open on GitHub">
+            Open in browser
+          </button>
+        )}
+        <button className="icon-button" onClick={onClose} aria-label="Close detail panel" title="Close">
+          ✕
+        </button>
+      </div>
+
+      {loading && <p className="placeholder">Loading...</p>}
+      {loadError && <div className="error-banner">{loadError}</div>}
+
+      {detail && (
+        <div className="thread-body">
+          <div className="thread-meta">
+            <span className={stateClass(detail.state)}>{detail.state}</span>
+            <span className="pr-meta">
+              {detail.author} opened this on {shortDate(detail.createdAt)}
+            </span>
+            {detail.kind === 'pr' && detail.headRefName && (
+              <span className="pr-meta">
+                {detail.baseRefName} ← {detail.headRefName}
+              </span>
+            )}
+            {detail.kind === 'pr' && detail.changedFiles > 0 && (
+              <span className="pr-meta">
+                {detail.changedFiles} files, +{detail.additions} −{detail.deletions}
+              </span>
+            )}
+            {detail.assignees.length > 0 && (
+              <span className="pr-meta">assigned to {detail.assignees.join(', ')}</span>
+            )}
+            <Labels labels={detail.labels} />
+          </div>
+
+          <article className="thread-card">
+            <header>
+              {detail.author} · {shortDate(detail.createdAt)}
+            </header>
+            <p className="thread-text">{detail.body.trim() || 'No description.'}</p>
+          </article>
+
+          {detail.comments.map((comment, index) => (
+            <article className="thread-card" key={index}>
+              <header>
+                {comment.author} · {shortDate(comment.createdAt)}
+              </header>
+              <p className="thread-text">{comment.body.trim()}</p>
+            </article>
+          ))}
+
+          {detail.comments.length === 0 && <p className="placeholder">No comments.</p>}
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/product/akbun-gitdesktop/src/renderer/src/components/TopBar.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/TopBar.tsx
@@ -24,17 +24,17 @@ function noticeFor(status: CliStatus): string {
     return 'git CLI was not found. This app runs git commands directly, so install git to use any feature.'
   }
   if (!status.gh.available) {
-    return 'gh CLI was not found. Every feature works except the pull request list.'
+    return 'gh CLI was not found. Every feature works except the pull request, issue and project tabs.'
   }
   if (!status.gh.authenticated) {
-    return 'gh CLI is installed but not logged in. Run gh auth login to load pull requests.'
+    return 'gh CLI is installed but not logged in. Run gh auth login to load pull requests, issues and projects.'
   }
   return ''
 }
 
 /**
  * Fixed top bar. It shows how the app depends on the two CLIs it shells out to,
- * git for everything and gh for pull requests, and opens the settings dialog.
+ * git for everything and gh for the GitHub tabs, and opens the settings dialog.
  */
 export default function TopBar({ status, onOpenSettings }: Props): JSX.Element {
   const notice = status ? noticeFor(status) : ''

--- a/product/akbun-gitdesktop/src/renderer/src/lib/github.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/lib/github.ts
@@ -1,0 +1,29 @@
+/** Helpers shared by the panels that read GitHub through the gh CLI. */
+
+/**
+ * Turns a gh failure into a message that says what to do about it.
+ * Almost every gh failure in this app is a missing install, a missing login or
+ * a missing token scope, and the raw stderr says none of that.
+ */
+export function ghErrorMessage(what: string, error: string, hint = ''): string {
+  const lines = [
+    `Could not load ${what}. Check that gh is installed and that gh auth login has been run.`
+  ]
+  if (hint) lines.push(hint)
+  lines.push(error)
+  return lines.join('\n')
+}
+
+/** Projects live behind a token scope that gh auth login does not ask for. */
+export const PROJECT_SCOPE_HINT =
+  'Projects also need the project scope. Run: gh auth refresh -s read:project'
+
+/** OPEN, CLOSED, MERGED and DRAFT each get their own colour. */
+export function stateClass(state: string): string {
+  return `pr-state pr-state-${state.toLowerCase()}`
+}
+
+/** GitHub timestamps are ISO strings, and the date alone is enough in a list. */
+export function shortDate(timestamp: string): string {
+  return timestamp.slice(0, 10)
+}

--- a/product/akbun-gitdesktop/src/renderer/src/lib/github.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/lib/github.ts
@@ -1,5 +1,74 @@
 /** Helpers shared by the panels that read GitHub through the gh CLI. */
 
+import type { IssueInfo } from '../../../shared/types'
+
+/** One row of the issue tree: the issue plus where it sits in the hierarchy. */
+export interface IssueTreeRow {
+  issue: IssueInfo
+  depth: number
+  /** Last child of its parent, which is what decides the corner of the connector. */
+  isLast: boolean
+  /**
+   * One entry per level above this row's connector, true where an ancestor still
+   * has siblings below. That is where the vertical rail keeps going.
+   */
+  guides: boolean[]
+  childCount: number
+  /** Parent that exists on GitHub but fell outside the loaded list. 0 otherwise. */
+  detachedParent: number
+}
+
+/**
+ * Lays the issues out as a tree of sub-issues, parents before their children.
+ *
+ * An issue whose parent is not in the list stays at the top level, because the
+ * list is a window over the newest issues and a parent can fall outside it.
+ */
+export function buildIssueTree(issues: IssueInfo[]): IssueTreeRow[] {
+  const byNumber = new Map(issues.map((issue) => [issue.number, issue]))
+  const children = new Map<number, IssueInfo[]>()
+  const roots: IssueInfo[] = []
+
+  for (const issue of issues) {
+    const parent = byNumber.has(issue.parent) ? issue.parent : 0
+    if (parent === 0) {
+      roots.push(issue)
+      continue
+    }
+    const siblings = children.get(parent) ?? []
+    siblings.push(issue)
+    children.set(parent, siblings)
+  }
+
+  const rows: IssueTreeRow[] = []
+  // A parent chain that loops back on itself would recurse forever otherwise.
+  const visited = new Set<number>()
+
+  const walk = (issue: IssueInfo, depth: number, isLast: boolean, guides: boolean[]): void => {
+    if (visited.has(issue.number)) return
+    visited.add(issue.number)
+    const kids = children.get(issue.number) ?? []
+    rows.push({
+      issue,
+      depth,
+      isLast,
+      guides,
+      childCount: kids.length,
+      detachedParent: depth === 0 && issue.parent !== 0 ? issue.parent : 0
+    })
+    const kidGuides = depth === 0 ? [] : [...guides, !isLast]
+    kids.forEach((kid, index) => walk(kid, depth + 1, index === kids.length - 1, kidGuides))
+  }
+
+  roots.forEach((root, index) => walk(root, 0, index === roots.length - 1, []))
+  // A parent chain that loops has no root, and no issue may go missing from the
+  // list because of it, so whatever the walk did not reach starts its own tree.
+  for (const issue of issues) {
+    if (!visited.has(issue.number)) walk(issue, 0, true, [])
+  }
+  return rows
+}
+
 /**
  * Turns a gh failure into a message that says what to do about it.
  * Almost every gh failure in this app is a missing install, a missing login or

--- a/product/akbun-gitdesktop/src/renderer/src/styles.css
+++ b/product/akbun-gitdesktop/src/renderer/src/styles.css
@@ -652,6 +652,65 @@ button:focus-visible,
   font-size: 11px;
 }
 
+/* Issue tree */
+
+.issue-tree li {
+  position: relative;
+}
+
+/*
+ * The rails are absolutely positioned so they cover the row padding as well.
+ * Laid out inside the row they would stop at the text and leave the vertical
+ * line broken between one row and the next.
+ */
+.issue-rails {
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  pointer-events: none;
+}
+
+.issue-rail {
+  position: relative;
+  width: 22px;
+}
+
+.issue-rail.through::before,
+.issue-rail.elbow::before {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid var(--border-strong);
+}
+
+/* The last child ends the line at the elbow instead of running it through. */
+.issue-rail.elbow.last::before {
+  bottom: 50%;
+}
+
+.issue-rail.elbow::after {
+  content: '';
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  width: 9px;
+  border-top: 1px solid var(--border-strong);
+}
+
+.issue-sub-count {
+  font-size: 10px;
+  border-radius: 8px;
+  padding: 1px 7px;
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+
 .label-row {
   display: inline-flex;
   flex-wrap: wrap;

--- a/product/akbun-gitdesktop/src/renderer/src/styles.css
+++ b/product/akbun-gitdesktop/src/renderer/src/styles.css
@@ -582,7 +582,7 @@ button:focus-visible,
   font-size: 11px;
 }
 
-/* Pull requests */
+/* Pull requests and issues */
 
 .pr-list {
   list-style: none;
@@ -596,19 +596,33 @@ button:focus-visible,
   gap: 10px;
   padding: 7px 6px;
   border-bottom: 1px solid var(--border);
+  border-left: 3px solid transparent;
+  cursor: pointer;
 }
 
-.pr-list a {
-  color: var(--text);
-  text-decoration: none;
+.pr-list li:hover {
+  background: var(--bg-hover);
+}
+
+.pr-list li.selected {
+  background: var(--bg-selected);
+  border-left-color: var(--accent);
+}
+
+/* The title keeps a floor so the meta text on its right cannot squeeze it away. */
+.pr-title {
   flex: 1;
+  min-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.pr-list a:hover {
-  color: var(--accent);
+.pr-list .pr-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pr-state {
@@ -638,9 +652,180 @@ button:focus-visible,
   font-size: 11px;
 }
 
+.label-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.label-chip {
+  font-size: 10px;
+  border-radius: 8px;
+  padding: 1px 7px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+
 .placeholder {
   color: var(--text-dim);
   padding: 12px;
+}
+
+/* Issue and pull request detail */
+
+.thread-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  background: var(--bg);
+}
+
+.thread-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.thread-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  margin-bottom: 10px;
+  overflow: hidden;
+}
+
+.thread-card header {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-hover);
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.thread-text {
+  padding: 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  line-height: 1.6;
+}
+
+/* Project board */
+
+.project-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.project-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.project-toolbar select {
+  max-width: 320px;
+}
+
+.project-toolbar button {
+  white-space: nowrap;
+}
+
+.project-board {
+  display: flex;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
+  overflow-x: auto;
+  padding: 12px;
+  align-items: flex-start;
+}
+
+.project-column {
+  width: 260px;
+  min-width: 260px;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.project-column h3 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
+.project-count {
+  background: var(--bg-hover);
+  border-radius: 8px;
+  padding: 1px 7px;
+  font-size: 11px;
+}
+
+.project-column ul {
+  list-style: none;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.project-column li {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border);
+  border-left: 3px solid transparent;
+  border-radius: 6px;
+  background: var(--bg);
+  cursor: pointer;
+}
+
+.project-column li:last-child {
+  margin-bottom: 0;
+}
+
+.project-column li:hover {
+  background: var(--bg-hover);
+}
+
+.project-column li.selected {
+  background: var(--bg-selected);
+  border-left-color: var(--accent);
+}
+
+.project-column li.placeholder {
+  border: none;
+  background: transparent;
+  cursor: default;
+  padding: 6px 8px;
+}
+
+.project-card-title {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.project-card-meta {
+  color: var(--text-dim);
+  font-size: 11px;
 }
 
 /* Diff drawer */

--- a/product/akbun-gitdesktop/src/shared/types.ts
+++ b/product/akbun-gitdesktop/src/shared/types.ts
@@ -47,6 +47,8 @@ export interface IssueInfo {
   url: string
   updatedAt: string
   labels: string[]
+  /** Number of the issue this one is a sub-issue of. 0 when it has no parent. */
+  parent: number
 }
 
 export interface ThreadComment {

--- a/product/akbun-gitdesktop/src/shared/types.ts
+++ b/product/akbun-gitdesktop/src/shared/types.ts
@@ -36,6 +36,87 @@ export interface PullRequestInfo {
   headRefName: string
   url: string
   updatedAt: string
+  labels: string[]
+}
+
+export interface IssueInfo {
+  number: number
+  title: string
+  state: string
+  author: string
+  url: string
+  updatedAt: string
+  labels: string[]
+}
+
+export interface ThreadComment {
+  author: string
+  createdAt: string
+  body: string
+}
+
+/**
+ * One issue or pull request with its body and comments.
+ * The two are one type because GitHub numbers them in one sequence and the app
+ * shows them in one drawer. The branch and diff size fields stay empty for issues.
+ */
+export interface ThreadDetail {
+  kind: 'issue' | 'pr'
+  number: number
+  title: string
+  state: string
+  author: string
+  url: string
+  createdAt: string
+  updatedAt: string
+  labels: string[]
+  assignees: string[]
+  body: string
+  comments: ThreadComment[]
+  baseRefName: string
+  headRefName: string
+  additions: number
+  deletions: number
+  changedFiles: number
+}
+
+export interface ProjectInfo {
+  number: number
+  title: string
+  url: string
+  closed: boolean
+  itemCount: number
+}
+
+/** Projects belong to an owner, not to a repository, so the owner comes with the list. */
+export interface ProjectListResult {
+  owner: string
+  nameWithOwner: string
+  projects: ProjectInfo[]
+}
+
+export interface ProjectItem {
+  id: string
+  title: string
+  status: string
+  /** Issue, PullRequest or DraftIssue. */
+  type: string
+  url: string
+  /** 0 for a draft issue, which has no issue number. */
+  number: number
+  /** owner/name of the repository the item lives in. Empty for a draft issue. */
+  repository: string
+  assignees: string[]
+  labels: string[]
+}
+
+export interface ProjectColumn {
+  name: string
+  items: ProjectItem[]
+}
+
+export interface ProjectBoard {
+  columns: ProjectColumn[]
 }
 
 export interface OpenerApp {


### PR DESCRIPTION
# 구현

Issues, Projects 탭과 issue, PR 상세 drawer 추가. 하위 issue는 트리로 표시
- 탭 5개와 drawer를 Playwright로 구동해 확인, renderer 에러 0건

# 어려웠던 점

gh 미설치 환경이라 응답 JSON 형태를 실물로 확인 불가
- gh를 흉내내는 stub 바이너리로 파싱을 검증했고, 부모 관계가 순환할 때 issue가 목록에서 사라지던 결함을 이 단계에서 발견

# 리스크

gh project와 하위 issue GraphQL의 필드 이름에 의존
- 필드가 바뀌면 Projects 탭은 에러 배너, issue 트리는 평평한 목록으로 낮아짐

Issue #663
