### PR TITLE
akbun-makevideo 재생 품질 계측 추가

### DIFF
--- a/product/akbun-makevideo/README.md
+++ b/product/akbun-makevideo/README.md
@@ -53,6 +53,7 @@ Cmd on macOS, Ctrl elsewhere.
 | [workspace/](./workspace/) | Source code: the page in src/, the Tauri shell and the render crate in src-tauri/ |
 | [wiki/](./wiki/) | What the next agent reads before taking over, one page per part under [wiki/architecture/](./wiki/architecture/) |
 | [adr/](./adr/) | Decision records |
+| [quality/](./quality/) | Playback quality harness, thresholds and baseline |
 
 ## Where things go
 

--- a/product/akbun-makevideo/adr/2026-08-playback-quality-harness.md
+++ b/product/akbun-makevideo/adr/2026-08-playback-quality-harness.md
@@ -1,0 +1,13 @@
+# Playback quality is judged by one numeric harness
+
+## Decision
+
+Use one synthetic 1080p30 source and four fixed soak scenarios to measure frame interval p50 and p99, dropped frames, A/V drift, startup delay and process-tree memory growth.
+
+Keep the current media element result in `quality/media-element-macos.json` as the first engine baseline.
+
+## Why
+
+- Playback regressions become comparable across the media element, frame source and native surface stages.
+- A generated colour pattern with burned-in timecode is reproducible without committing a large video.
+- The four scenarios cover continuous playback, restart, track pressure and seek pressure without adding symptom-specific tests.

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -13,3 +13,4 @@
 | [2026-08-one-compositor-for-preview-and-render.md](./2026-08-one-compositor-for-preview-and-render.md) | One compositor for the preview and the render |
 | [2026-08-in-page-menu-bar.md](./2026-08-in-page-menu-bar.md) | The menu bar is HTML, not a native menu |
 | [2026-08-updater-fixed-tag-endpoint.md](./2026-08-updater-fixed-tag-endpoint.md) | The updater polls a fixed per-product tag, not releases/latest |
+| [2026-08-playback-quality-harness.md](./2026-08-playback-quality-harness.md) | Playback engines pass one numeric quality harness |

--- a/product/akbun-makevideo/quality/README.md
+++ b/product/akbun-makevideo/quality/README.md
@@ -1,0 +1,110 @@
+# 재생 품질 계측
+
+media element 재생과 이후 엔진을 같은 수치로 비교하는 하네스다.
+
+## 지표
+
+- 프레임 표시 간격 p50
+- 프레임 표시 간격 p99
+- 드랍 프레임 수와 비율
+- 오디오·영상 타임라인 시각 차이 p99
+- 재생 요청부터 첫 프레임까지의 지연 p99
+- 앱과 webview 자식 프로세스의 분당 RSS 증가량
+
+30 fps 기본 합격 기준은 다음과 같다.
+
+| 지표 | 기준 |
+|---|---:|
+| 프레임 간격 p50 | 42 ms 이하 |
+| 프레임 간격 p99 | 67 ms 이하 |
+| 드랍 프레임 비율 | 0.1% 이하 |
+| A/V drift p99 | 50 ms 이하 |
+| 시작 지연 p99 | 500 ms 이하 |
+| RSS 증가 | 64 MiB 이하 |
+
+## 측정 소재 준비
+
+- 1080p30 색 패턴과 번인 타임코드 영상 생성
+- 1 kHz 오디오 포함
+- 기본 길이 10분
+- 생성물은 `/tmp/akbun-makevideo-quality`에 저장
+- 대용량 영상은 저장소에 저장하지 않음
+
+합성 영상과 4개 영상·오디오 트랙 프로젝트를 생성한다.
+
+```bash
+cd product/akbun-makevideo/workspace
+npm run quality:media
+```
+
+짧은 하네스 점검에는 영상 길이를 줄인다.
+
+```bash
+DURATION_SECONDS=30 npm run quality:media
+```
+
+## 실행
+
+1. 개발 앱 실행
+2. `/tmp/akbun-makevideo-quality/project.akbunvideo` 열기
+3. Settings 메뉴에서 Playback Quality Soak 실행
+4. 저장 대화상자에서 JSON 보고서 경로 선택
+
+전체 soak를 실행하고 보고서를 저장한다.
+
+```js
+await makevideoQuality.runAndSave()
+```
+
+같은 실행은 Settings → Playback Quality Soak에서도 시작할 수 있다.
+
+빠른 동작 점검은 각 구간을 줄여 실행한다.
+
+```js
+await makevideoQuality.runAndSave({
+  continuousMs: 5000,
+  restartCount: 2,
+  restartPlayMs: 1000,
+  restartPauseMs: 100,
+  trackStepMs: 1000,
+  seekCount: 3,
+  seekIntervalMs: 300,
+})
+```
+
+같은 점검은 Settings → Playback Quality Smoke에서도 시작할 수 있다.
+
+## 자동 실행
+
+환경변수로 프로젝트 열기와 보고서 저장을 자동화할 수 있다.
+
+```bash
+AKBUN_MAKEVIDEO_QUALITY_PROJECT=/tmp/akbun-makevideo-quality/project.akbunvideo \
+AKBUN_MAKEVIDEO_QUALITY_REPORT=/tmp/media-element.json \
+npm start
+```
+
+하네스 자체를 빠르게 점검한다.
+
+```bash
+AKBUN_MAKEVIDEO_QUALITY_PROJECT=/tmp/akbun-makevideo-quality/project.akbunvideo \
+AKBUN_MAKEVIDEO_QUALITY_REPORT=/tmp/media-element-smoke.json \
+AKBUN_MAKEVIDEO_QUALITY_SMOKE=1 \
+npm start
+```
+
+## 시나리오
+
+- `continuous-playback`: 기본 5분 연속 재생
+- `stop-and-restart`: 10회 정지·재시작
+- `increasing-track-count`: 영상·오디오 활성 트랙을 1개에서 4개까지 증가
+- `repeated-seek`: 재생 중 20회 seek
+
+## 기준선
+
+- [media-element-macos.json](./media-element-macos.json)
+- Apple M3 Pro의 macOS WebKit에서 2026-08-04 측정
+- 5분 연속 재생: p50 33 ms, p99 69 ms, 8,983 표시 프레임 중 14 드랍
+- 현재 경로의 상태를 고정한 비교 기준이며 합격 목표가 아님
+- 이후 엔진은 동일 소재와 기본 설정으로 실행
+- 절대 합격 기준과 media element 기준선 모두에 대해 회귀 여부 확인

--- a/product/akbun-makevideo/quality/media-element-macos.json
+++ b/product/akbun-makevideo/quality/media-element-macos.json
@@ -1,0 +1,170 @@
+{
+  "capturedAt": "2026-08-03T23:38:38.775Z",
+  "config": {
+    "continuousMs": 300000,
+    "restartCount": 10,
+    "restartPauseMs": 500,
+    "restartPlayMs": 3000,
+    "seekCount": 20,
+    "seekIntervalMs": 1000,
+    "trackStepMs": 15000
+  },
+  "engine": "media-element",
+  "pass": false,
+  "project": {
+    "fps": 30,
+    "height": 1080,
+    "width": 1920
+  },
+  "scenarios": [
+    {
+      "durationMs": 300082,
+      "evaluation": {
+        "checks": {
+          "avDriftP99Ms": true,
+          "droppedFrames": false,
+          "frameIntervalP50Ms": true,
+          "frameIntervalP99Ms": false,
+          "memoryGrowthBytes": true,
+          "startupDelayP99Ms": true
+        },
+        "pass": false
+      },
+      "fps": 30,
+      "limits": {
+        "avDriftP99Ms": 50,
+        "droppedFrameRate": 0.001,
+        "frameIntervalP50Ms": 42,
+        "frameIntervalP99Ms": 67,
+        "memoryGrowthBytes": 67108864,
+        "startupDelayP99Ms": 500
+      },
+      "metadata": {},
+      "metrics": {
+        "avDriftP99Ms": 0,
+        "droppedFrames": 14,
+        "frameIntervalP50Ms": 33,
+        "frameIntervalP99Ms": 69,
+        "memoryGrowthBytes": 47464448,
+        "memoryGrowthBytesPerMinute": 9490295.585873194,
+        "startupDelayP99Ms": 139,
+        "totalFrames": 8983
+      },
+      "scenario": "continuous-playback"
+    },
+    {
+      "durationMs": 42819,
+      "evaluation": {
+        "checks": {
+          "avDriftP99Ms": false,
+          "droppedFrames": false,
+          "frameIntervalP50Ms": true,
+          "frameIntervalP99Ms": false,
+          "memoryGrowthBytes": true,
+          "startupDelayP99Ms": true
+        },
+        "pass": false
+      },
+      "fps": 30,
+      "limits": {
+        "avDriftP99Ms": 50,
+        "droppedFrameRate": 0.001,
+        "frameIntervalP50Ms": 42,
+        "frameIntervalP99Ms": 67,
+        "memoryGrowthBytes": 67108864,
+        "startupDelayP99Ms": 500
+      },
+      "metadata": {
+        "repetitions": 10
+      },
+      "metrics": {
+        "avDriftP99Ms": 3492.1139990338443,
+        "droppedFrames": 2,
+        "frameIntervalP50Ms": 33,
+        "frameIntervalP99Ms": 330,
+        "memoryGrowthBytes": 56688640,
+        "memoryGrowthBytesPerMinute": 79434792.9657395,
+        "startupDelayP99Ms": 368.9999999999418,
+        "totalFrames": 878
+      },
+      "scenario": "stop-and-restart"
+    },
+    {
+      "durationMs": 62261,
+      "evaluation": {
+        "checks": {
+          "avDriftP99Ms": true,
+          "droppedFrames": true,
+          "frameIntervalP50Ms": true,
+          "frameIntervalP99Ms": false,
+          "memoryGrowthBytes": false,
+          "startupDelayP99Ms": false
+        },
+        "pass": false
+      },
+      "fps": 30,
+      "limits": {
+        "avDriftP99Ms": 50,
+        "droppedFrameRate": 0.001,
+        "frameIntervalP50Ms": 42,
+        "frameIntervalP99Ms": 67,
+        "memoryGrowthBytes": 67108864,
+        "startupDelayP99Ms": 500
+      },
+      "metadata": {
+        "maximumAudioTracks": 4,
+        "maximumVideoTracks": 4
+      },
+      "metrics": {
+        "avDriftP99Ms": 0,
+        "droppedFrames": 0,
+        "frameIntervalP50Ms": 33,
+        "frameIntervalP99Ms": 68,
+        "memoryGrowthBytes": 128925696,
+        "memoryGrowthBytesPerMinute": 124243776.36080372,
+        "startupDelayP99Ms": 1711,
+        "totalFrames": 1700
+      },
+      "scenario": "increasing-track-count"
+    },
+    {
+      "durationMs": 30654,
+      "evaluation": {
+        "checks": {
+          "avDriftP99Ms": false,
+          "droppedFrames": false,
+          "frameIntervalP50Ms": true,
+          "frameIntervalP99Ms": false,
+          "memoryGrowthBytes": true,
+          "startupDelayP99Ms": false
+        },
+        "pass": false
+      },
+      "fps": 30,
+      "limits": {
+        "avDriftP99Ms": 50,
+        "droppedFrameRate": 0.001,
+        "frameIntervalP50Ms": 42,
+        "frameIntervalP99Ms": 67,
+        "memoryGrowthBytes": 67108864,
+        "startupDelayP99Ms": 500
+      },
+      "metadata": {
+        "repetitions": 20
+      },
+      "metrics": {
+        "avDriftP99Ms": 14396.088316697344,
+        "droppedFrames": 3,
+        "frameIntervalP50Ms": 34,
+        "frameIntervalP99Ms": 499,
+        "memoryGrowthBytes": 56000512,
+        "memoryGrowthBytesPerMinute": 109611493.44294384,
+        "startupDelayP99Ms": 815,
+        "totalFrames": 546
+      },
+      "scenario": "repeated-seek"
+    }
+  ],
+  "schemaVersion": 1,
+  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"
+}

--- a/product/akbun-makevideo/wiki/development.md
+++ b/product/akbun-makevideo/wiki/development.md
@@ -41,6 +41,7 @@ sudo apt-get install -y mesa-vulkan-drivers ffmpeg   # what CI does
 What is covered:
 
 - `test/timeline.test.js` — placing, overlap, moving between tracks, trimming against the source bounds, splitting, snapping, track limits, and reading an older project file
+- `test/quality.test.js` — quality percentiles, the six acceptance checks and report aggregation
 - `crates/render/src/layout.rs` — where a clip lands in the frame, the case both paths used to answer separately
 - `crates/render/src/ffmpeg.rs` — one test per feature of the filter graph, the decoder and encoder arguments for the composited route, the preset sizes and the progress parser
 - `crates/render/src/probe.rs` — ffprobe output including the cover art case, where an mp3 reports a video stream
@@ -83,6 +84,10 @@ Two clips of different aspect ratios on two tracks is the case worth checking, b
 **The software compositor is slow, not broken.** 114 ms a frame at 1080p with two layers, against 23 ms for a software Vulkan device. It is what runs on a machine with no graphics adapter, and the picture is the same.
 
 **The composited route moves a lot of bytes.** Every frame leaves ffmpeg as raw RGBA and goes back the same way, about 250 MB for each second of 1080p30 timeline. On a software rasteriser that made a test render 3.4x slower than the filter graph; on a Mac the drawing is on the GPU and the pipe traffic is what remains. `Settings → Compositor → ffmpeg filter graph` is the faster route when the preview matching the file does not matter.
+
+## Playback quality
+
+The repeatable playback soak and its media element baseline live in [quality/](../quality/README.md). The source video is generated locally, and the app reports frame timing, drops, A/V drift, startup delay and process-tree memory growth as JSON.
 
 ## Release
 

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",
@@ -11,6 +11,7 @@
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-render",
     "test:gpu": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-compositor",
     "test:nogpu": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-compositor --no-default-features",
+    "quality:media": "bash scripts/generate-quality-media.sh",
     "dist": "tauri build",
     "tauri": "tauri"
   },

--- a/product/akbun-makevideo/workspace/scripts/generate-quality-media.sh
+++ b/product/akbun-makevideo/workspace/scripts/generate-quality-media.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+duration="${DURATION_SECONDS:-600}"
+output_dir="${QUALITY_OUTPUT_DIR:-/tmp/akbun-makevideo-quality}"
+video="$output_dir/timecode-pattern-1080p30.mp4"
+project="$output_dir/project.akbunvideo"
+
+mkdir -p "$output_dir"
+
+ffmpeg -hide_banner -loglevel warning -y \
+  -f lavfi -i "testsrc=size=1920x1080:rate=30:duration=$duration:decimals=3" \
+  -f lavfi -i "sine=frequency=1000:sample_rate=48000:duration=$duration" \
+  -c:v libx264 -preset veryfast -pix_fmt yuv420p -g 30 \
+  -c:a aac -b:a 192k -shortest "$video"
+
+duration_ms=$((duration * 1000))
+tracks=""
+for index in 1 2 3 4; do
+  comma=""
+  if [[ -n "$tracks" ]]; then comma=","; fi
+  tracks+="$comma
+    {\"id\":\"quality-v$index\",\"kind\":\"video\",\"name\":\"V$index\",\"muted\":false,\"hidden\":$([[ $index -eq 1 ]] && echo false || echo true),\"clips\":[{\"id\":\"quality-vc$index\",\"assetId\":\"quality-source\",\"startMs\":0,\"inMs\":0,\"outMs\":$duration_ms,\"volume\":1,\"opacity\":1}]},
+    {\"id\":\"quality-a$index\",\"kind\":\"audio\",\"name\":\"A$index\",\"muted\":$([[ $index -eq 1 ]] && echo false || echo true),\"hidden\":false,\"clips\":[{\"id\":\"quality-ac$index\",\"assetId\":\"quality-source\",\"startMs\":0,\"inMs\":0,\"outMs\":$duration_ms,\"volume\":1,\"opacity\":1}]}"
+done
+
+printf '%s\n' "{
+  \"version\": 1,
+  \"settings\": {\"width\": 1920, \"height\": 1080, \"fps\": 30},
+  \"assets\": [{
+    \"id\": \"quality-source\",
+    \"path\": \"$video\",
+    \"name\": \"timecode-pattern-1080p30.mp4\",
+    \"kind\": \"video\",
+    \"durationMs\": $duration_ms,
+    \"width\": 1920,
+    \"height\": 1080,
+    \"hasAudio\": true
+  }],
+  \"tracks\": [$tracks
+  ]
+}" > "$project"
+
+echo "$project"

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -9,6 +9,7 @@ use makevideo_compositor::{Backend, Compositor};
 use makevideo_render::accel::{self, Acceleration};
 use makevideo_render::{ffmpeg, probe, tools, workspace, Asset, AssetKind, Project};
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -134,6 +135,9 @@ pub struct Bootstrap {
     pub acceleration: AccelProbe,
     /// What is drawing frames, and whether it is a real graphics device.
     pub compositor: CompositorInfo,
+    pub quality_project: Option<String>,
+    pub quality_report: Option<String>,
+    pub quality_smoke: bool,
 }
 
 pub fn allow_asset_file(app: &AppHandle, path: &str) {
@@ -406,6 +410,9 @@ pub fn bootstrap(app: AppHandle, state: State<AppState>) -> Bootstrap {
         ffprobe: find_tool(&app, "ffprobe", &settings.ffmpeg_dir),
         ffmpeg,
         settings,
+        quality_project: std::env::var("AKBUN_MAKEVIDEO_QUALITY_PROJECT").ok(),
+        quality_report: std::env::var("AKBUN_MAKEVIDEO_QUALITY_REPORT").ok(),
+        quality_smoke: std::env::var("AKBUN_MAKEVIDEO_QUALITY_SMOKE").as_deref() == Ok("1"),
     }
 }
 
@@ -862,5 +869,75 @@ pub fn cancel_render(state: State<AppState>) {
     state.cancelled.store(true, Ordering::SeqCst);
     if let Some(child) = state.render.lock().unwrap().as_mut() {
         let _ = child.kill();
+    }
+}
+
+fn process_tree_rss_bytes(output: &str, root: u32) -> u64 {
+    let rows: Vec<(u32, u32, u64)> = output
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some((
+                fields.next()?.parse().ok()?,
+                fields.next()?.parse().ok()?,
+                fields.next()?.parse().ok()?,
+            ))
+        })
+        .collect();
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut rss = HashMap::new();
+    for (pid, parent, kib) in rows {
+        children.entry(parent).or_default().push(pid);
+        rss.insert(pid, kib);
+    }
+    let mut pending = vec![root];
+    let mut found = HashSet::new();
+    while let Some(pid) = pending.pop() {
+        if !found.insert(pid) {
+            continue;
+        }
+        if let Some(next) = children.get(&pid) {
+            pending.extend(next);
+        }
+    }
+    found
+        .iter()
+        .filter_map(|pid| rss.get(pid))
+        .sum::<u64>()
+        .saturating_mul(1024)
+}
+
+/// Resident memory for the app and its webview/helper children. The quality
+/// harness samples the whole process tree because decoder memory does not live
+/// solely in the Rust process.
+#[tauri::command]
+pub fn process_memory_bytes() -> Result<u64, String> {
+    let output = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,rss="])
+        .output()
+        .map_err(|error| format!("cannot read process memory: {error}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    Ok(process_tree_rss_bytes(
+        &String::from_utf8_lossy(&output.stdout),
+        std::process::id(),
+    ))
+}
+
+#[tauri::command]
+pub fn save_quality_report(path: String, report: serde_json::Value) -> Result<(), String> {
+    let text = serde_json::to_string_pretty(&report).map_err(|error| error.to_string())?;
+    std::fs::write(&path, text).map_err(|error| format!("cannot write {path}: {error}"))
+}
+
+#[cfg(test)]
+mod quality_tests {
+    use super::process_tree_rss_bytes;
+
+    #[test]
+    fn memory_includes_descendants_but_not_neighbours() {
+        let ps = "10 1 100\n11 10 20\n12 11 5\n20 1 900\n";
+        assert_eq!(process_tree_rss_bytes(ps, 10), 125 * 1024);
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -49,6 +49,8 @@ pub fn run() {
             commands::start_render,
             commands::cancel_render,
             commands::preview_frame,
+            commands::process_memory_bytes,
+            commands::save_quality_report,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -51,6 +51,9 @@ if (!window.__TAURI__) {
       ffprobe: null,
       acceleration: { available: null, tried: [] },
       compositor: { setting: 'auto', device: 'software (CPU)', gpu: false, fellBack: true },
+      qualityProject: null,
+      qualityReport: null,
+      qualitySmoke: false,
     }),
     saveSettings: async (settings) => ({
       settings,
@@ -61,6 +64,9 @@ if (!window.__TAURI__) {
       ffprobe: null,
       acceleration: { available: null, tried: [] },
       compositor: { setting: 'auto', device: 'software (CPU)', gpu: false, fellBack: true },
+      qualityProject: null,
+      qualityReport: null,
+      qualitySmoke: false,
     }),
     pickMedia: unavailable,
     pickProjectOpen: unavailable,
@@ -69,6 +75,12 @@ if (!window.__TAURI__) {
     pickFolder: unavailable,
     listProjects: async () => [],
     previewFrame: unavailable,
+    processMemoryBytes: async () =>
+      performance.memory && performance.memory.usedJSHeapSize
+        ? performance.memory.usedJSHeapSize
+        : null,
+    saveQualityReport: async () => null,
+    writeQualityReport: async () => null,
     // Pretends the folder was made, the way saveProject below pretends the
     // file was written, so the New Project flow can be walked in a browser.
     createProject: async (name) => ({
@@ -186,6 +198,18 @@ window.api = {
       pixels: bytes.subarray(8),
     };
   },
+  processMemoryBytes: () => invoke('process_memory_bytes'),
+  saveQualityReport: async (report) => {
+    const path = await saveDialog({
+      title: 'Save Playback Quality Report',
+      defaultPath: 'media-element-baseline.json',
+      filters: [{ name: 'JSON report', extensions: ['json'] }],
+    });
+    if (!path) return null;
+    await invoke('save_quality_report', { path, report });
+    return path;
+  },
+  writeQualityReport: (path, report) => invoke('save_quality_report', { path, report }),
   createProject: (name) => invoke('create_project', { name }),
 
   // Only paths cross this line. Nothing here copies a byte of media.

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -62,6 +62,9 @@
           <li><button data-action="project-settings">Project Resolution…</button></li>
           <li><button data-action="app-settings">Preview &amp; Tools…</button></li>
           <li class="sep"></li>
+          <li><button data-action="quality-soak">Playback Quality Soak…</button></li>
+          <li><button data-action="quality-smoke">Playback Quality Smoke…</button></li>
+          <li class="sep"></li>
           <li><button data-action="check-update">Check for Updates</button></li>
           <li><button data-action="about">About</button></li>
         </ul>
@@ -278,6 +281,7 @@
 
   <script src="timeline.js"></script>
   <script src="api.js"></script>
+  <script src="quality.js"></script>
   <script src="preview.js"></script>
   <script src="renderer.js"></script>
 </body>

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -38,7 +38,7 @@ function clamp01(value) {
 }
 
 function createPreview(options) {
-  const { stage, inner, wrap, exactCanvas, getProject, onTick } = options;
+  const { stage, inner, wrap, exactCanvas, getProject, onTick, qualityMonitor } = options;
   const L = globalThis.timelineLib;
 
   const pool = new Map();
@@ -96,13 +96,17 @@ function createPreview(options) {
     element.preload = 'auto';
     element.className = 'stage-media';
     element.playsInline = true;
+    if (wantsPicture && qualityMonitor) qualityMonitor.watchVideo(element);
     return { element, kind: wantsPicture ? 'video' : 'audio' };
   }
 
   function entryFor(clip, asset, wantsPicture) {
     let entry = pool.get(clip.id);
     if (entry && entry.path === asset.path && entry.wantsPicture === wantsPicture) return entry;
-    if (entry) entry.element.remove();
+    if (entry) {
+      if (entry.kind === 'video' && qualityMonitor) qualityMonitor.unwatchVideo(entry.element);
+      entry.element.remove();
+    }
     const made = makeElement(asset, wantsPicture);
     entry = {
       element: made.element,
@@ -190,6 +194,15 @@ function createPreview(options) {
       entry.element.volume = clamp01(clip.volume);
       entry.element.muted =
         (track.kind === 'video' && track.muted) || (scrubbing && muteWhileScrubbing);
+      if (
+        qualityMonitor &&
+        (playing || starting) &&
+        !isReference &&
+        reference &&
+        track.kind !== reference.track.kind
+      ) {
+        qualityMonitor.sampleDrift(drift * 1000);
+      }
       if (playing || starting) ensurePlaying(entry.element);
       if (!playing && !starting && !entry.element.paused) entry.element.pause();
     }
@@ -264,6 +277,7 @@ function createPreview(options) {
     if (totalMs() <= 0) return;
     clearExact();
     if (mode === 'timeline' && positionMs >= totalMs()) positionMs = 0;
+    if (qualityMonitor) qualityMonitor.playbackRequested();
     starting = true;
     if (onTick) onTick(positionMs, transportActive());
     const generation = ++playGeneration;
@@ -306,6 +320,7 @@ function createPreview(options) {
   }
 
   function seek(ms) {
+    if (qualityMonitor && qualityMonitor.isRunning()) qualityMonitor.discontinuity();
     positionMs = Math.max(0, Math.min(ms, Math.max(totalMs(), 0)));
     clockOrigin = performance.now() - positionMs;
     clock = null;
@@ -334,6 +349,7 @@ function createPreview(options) {
     for (const [clipId, entry] of pool) {
       if (alive.has(clipId)) continue;
       entry.element.pause && entry.element.pause();
+      if (entry.kind === 'video' && qualityMonitor) qualityMonitor.unwatchVideo(entry.element);
       entry.element.removeAttribute('src');
       entry.element.remove();
       pool.delete(clipId);
@@ -343,6 +359,7 @@ function createPreview(options) {
   function clear() {
     for (const entry of pool.values()) {
       entry.element.pause && entry.element.pause();
+      if (entry.kind === 'video' && qualityMonitor) qualityMonitor.unwatchVideo(entry.element);
       entry.element.removeAttribute('src');
       entry.element.remove();
     }
@@ -358,7 +375,12 @@ function createPreview(options) {
     clearExact();
     pause();
     for (const entry of pool.values()) hide(entry);
-    if (assetElement) assetElement.remove();
+    if (assetElement) {
+      if (assetElement.tagName === 'VIDEO' && qualityMonitor) {
+        qualityMonitor.unwatchVideo(assetElement);
+      }
+      assetElement.remove();
+    }
     assetShown = asset || null;
     if (!asset) {
       assetElement = null;
@@ -377,6 +399,9 @@ function createPreview(options) {
     mode = 'timeline';
     pause();
     if (assetElement) {
+      if (assetElement.tagName === 'VIDEO' && qualityMonitor) {
+        qualityMonitor.unwatchVideo(assetElement);
+      }
       assetElement.remove();
       assetElement = null;
     }

--- a/product/akbun-makevideo/workspace/src/quality.js
+++ b/product/akbun-makevideo/workspace/src/quality.js
@@ -239,6 +239,34 @@ function delay(ms) {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
+async function sampleMemorySafely(memoryBytes, monitor) {
+  try {
+    monitor.sampleMemory(await memoryBytes());
+  } catch {
+    monitor.sampleMemory(null);
+  }
+}
+
+function startMemorySampling(memoryBytes, monitor) {
+  let stopped = false;
+  let timer = null;
+  let current = Promise.resolve();
+
+  function schedule() {
+    current = sampleMemorySafely(memoryBytes, monitor).then(() => {
+      if (!stopped) timer = window.setTimeout(schedule, 1000);
+    });
+  }
+
+  schedule();
+  return async () => {
+    stopped = true;
+    if (timer !== null) window.clearTimeout(timer);
+    await current;
+    await sampleMemorySafely(memoryBytes, monitor);
+  };
+}
+
 function createQualityHarness(options) {
   const monitor = options.monitor;
   const preview = options.preview;
@@ -246,22 +274,15 @@ function createQualityHarness(options) {
   const refresh = options.refresh || (() => {});
   const memoryBytes = options.memoryBytes || (async () => null);
 
-  async function sampleMemory() {
-    const value = await memoryBytes();
-    monitor.sampleMemory(value);
-  }
-
   async function measure(name, action, metadata) {
     const project = getProject();
     monitor.start(name, project.settings.fps || 30, metadata);
-    const timer = window.setInterval(sampleMemory, 1000);
-    await sampleMemory();
+    const stopMemorySampling = startMemorySampling(memoryBytes, monitor);
     try {
       await action();
     } finally {
       preview.pause();
-      window.clearInterval(timer);
-      await sampleMemory();
+      await stopMemorySampling();
     }
     return monitor.finish();
   }
@@ -374,6 +395,7 @@ if (typeof module !== 'undefined' && module.exports) {
     percentile,
     evaluateQuality,
     createQualityMonitor,
+    sampleMemorySafely,
   };
 } else {
   globalThis.qualityLib = {

--- a/product/akbun-makevideo/workspace/src/quality.js
+++ b/product/akbun-makevideo/workspace/src/quality.js
@@ -1,0 +1,384 @@
+'use strict';
+
+const DEFAULT_QUALITY_LIMITS = {
+  frameIntervalP50Ms: Math.ceil(1000 / 30 * 1.25),
+  frameIntervalP99Ms: Math.ceil(1000 / 30 * 2),
+  droppedFrameRate: 0.001,
+  avDriftP99Ms: 50,
+  startupDelayP99Ms: 500,
+  memoryGrowthBytes: 64 * 1024 * 1024,
+};
+
+function percentile(values, fraction) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.ceil(fraction * sorted.length) - 1;
+  return sorted[Math.max(0, Math.min(index, sorted.length - 1))];
+}
+
+function finite(value) {
+  return Number.isFinite(value) ? value : null;
+}
+
+function videoCounters(element) {
+  if (typeof element.getVideoPlaybackQuality === 'function') {
+    const value = element.getVideoPlaybackQuality();
+    if (value.totalVideoFrames > 0 || value.droppedVideoFrames > 0) {
+      return {
+        available: true,
+        dropped: value.droppedVideoFrames || 0,
+        total: value.totalVideoFrames || 0,
+      };
+    }
+  }
+  const available = Number.isFinite(element.webkitDroppedFrameCount);
+  return {
+    available,
+    dropped: element.webkitDroppedFrameCount || 0,
+    total: element.webkitDecodedFrameCount || 0,
+  };
+}
+
+function evaluateQuality(metrics, limits) {
+  const checks = {
+    frameIntervalP50Ms:
+      metrics.frameIntervalP50Ms !== null &&
+      metrics.frameIntervalP50Ms <= limits.frameIntervalP50Ms,
+    frameIntervalP99Ms:
+      metrics.frameIntervalP99Ms !== null &&
+      metrics.frameIntervalP99Ms <= limits.frameIntervalP99Ms,
+    droppedFrames:
+      metrics.totalFrames > 0 &&
+      metrics.droppedFrames / metrics.totalFrames <= limits.droppedFrameRate,
+    avDriftP99Ms:
+      metrics.avDriftP99Ms !== null && metrics.avDriftP99Ms <= limits.avDriftP99Ms,
+    startupDelayP99Ms:
+      metrics.startupDelayP99Ms !== null &&
+      metrics.startupDelayP99Ms <= limits.startupDelayP99Ms,
+    memoryGrowthBytes:
+      metrics.memoryGrowthBytes !== null &&
+      metrics.memoryGrowthBytes <= limits.memoryGrowthBytes,
+  };
+  return { pass: Object.values(checks).every(Boolean), checks };
+}
+
+function createQualityMonitor(options) {
+  const now = options.now || (() => performance.now());
+  const limits = Object.assign({}, DEFAULT_QUALITY_LIMITS, options.limits || {});
+  const videos = new Set();
+  const frameRequests = new Map();
+  let run = null;
+
+  function primaryVideo() {
+    return [...videos]
+      .filter((element) => element.classList.contains('on'))
+      .sort((left, right) => Number(right.style.zIndex || 0) - Number(left.style.zIndex || 0))[0];
+  }
+
+  function watchVideo(element) {
+    if (videos.has(element)) return;
+    videos.add(element);
+    if (typeof element.requestVideoFrameCallback !== 'function') return;
+    const frame = (timestamp, metadata) => {
+      if (run && primaryVideo() === element) {
+        collectCounters(element);
+        if (run.lastFrameAt !== null) run.frameIntervals.push(timestamp - run.lastFrameAt);
+        run.lastFrameAt = timestamp;
+        run.presentedCallbacks += 1;
+        const presented = metadata && metadata.presentedFrames;
+        const mediaTime = metadata && metadata.mediaTime;
+        if (
+          run.lastVideo === element &&
+          Number.isFinite(presented) &&
+          Number.isFinite(run.lastPresentedFrames) &&
+          Number.isFinite(mediaTime) &&
+          Number.isFinite(run.lastMediaTime) &&
+          mediaTime > run.lastMediaTime &&
+          mediaTime - run.lastMediaTime <= 1
+        ) {
+          const expected = Math.max(1, Math.round((mediaTime - run.lastMediaTime) * run.fps));
+          const displayed = Math.max(1, presented - run.lastPresentedFrames);
+          run.callbackDrops += Math.max(0, expected - displayed);
+          run.callbackFrames += expected;
+        } else {
+          run.callbackFrames += 1;
+        }
+        run.lastVideo = element;
+        run.lastPresentedFrames = presented;
+        run.lastMediaTime = mediaTime;
+        if (run.pendingStartupAt !== null) {
+          run.startupDelays.push(timestamp - run.pendingStartupAt);
+          run.pendingStartupAt = null;
+        }
+      }
+      if (videos.has(element)) {
+        frameRequests.set(element, element.requestVideoFrameCallback(frame));
+      }
+    };
+    frameRequests.set(element, element.requestVideoFrameCallback(frame));
+  }
+
+  function collectCounters(element) {
+    if (!run) return;
+    const after = videoCounters(element);
+    if (!after.available) return;
+    const before = run.counters.get(element) || { dropped: 0, total: 0 };
+    run.counterDrops += after.dropped >= before.dropped
+      ? after.dropped - before.dropped
+      : after.dropped;
+    run.counterFrames += after.total >= before.total ? after.total - before.total : after.total;
+    run.counters.set(element, after);
+    run.hasVideoCounters = true;
+  }
+
+  function unwatchVideo(element) {
+    videos.delete(element);
+    const request = frameRequests.get(element);
+    if (request !== undefined && typeof element.cancelVideoFrameCallback === 'function') {
+      element.cancelVideoFrameCallback(request);
+    }
+    frameRequests.delete(element);
+  }
+
+  function start(name, fps, metadata) {
+    const startedAt = now();
+    const counters = new Map();
+    for (const element of videos) counters.set(element, videoCounters(element));
+    run = {
+      name,
+      fps,
+      metadata: metadata || {},
+      startedAt,
+      frameIntervals: [],
+      drift: [],
+      startupDelays: [],
+      memory: [],
+      counters,
+      lastFrameAt: null,
+      pendingStartupAt: null,
+      presentedCallbacks: 0,
+      callbackDrops: 0,
+      callbackFrames: 0,
+      counterDrops: 0,
+      counterFrames: 0,
+      hasVideoCounters: false,
+      lastVideo: null,
+      lastPresentedFrames: null,
+      lastMediaTime: null,
+    };
+  }
+
+  function discontinuity() {
+    if (!run) return;
+    run.lastFrameAt = null;
+    run.lastVideo = null;
+    run.lastPresentedFrames = null;
+    run.lastMediaTime = null;
+  }
+
+  function playbackRequested() {
+    if (!run) return;
+    run.pendingStartupAt = now();
+    discontinuity();
+  }
+
+  function sampleDrift(valueMs) {
+    if (run && Number.isFinite(valueMs)) run.drift.push(Math.abs(valueMs));
+  }
+
+  function sampleMemory(valueBytes) {
+    if (run && Number.isFinite(valueBytes)) run.memory.push(valueBytes);
+  }
+
+  function finish() {
+    if (!run) throw new Error('quality run has not started');
+    const endedAt = now();
+    for (const element of videos) collectCounters(element);
+    const memoryStart = run.memory[0];
+    const memoryPeak = run.memory.length ? Math.max(...run.memory) : null;
+    const memoryGrowthBytes = memoryPeak === null ? null : Math.max(0, memoryPeak - memoryStart);
+    const durationMs = Math.max(1, endedAt - run.startedAt);
+    const metrics = {
+      frameIntervalP50Ms: finite(percentile(run.frameIntervals, 0.5)),
+      frameIntervalP99Ms: finite(percentile(run.frameIntervals, 0.99)),
+      droppedFrames: run.hasVideoCounters ? run.counterDrops : run.callbackDrops,
+      totalFrames: run.hasVideoCounters ? run.counterFrames : run.callbackFrames,
+      avDriftP99Ms: finite(percentile(run.drift, 0.99)),
+      startupDelayP99Ms: finite(percentile(run.startupDelays, 0.99)),
+      memoryGrowthBytes,
+      memoryGrowthBytesPerMinute:
+        memoryGrowthBytes === null ? null : memoryGrowthBytes * 60000 / durationMs,
+    };
+    const report = {
+      scenario: run.name,
+      durationMs,
+      fps: run.fps,
+      metadata: run.metadata,
+      metrics,
+      limits,
+      evaluation: evaluateQuality(metrics, limits),
+    };
+    run = null;
+    return report;
+  }
+
+  return {
+    watchVideo,
+    unwatchVideo,
+    start,
+    finish,
+    playbackRequested,
+    sampleDrift,
+    sampleMemory,
+    discontinuity,
+    isRunning: () => Boolean(run),
+  };
+}
+
+function delay(ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function createQualityHarness(options) {
+  const monitor = options.monitor;
+  const preview = options.preview;
+  const getProject = options.getProject;
+  const refresh = options.refresh || (() => {});
+  const memoryBytes = options.memoryBytes || (async () => null);
+
+  async function sampleMemory() {
+    const value = await memoryBytes();
+    monitor.sampleMemory(value);
+  }
+
+  async function measure(name, action, metadata) {
+    const project = getProject();
+    monitor.start(name, project.settings.fps || 30, metadata);
+    const timer = window.setInterval(sampleMemory, 1000);
+    await sampleMemory();
+    try {
+      await action();
+    } finally {
+      preview.pause();
+      window.clearInterval(timer);
+      await sampleMemory();
+    }
+    return monitor.finish();
+  }
+
+  async function playFor(durationMs) {
+    await preview.play();
+    await delay(durationMs);
+    preview.pause();
+  }
+
+  async function continuous(config) {
+    preview.seek(0);
+    return measure('continuous-playback', () => playFor(config.continuousMs));
+  }
+
+  async function stopRestart(config) {
+    preview.seek(0);
+    return measure('stop-and-restart', async () => {
+      for (let index = 0; index < config.restartCount; index += 1) {
+        await playFor(config.restartPlayMs);
+        await delay(config.restartPauseMs);
+      }
+    }, { repetitions: config.restartCount });
+  }
+
+  async function trackGrowth(config) {
+    const tracks = getProject().tracks;
+    const saved = tracks.map((track) => ({ track, hidden: track.hidden, muted: track.muted }));
+    const video = tracks.filter((track) => track.kind === 'video');
+    const audio = tracks.filter((track) => track.kind === 'audio');
+    try {
+      return await measure('increasing-track-count', async () => {
+        const maximum = Math.max(video.length, audio.length);
+        for (let count = 1; count <= maximum; count += 1) {
+          video.forEach((track, index) => { track.hidden = index >= count; });
+          audio.forEach((track, index) => { track.muted = index >= count; });
+          refresh();
+          preview.seek(0);
+          await playFor(config.trackStepMs);
+        }
+      }, { maximumVideoTracks: video.length, maximumAudioTracks: audio.length });
+    } finally {
+      for (const item of saved) {
+        item.track.hidden = item.hidden;
+        item.track.muted = item.muted;
+      }
+      refresh();
+    }
+  }
+
+  async function repeatedSeek(config) {
+    return measure('repeated-seek', async () => {
+      await preview.play();
+      for (let index = 0; index < config.seekCount; index += 1) {
+        await delay(config.seekIntervalMs);
+        const span = Math.max(1000, preview.total() - 1000);
+        preview.seek((index * 7000) % span);
+      }
+    }, { repetitions: config.seekCount });
+  }
+
+  async function runAll(overrides) {
+    const config = Object.assign({
+      continuousMs: 5 * 60 * 1000,
+      restartCount: 10,
+      restartPlayMs: 3000,
+      restartPauseMs: 500,
+      trackStepMs: 15000,
+      seekCount: 20,
+      seekIntervalMs: 1000,
+    }, overrides || {});
+    const project = getProject();
+    if (preview.mode() !== 'timeline' || preview.total() <= 0) {
+      throw new Error('open the generated quality project in Timeline mode first');
+    }
+    const reports = [];
+    reports.push(await continuous(config));
+    reports.push(await stopRestart(config));
+    reports.push(await trackGrowth(config));
+    reports.push(await repeatedSeek(config));
+    preview.seek(0);
+    return {
+      schemaVersion: 1,
+      capturedAt: new Date().toISOString(),
+      engine: 'media-element',
+      userAgent: navigator.userAgent,
+      project: {
+        width: project.settings.width,
+        height: project.settings.height,
+        fps: project.settings.fps,
+      },
+      config,
+      pass: reports.every((report) => report.evaluation.pass),
+      scenarios: reports,
+    };
+  }
+
+  async function runAndSave(overrides) {
+    const report = await runAll(overrides);
+    if (options.saveReport) await options.saveReport(report);
+    return report;
+  }
+
+  return { runAll, runAndSave };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    DEFAULT_QUALITY_LIMITS,
+    percentile,
+    evaluateQuality,
+    createQualityMonitor,
+  };
+} else {
+  globalThis.qualityLib = {
+    DEFAULT_QUALITY_LIMITS,
+    createQualityMonitor,
+    createQualityHarness,
+  };
+}

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -67,6 +67,7 @@ const state = {
 };
 
 let preview = null;
+let qualityMonitor = null;
 
 // --- helpers ---------------------------------------------------------------
 
@@ -871,9 +872,23 @@ async function openProjectPath(path) {
   try {
     const project = await window.api.openProject(path);
     loadProject(project, path);
+    return true;
   } catch (error) {
     await window.api.message(String(error), { title: 'Cannot open', kind: 'error' });
+    return false;
   }
+}
+
+function qualitySmokeConfig() {
+  return {
+    continuousMs: 5000,
+    restartCount: 2,
+    restartPlayMs: 1000,
+    restartPauseMs: 100,
+    trackStepMs: 1000,
+    seekCount: 3,
+    seekIntervalMs: 300,
+  };
 }
 
 async function saveProject(forcePicker) {
@@ -1014,6 +1029,20 @@ const actions = {
   'app-settings': () => {
     fillAppSheet();
     openSheet('app-settings');
+  },
+  'quality-soak': async () => {
+    try {
+      await globalThis.makevideoQuality.runAndSave();
+    } catch (error) {
+      await window.api.message(String(error), { title: 'Playback quality failed' });
+    }
+  },
+  'quality-smoke': async () => {
+    try {
+      await globalThis.makevideoQuality.runAndSave(qualitySmokeConfig());
+    } catch (error) {
+      await window.api.message(String(error), { title: 'Playback quality failed' });
+    }
   },
   'check-update': () => window.api.checkUpdate(),
   about: () =>
@@ -1329,12 +1358,14 @@ async function boot() {
   state.settings = state.boot.settings;
   state.pxPerSecond = zoomToPxPerSecond(dom.zoom.value);
 
+  qualityMonitor = globalThis.qualityLib.createQualityMonitor({});
   preview = globalThis.previewLib.createPreview({
     stage: dom.stage,
     inner: dom.stageInner,
     exactCanvas: dom.stageExact,
     wrap: dom.stageWrap,
     getProject: () => state.project,
+    qualityMonitor,
     onTick: (ms, playing) => {
       updatePlayhead(ms);
       followPlayhead(ms);
@@ -1356,6 +1387,14 @@ async function boot() {
     fps: state.settings.defaultFps,
   });
   applySettings(state.settings);
+  globalThis.makevideoQuality = globalThis.qualityLib.createQualityHarness({
+    monitor: qualityMonitor,
+    preview,
+    getProject: () => state.project,
+    refresh,
+    memoryBytes: window.api.processMemoryBytes,
+    saveReport: window.api.saveQualityReport,
+  });
   updateToolWarning();
 
   wireMenus();
@@ -1380,6 +1419,15 @@ async function boot() {
 
   refresh();
   setPreviewSource('timeline');
+  if (state.boot.qualityProject && state.boot.qualityReport) {
+    window.setTimeout(async () => {
+      if (!(await openProjectPath(state.boot.qualityProject))) return;
+      const config = state.boot.qualitySmoke ? qualitySmokeConfig() : undefined;
+      const report = await globalThis.makevideoQuality.runAll(config);
+      await window.api.writeQualityReport(state.boot.qualityReport, report);
+      window.api.closeWindow();
+    }, 250);
+  }
 }
 
 // lib.rs opens the devtools in debug builds because the window is the whole

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1034,14 +1034,20 @@ const actions = {
     try {
       await globalThis.makevideoQuality.runAndSave();
     } catch (error) {
-      await window.api.message(String(error), { title: 'Playback quality failed' });
+      await window.api.message(String(error), {
+        title: 'Playback quality failed',
+        kind: 'error',
+      });
     }
   },
   'quality-smoke': async () => {
     try {
       await globalThis.makevideoQuality.runAndSave(qualitySmokeConfig());
     } catch (error) {
-      await window.api.message(String(error), { title: 'Playback quality failed' });
+      await window.api.message(String(error), {
+        title: 'Playback quality failed',
+        kind: 'error',
+      });
     }
   },
   'check-update': () => window.api.checkUpdate(),

--- a/product/akbun-makevideo/workspace/test/quality.test.js
+++ b/product/akbun-makevideo/workspace/test/quality.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  DEFAULT_QUALITY_LIMITS,
+  percentile,
+  evaluateQuality,
+  createQualityMonitor,
+} = require('../src/quality.js');
+
+test('percentile uses the nearest rank', () => {
+  assert.strictEqual(percentile([40, 10, 30, 20], 0.5), 20);
+  assert.strictEqual(percentile([40, 10, 30, 20], 0.99), 40);
+  assert.strictEqual(percentile([], 0.5), null);
+});
+
+test('quality checks keep the six acceptance criteria separate', () => {
+  const metrics = {
+    frameIntervalP50Ms: 33,
+    frameIntervalP99Ms: 50,
+    droppedFrames: 0,
+    totalFrames: 300,
+    avDriftP99Ms: 20,
+    startupDelayP99Ms: 200,
+    memoryGrowthBytes: 1024,
+  };
+  const result = evaluateQuality(metrics, DEFAULT_QUALITY_LIMITS);
+  assert.strictEqual(result.pass, true);
+  assert.deepStrictEqual(Object.keys(result.checks), [
+    'frameIntervalP50Ms',
+    'frameIntervalP99Ms',
+    'droppedFrames',
+    'avDriftP99Ms',
+    'startupDelayP99Ms',
+    'memoryGrowthBytes',
+  ]);
+});
+
+test('monitor records frame timing, drops, drift, startup and memory', () => {
+  let callback;
+  let now = 100;
+  const classes = new Set(['on']);
+  const counters = { droppedVideoFrames: 1, totalVideoFrames: 10 };
+  const video = {
+    classList: { contains: (value) => classes.has(value) },
+    style: { zIndex: '1' },
+    requestVideoFrameCallback(next) { callback = next; },
+    getVideoPlaybackQuality() { return counters; },
+  };
+  const monitor = createQualityMonitor({ now: () => now });
+  monitor.watchVideo(video);
+  monitor.start('continuous', 30);
+  monitor.sampleMemory(1000);
+  monitor.playbackRequested();
+  now = 130;
+  callback(130, { presentedFrames: 11, mediaTime: 0.1 });
+  callback(163, { presentedFrames: 14, mediaTime: 0.2 });
+  monitor.sampleDrift(24);
+  monitor.sampleMemory(4000);
+  counters.droppedVideoFrames = 3;
+  counters.totalVideoFrames = 70;
+  now = 60100;
+  const report = monitor.finish();
+
+  assert.strictEqual(report.metrics.frameIntervalP50Ms, 33);
+  assert.strictEqual(report.metrics.droppedFrames, 2);
+  assert.strictEqual(report.metrics.totalFrames, 60);
+  assert.strictEqual(report.metrics.avDriftP99Ms, 24);
+  assert.strictEqual(report.metrics.startupDelayP99Ms, 30);
+  assert.strictEqual(report.metrics.memoryGrowthBytes, 3000);
+  assert.strictEqual(report.metrics.memoryGrowthBytesPerMinute, 3000);
+});
+
+test('a seek discontinuity is not counted as thousands of dropped frames', () => {
+  let callback;
+  let now = 0;
+  const video = {
+    classList: { contains: () => true },
+    style: {},
+    requestVideoFrameCallback(next) { callback = next; },
+  };
+  const monitor = createQualityMonitor({ now: () => now });
+  monitor.watchVideo(video);
+  monitor.start('seek', 30);
+  callback(0, { presentedFrames: 1, mediaTime: 0 });
+  callback(33, { presentedFrames: 2, mediaTime: 14 });
+  now = 1000;
+  monitor.sampleMemory(1000);
+  monitor.sampleDrift(0);
+  monitor.playbackRequested();
+  callback(1033, { presentedFrames: 3, mediaTime: 14.033 });
+  const report = monitor.finish();
+  assert.strictEqual(report.metrics.droppedFrames, 0);
+  assert.strictEqual(report.metrics.totalFrames, 3);
+});

--- a/product/akbun-makevideo/workspace/test/quality.test.js
+++ b/product/akbun-makevideo/workspace/test/quality.test.js
@@ -7,6 +7,7 @@ const {
   percentile,
   evaluateQuality,
   createQualityMonitor,
+  sampleMemorySafely,
 } = require('../src/quality.js');
 
 test('percentile uses the nearest rank', () => {
@@ -93,4 +94,13 @@ test('a seek discontinuity is not counted as thousands of dropped frames', () =>
   const report = monitor.finish();
   assert.strictEqual(report.metrics.droppedFrames, 0);
   assert.strictEqual(report.metrics.totalFrames, 3);
+});
+
+test('memory sampling failures are recorded without escaping', async () => {
+  const samples = [];
+  await sampleMemorySafely(
+    async () => { throw new Error('unavailable'); },
+    { sampleMemory: (value) => samples.push(value) },
+  );
+  assert.deepStrictEqual(samples, [null]);
 });


### PR DESCRIPTION
# 구현

재생 품질 6개 지표 계측, 4개 soak 시나리오, 합성 소재 생성과 자동 JSON 보고서 추가
- JavaScript 테스트 44개와 Rust 단위 테스트 통과, cargo check 및 5분 전체 soak 완료

# 어려웠던 점

WebKit 프레임 카운터 부재와 seek 구간의 드랍 프레임 오탐 제거
- requestVideoFrameCallback의 mediaTime으로 드랍을 추정하고 1초 초과 불연속 구간 제외

# 리스크

현재 media element 기준선이 일부 절대 합격 기준 미달
- Apple M3 Pro 기준 연속 재생 p99 69 ms, 8,983 표시 프레임 중 14 드랍

Issue #668
