### PR TITLE
ci: product release body에 변경 목록 추가와 영어 개조식 전환

### DIFF
--- a/.github/workflows/release-akbun-folderview.yml
+++ b/.github/workflows/release-akbun-folderview.yml
@@ -80,12 +80,28 @@ jobs:
           # Only NSIS is built, but latest.json prefers msi by default.
           updaterJsonPreferNsis: true
           releaseBody: |
-            직접 추가한 사진과 영상만 모아 태그, 등급, 검색으로 찾는 Windows 데스크톱 앱이다.
+            ## About
 
-            - 설치 파일은 Windows x64 전용이다.
-            - exe를 내려받아 실행하면 사용자 폴더에 설치되고 바로 실행된다. 관리자 권한은 필요 없다.
-            - 코드 서명이 없어 SmartScreen 경고가 나온다. "추가 정보"를 누르고 "실행"을 선택하면 설치된다.
-            - 설치 후에는 Settings의 Check for Updates로 다음 버전을 받는다.
+            - Windows desktop app that collects only the photos and videos you add, and finds them again by tag, rating and search.
+
+            ## Install
+
+            - The installer is Windows x64 only.
+            - Downloading and running the exe installs into the user folder and launches at once. No administrator rights needed.
+            - Unsigned build, so SmartScreen warns. Choose "More info" then "Run anyway".
+            - After installing, Check for Updates in Settings fetches newer versions.
+
+      # tauri-action has no --generate-notes equivalent, so the commit list is
+      # generated and appended to the body the action already wrote.
+      - name: Append the change list to the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $version = node -p "require('./package.json').version"
+          $tag = "akbun-folderview-v$version"
+          gh release view $tag --json body --jq .body --repo ${{ github.repository }} > notes.md
+          gh api "repos/${{ github.repository }}/releases/generate-notes" -f tag_name=$tag --jq .body >> notes.md
+          gh release edit $tag --notes-file notes.md --repo ${{ github.repository }}
 
       # releases/latest is repository-wide, so any other product's release
       # steals it and installed copies silently see the wrong latest.json.

--- a/.github/workflows/release-akbun-mactaskbar.yml
+++ b/.github/workflows/release-akbun-mactaskbar.yml
@@ -71,21 +71,25 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cat > release-notes.md <<'EOF'
-          macOS menu bar manager. Two divider icons split the status bar into three sections, and one click on the control icon pages through them: visible only, visible plus hidden, everything. A revealed section folds back up on its own after a while, and ⌃⌘B cycles the sections from anywhere. The item list window shows every status item on the bar, including the ones macOS is currently drawing nowhere.
+          ## About
 
-          Assign icons to a section in the "all" state: hold Command and drag an icon to the left of a divider. macOS remembers the order.
+          - macOS menu bar manager. Two divider icons split the status bar into three sections.
+          - One click on the control icon pages through them: visible only, visible plus hidden, everything.
+          - A revealed section folds back up on its own after a while. `⌃⌘B` cycles the sections from anywhere.
+          - The item list window lists every status item on the bar, including the ones macOS is currently drawing nowhere.
+          - To pin icons to a section in the "all" state, hold Command and drag an icon to the left of a divider. macOS remembers the order.
+          - The shortcut defaults to `⌃⌘B`, changeable or removable in the item list window, since macOS gives no way to find out whether another app already owns a combination.
+          - No icon after launch means the menu bar had no room left and macOS placed the control icon under the camera housing. The app opens its item list window on detecting this, and the shortcut works regardless.
 
-          The shortcut defaults to ⌃⌘B and can be changed or turned off in the item list window, since macOS gives no way to find out whether another app already owns a combination.
+          ## Install
 
-          If no icon appears after launch, the menu bar had no room left and macOS placed the control icon under the camera housing, where nothing is drawn. The app opens its item list window when it detects this, and the shortcut works regardless.
-
-          The dmg is Apple Silicon (arm64) only and unsigned, so the first launch fails with "damaged and can't be opened". Remove the quarantine attribute after installing:
-
-          ```bash
-          xattr -cr /Applications/akbun-mactaskbar.app
-          ```
+          - The dmg is Apple Silicon (arm64) only.
+          - Unsigned build, so the first launch fails with "damaged and can't be opened".
+          - Fix by removing the quarantine attribute after installing: `xattr -cr /Applications/akbun-mactaskbar.app`
           EOF
+          # --generate-notes appends the "What's Changed" commit list under the notes file.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \
+            --generate-notes \
             product/akbun-mactaskbar/workspace/build/*.dmg

--- a/.github/workflows/release-akbun-makepresentation.yml
+++ b/.github/workflows/release-akbun-makepresentation.yml
@@ -78,12 +78,28 @@ jobs:
           releaseDraft: false
           prerelease: false
           releaseBody: |
-            Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode.
+            ## About
+
+            - Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode.
+
+            ## Install
 
             - The installer is a macOS (Apple Silicon) dmg.
-            - The build is not code signed, so after dragging the app to Applications run once in Terminal:
-              xattr -cr /Applications/akbun-makepresentation.app
+            - Unsigned build, so after dragging the app to Applications run once in Terminal: `xattr -cr /Applications/akbun-makepresentation.app`
             - After that, the Updates button inside the app fetches newer versions on its own.
+
+      # tauri-action has no --generate-notes equivalent, so the commit list is
+      # generated and appended to the body the action already wrote.
+      - name: Append the change list to the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="akbun-makepresentation-v${VERSION}"
+          gh release view "$TAG" --json body --jq .body > "$RUNNER_TEMP/notes.md"
+          gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body >> "$RUNNER_TEMP/notes.md"
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.md"
 
       # Several products release from this repository, so the GitHub-wide
       # "latest" release is whichever product shipped last. The app therefore

--- a/.github/workflows/release-akbun-makevideo.yml
+++ b/.github/workflows/release-akbun-makevideo.yml
@@ -98,13 +98,29 @@ jobs:
           releaseDraft: false
           prerelease: false
           releaseBody: |
-            Desktop video editor: multi track timeline, live preview, render to FHD and 4K.
+            ## About
+
+            - Desktop video editor: multi track timeline, live preview, render to FHD and 4K.
+
+            ## Install
 
             - The installer is a macOS (Apple Silicon) dmg.
             - Rendering needs ffmpeg on the machine: `brew install ffmpeg`.
-            - The build is not code signed, so after dragging the app to Applications run once in Terminal:
-              xattr -cr /Applications/akbun-makevideo.app
+            - Unsigned build, so after dragging the app to Applications run once in Terminal: `xattr -cr /Applications/akbun-makevideo.app`
             - After that, Settings → Check for Updates fetches newer versions on its own.
+
+      # tauri-action has no --generate-notes equivalent, so the commit list is
+      # generated and appended to the body the action already wrote.
+      - name: Append the change list to the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="akbun-makevideo-v${VERSION}"
+          gh release view "$TAG" --json body --jq .body > "$RUNNER_TEMP/notes.md"
+          gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body >> "$RUNNER_TEMP/notes.md"
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/notes.md"
 
       # Several products release from this repository, so the GitHub-wide
       # "latest" release is whichever product shipped last. The app therefore

--- a/.github/workflows/release-akbun-screenshot.yml
+++ b/.github/workflows/release-akbun-screenshot.yml
@@ -93,15 +93,20 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cat > release-notes.md <<'EOF'
-          macOS menu bar screenshot app. Area capture by drag, then a floating preview with save, copy and close.
+          ## About
 
-          The dmg is Apple Silicon (arm64) only and unsigned, so the first launch fails with "damaged and can't be opened". Remove the quarantine attribute after installing:
+          - macOS menu bar screenshot app.
+          - Area capture by drag, then a floating preview with save, copy and close.
 
-          ```bash
-          xattr -cr /Applications/akbun-screenshot.app
-          ```
+          ## Install
+
+          - The dmg is Apple Silicon (arm64) only.
+          - Unsigned build, so the first launch fails with "damaged and can't be opened".
+          - Fix by removing the quarantine attribute after installing: `xattr -cr /Applications/akbun-screenshot.app`
           EOF
+          # --generate-notes appends the "What's Changed" commit list under the notes file.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \
+            --generate-notes \
             product/akbun-screenshot/workspace/release/*.dmg

--- a/.github/workflows/release-akbun-shadowing-player.yml
+++ b/.github/workflows/release-akbun-shadowing-player.yml
@@ -92,12 +92,19 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cat > release-notes.md <<'EOF'
-          - 언어 공부(쉐도잉)용 구간 반복 오디오 플레이어 macOS 빌드다.
-          - dmg는 Apple Silicon(arm64) 전용이다.
-          - 코드 서명이 없어 처음 실행하면 "damaged and can't be opened" 오류가 난다.
-          - 설치 후 `xattr -cr /Applications/akbun-shadowing-player.app`로 quarantine 속성을 지우면 실행된다.
+          ## About
+
+          - Section-repeat audio player for language shadowing practice, macOS build.
+
+          ## Install
+
+          - The dmg is Apple Silicon (arm64) only.
+          - Unsigned build, so the first launch fails with "damaged and can't be opened".
+          - Fix by removing the quarantine attribute after installing: `xattr -cr /Applications/akbun-shadowing-player.app`
           EOF
+          # --generate-notes appends the "What's Changed" commit list under the notes file.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \
+            --generate-notes \
             product/akbun-shadowing-player/release/*.dmg

--- a/.github/workflows/release-akbun-terraform-apply-remote.yml
+++ b/.github/workflows/release-akbun-terraform-apply-remote.yml
@@ -86,11 +86,18 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cat > release-notes.md <<'EOF'
-          - GitHub pull request comment로 terraform plan/apply를 실행하는 셀프호스팅 서버다.
-          - 바이너리는 linux x86_64 전용이다. 다른 아키텍처는 소스에서 직접 빌드한다.
-          - 실행에는 terraform CLI와 GitHub webhook 설정이 필요하다. docs/user-guide.md를 참고한다.
+          ## About
+
+          - Self-hosted server that runs terraform plan and apply from GitHub pull request comments.
+
+          ## Install
+
+          - The binary is linux x86_64 only. Other architectures build from source.
+          - Running it needs the terraform CLI and a GitHub webhook. See docs/user-guide.md.
           EOF
+          # --generate-notes appends the "What's Changed" commit list under the notes file.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \
+            --generate-notes \
             product/akbun-terraform-apply-remote/target/release/akbun-terraform-apply-remote

--- a/.github/workflows/release-k8supgradeview.yml
+++ b/.github/workflows/release-k8supgradeview.yml
@@ -92,12 +92,19 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cat > release-notes.md <<'EOF'
-          - EKS 업그레이드 작업용 노드/파드 조회 데스크톱 앱 macOS 빌드다.
-          - dmg는 Apple Silicon(arm64) 전용이다.
-          - 코드 서명이 없어 처음 실행하면 "damaged and can't be opened" 오류가 난다.
-          - 설치 후 `xattr -cr /Applications/akbun-k8supgradeview.app`로 quarantine 속성을 지우면 실행된다.
+          ## About
+
+          - Desktop app that lists nodes and pods for EKS upgrade work, macOS build.
+
+          ## Install
+
+          - The dmg is Apple Silicon (arm64) only.
+          - Unsigned build, so the first launch fails with "damaged and can't be opened".
+          - Fix by removing the quarantine attribute after installing: `xattr -cr /Applications/akbun-k8supgradeview.app`
           EOF
+          # --generate-notes appends the "What's Changed" commit list under the notes file.
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \
+            --generate-notes \
             product/akbun-k8supgradeview/workspace/release/*.dmg

--- a/.github/workflows/release-tistory-skin.yml
+++ b/.github/workflows/release-tistory-skin.yml
@@ -62,7 +62,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           cd product/tistory-skin/akbun
+          cat > release-notes.md <<'EOF'
+          ## About
+
+          - Tistory blog skin, distributed as a zip artifact.
+
+          ## Install
+
+          - The zip contains skin.html, style.css, index.xml and the images directory.
+          - Upload it from the Tistory skin editor. No build step needed.
+          EOF
+          # --generate-notes appends the "What's Changed" commit list under the notes file.
           gh release create "${{ steps.version.outputs.tag }}" akbun-skin.zip \
             --target "${{ github.sha }}" \
             --title "tistory-${{ steps.version.outputs.version }}" \
-            --notes "티스토리 스킨 tistory-${{ steps.version.outputs.version }} 배포 아티팩트. skin.html, style.css, index.xml 포함."
+            --notes-file release-notes.md \
+            --generate-notes


### PR DESCRIPTION
# 구현

gitdesktop을 제외한 release workflow 9개에 What's Changed 변경 목록 추가와 body 영어 개조식 전환
- gh release create 6개는 --generate-notes 추가, tauri-action 3개는 release 생성 뒤 body 재작성 단계 추가

# 어려웠던 점

tauri-action에 변경 목록 생성 input이 없어 release 생성 시점에 붙일 수 없었음
- releaseBody를 읽어 generate-notes API 결과를 이어 붙이고 gh release edit으로 되돌려 넣는 후속 단계로 우회

# 리스크

Full Changelog 비교 링크가 같은 product의 이전 tag가 아니라 저장소에서 마지막으로 release된 다른 product를 가리킴
- previous_tag_name 미지정 시 GitHub 기본 동작이며 gitdesktop도 동일. 비교가 필요해지면 product별 직전 tag를 계산해 넘김

Issue #689