### PR TITLE
fix(akbun-makevideo): 타임라인 드래그앤드롭과 reload 초기화

### DIFF
--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -147,7 +147,6 @@ function renderAssets() {
     const item = document.createElement('li');
     item.className = 'asset';
     item.dataset.id = asset.id;
-    item.draggable = true;
     item.title = asset.path;
     if (asset.id === state.selectedAssetId) item.classList.add('selected');
 
@@ -600,6 +599,61 @@ function laneAtPoint(x, y) {
   return under.closest('.lane');
 }
 
+/** Dragging an asset out of the panel and onto a lane runs on pointer events
+ *  rather than HTML5 drag and drop.
+ *
+ *  The webview that shows this page is also the view that catches files dropped
+ *  from Finder, and that handler reports every drag event as handled — including
+ *  a drag that started inside the page and carries no file at all. WebKit never
+ *  gets it, so `dragover` and `drop` do not fire and a `draggable` asset lands
+ *  nowhere. Pointer events are not routed through it. */
+let assetDrag = null;
+
+function beginAssetDrag(event) {
+  if (event.button !== 0) return;
+  const item = event.target.closest('.asset');
+  if (!item || event.target.closest('[data-remove]')) return;
+  const asset = L.findAsset(state.project, item.dataset.id);
+  if (!asset) return;
+  assetDrag = { asset, startX: event.clientX, startY: event.clientY, ghost: null };
+}
+
+function updateAssetDrag(event) {
+  // A few pixels of slack, so a click that wobbles still reads as a click.
+  if (!assetDrag.ghost) {
+    const travelled =
+      Math.abs(event.clientX - assetDrag.startX) + Math.abs(event.clientY - assetDrag.startY);
+    if (travelled < 4) return;
+    assetDrag.ghost = document.createElement('div');
+    assetDrag.ghost.className = 'drag-ghost';
+    assetDrag.ghost.textContent = assetDrag.asset.name || baseName(assetDrag.asset.path);
+    document.body.appendChild(assetDrag.ghost);
+    document.body.classList.add('dragging');
+  }
+  assetDrag.ghost.style.left = `${event.clientX + 12}px`;
+  assetDrag.ghost.style.top = `${event.clientY + 12}px`;
+  const lane = laneAtPoint(event.clientX, event.clientY);
+  for (const node of dom.lanes.querySelectorAll('.lane')) {
+    node.classList.toggle('drop-target', node === lane);
+  }
+}
+
+function endAssetDrag(event) {
+  const current = assetDrag;
+  assetDrag = null;
+  if (!current || !current.ghost) return;
+  current.ghost.remove();
+  document.body.classList.remove('dragging');
+  for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
+
+  const lane = laneAtPoint(event.clientX, event.clientY);
+  if (!lane) return;
+  const at = L.snapTime(state.project, timeAtClientX(event.clientX), snapTolerance());
+  if (!dropAssetsOnTrack(lane.dataset.trackId, [current.asset], at)) return;
+  markDirty();
+  renderTimeline();
+}
+
 async function handleOsDrop(payload) {
   if (payload.type === 'over') {
     const point = payload.position || { x: 0, y: 0 };
@@ -1009,6 +1063,13 @@ function wireMenus() {
   document.addEventListener('pointerdown', (event) => {
     if (!event.target.closest('#menus')) closeMenus();
   });
+  // The webview brings its own right-click menu, and the first item on it is
+  // Reload. The project lives in this page and nowhere else until it is saved,
+  // so that one click empties the assets and the timeline with no warning.
+  // Text fields keep their menu, because copy and paste belong there.
+  document.addEventListener('contextmenu', (event) => {
+    if (!event.target.closest('input, textarea')) event.preventDefault();
+  });
 }
 
 function wireAssets() {
@@ -1033,12 +1094,11 @@ function wireAssets() {
     if (!item) return;
     setPreviewSource('asset');
   });
-  dom.assetList.addEventListener('dragstart', (event) => {
-    const item = event.target.closest('.asset');
-    if (!item) return;
-    event.dataTransfer.setData('text/plain', item.dataset.id);
-    event.dataTransfer.effectAllowed = 'copy';
+  dom.assetList.addEventListener('pointerdown', beginAssetDrag);
+  window.addEventListener('pointermove', (event) => {
+    if (assetDrag) updateAssetDrag(event);
   });
+  window.addEventListener('pointerup', endAssetDrag);
 }
 
 function wireTimeline() {
@@ -1092,35 +1152,6 @@ function wireTimeline() {
     if (scrubbing) {
       scrubbing = false;
       preview.setScrubbing(false);
-    }
-  });
-
-  // Dragging an asset out of the panel and onto a lane.
-  dom.lanes.addEventListener('dragover', (event) => {
-    const lane = event.target.closest('.lane');
-    if (!lane) return;
-    event.preventDefault();
-    event.dataTransfer.dropEffect = 'copy';
-    for (const node of dom.lanes.querySelectorAll('.lane')) {
-      node.classList.toggle('drop-target', node === lane);
-    }
-  });
-  dom.lanes.addEventListener('dragleave', (event) => {
-    const lane = event.target.closest('.lane');
-    if (lane) lane.classList.remove('drop-target');
-  });
-  dom.lanes.addEventListener('drop', (event) => {
-    const lane = event.target.closest('.lane');
-    for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
-    if (!lane) return;
-    event.preventDefault();
-    const assetId = event.dataTransfer.getData('text/plain');
-    const asset = L.findAsset(state.project, assetId);
-    if (!asset) return;
-    const at = L.snapTime(state.project, timeAtClientX(event.clientX), snapTolerance());
-    if (dropAssetsOnTrack(lane.dataset.trackId, [asset], at)) {
-      markDirty();
-      renderTimeline();
     }
   });
 }

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -638,13 +638,26 @@ function updateAssetDrag(event) {
   }
 }
 
-function endAssetDrag(event) {
+/** Put the page back the way it was and report the drag that was running, if it
+ *  had got as far as showing a ghost.
+ *
+ *  A drag does not always end in a pointerup: the pointer sequence can be
+ *  cancelled, or the window can lose focus mid-drag and the button come up
+ *  somewhere else entirely. Every one of those paths comes through here, so a
+ *  ghost is never left stuck to the cursor. */
+function clearAssetDrag() {
   const current = assetDrag;
   assetDrag = null;
-  if (!current || !current.ghost) return;
+  if (!current || !current.ghost) return null;
   current.ghost.remove();
   document.body.classList.remove('dragging');
   for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
+  return current;
+}
+
+function endAssetDrag(event) {
+  const current = clearAssetDrag();
+  if (!current) return;
 
   const lane = laneAtPoint(event.clientX, event.clientY);
   if (!lane) return;
@@ -1099,6 +1112,8 @@ function wireAssets() {
     if (assetDrag) updateAssetDrag(event);
   });
   window.addEventListener('pointerup', endAssetDrag);
+  window.addEventListener('pointercancel', clearAssetDrag);
+  window.addEventListener('blur', clearAssetDrag);
 }
 
 function wireTimeline() {

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -667,6 +667,24 @@ button.icon.on {
   box-shadow: inset 0 0 0 2px var(--accent);
 }
 
+/* What follows the pointer while an asset is on its way to a lane. */
+.drag-ghost {
+  position: fixed;
+  z-index: 400;
+  padding: 3px 8px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: var(--panel-2);
+  color: var(--fg);
+  font-size: 12px;
+  opacity: 0.92;
+  pointer-events: none;
+}
+
 .clip {
   position: absolute;
   top: 4px;


### PR DESCRIPTION
# 구현

패널에서 트랙으로 끄는 드래그를 pointer 이벤트로 교체하고, 텍스트 입력 밖 context menu 차단
- 브라우저에서 index.html을 띄워 실제 드래그로 검증. V1에 포인터 위치 시각으로 clip 생성, ghost와 drop-target 잔여 없음, 단순 클릭 선택과 asset 삭제 버튼 정상, 기존 테스트 36개 통과

# 어려웠던 점

증상은 drop 코드처럼 보였으나 원인이 페이지 밖 tauri-runtime-wry에 있었음
- 핸들러가 파일 경로 없는 내부 드래그에도 true를 반환해 wry가 이벤트를 삼킴. 페이지 쪽 수정으로는 도달할 수 없어 drag and drop API 사용 자체를 포기

# 리스크

pointer 드래그라 브라우저가 주는 드래그 이미지와 자동 스크롤이 없음
- 타임라인 화면 밖으로 끌면 스크롤이 따라가지 않으므로, 긴 타임라인에서 먼 위치에 놓으려면 먼저 스크롤한 뒤 끌어야 함

Issue #665