### PR TITLE
fix(akbun-makevideo): 재생 클럭 안정화

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-preview-in-the-webview.md
+++ b/product/akbun-makevideo/adr/2026-08-preview-in-the-webview.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-The preview keeps one `<video>` or `<audio>` element per clip, stacks them in the stage, and drives them from a `requestAnimationFrame` clock. Rust decodes nothing for the preview. The preview and the render are therefore two independent implementations of the same timeline, and the wiki says so.
+The preview keeps one `<video>` or `<audio>` element per clip and stacks them in the stage. The active reference element's `currentTime` drives the playhead, while followers use small `playbackRate` changes and seek only after large drift. Rust decodes nothing for the preview. The preview and the render are therefore two independent implementations of the same timeline, and the wiki says so.
 
 ## Reason
 
@@ -20,9 +20,8 @@ The honest limit of this approach is the number of simultaneous elements. Four v
 
 ## Where a lower quality actually saves
 
-Not where it looks like it does. A `<video>` decodes its source at full resolution whatever size it is drawn at, so shrinking the stage does not make the decoder do less work. The two things that do change:
+Not where it looks like it does. A `<video>` decodes its source at full resolution whatever size it is drawn at, so shrinking the stage does not make the decoder do less work. The thing that changes:
 
 1. `#stage-inner` is laid out at the quality scale and transformed back up, so the browser composites a smaller surface.
-2. The drift tolerance loosens, from 0.12 s to 0.4 s. Seeking is the expensive operation during playback, and letting an element run further before it is pulled back is most of the saving.
 
-Writing this down because "quality" reads like it should reduce decode cost, and someone will otherwise spend an afternoon wondering why Quarter did not help as much as expected.
+Playback synchronization is independent of preview quality. The reference element runs freely, ordinary follower drift changes playback speed by at most 5%, and a follower seeks only after one second of drift. Writing this down because "quality" reads like it should reduce decode cost, and someone will otherwise spend an afternoon wondering why Quarter did not help as much as expected.

--- a/product/akbun-makevideo/wiki/architecture/preview.md
+++ b/product/akbun-makevideo/wiki/architecture/preview.md
@@ -1,11 +1,13 @@
 # The preview
 
-`src/preview.js` keeps one media element per clip in a pool, stacks them in `#stage-inner`, and drives them from a clock:
+`src/preview.js` keeps one media element per clip in a pool and stacks them in `#stage-inner`:
 
-1. A `requestAnimationFrame` loop computes the playhead from `performance.now()`.
-2. `clipsAt()` says which clips are live at that instant.
-3. Each live element is shown, given a z-index from its track, and seeked if it has drifted further than the current quality tolerance allows.
-4. Everything not live is hidden and paused.
+1. Playback starts after the active reference media element has started playing.
+2. The reference element's `currentTime` drives the playhead. Gaps and still-only sections fall back to `performance.now()`.
+3. `clipsAt()` says which clips are live at that instant.
+4. Each live follower is shown, given a z-index from its track, and synchronized with small `playbackRate` changes.
+5. A follower seeks only when it is at least one second from the reference.
+6. Everything not live is hidden and paused.
 
 This is not the render. The differences are real and worth knowing:
 
@@ -19,12 +21,12 @@ That exact frame is the other half of the preview: when the playhead stops, the 
 
 ## Preview quality
 
-Set in Settings and defaulted to **Half**. It changes two things:
+Set in Settings and defaulted to **Half**. It changes the layout scale:
 
-| Setting | Layout scale | Drift tolerance |
-|---|---|---|
-| Full | 1 | 0.12 s |
-| Half | 0.5 | 0.25 s |
-| Quarter | 0.25 | 0.4 s |
+| Setting | Layout scale |
+|---|---|
+| Full | 1 |
+| Half | 0.5 |
+| Quarter | 0.25 |
 
-The stage box stays the same size on screen. What changes is that `#stage-inner` is laid out at `scale` and transformed back up, so the browser composites a smaller surface, and how far an element may run from the playhead before it is seeked back. The second one matters more: seeking is the expensive operation, and a looser tolerance is most of the saving. Lowering the quality does **not** make the decoder do less work, because the element still decodes its source at full resolution.
+The stage box stays the same size on screen. `#stage-inner` is laid out at `scale` and transformed back up, so the browser composites a smaller surface. Lowering the quality does **not** make the decoder do less work, because the element still decodes its source at full resolution.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -8,14 +8,29 @@
 // rather than the render itself; see adr/2026-08-preview-in-the-webview.md.
 
 // scale is what the stacked elements are actually laid out at before being
-// scaled back up, so a lower setting composites a smaller surface. drift is how
-// far an element may run from the playhead before it is seeked back: seeking is
-// the expensive part, so a looser tolerance is most of the saving.
+// scaled back up, so a lower setting composites a smaller surface.
 const QUALITY = {
-  full: { scale: 1, drift: 0.12 },
-  half: { scale: 0.5, drift: 0.25 },
-  quarter: { scale: 0.25, drift: 0.4 },
+  full: { scale: 1 },
+  half: { scale: 0.5 },
+  quarter: { scale: 0.25 },
 };
+
+const RATE_SYNC_THRESHOLD = 0.04;
+const HARD_SYNC_THRESHOLD = 1;
+const MAX_RATE_ADJUSTMENT = 0.05;
+
+function timelineTimeFromMedia(clip, currentTime) {
+  return clip.startMs + (currentTime * 1000 - clip.inMs);
+}
+
+function playbackRateForDrift(drift) {
+  if (Math.abs(drift) <= RATE_SYNC_THRESHOLD) return 1;
+  const adjustment = Math.max(
+    -MAX_RATE_ADJUSTMENT,
+    Math.min(MAX_RATE_ADJUSTMENT, drift * 0.25)
+  );
+  return 1 + adjustment;
+}
 
 function clamp01(value) {
   if (!Number.isFinite(value)) return 1;
@@ -34,9 +49,14 @@ function createPreview(options) {
   let scrubbing = false;
   let muteWhileScrubbing = true;
   let playing = false;
+  let starting = false;
   let positionMs = 0;
   let clockOrigin = 0;
+  let clock = null;
+  let timelineDiscontinuity = false;
+  let playGeneration = 0;
   let lastReported = -1;
+  const playPromises = new WeakMap();
 
   function settings() {
     const project = getProject();
@@ -97,19 +117,35 @@ function createPreview(options) {
 
   function hide(entry) {
     entry.element.classList.remove('on');
-    if (entry.kind !== 'image' && !entry.element.paused) entry.element.pause();
+    if (entry.kind !== 'image') {
+      entry.element.playbackRate = 1;
+      if (!entry.element.paused) entry.element.pause();
+    }
   }
 
-  /** Put every element where the playhead says it should be. Called every
-   *  frame, so it does the least work it can: a seek only when the element has
-   *  drifted past the tolerance for the current quality. */
+  function ensurePlaying(element) {
+    if (!element.paused) return Promise.resolve(true);
+    const pending = playPromises.get(element);
+    if (pending) return pending;
+    const started = Promise.resolve(element.play())
+      .then(() => !element.paused)
+      .catch(() => false)
+      .finally(() => playPromises.delete(element));
+    playPromises.set(element, started);
+    return started;
+  }
+
+  /** Put every element where the playhead says it should be. The clock element
+   *  runs freely. Followers change rate for ordinary drift and seek only when
+   *  they are far enough away that gradual correction would be visible. */
   function syncTimeline() {
     const project = getProject();
-    if (!project) return;
-    const drift = QUALITY[quality].drift;
+    if (!project) return null;
     const videoTracks = L.tracksOf(project, 'video');
     const active = L.clipsAt(project, positionMs);
     const live = new Set();
+    const media = [];
+    let seekFailed = false;
 
     for (const { track, clip, sourceMs } of active) {
       if (track.hidden) continue;
@@ -118,6 +154,7 @@ function createPreview(options) {
       if (!asset) continue;
       const wantsPicture = track.kind === 'video' && asset.kind !== 'audio';
       const entry = entryFor(clip, asset, wantsPicture);
+      const wasLive = entry.element.classList.contains('on');
       live.add(clip.id);
       entry.element.classList.add('on');
       if (wantsPicture) {
@@ -127,30 +164,47 @@ function createPreview(options) {
       if (entry.kind === 'image') continue;
 
       const target = sourceMs / 1000;
-      if (Math.abs(entry.element.currentTime - target) > (playing ? drift : 0.03)) {
+      media.push({ entry, track, clip, target, wasLive });
+    }
+
+    const reference =
+      media.find(({ clip }) => clock && clip.id === clock.clip.id) || media[0] || null;
+
+    for (const item of media) {
+      const { entry, track, clip, target, wasLive } = item;
+      const drift = target - entry.element.currentTime;
+      const isReference = item === reference;
+      const needsInitialSeek = !playing || !wasLive || timelineDiscontinuity;
+      const needsHardSeek = !isReference && Math.abs(drift) >= HARD_SYNC_THRESHOLD;
+
+      if ((needsInitialSeek && Math.abs(drift) > 0.03) || needsHardSeek) {
         try {
           entry.element.currentTime = target;
         } catch (error) {
-          // Seeking before metadata arrives throws; the next frame retries.
+          seekFailed = true;
         }
       }
+      entry.element.playbackRate =
+        playing && !isReference && !needsHardSeek ? playbackRateForDrift(drift) : 1;
       entry.element.volume = clamp01(clip.volume);
       entry.element.muted =
         (track.kind === 'video' && track.muted) || (scrubbing && muteWhileScrubbing);
-      if (playing && entry.element.paused) entry.element.play().catch(() => {});
-      if (!playing && !entry.element.paused) entry.element.pause();
+      if (playing || starting) ensurePlaying(entry.element);
+      if (!playing && !starting && !entry.element.paused) entry.element.pause();
     }
 
     for (const [clipId, entry] of pool) {
       if (!live.has(clipId)) hide(entry);
     }
+    timelineDiscontinuity = seekFailed;
+    return reference;
   }
 
   function syncAsset() {
     if (!assetElement) return;
     if (assetElement.tagName === 'IMG') return;
-    if (playing && assetElement.paused) assetElement.play().catch(() => {});
-    if (!playing && !assetElement.paused) assetElement.pause();
+    if ((playing || starting) && assetElement.paused) ensurePlaying(assetElement);
+    if (!playing && !starting && !assetElement.paused) assetElement.pause();
     positionMs = assetElement.currentTime * 1000;
   }
 
@@ -168,15 +222,24 @@ function createPreview(options) {
 
   function frame() {
     if (playing && mode === 'timeline') {
-      positionMs = performance.now() - clockOrigin;
+      if (clock && Number.isFinite(clock.entry.element.currentTime)) {
+        positionMs = timelineTimeFromMedia(clock.clip, clock.entry.element.currentTime);
+      } else {
+        positionMs = performance.now() - clockOrigin;
+      }
       const total = totalMs();
       if (positionMs >= total) {
         positionMs = total;
         pause();
       }
     }
-    if (mode === 'timeline') syncTimeline();
-    else syncAsset();
+    if (mode === 'timeline') {
+      const nextClock = syncTimeline();
+      if (!clock || !nextClock || clock.clip.id !== nextClock.clip.id) {
+        clock = nextClock;
+        clockOrigin = performance.now() - positionMs;
+      }
+    } else syncAsset();
 
     const rounded = Math.round(positionMs);
     if (rounded !== lastReported) {
@@ -186,21 +249,46 @@ function createPreview(options) {
     requestAnimationFrame(frame);
   }
 
-  function play() {
-    if (playing) return;
+  async function play() {
+    if (playing || starting) return;
     if (totalMs() <= 0) return;
     clearExact();
     if (mode === 'timeline' && positionMs >= totalMs()) positionMs = 0;
+    starting = true;
+    const generation = ++playGeneration;
+    let reference = null;
+    if (mode === 'timeline') {
+      clock = null;
+      reference = syncTimeline();
+      if (reference && !(await ensurePlaying(reference.entry.element))) {
+        if (generation === playGeneration) pause();
+        return;
+      }
+    } else if (assetElement) {
+      if (!(await ensurePlaying(assetElement))) {
+        if (generation === playGeneration) pause();
+        return;
+      }
+    }
+    if (generation !== playGeneration || !starting) return;
+    starting = false;
     playing = true;
+    clock = reference;
     clockOrigin = performance.now() - positionMs;
     if (onTick) onTick(positionMs, playing);
   }
 
   function pause() {
-    if (!playing) return;
+    if (!playing && !starting) return;
+    playGeneration += 1;
+    starting = false;
     playing = false;
+    clock = null;
     for (const entry of pool.values()) {
-      if (entry.kind !== 'image' && !entry.element.paused) entry.element.pause();
+      if (entry.kind !== 'image') {
+        entry.element.playbackRate = 1;
+        if (!entry.element.paused) entry.element.pause();
+      }
     }
     if (assetElement && assetElement.pause) assetElement.pause();
     if (onTick) onTick(positionMs, playing);
@@ -209,6 +297,8 @@ function createPreview(options) {
   function seek(ms) {
     positionMs = Math.max(0, Math.min(ms, Math.max(totalMs(), 0)));
     clockOrigin = performance.now() - positionMs;
+    clock = null;
+    timelineDiscontinuity = mode === 'timeline';
     if (mode === 'asset' && assetElement && assetElement.currentTime !== undefined) {
       try {
         assetElement.currentTime = positionMs / 1000;
@@ -216,6 +306,7 @@ function createPreview(options) {
         // Same as above: retried on the next frame.
       }
     }
+    if (mode === 'timeline') clock = syncTimeline();
     if (onTick) onTick(positionMs, playing);
   }
 
@@ -246,7 +337,9 @@ function createPreview(options) {
     }
     pool.clear();
     positionMs = 0;
+    starting = false;
     playing = false;
+    clock = null;
   }
 
   function showAsset(asset) {
@@ -333,8 +426,8 @@ function createPreview(options) {
     showExact,
     clearExact,
     isExact,
-    toggle: () => (playing ? pause() : play()),
-    isPlaying: () => playing,
+    toggle: () => (playing || starting ? pause() : play()),
+    isPlaying: () => playing || starting,
     seek,
     position: () => positionMs,
     total: totalMs,
@@ -350,7 +443,13 @@ function createPreview(options) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { createPreview, QUALITY };
+  module.exports = {
+    createPreview,
+    QUALITY,
+    timelineTimeFromMedia,
+    playbackRateForDrift,
+    HARD_SYNC_THRESHOLD,
+  };
 } else {
   globalThis.previewLib = { createPreview, QUALITY };
 }

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -174,7 +174,8 @@ function createPreview(options) {
       const { entry, track, clip, target, wasLive } = item;
       const drift = target - entry.element.currentTime;
       const isReference = item === reference;
-      const needsInitialSeek = !playing || !wasLive || timelineDiscontinuity;
+      const needsInitialSeek =
+        !playing || !wasLive || timelineDiscontinuity || (isReference && entry.element.paused);
       const needsHardSeek = !isReference && Math.abs(drift) >= HARD_SYNC_THRESHOLD;
 
       if ((needsInitialSeek && Math.abs(drift) > 0.03) || needsHardSeek) {
@@ -220,9 +221,17 @@ function createPreview(options) {
     return project ? L.projectDurationMs(project) : 0;
   }
 
+  function transportActive() {
+    return playing || starting;
+  }
+
   function frame() {
     if (playing && mode === 'timeline') {
-      if (clock && Number.isFinite(clock.entry.element.currentTime)) {
+      if (
+        clock &&
+        !clock.entry.element.paused &&
+        Number.isFinite(clock.entry.element.currentTime)
+      ) {
         positionMs = timelineTimeFromMedia(clock.clip, clock.entry.element.currentTime);
       } else {
         positionMs = performance.now() - clockOrigin;
@@ -235,8 +244,9 @@ function createPreview(options) {
     }
     if (mode === 'timeline') {
       const nextClock = syncTimeline();
-      if (!clock || !nextClock || clock.clip.id !== nextClock.clip.id) {
-        clock = nextClock;
+      const readyClock = nextClock && !nextClock.entry.element.paused ? nextClock : null;
+      if (!clock || !readyClock || clock.clip.id !== readyClock.clip.id) {
+        clock = readyClock;
         clockOrigin = performance.now() - positionMs;
       }
     } else syncAsset();
@@ -244,7 +254,7 @@ function createPreview(options) {
     const rounded = Math.round(positionMs);
     if (rounded !== lastReported) {
       lastReported = rounded;
-      if (onTick) onTick(positionMs, playing);
+      if (onTick) onTick(positionMs, transportActive());
     }
     requestAnimationFrame(frame);
   }
@@ -255,6 +265,7 @@ function createPreview(options) {
     clearExact();
     if (mode === 'timeline' && positionMs >= totalMs()) positionMs = 0;
     starting = true;
+    if (onTick) onTick(positionMs, transportActive());
     const generation = ++playGeneration;
     let reference = null;
     if (mode === 'timeline') {
@@ -275,7 +286,7 @@ function createPreview(options) {
     playing = true;
     clock = reference;
     clockOrigin = performance.now() - positionMs;
-    if (onTick) onTick(positionMs, playing);
+    if (onTick) onTick(positionMs, transportActive());
   }
 
   function pause() {
@@ -291,7 +302,7 @@ function createPreview(options) {
       }
     }
     if (assetElement && assetElement.pause) assetElement.pause();
-    if (onTick) onTick(positionMs, playing);
+    if (onTick) onTick(positionMs, transportActive());
   }
 
   function seek(ms) {
@@ -307,7 +318,7 @@ function createPreview(options) {
       }
     }
     if (mode === 'timeline') clock = syncTimeline();
-    if (onTick) onTick(positionMs, playing);
+    if (onTick) onTick(positionMs, transportActive());
   }
 
   /** Elements outlive the clips that made them unless something removes them,
@@ -427,7 +438,7 @@ function createPreview(options) {
     clearExact,
     isExact,
     toggle: () => (playing || starting ? pause() : play()),
-    isPlaying: () => playing || starting,
+    isPlaying: transportActive,
     seek,
     position: () => positionMs,
     total: totalMs,

--- a/product/akbun-makevideo/workspace/test/preview.test.js
+++ b/product/akbun-makevideo/workspace/test/preview.test.js
@@ -77,6 +77,7 @@ test('pre-roll waits for media and followers correct drift without seeking', asy
     window: global.window,
     timelineLib: global.timelineLib,
     requestAnimationFrame: global.requestAnimationFrame,
+    performance: global.performance,
   };
   context.after(() => Object.assign(global, original));
 
@@ -86,6 +87,7 @@ test('pre-roll waits for media and followers correct drift without seeking', asy
   });
   const elements = [];
   const frames = [];
+  let now = 0;
   global.document = {
     createElement(tagName) {
       const start = elements.length === 0 ? () => referenceStarted : () => Promise.resolve();
@@ -96,6 +98,7 @@ test('pre-roll waits for media and followers correct drift without seeking', asy
   };
   global.window = { api: { fileUrl: (path) => path } };
   global.requestAnimationFrame = (callback) => frames.push(callback);
+  global.performance = { now: () => now };
 
   const videoTrack = { id: 'v1', kind: 'video', clips: [], hidden: false, muted: false };
   const audioTrack = { id: 'a1', kind: 'audio', clips: [], hidden: false, muted: false };
@@ -133,7 +136,8 @@ test('pre-roll waits for media and followers correct drift without seeking', asy
 
   const play = preview.play();
   await Promise.resolve();
-  assert.strictEqual(ticks.some((tick) => tick.playing), false);
+  assert.strictEqual(ticks.at(-1).playing, true);
+  assert.strictEqual(preview.position(), 0);
 
   startReference();
   await play;
@@ -146,6 +150,11 @@ test('pre-roll waits for media and followers correct drift without seeking', asy
   assert.strictEqual(preview.position(), 200);
   assert.strictEqual(follower.currentTime, 0.1);
   assert.strictEqual(follower.playbackRate, 1.025);
+
+  reference.paused = true;
+  now = 300;
+  frames.shift()();
+  assert.strictEqual(preview.position(), 300);
 
   preview.seek(500);
   assert.strictEqual(reference.currentTime, 0.5);

--- a/product/akbun-makevideo/workspace/test/preview.test.js
+++ b/product/akbun-makevideo/workspace/test/preview.test.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  timelineTimeFromMedia,
+  playbackRateForDrift,
+  HARD_SYNC_THRESHOLD,
+} = require('../src/preview.js');
+
+test('media time drives the timeline through clip trims and placement', () => {
+  const clip = { startMs: 5000, inMs: 2000 };
+  assert.strictEqual(timelineTimeFromMedia(clip, 3.5), 6500);
+});
+
+test('small follower drift keeps the normal playback rate', () => {
+  assert.strictEqual(playbackRateForDrift(0.02), 1);
+  assert.strictEqual(playbackRateForDrift(-0.02), 1);
+});
+
+test('follower drift is corrected without large playback rate changes', () => {
+  assert.strictEqual(playbackRateForDrift(0.1), 1.025);
+  assert.strictEqual(playbackRateForDrift(-0.1), 0.975);
+  assert.strictEqual(playbackRateForDrift(10), 1.05);
+  assert.strictEqual(playbackRateForDrift(-10), 0.95);
+  assert.strictEqual(HARD_SYNC_THRESHOLD, 1);
+});
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set();
+  }
+
+  add(value) {
+    this.values.add(value);
+  }
+
+  remove(value) {
+    this.values.delete(value);
+  }
+
+  contains(value) {
+    return this.values.has(value);
+  }
+}
+
+function fakeMedia(tagName, start) {
+  let currentTime = 0;
+  return {
+    tagName,
+    paused: true,
+    playbackRate: 1,
+    classList: new FakeClassList(),
+    style: {},
+    get currentTime() {
+      return currentTime;
+    },
+    set currentTime(value) {
+      currentTime = value;
+    },
+    play() {
+      return start().then(() => {
+        this.paused = false;
+      });
+    },
+    pause() {
+      this.paused = true;
+    },
+    remove() {},
+    removeAttribute() {},
+  };
+}
+
+test('pre-roll waits for media and followers correct drift without seeking', async (context) => {
+  const original = {
+    document: global.document,
+    window: global.window,
+    timelineLib: global.timelineLib,
+    requestAnimationFrame: global.requestAnimationFrame,
+  };
+  context.after(() => Object.assign(global, original));
+
+  let startReference;
+  const referenceStarted = new Promise((resolve) => {
+    startReference = resolve;
+  });
+  const elements = [];
+  const frames = [];
+  global.document = {
+    createElement(tagName) {
+      const start = elements.length === 0 ? () => referenceStarted : () => Promise.resolve();
+      const element = fakeMedia(tagName.toUpperCase(), start);
+      elements.push(element);
+      return element;
+    },
+  };
+  global.window = { api: { fileUrl: (path) => path } };
+  global.requestAnimationFrame = (callback) => frames.push(callback);
+
+  const videoTrack = { id: 'v1', kind: 'video', clips: [], hidden: false, muted: false };
+  const audioTrack = { id: 'a1', kind: 'audio', clips: [], hidden: false, muted: false };
+  const videoClip = {
+    id: 'c1', assetId: 'video', startMs: 0, inMs: 0, outMs: 10000, opacity: 1, volume: 1,
+  };
+  const audioClip = {
+    id: 'c2', assetId: 'audio', startMs: 0, inMs: 0, outMs: 10000, opacity: 1, volume: 1,
+  };
+  videoTrack.clips.push(videoClip);
+  audioTrack.clips.push(audioClip);
+  const assets = {
+    video: { id: 'video', path: '/video.mp4', kind: 'video' },
+    audio: { id: 'audio', path: '/audio.mp3', kind: 'audio' },
+  };
+  const project = { settings: { width: 1920, height: 1080 }, tracks: [videoTrack, audioTrack] };
+  global.timelineLib = {
+    tracksOf: (value, kind) => value.tracks.filter((track) => track.kind === kind),
+    clipsAt: (value, timeMs) => value.tracks.flatMap((track) => track.clips
+      .filter((clip) => timeMs >= clip.startMs && timeMs < clip.outMs)
+      .map((clip) => ({ track, clip, sourceMs: clip.inMs + timeMs - clip.startMs }))),
+    findAsset: (value, assetId) => assets[assetId],
+    projectDurationMs: () => 10000,
+  };
+
+  const ticks = [];
+  const preview = require('../src/preview.js').createPreview({
+    stage: { style: {} },
+    inner: { style: {}, appendChild() {} },
+    wrap: null,
+    exactCanvas: null,
+    getProject: () => project,
+    onTick: (position, playing) => ticks.push({ position, playing }),
+  });
+
+  const play = preview.play();
+  await Promise.resolve();
+  assert.strictEqual(ticks.some((tick) => tick.playing), false);
+
+  startReference();
+  await play;
+  assert.strictEqual(ticks.some((tick) => tick.playing), true);
+
+  const [reference, follower] = elements;
+  reference.currentTime = 0.2;
+  follower.currentTime = 0.1;
+  frames.shift()();
+  assert.strictEqual(preview.position(), 200);
+  assert.strictEqual(follower.currentTime, 0.1);
+  assert.strictEqual(follower.playbackRate, 1.025);
+
+  preview.seek(500);
+  assert.strictEqual(reference.currentTime, 0.5);
+  assert.strictEqual(follower.currentTime, 0.5);
+});


### PR DESCRIPTION
# 구현

기준 미디어 클럭과 pre-roll 도입, 보조 미디어 playbackRate 동기화

- Node 테스트 40개 통과, 재생 중 반복 seek 방지 통합 테스트 포함

# 어려웠던 점

명시적 seek와 클립 경계에서 기준 미디어 교체 시 클럭 연속성 유지

- 불연속 이동만 즉시 seek하고 일반 drift는 최대 5% 재생률 보정으로 분리

# 리스크

활성 미디어가 없는 이미지·공백 구간에서 wall clock fallback 유지

- 다음 미디어 진입 시 최초 1회 seek로 기준 위치 정렬

Issue #667
