### PR TITLE
feat(claude): add /repo-pr-copilot-review slash command

### DIFF
--- a/.claude/commands/repo-pr-copilot-review.md
+++ b/.claude/commands/repo-pr-copilot-review.md
@@ -4,14 +4,13 @@ argument-hint: [PR 번호]
 allowed-tools: Bash
 ---
 
-PR `$1`(없으면 현재 branch의 PR)에 Copilot code review를 요청한다.
+PR `$1`(없으면 현재 branch의 PR)에 Copilot code review를 요청한다. 요청을 걸기만 하고 끝낸다. 올라온 리뷰를 읽지 않고 기다리지도 않는다.
 
 ## 순서
 
 1. 대상 PR과 저장소를 확인한다.
-2. 이미 Copilot 리뷰가 있는지 확인한다.
-3. 없으면 최초 요청, 있으면 재요청을 한다.
-4. 요청이 걸렸는지 확인하고 사용자에게 알린다.
+2. 요청한다. Copilot 리뷰가 이미 있으면 재요청 경로로 간다.
+3. 요청이 걸린 것만 확인하고 끝낸다.
 
 ## 대상 확인
 
@@ -29,12 +28,6 @@ Copilot은 `copilot-pull-request-reviewer[bot]` 계정으로 리뷰한다. 일�
 ```bash
 gh api --method POST "repos/$REPO/pulls/$PR/requested_reviewers" \
   -f "reviewers[]=copilot-pull-request-reviewer[bot]"
-```
-
-gh가 최신이면 아래 한 줄로도 된다. 실패하면 위 REST 호출로 넘어간다.
-
-```bash
-gh pr edit "$PR" --add-reviewer "@copilot"
 ```
 
 ## 재요청
@@ -70,21 +63,13 @@ mutation($pr:ID!, $bot:ID!) {
 
 ## 확인
 
-요청이 걸리면 reviewRequests에 bot이 나타난다.
+요청이 걸리면 reviewRequests에 bot이 나타난다. 여기까지만 보고 끝낸다.
 
 ```bash
 gh pr view "$PR" --json reviewRequests -q '.reviewRequests[].login'
 ```
 
-리뷰 본문이 올라오기까지 몇 분 걸린다. 결과는 아래로 본다.
-
-```bash
-gh api "repos/$REPO/pulls/$PR/reviews" \
-  --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | .submitted_at'
-```
-
 ## 주의
 
-- 이 command는 리뷰를 요청하기만 한다. 올라온 comment를 읽고 고치는 것은 [/repo-pr-fix](./repo-pr-fix.md)가 한다.
-- 요청 후 리뷰를 기다리며 polling하지 않는다. 요청을 걸고 확인 명령을 안내한 뒤 끝낸다.
+- 리뷰 본문을 조회하거나 polling하지 않는다. 올라온 comment를 읽고 고치는 것은 [/repo-pr-fix](./repo-pr-fix.md)가 한다.
 - 저장소나 조직에서 Copilot code review가 꺼져 있으면 REST 호출이 422로 실패한다. 이때는 코드를 고치지 말고 설정 문제임을 알린다.

--- a/.claude/commands/repo-pr-copilot-review.md
+++ b/.claude/commands/repo-pr-copilot-review.md
@@ -1,0 +1,90 @@
+---
+description: PR에 GitHub Copilot code review를 요청한다. 이미 리뷰가 있으면 재요청한다
+argument-hint: [PR 번호]
+allowed-tools: Bash
+---
+
+PR `$1`(없으면 현재 branch의 PR)에 Copilot code review를 요청한다.
+
+## 순서
+
+1. 대상 PR과 저장소를 확인한다.
+2. 이미 Copilot 리뷰가 있는지 확인한다.
+3. 없으면 최초 요청, 있으면 재요청을 한다.
+4. 요청이 걸렸는지 확인하고 사용자에게 알린다.
+
+## 대상 확인
+
+`$1`이 없으면 현재 branch의 PR을 쓴다.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+PR=${1:-$(gh pr view --json number -q .number)}
+```
+
+## 최초 요청
+
+Copilot은 `copilot-pull-request-reviewer[bot]` 계정으로 리뷰한다. 일반 reviewer와 같은 REST endpoint를 쓴다.
+
+```bash
+gh api --method POST "repos/$REPO/pulls/$PR/requested_reviewers" \
+  -f "reviewers[]=copilot-pull-request-reviewer[bot]"
+```
+
+gh가 최신이면 아래 한 줄로도 된다. 실패하면 위 REST 호출로 넘어간다.
+
+```bash
+gh pr edit "$PR" --add-reviewer "@copilot"
+```
+
+## 재요청
+
+Copilot이 이미 리뷰를 남긴 PR에는 위 REST 호출이 200을 주고도 아무 일이 없다. 리뷰가 끝난 reviewer는 REST로 다시 부를 수 없기 때문이다. 이때는 GraphQL `requestReviews`의 `botIds`를 쓴다. REST와 gh CLI 어디에도 노출되지 않는 필드다.
+
+bot의 node id는 하드코딩하지 않고 기존 리뷰에서 꺼낸다. 재요청이 필요한 상황이면 이미 리뷰가 있으므로 항상 찾을 수 있다.
+
+```bash
+gh api graphql -F owner="${REPO%/*}" -F name="${REPO#*/}" -F number="$PR" -f query='
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      id
+      reviews(first:100) {
+        nodes { author { __typename ... on Bot { id login } } }
+      }
+    }
+  }
+}'
+```
+
+`login`이 `copilot-pull-request-reviewer`인 노드의 `id`와 pullRequest의 `id`로 재요청한다. `union: true`를 빼면 기존 reviewer가 전부 지워지므로 반드시 넣는다.
+
+```bash
+gh api graphql -f pr="$PR_NODE_ID" -f bot="$BOT_NODE_ID" -f query='
+mutation($pr:ID!, $bot:ID!) {
+  requestReviews(input: {pullRequestId: $pr, botIds: [$bot], union: true}) {
+    pullRequest { id }
+  }
+}'
+```
+
+## 확인
+
+요청이 걸리면 reviewRequests에 bot이 나타난다.
+
+```bash
+gh pr view "$PR" --json reviewRequests -q '.reviewRequests[].login'
+```
+
+리뷰 본문이 올라오기까지 몇 분 걸린다. 결과는 아래로 본다.
+
+```bash
+gh api "repos/$REPO/pulls/$PR/reviews" \
+  --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | .submitted_at'
+```
+
+## 주의
+
+- 이 command는 리뷰를 요청하기만 한다. 올라온 comment를 읽고 고치는 것은 [/repo-pr-fix](./repo-pr-fix.md)가 한다.
+- 요청 후 리뷰를 기다리며 polling하지 않는다. 요청을 걸고 확인 명령을 안내한 뒤 끝낸다.
+- 저장소나 조직에서 Copilot code review가 꺼져 있으면 REST 호출이 422로 실패한다. 이때는 코드를 고치지 말고 설정 문제임을 알린다.

--- a/.claude/commands/repo-pr-copilot-review.md
+++ b/.claude/commands/repo-pr-copilot-review.md
@@ -9,7 +9,7 @@ PR `$1`(없으면 현재 branch의 PR)에 Copilot code review를 요청한다. �
 ## 순서
 
 1. 대상 PR과 저장소를 확인한다.
-2. 요청한다. Copilot 리뷰가 이미 있으면 재요청 경로로 간다.
+2. 요청한다.
 3. 요청이 걸린 것만 확인하고 끝낸다.
 
 ## 대상 확인
@@ -21,45 +21,43 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 PR=${1:-$(gh pr view --json number -q .number)}
 ```
 
-## 최초 요청
+## 요청
 
-Copilot은 `copilot-pull-request-reviewer[bot]` 계정으로 리뷰한다. 일반 reviewer와 같은 REST endpoint를 쓴다.
+gh 2.88.0부터 `@copilot`을 reviewer로 직접 넘길 수 있다. 최초 요청과 재요청 모두 이 한 줄로 끝난다.
+
+```bash
+gh pr edit "$PR" --add-reviewer "@copilot"
+```
+
+## gh api로 직접 호출
+
+gh가 2.88.0 미만이거나 API를 직접 써야 할 때 쓴다. Copilot은 `copilot-pull-request-reviewer[bot]` 계정으로 리뷰한다.
+
+최초 요청은 일반 reviewer와 같은 REST endpoint로 된다.
 
 ```bash
 gh api --method POST "repos/$REPO/pulls/$PR/requested_reviewers" \
   -f "reviewers[]=copilot-pull-request-reviewer[bot]"
 ```
 
-## 재요청
-
-Copilot이 이미 리뷰를 남긴 PR에는 위 REST 호출이 200을 주고도 아무 일이 없다. 리뷰가 끝난 reviewer는 REST로 다시 부를 수 없기 때문이다. 이때는 GraphQL `requestReviews`의 `botIds`를 쓴다. REST와 gh CLI 어디에도 노출되지 않는 필드다.
-
-bot의 node id는 하드코딩하지 않고 기존 리뷰에서 꺼낸다. 재요청이 필요한 상황이면 이미 리뷰가 있으므로 항상 찾을 수 있다.
+재요청은 이 REST 호출로 안 된다. 200을 주고도 아무 일이 없다. 리뷰를 마친 reviewer는 REST로 다시 부를 수 없기 때문이다. GraphQL `requestReviewsByLogin`의 `botLogins`를 쓴다. `gh pr edit`이 내부에서 호출하는 것과 같은 mutation이다.
 
 ```bash
-gh api graphql -F owner="${REPO%/*}" -F name="${REPO#*/}" -F number="$PR" -f query='
-query($owner:String!, $name:String!, $number:Int!) {
-  repository(owner:$owner, name:$name) {
-    pullRequest(number:$number) {
-      id
-      reviews(first:100) {
-        nodes { author { __typename ... on Bot { id login } } }
-      }
-    }
-  }
+PR_ID=$(gh pr view "$PR" --json id -q .id)
+gh api graphql -f pr="$PR_ID" -f query='
+mutation($pr:ID!) {
+  requestReviewsByLogin(input: {
+    pullRequestId: $pr,
+    botLogins: ["copilot-pull-request-reviewer[bot]"],
+    union: true
+  }) { clientMutationId }
 }'
 ```
 
-`login`이 `copilot-pull-request-reviewer`인 노드의 `id`와 pullRequest의 `id`로 재요청한다. `union: true`를 빼면 기존 reviewer가 전부 지워지므로 반드시 넣는다.
+두 가지를 지킨다.
 
-```bash
-gh api graphql -f pr="$PR_NODE_ID" -f bot="$BOT_NODE_ID" -f query='
-mutation($pr:ID!, $bot:ID!) {
-  requestReviews(input: {pullRequestId: $pr, botIds: [$bot], union: true}) {
-    pullRequest { id }
-  }
-}'
-```
+- `botLogins`에는 `[bot]` 접미사를 붙인다. `gh pr edit`은 자동으로 붙여 주지만 raw GraphQL은 아니다.
+- `union: true`를 빼면 기존 reviewer가 전부 지워진다.
 
 ## 확인
 
@@ -72,4 +70,5 @@ gh pr view "$PR" --json reviewRequests -q '.reviewRequests[].login'
 ## 주의
 
 - 리뷰 본문을 조회하거나 polling하지 않는다. 올라온 comment를 읽고 고치는 것은 [/repo-pr-fix](./repo-pr-fix.md)가 한다.
-- 저장소나 조직에서 Copilot code review가 꺼져 있으면 REST 호출이 422로 실패한다. 이때는 코드를 고치지 말고 설정 문제임을 알린다.
+- head commit이 그대로인 PR에 다시 요청하면 Copilot이 같은 내용을 다시 리뷰한다. 코드를 push한 뒤에 요청한다.
+- 저장소나 조직에서 Copilot code review가 꺼져 있으면 요청이 422로 실패한다. 이때는 코드를 고치지 말고 설정 문제임을 알린다.


### PR DESCRIPTION
# 구현

PR에 Copilot code review를 요청하는 repo-pr-copilot-review command 추가
- 기본 경로는 gh pr edit --add-reviewer @copilot, gh api 직접 호출은 최초 요청 REST와 재요청 GraphQL로 분리

# 어려웠던 점

재요청 방법이 자료마다 엇갈려 gh 미설치 환경에서 실행 없이 판별해야 했음
- cli/cli HEAD에 botIds가 없고 requestReviewsByLogin에 botLogins를 넘기는 것을 소스에서 확인해 커뮤니티 자료의 botIds 방식을 폐기

# 리스크

명령을 실행해 검증하지 못했고 gh 내부 mutation 이름에 의존
- gh 2.88.0 미만이거나 mutation이 바뀌면 재요청 경로만 실패. 최초 요청 REST 경로는 영향 없음

Issue #691


---
_Generated by [Claude Code](https://claude.ai/code/session_016p2aioTrgXzXdHhBpU42WU)_