### PR TITLE
kgateway quickstart 핸즈온 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 88. Java heap dump 자동 수집과 분석 핸즈온 (OOM 증거 남기기) (26.7.18) - [링크](./computer_science/java/heapdump/)
 89. git credential helper 원리와 CodeBuild connection 핸즈온 (26.7.26) - [링크](./computer_science/git/git_credential_helper/)
 90. ECS quickstart (26.8.2) - [링크](./aws/ecs/quickstart/)
+91. kgateway quickstart (Gateway API 라우팅, TrafficPolicy, GPU 노드 LLM 백엔드) (26.8.4) - [링크](./kubernetes/kgateway/quickstart/)
 
 ## 직접 만든 제품
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-04
+
+* **Creation**: [kgateway의 AI·추론 라우팅은 Envoy data plane을 떠나 agentgateway로 갔다](topics/kgateway-ai-moved-to-agentgateway.md) topic 기록. kgateway quickstart 핸즈온을 만들며 검색으로 나오는 InferencePool 문서가 v2.4 chart에 존재하지 않는 값을 쓰고 있다는 것을 확인하고, 문서 대신 chart values와 ClusterRole로 판정하는 방법을 남긴다.
+
 ## 2026-08-03
 
 * **Creation**: [화살표 선분은 둥근 마감을 쓰지 않고 머리 길이를 화살표 길이로 제한한다](decisions/2026-08-arrow-shaft-square-cap.md) 결정 기록. akbun-makepresentation에서 화살표 끝에 점이 붙는다는 보고를 받고 고치다가, 같은 판단이 akbun-screenshot Issue #617의 ADR에만 남아 있어 두 번째로 만난 것을 알게 되면서 남긴다.

--- a/knowledge/topics/index.md
+++ b/knowledge/topics/index.md
@@ -8,3 +8,4 @@
 * [Electron 메뉴바 앱은 창 정리와 메뉴바 공간에서 조용히 실패한다](electron-menubar-silent-failures.md) - 앱이 살아 있는데 아무것도 안 보일 때 원인을 코드와 환경으로 갈라내는 방법.
 * [macOS 메뉴바 status item은 넓은 자리 차지로만 가릴 수 있고, 노치 뒤에서는 좌표가 있어도 그려지지 않는다](macos-menubar-status-items.md) - 다른 앱의 메뉴바 아이콘을 다루는 세 제약과 실측으로 검증한 우회 방법.
 * [hidden 속성으로 감추는 패널은 자기 display 규칙에 조용히 진다](hidden-attribute-loses-to-display.md) - el.hidden이 true인데 패널이 그대로 보일 때의 판정 방법과 시트 한 줄 해결.
+* [kgateway의 AI·추론 라우팅은 Envoy data plane을 떠나 agentgateway로 갔다](kgateway-ai-moved-to-agentgateway.md) - InferencePool이 조용히 무시될 때 chart와 ClusterRole로 판정하는 방법.

--- a/knowledge/topics/kgateway-ai-moved-to-agentgateway.md
+++ b/knowledge/topics/kgateway-ai-moved-to-agentgateway.md
@@ -1,0 +1,38 @@
+---
+type: Topic
+title: kgateway의 AI·추론 라우팅은 Envoy data plane을 떠나 agentgateway로 갔다
+description: kgateway 문서를 따라 하다 InferencePool이 아무 일도 하지 않는 이유와, 버전으로 판정하는 방법.
+tags: [kubernetes, kgateway, gateway-api, ai]
+timestamp: 2026-08-04T00:00:00Z
+---
+
+## 문제
+
+kgateway로 LLM 트래픽을 다루려고 검색하면 `--set inferenceExtension.enabled=true`로 설치하고 InferencePool을 만들라는 글이 먼저 나온다. v2.4에서 그대로 따라 하면 helm은 성공하고 InferencePool도 apply되지만 아무 일도 일어나지 않는다. 오류가 없어서 설정이 틀렸다고 의심하게 되는데, 사실은 기능 자체가 그 자리에 없다.
+
+## 무슨 일이 있었나
+
+kgateway는 data plane을 두 갈래로 나눴다. Envoy는 API gateway 용도로 남기고, AI·MCP·추론 연결은 agentgateway가 맡는다. v2.1에서 Envoy 기반 AI Gateway와 Envoy 기반 Inference Extension을 deprecated로 표시했고 v2.2에서 제거를 예고했다. 그 결과 문서는 `/docs/envoy/`와 `/docs/agentgateway/`로 갈라졌고, 검색이 물어다 주는 글은 대개 갈라지기 전 것이다.
+
+Gateway API Inference Extension 쪽 getting started도 이 변화를 반영했다. 구현체 탭에 kgateway가 없고 GKE, Istio, agentgateway, NGINX Gateway Fabric만 남아 있다.
+
+## 설치본으로 판정하는 방법
+
+문서를 믿기 전에 chart를 본다. 두 가지면 갈린다.
+
+- `helm show values oci://cr.kgateway.dev/kgateway-dev/charts/kgateway --version <버전>`에 `inferenceExtension` 키가 있는가. v2.4.2에는 없다.
+- control plane의 ClusterRole에 `inference.networking.k8s.io` apiGroup이 있는가. 없으면 InferencePool을 읽을 권한조차 없다는 뜻이라 논쟁의 여지가 없다.
+
+같은 방법이 GatewayClass에도 통한다. v2.4.2 chart가 만드는 클래스는 `kgateway`와 `kgateway-waypoint` 둘뿐이라 `agentgateway` 클래스를 기대하는 문서는 그 시점 것이 아니다.
+
+이 판정은 kgateway에만 쓰는 요령이 아니다. control plane이 어떤 CRD를 읽는지는 ClusterRole에 다 적혀 있어서, "이 버전이 이 리소스를 처리하는가"는 문서보다 RBAC이 정확하다.
+
+## 그래서 어떻게 하는가
+
+GPU가 한 장인 실습 환경이라면 InferencePool을 억지로 붙일 이유가 없다. 고를 대상이 하나뿐이라 KV 캐시 적중이나 GPU 사용률로 고르는 라우팅이 줄 것이 없다. 표준 HTTPRoute로 백엔드를 붙이고, 생성 트래픽에 맞춰 timeout과 retry만 조정하면 kgateway가 할 몫은 끝난다.
+
+모델 인지 라우팅이 실제로 필요해지는 시점은 GPU가 여러 장이 되고 나서이고, 그때는 kgateway가 아니라 agentgateway를 올리는 작업이 된다.
+
+## 관련
+
+- [kgateway quickstart 핸즈온](../../kubernetes/kgateway/quickstart/) - 이 판정을 하며 만든 실습

--- a/kubernetes/kgateway/quickstart/README.md
+++ b/kubernetes/kgateway/quickstart/README.md
@@ -1,0 +1,36 @@
+# kgateway quickstart
+
+kgateway를 처음 만지는 사람이 Gateway API 라우팅과 kgateway 고유 정책까지 한 번에 훑는 핸즈온이다. 마지막에는 LLM 백엔드를 gateway 뒤에 놓고 생성 트래픽에 맞게 timeout과 retry를 조정한다.
+
+실습 환경은 두 트랙이다. 라우팅 리소스는 두 트랙이 같고 백엔드만 다르다.
+
+| 트랙 | 환경 | 다루는 것 |
+|---|---|---|
+| A | 맥 + kind 단일 노드 cluster | 설치, 라우팅, 정책, 시뮬레이터 LLM |
+| B | GPU 1장이 달린 노드 한 대 | 같은 라우팅 위에 진짜 vLLM |
+
+Track A만으로 끝까지 갈 수 있다. Track B는 GPU 추론까지 볼 때만 한다.
+
+## 문서
+
+| 문서 | 내용 |
+|---|---|
+| [1-why-kgateway.md](docs/1-why-kgateway.md) | Gateway API와 kgateway의 위치, kgateway CRD, AI 기능이 어디로 갔는지 |
+| [2-setup.md](docs/2-setup.md) | Track A 환경: 맥 kind cluster와 kgateway 설치 |
+| [3-routing.md](docs/3-routing.md) | httpbin, HTTPRoute, 가중치 분배 |
+| [4-trafficpolicy.md](docs/4-trafficpolicy.md) | local rate limit, 헤더 변환 |
+| [5-setup.md](docs/5-setup.md) | Track B 환경: GPU 노드 단일 cluster와 device plugin |
+| [6-llm-routing.md](docs/6-llm-routing.md) | LLM 백엔드 라우팅, 생성 트래픽 timeout과 retry |
+| [7-cleanup.md](docs/7-cleanup.md) | 두 트랙의 정리 절차 |
+
+## 실습 리소스
+
+- [manifests/](manifests/) — apply하는 YAML 전부. 파일별 설명은 그 안의 README에 있다
+
+## 버전
+
+| 대상 | 버전 |
+|---|---|
+| kgateway | v2.4.2 |
+| Gateway API | v1.6.1 |
+| NVIDIA device plugin | v0.19.3 |

--- a/kubernetes/kgateway/quickstart/docs/1-why-kgateway.md
+++ b/kubernetes/kgateway/quickstart/docs/1-why-kgateway.md
@@ -1,0 +1,48 @@
+# kgateway가 무엇이고 어디에 서 있는가
+
+kgateway는 Kubernetes Gateway API를 구현한 Envoy 기반 control plane이다. Gateway 리소스를 만들면 kgateway가 Envoy 프록시를 파드로 띄우고, HTTPRoute를 읽어 그 Envoy의 라우팅 설정을 xDS로 밀어 넣는다.
+
+## Ingress가 아니라 Gateway API인 이유
+
+- Ingress는 스펙이 작아서 재시도, timeout, 헤더 조작 같은 것을 표준으로 표현할 수 없다. 구현체마다 annotation으로 우회했고 그래서 컨트롤러를 바꾸면 설정이 통째로 안 맞는다.
+- Gateway API는 그 역할을 세 리소스로 쪼갠다. 인프라 담당이 GatewayClass와 Gateway를, 앱 담당이 HTTPRoute를 갖는다.
+- 권한 경계가 리소스 경계와 같아서 namespace RBAC만으로 "앱 팀은 자기 route만 고친다"가 성립한다.
+
+| 리소스 | 소유자 | 담는 것 |
+|---|---|---|
+| GatewayClass | 플랫폼 | 어느 구현체가 처리할지. kgateway가 설치되면 `kgateway`가 생긴다 |
+| Gateway | 인프라 | listener. 포트, 프로토콜, 어느 namespace의 route를 붙일지 |
+| HTTPRoute | 앱 | hostname, path 매칭, backend와 가중치 |
+
+## kgateway의 위치
+
+- control plane은 `kgateway-system`에 파드 하나로 뜬다. 트래픽이 여기를 지나가지 않는다.
+- data plane은 Gateway 리소스마다 따로 뜨는 Envoy 파드다. Gateway를 지우면 같이 사라진다.
+- 즉 Gateway 하나가 곧 프록시 한 벌이다. 팀별로 Gateway를 나누면 프록시도 나뉜다.
+
+## 표준으로 모자란 부분은 kgateway CRD가 채운다
+
+Gateway API 표준에 없는 정책은 `gateway.kgateway.dev` 그룹의 CRD로 붙인다. v2.4.2 기준 여덟 개다.
+
+| CRD | 쓰임 |
+|---|---|
+| TrafficPolicy | rate limit, 인증, 변환, timeout, retry. 이 핸즈온에서 다루는 것 |
+| BackendConfigPolicy | backend 쪽 연결 설정 |
+| Backend | 클러스터 밖 대상(정적 host, AWS 등)을 backend로 선언 |
+| DirectResponse | backend 없이 고정 응답 |
+| GatewayParameters | Gateway가 만들 Envoy Deployment와 Service의 모양 |
+| HTTPListenerPolicy / ListenerPolicy | listener 단위 설정 |
+| GatewayExtension | 외부 처리 서버(extAuth, extProc) 연결 |
+
+정책은 `targetRefs`로 HTTPRoute나 Gateway에 붙는다. 정책이 리소스를 참조하지, 리소스가 정책을 참조하지 않는다. 그래서 앱 팀이 HTTPRoute를 고쳐도 플랫폼이 건 정책은 그대로 남는다.
+
+## AI 트래픽은 지금 어디에 있는가
+
+- kgateway v2.1에서 Envoy 기반 AI Gateway와 Envoy 기반 Inference Extension이 deprecated됐다. 같은 기능을 agentgateway data plane에서 구현하기 때문이다.
+- v2.4.2 helm chart에는 `inferenceExtension` 값이 없고, control plane의 ClusterRole에도 `inference.networking.k8s.io` 권한이 없다. Envoy 쪽에서는 제거가 끝난 상태다.
+- 그래서 `--set inferenceExtension.enabled=true`나 InferencePool을 쓰는 글은 v2.0~v2.1 시절 문서다. 지금 그대로 따라 하면 값이 무시되거나 InferencePool이 아무에게도 처리되지 않는다.
+- 이 핸즈온의 LLM 라우팅([6-llm-routing.md](6-llm-routing.md))은 InferencePool 없이 표준 HTTPRoute로만 한다. 모델 인지 라우팅까지 필요하면 그때 agentgateway를 얹는다.
+
+## 다음
+
+맥에서 kind cluster를 띄우는 [2-setup.md](2-setup.md)로 넘어간다.

--- a/kubernetes/kgateway/quickstart/docs/2-setup.md
+++ b/kubernetes/kgateway/quickstart/docs/2-setup.md
@@ -1,0 +1,100 @@
+# 실습 환경 준비: 맥 kind cluster
+
+이 문서는 Track A의 환경을 만든다. [3-routing.md](3-routing.md)와 [4-trafficpolicy.md](4-trafficpolicy.md)는 여기서 만든 cluster를 전제로 한다. GPU 노드에서 하는 Track B는 [5-setup.md](5-setup.md)에 따로 있다.
+
+## 사전 준비
+
+- Docker Desktop 또는 colima
+- kind, kubectl, helm
+
+맥에 없으면 한 번에 설치한다.
+
+```bash
+brew install kind kubectl helm
+```
+
+## 버전
+
+| 대상 | 버전 | 이유 |
+|---|---|---|
+| kgateway | v2.4.2 | 작성 시점 최신 stable |
+| Gateway API | v1.6.1 | kgateway v2.4.2의 go.mod가 참조하는 버전 |
+| kind 노드 이미지 | kind 기본값 | 고정하지 않는다. kind 버전에 맞는 기본 이미지를 쓴다 |
+
+## cluster 생성
+
+노드 하나짜리 cluster를 만든다. GPU 노드 한 대를 쓰는 Track B와 노드 수를 맞추기 위함이고, quickstart에 노드가 더 필요하지도 않다.
+
+[kind-config.yaml](../manifests/kind/kind-config.yaml)은 NodePort 30080을 맥의 localhost:8080으로 내보낸다. kind에서 `LoadBalancer` service는 external IP를 못 받고 계속 Pending이므로, gateway를 NodePort로 고정하고 포트를 뚫어 두는 쪽이 단순하다.
+
+```bash
+kind create cluster --config manifests/kind/kind-config.yaml
+```
+
+## Gateway API CRD 설치
+
+kgateway는 표준 CRD를 스스로 설치하지 않는다. 먼저 넣어야 한다.
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+```
+
+## kgateway 설치
+
+CRD chart와 control plane chart가 나뉘어 있다. 순서를 바꾸면 control plane이 자기 CRD를 못 찾는다.
+
+```bash
+helm upgrade -i kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+  --create-namespace --namespace kgateway-system --version v2.4.2
+```
+
+```bash
+helm upgrade -i kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+  --namespace kgateway-system --version v2.4.2
+```
+
+## 설치 확인
+
+control plane 파드가 Running이면 된다.
+
+```bash
+kubectl get pods -n kgateway-system
+```
+
+GatewayClass는 chart가 아니라 control plane이 직접 만든다. 그래서 이 목록이 비어 있지 않다는 것 자체가 control plane이 살아서 일을 시작했다는 신호다.
+
+```bash
+kubectl get gatewayclass
+```
+
+`kgateway`가 있으면 된다. chart가 관리하는 클래스는 `kgateway`와 Istio ambient waypoint용 `kgateway-waypoint` 둘인데, 이 핸즈온은 앞의 것만 쓴다.
+
+## Gateway 생성
+
+[gateway-parameters.yaml](../manifests/gateway/gateway-parameters.yaml)이 프록시 service를 NodePort 30080으로 고정한다. Gateway보다 먼저 있어야 첫 프록시가 뜰 때 반영된다.
+
+```bash
+kubectl apply -f manifests/gateway/gateway-parameters.yaml
+```
+
+[http-gateway.yaml](../manifests/gateway/http-gateway.yaml)은 8080 listener 하나를 열고, `infrastructure.parametersRef`로 위 GatewayParameters를 가리킨다.
+
+```bash
+kubectl apply -f manifests/gateway/http-gateway.yaml
+```
+
+Gateway를 만들면 kgateway가 같은 namespace에 Envoy Deployment와 Service를 새로 만든다. 이 파드가 실제 트래픽이 지나가는 곳이다.
+
+```bash
+kubectl get gateway,deploy,svc -n kgateway-system
+```
+
+`PROGRAMMED=True`가 되면 Envoy에 설정이 들어간 것이다. 아직 HTTPRoute가 없어 listener는 비어 있다.
+
+## 정리
+
+Track A가 끝나면 cluster째 지운다. 절차는 [7-cleanup.md](7-cleanup.md)에 있다.
+
+## 다음
+
+httpbin을 붙여 트래픽을 흘리는 [3-routing.md](3-routing.md)로 넘어간다.

--- a/kubernetes/kgateway/quickstart/docs/3-routing.md
+++ b/kubernetes/kgateway/quickstart/docs/3-routing.md
@@ -1,0 +1,79 @@
+# HTTPRoute로 트래픽 보내기
+
+환경은 [2-setup.md](2-setup.md)에서 만든 kind cluster를 쓴다. Gateway가 `PROGRAMMED=True`인 상태에서 시작한다.
+
+## 샘플 앱 배포
+
+kgateway 저장소의 httpbin 예제를 그대로 쓴다. `httpbin` namespace에 service 하나(port 8000)와 파드 하나가 뜬다.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kgateway-dev/kgateway/v2.4.2/examples/httpbin.yaml
+```
+
+```bash
+kubectl get pods,svc -n httpbin
+```
+
+## HTTPRoute 붙이기
+
+[httpbin-httproute.yaml](../manifests/routing/httpbin-httproute.yaml)은 `httpbin.example.com`으로 온 모든 경로를 httpbin service로 보낸다.
+
+`parentRefs`가 다른 namespace의 Gateway를 가리키는 것이 핵심이다. HTTPRoute는 앱 namespace에 있고 Gateway는 인프라 namespace에 있다. 이 연결은 Gateway의 `allowedRoutes.namespaces.from: All`이 허용해 주기 때문에 성립한다.
+
+```bash
+kubectl apply -f manifests/routing/httpbin-httproute.yaml
+```
+
+route가 실제로 Gateway에 붙었는지는 status로 본다. apply 성공은 "YAML이 문법에 맞다"까지만 보장한다.
+
+```bash
+kubectl get httproute httpbin -n httpbin -o yaml
+```
+
+`Accepted=True`와 `ResolvedRefs=True`를 확인한다. backend service 이름을 틀리면 `ResolvedRefs=False`가 되고, 이때 요청은 500으로 떨어진다.
+
+## 호출
+
+kind가 30080을 localhost:8080으로 내보내고 있다. hostname 매칭이 걸려 있으므로 Host 헤더를 줘야 route를 탄다.
+
+```bash
+curl -i http://localhost:8080/status/200 -H "host: httpbin.example.com"
+```
+
+Host 헤더 없이 부르면 404가 나온다. 이것은 앱이 없다는 뜻이 아니라 어떤 listener의 어떤 route에도 매칭되지 않았다는 뜻이다.
+
+```bash
+curl -i http://localhost:8080/status/200
+```
+
+## 가중치 분배
+
+두 번째 백엔드를 띄운다. 같은 이미지지만 service가 다르다.
+
+```bash
+kubectl apply -f manifests/routing/httpbin-v2-deployment.yaml
+kubectl apply -f manifests/routing/httpbin-v2-service.yaml
+```
+
+[httpbin-split-httproute.yaml](../manifests/routing/httpbin-split-httproute.yaml)은 `split.example.com`을 v1에 80, v2에 20으로 나눈다. `weight`는 비율이지 백분율이 아니다. 합이 100일 필요가 없고 상대값으로만 계산된다.
+
+응답 본문만 봐서는 어느 쪽이 받았는지 알 수 없으므로, backendRef마다 `ResponseHeaderModifier` 필터를 걸어 `x-version`을 붙인다. 게이트웨이가 자기가 고른 backend를 스스로 표시하게 하는 방식이라 앱을 고칠 필요가 없다.
+
+```bash
+kubectl apply -f manifests/routing/httpbin-split-httproute.yaml
+```
+
+스무 번 부르고 헤더만 세면 대략 16:4로 갈린다.
+
+```bash
+for i in $(seq 20); do
+  curl -s -o /dev/null -D - http://localhost:8080/status/200 -H "host: split.example.com" \
+    | grep -i '^x-version'
+done | sort | uniq -c
+```
+
+호출 수가 적으면 비율이 꽤 흔들린다. Envoy는 요청마다 독립적으로 뽑을 뿐 20건 안에서 정확히 16:4를 맞춰 주지 않는다.
+
+## 다음
+
+이 route에 정책을 얹는 [4-trafficpolicy.md](4-trafficpolicy.md)로 넘어간다.

--- a/kubernetes/kgateway/quickstart/docs/4-trafficpolicy.md
+++ b/kubernetes/kgateway/quickstart/docs/4-trafficpolicy.md
@@ -1,0 +1,61 @@
+# TrafficPolicy로 route에 정책 얹기
+
+[3-routing.md](3-routing.md)에서 만든 `httpbin` HTTPRoute에 정책을 붙인다.
+
+## 정책이 route를 참조한다
+
+TrafficPolicy는 `targetRefs`로 대상을 가리킨다. 방향이 이쪽인 것이 중요하다.
+
+- HTTPRoute에는 정책 관련 필드가 하나도 늘지 않는다. 앱 팀 YAML은 그대로다.
+- 플랫폼 팀이 정책을 지우면 route는 살아 있고 정책만 사라진다.
+- 같은 정책을 Gateway에 붙이면 그 Gateway를 지나는 모든 route에 적용된다. route에 붙은 더 좁은 정책이 이긴다.
+
+## local rate limit
+
+[httpbin-ratelimit-trafficpolicy.yaml](../manifests/policy/httpbin-ratelimit-trafficpolicy.yaml)은 30초에 3건만 통과시킨다. token bucket 방식이라 `maxTokens`가 순간에 몰아 쓸 수 있는 양이고, `fillInterval`마다 `tokensPerFill`만큼 다시 채운다.
+
+local이라는 이름은 Envoy 파드가 자기 안에서 센다는 뜻이다. 별도 rate limit 서버가 필요 없는 대신, 프록시 replica가 늘면 한도도 replica 수만큼 늘어난다. 정확한 총량이 필요하면 `rateLimit.global`과 외부 서버를 쓴다.
+
+```bash
+kubectl apply -f manifests/policy/httpbin-ratelimit-trafficpolicy.yaml
+```
+
+다섯 번 연속으로 부르면 앞 세 번은 200, 나머지는 429가 나온다.
+
+```bash
+for i in $(seq 5); do
+  curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/status/200 -H "host: httpbin.example.com"
+done
+```
+
+## 헤더 변환
+
+[httpbin-transformation-trafficpolicy.yaml](../manifests/policy/httpbin-transformation-trafficpolicy.yaml)은 요청에 `x-handson`을 넣고 응답에 `x-gateway`를 붙인다.
+
+`set`과 `add`가 다르다. `set`은 같은 이름이 있으면 덮어쓰고, `add`는 뒤에 덧붙인다. 클라이언트가 보낸 값을 신뢰하면 안 되는 헤더는 `set`으로 덮어써야 한다.
+
+```bash
+kubectl apply -f manifests/policy/httpbin-transformation-trafficpolicy.yaml
+```
+
+httpbin의 `/headers`는 자기가 받은 요청 헤더를 그대로 돌려준다. 응답 본문에서 요청 변환을, 응답 헤더에서 응답 변환을 한 번에 확인할 수 있다.
+
+```bash
+curl -i http://localhost:8080/headers -H "host: httpbin.example.com"
+```
+
+본문에 `X-Handson: kgateway-quickstart`가, 헤더에 `x-gateway: kgateway`가 보이면 된다. rate limit이 아직 걸려 있어 429가 나오면 30초 기다렸다 다시 부른다.
+
+## 정책이 안 먹을 때
+
+TrafficPolicy도 status를 남긴다. 대상 이름을 틀리면 apply는 성공하고 아무 일도 일어나지 않으므로, 안 먹는다 싶으면 여기부터 본다.
+
+```bash
+kubectl get trafficpolicy -n httpbin -o yaml
+```
+
+`targetRefs`의 `group`과 `kind`까지 정확해야 한다. HTTPRoute는 `gateway.networking.k8s.io` 그룹이고 kgateway CRD 그룹이 아니다.
+
+## 다음
+
+여기까지가 kind에서 하는 Track A다. GPU 노드로 넘어가려면 [5-setup.md](5-setup.md)를, 환경을 정리하려면 [7-cleanup.md](7-cleanup.md)를 본다.

--- a/kubernetes/kgateway/quickstart/docs/5-setup.md
+++ b/kubernetes/kgateway/quickstart/docs/5-setup.md
@@ -1,0 +1,76 @@
+# 실습 환경 준비: GPU 노드 한 대
+
+Track B의 환경이다. GPU가 달린 노드 한 대에 Kubernetes를 올리고 kgateway까지 설치한다. [6-llm-routing.md](6-llm-routing.md)가 이 환경을 전제로 한다.
+
+Track A의 kind cluster만으로도 [6-llm-routing.md](6-llm-routing.md)를 끝까지 할 수 있다. 그때는 vLLM 대신 시뮬레이터를 쓴다. 진짜 GPU 추론까지 보고 싶을 때만 이 문서가 필요하다.
+
+## 전제
+
+- GPU 한 장이 달린 리눅스 노드 한 대. control plane과 worker를 겸한다
+- NVIDIA 드라이버가 이미 설치돼 있고 `nvidia-smi`가 GPU를 보여준다
+- 이 노드에서 kubectl과 helm을 쓸 수 있다
+
+kind를 쓰지 않는다. 컨테이너 안의 컨테이너로 GPU를 넘기려면 런타임 설정을 두 겹으로 맞춰야 하는데, 노드가 어차피 한 대라 kind가 주는 이점이 없다.
+
+## 단일 노드 cluster
+
+k3s가 가장 짧다. 설치가 끝나면 kubeconfig가 `/etc/rancher/k3s/k3s.yaml`에 생긴다.
+
+```bash
+curl -sfL https://get.k3s.io | sh -
+```
+
+노드가 한 대이므로 control plane에 워크로드가 올라가야 한다. k3s는 기본으로 taint를 걸지 않지만, kubeadm으로 만든 cluster라면 taint를 지운다.
+
+```bash
+kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+```
+
+## GPU를 파드에 노출
+
+컨테이너 런타임이 GPU를 넘길 수 있어야 하고, device plugin이 그것을 `nvidia.com/gpu` 자원으로 광고해야 한다. 둘 중 하나만 있으면 파드는 Pending에서 멈춘다.
+
+- 드라이버와 컨테이너 툴킷이 이미 있으면 device plugin만 넣는다
+- 드라이버부터 자동으로 맞추려면 NVIDIA GPU Operator를 쓴다. 노드 한 대에는 과할 수 있다
+
+device plugin만 넣는 쪽은 DaemonSet 하나다.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.19.3/deployments/static/nvidia-device-plugin.yml
+```
+
+노드 allocatable에 `nvidia.com/gpu: 1`이 보여야 다음으로 넘어갈 수 있다.
+
+```bash
+kubectl get node -o jsonpath='{.items[0].status.allocatable}' | tr ',' '\n' | grep nvidia
+```
+
+## kgateway 설치
+
+Track A와 완전히 같다. Gateway API CRD를 먼저 넣고 kgateway chart 두 개를 순서대로 설치한다.
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+```
+
+```bash
+helm upgrade -i kgateway-crds oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds \
+  --create-namespace --namespace kgateway-system --version v2.4.2
+helm upgrade -i kgateway oci://cr.kgateway.dev/kgateway-dev/charts/kgateway \
+  --namespace kgateway-system --version v2.4.2
+```
+
+Gateway와 GatewayParameters도 같은 파일을 쓴다. NodePort 30080으로 고정돼 있으므로 노드 IP의 30080으로 붙는다. kind에서 쓰던 localhost:8080이 여기서는 `<노드 IP>:30080`이 된다.
+
+```bash
+kubectl apply -f manifests/gateway/gateway-parameters.yaml
+kubectl apply -f manifests/gateway/http-gateway.yaml
+```
+
+```bash
+kubectl get gateway -n kgateway-system
+```
+
+## 다음
+
+LLM 백엔드를 붙이는 [6-llm-routing.md](6-llm-routing.md)로 넘어간다.

--- a/kubernetes/kgateway/quickstart/docs/6-llm-routing.md
+++ b/kubernetes/kgateway/quickstart/docs/6-llm-routing.md
@@ -1,0 +1,109 @@
+# LLM 백엔드를 kgateway 뒤에 두기
+
+OpenAI 호환 API를 내는 백엔드를 kgateway 뒤에 놓고, 생성 요청에 맞게 timeout과 retry를 조정한다.
+
+환경은 둘 중 하나를 고른다. 라우팅 쪽 리소스는 두 환경이 완전히 같고 백엔드 Deployment만 다르다.
+
+| 트랙 | 환경 | 백엔드 | 접속 |
+|---|---|---|---|
+| A | 맥 kind ([2-setup.md](2-setup.md)) | 시뮬레이터. GPU 불필요 | `http://localhost:8080` |
+| B | GPU 노드 ([5-setup.md](5-setup.md)) | vLLM. GPU 1장 점유 | `http://<노드 IP>:30080` |
+
+아래 명령은 Track A 기준으로 적는다. Track B는 주소만 바꾼다.
+
+## namespace와 service
+
+service의 selector는 `app: vllm`이다. 두 트랙의 Deployment가 같은 label을 달고 있어서, service와 HTTPRoute는 어느 쪽이 떠 있든 그대로 동작한다.
+
+```bash
+kubectl apply -f manifests/llm/llm-namespace.yaml
+kubectl apply -f manifests/llm/vllm-service.yaml
+```
+
+## 백엔드 배포
+
+Track A는 시뮬레이터를 쓴다. 실제로 모델을 로드하지 않고 OpenAI API 모양의 응답만 만들어 준다. 라우팅과 정책을 확인하는 데는 이걸로 충분하고 GPU가 필요 없다.
+
+```bash
+kubectl apply -f manifests/llm/vllm-sim-deployment.yaml
+```
+
+Track B는 vLLM을 띄운다. `nvidia.com/gpu: 1`을 requests와 limits에 같이 적는다. GPU는 나눠 쓸 수 없어서 두 값이 항상 같아야 하고, 그래서 replica도 1이다.
+
+```bash
+kubectl apply -f manifests/llm/vllm-gpu-deployment.yaml
+```
+
+```bash
+kubectl get pods -n llm -w
+```
+
+vLLM은 모델을 내려받고 올리는 데 몇 분이 걸린다. 그동안 `/health`가 200을 주지 않으므로 `startupProbe`의 `failureThreshold`를 크게 잡아 뒀다. 이걸 짧게 두면 파드가 준비되기 전에 죽고 다시 처음부터 모델을 받는 무한 재시작에 빠진다.
+
+## HTTPRoute
+
+[vllm-httproute.yaml](../manifests/llm/vllm-httproute.yaml)은 `llm.example.com`의 `/v1` prefix만 백엔드로 보낸다. OpenAI 호환 API가 전부 `/v1` 아래에 있어서, 이렇게 잘라 두면 `/metrics` 같은 것이 gateway 밖으로 새지 않는다.
+
+```bash
+kubectl apply -f manifests/llm/vllm-httproute.yaml
+```
+
+```bash
+kubectl get httproute vllm -n llm -o yaml
+```
+
+## 호출
+
+모델 이름은 백엔드에 올린 것과 같아야 한다. 두 트랙 모두 `Qwen/Qwen2.5-0.5B-Instruct`로 맞춰 뒀다.
+
+```bash
+curl -s http://localhost:8080/v1/completions \
+  -H "host: llm.example.com" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-0.5B-Instruct",
+    "prompt": "kubernetes gateway API를 한 문장으로 설명하면",
+    "max_tokens": 64
+  }'
+```
+
+어떤 모델이 붙어 있는지는 `/v1/models`로 확인한다.
+
+```bash
+curl -s http://localhost:8080/v1/models -H "host: llm.example.com"
+```
+
+## 생성 트래픽에 맞춘 timeout과 retry
+
+여기가 일반 API와 갈리는 지점이다.
+
+- 응답이 초 단위로 안 끝난다. 프록시의 기본 timeout은 짧아서 긴 생성이 중간에 잘린다.
+- 잘려도 클라이언트에는 연결이 끊긴 것처럼만 보인다. 백엔드는 GPU를 계속 쓰고 있는데 응답을 받을 사람이 없다.
+- 그래서 재시도가 위험하다. 실패로 보이는 요청이 사실은 진행 중일 수 있고, 재시도는 GPU 작업을 하나 더 만든다.
+
+[vllm-trafficpolicy.yaml](../manifests/llm/vllm-trafficpolicy.yaml)은 이 셋을 반영한다. `request`를 넉넉히 주고, `streamIdle`로 "토큰이 한동안 안 나오면 끊는다"를 따로 잡고, `attempts`는 2로 억제한다.
+
+```bash
+kubectl apply -f manifests/llm/vllm-trafficpolicy.yaml
+```
+
+`max_tokens`를 크게 줘서 응답이 오래 걸리게 만들면 timeout이 늘어난 것을 확인할 수 있다.
+
+```bash
+time curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8080/v1/completions \
+  -H "host: llm.example.com" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen2.5-0.5B-Instruct", "prompt": "long story:", "max_tokens": 512}'
+```
+
+## 여기서 멈추는 이유
+
+이 구성은 백엔드를 "HTTP 서버 여럿" 이상으로 보지 않는다. 요청을 어디로 보낼지 고를 때 KV 캐시 적중이나 GPU 메모리 사용률 같은 것을 보지 않는다는 뜻이고, GPU가 여러 장이 되면 그 차이가 처리량으로 나타난다.
+
+모델을 아는 라우팅은 Gateway API Inference Extension의 InferencePool이 담당한다. 다만 kgateway의 Envoy data plane은 v2.1에서 이 기능을 deprecated했고 v2.4.2 chart에는 흔적이 없다([1-why-kgateway.md](1-why-kgateway.md)). 지금 이 조합을 하려면 agentgateway data plane을 따로 올려야 하므로, kgateway quickstart의 범위 밖으로 둔다.
+
+GPU가 한 장인 이 실습 환경에서는 어차피 고를 대상이 하나뿐이라 얻는 것도 없다.
+
+## 다음
+
+[7-cleanup.md](7-cleanup.md)로 정리한다.

--- a/kubernetes/kgateway/quickstart/docs/7-cleanup.md
+++ b/kubernetes/kgateway/quickstart/docs/7-cleanup.md
@@ -1,0 +1,45 @@
+# 정리
+
+## Track A: 맥 kind
+
+cluster를 지우면 안에 있던 것이 전부 사라진다. 리소스를 하나씩 지울 이유가 없다.
+
+```bash
+kind delete cluster --name kgateway
+```
+
+## Track B: GPU 노드
+
+노드를 재사용해야 하므로 필요한 것만 지운다. GPU를 먼저 놓아 주는 순서가 중요하다. vLLM 파드가 살아 있는 동안은 GPU가 계속 잡혀 있다.
+
+```bash
+kubectl delete namespace llm
+```
+
+GPU가 실제로 풀렸는지 확인한다.
+
+```bash
+kubectl describe node | grep -A5 "Allocated resources"
+```
+
+kgateway와 Gateway를 지운다. Gateway를 지우면 그 Gateway가 만든 Envoy Deployment와 Service도 같이 사라진다.
+
+```bash
+kubectl delete -f manifests/gateway/http-gateway.yaml
+kubectl delete -f manifests/gateway/gateway-parameters.yaml
+helm uninstall kgateway -n kgateway-system
+helm uninstall kgateway-crds -n kgateway-system
+kubectl delete namespace kgateway-system
+```
+
+Gateway API CRD까지 지운다. 다른 gateway 구현체를 쓸 계획이면 남겨 둔다.
+
+```bash
+kubectl delete -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+```
+
+k3s째 없앨 때는 설치 스크립트가 남긴 uninstall 스크립트를 쓴다.
+
+```bash
+/usr/local/bin/k3s-uninstall.sh
+```

--- a/kubernetes/kgateway/quickstart/manifests/README.md
+++ b/kubernetes/kgateway/quickstart/manifests/README.md
@@ -1,0 +1,21 @@
+# Manifests
+
+kgateway quickstart에서 apply하는 리소스다. 적용 순서와 확인 방법은 [../docs/](../docs/)에 있다.
+
+| 디렉터리/파일 | 설명 |
+|---|---|
+| `kind/kind-config.yaml` | 단일 노드 kind cluster. NodePort 30080을 맥 localhost:8080으로 노출 |
+| `gateway/gateway-parameters.yaml` | gateway proxy service를 NodePort 30080으로 고정하는 GatewayParameters |
+| `gateway/http-gateway.yaml` | 8080 HTTP listener 하나를 가진 Gateway |
+| `routing/httpbin-httproute.yaml` | httpbin.example.com을 httpbin service로 보내는 HTTPRoute |
+| `routing/httpbin-v2-deployment.yaml` | 가중치 분배 대상이 되는 두 번째 httpbin |
+| `routing/httpbin-v2-service.yaml` | httpbin-v2 service |
+| `routing/httpbin-split-httproute.yaml` | v1 80% v2 20% 가중치 분배와 backendRef별 응답 헤더 |
+| `policy/httpbin-ratelimit-trafficpolicy.yaml` | 30초당 3건 local rate limit TrafficPolicy |
+| `policy/httpbin-transformation-trafficpolicy.yaml` | 요청/응답 헤더를 바꾸는 transformation TrafficPolicy |
+| `llm/llm-namespace.yaml` | LLM 백엔드용 namespace |
+| `llm/vllm-sim-deployment.yaml` | GPU 없이 OpenAI API를 흉내내는 시뮬레이터. 맥 kind 트랙 |
+| `llm/vllm-gpu-deployment.yaml` | GPU 1장을 점유하는 vLLM. GPU 노드 트랙 |
+| `llm/vllm-service.yaml` | 두 트랙이 공유하는 service. selector는 `app: vllm` |
+| `llm/vllm-httproute.yaml` | llm.example.com/v1을 vllm service로 보내는 HTTPRoute |
+| `llm/vllm-trafficpolicy.yaml` | 생성 요청에 맞춘 timeout과 retry TrafficPolicy |

--- a/kubernetes/kgateway/quickstart/manifests/gateway/gateway-parameters.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/gateway/gateway-parameters.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: nodeport-proxy
+  namespace: kgateway-system
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: gateway
+spec:
+  kube:
+    service:
+      type: NodePort
+      ports:
+        - port: 8080
+          nodePort: 30080

--- a/kubernetes/kgateway/quickstart/manifests/gateway/http-gateway.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/gateway/http-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: http
+  namespace: kgateway-system
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: gateway
+spec:
+  gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      group: gateway.kgateway.dev
+      kind: GatewayParameters
+      name: nodeport-proxy
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/kubernetes/kgateway/quickstart/manifests/kind/kind-config.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/kind/kind-config.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: kgateway
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      # gateway NodePort 30080을 맥 localhost:8080으로 노출한다
+      - containerPort: 30080
+        hostPort: 8080
+        protocol: TCP

--- a/kubernetes/kgateway/quickstart/manifests/llm/llm-namespace.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/llm/llm-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: llm

--- a/kubernetes/kgateway/quickstart/manifests/llm/vllm-gpu-deployment.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/llm/vllm-gpu-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-gpu
+  namespace: llm
+  labels:
+    app: vllm
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: llm
+spec:
+  # GPU가 1장이므로 replica도 1이다. GPU는 파드끼리 나눠 쓸 수 없다
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v0.18.1
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+          args:
+            - --model
+            - Qwen/Qwen2.5-0.5B-Instruct
+            - --port
+            - "8000"
+            - --max-model-len
+            - "4096"
+            - --gpu-memory-utilization
+            - "0.6"
+          ports:
+            - name: http
+              containerPort: 8000
+          # 모델 로딩이 끝나야 /health가 200이므로 startupProbe로 기다린다
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: 1
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /root/.cache/huggingface
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: hf-cache
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi

--- a/kubernetes/kgateway/quickstart/manifests/llm/vllm-httproute.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/llm/vllm-httproute.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vllm
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: llm
+spec:
+  parentRefs:
+    - name: http
+      namespace: kgateway-system
+  hostnames:
+    - llm.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1
+      backendRefs:
+        - name: vllm
+          port: 8000

--- a/kubernetes/kgateway/quickstart/manifests/llm/vllm-service.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/llm/vllm-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm
+  namespace: llm
+  labels:
+    app: vllm
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: llm
+spec:
+  selector:
+    app: vllm
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000

--- a/kubernetes/kgateway/quickstart/manifests/llm/vllm-sim-deployment.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/llm/vllm-sim-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-sim
+  namespace: llm
+  labels:
+    app: vllm
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: llm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      containers:
+        - name: vllm-sim
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - --model
+            - Qwen/Qwen2.5-0.5B-Instruct
+            - --port
+            - "8000"
+          ports:
+            - name: http
+              containerPort: 8000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/kubernetes/kgateway/quickstart/manifests/llm/vllm-trafficpolicy.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/llm/vllm-trafficpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: vllm
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: llm
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: vllm
+  timeouts:
+    # 생성 요청은 초 단위로 끝나지 않는다. 기본 timeout으로는 긴 응답이 잘린다
+    request: 300s
+    streamIdle: 60s
+  retry:
+    attempts: 2
+    perTryTimeout: 120s
+    backoffBaseInterval: 100ms

--- a/kubernetes/kgateway/quickstart/manifests/policy/httpbin-ratelimit-trafficpolicy.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/policy/httpbin-ratelimit-trafficpolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: httpbin-ratelimit
+  namespace: httpbin
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httpbin
+  rateLimit:
+    local:
+      tokenBucket:
+        maxTokens: 3
+        tokensPerFill: 3
+        fillInterval: 30s

--- a/kubernetes/kgateway/quickstart/manifests/policy/httpbin-transformation-trafficpolicy.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/policy/httpbin-transformation-trafficpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: httpbin-transformation
+  namespace: httpbin
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: policy
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: httpbin
+  transformation:
+    request:
+      set:
+        - name: x-handson
+          value: kgateway-quickstart
+    response:
+      add:
+        - name: x-gateway
+          value: kgateway

--- a/kubernetes/kgateway/quickstart/manifests/routing/httpbin-httproute.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/routing/httpbin-httproute.yaml
@@ -1,0 +1,22 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: routing
+spec:
+  parentRefs:
+    - name: http
+      namespace: kgateway-system
+  hostnames:
+    - httpbin.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: httpbin
+          port: 8000

--- a/kubernetes/kgateway/quickstart/manifests/routing/httpbin-split-httproute.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/routing/httpbin-split-httproute.yaml
@@ -1,0 +1,38 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin-split
+  namespace: httpbin
+  labels:
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: routing
+spec:
+  parentRefs:
+    - name: http
+      namespace: kgateway-system
+  hostnames:
+    - split.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: httpbin
+          port: 8000
+          weight: 80
+          filters:
+            - type: ResponseHeaderModifier
+              responseHeaderModifier:
+                set:
+                  - name: x-version
+                    value: v1
+        - name: httpbin-v2
+          port: 8000
+          weight: 20
+          filters:
+            - type: ResponseHeaderModifier
+              responseHeaderModifier:
+                set:
+                  - name: x-version
+                    value: v2

--- a/kubernetes/kgateway/quickstart/manifests/routing/httpbin-v2-deployment.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/routing/httpbin-v2-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin-v2
+  namespace: httpbin
+  labels:
+    app: httpbin-v2
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: routing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin-v2
+  template:
+    metadata:
+      labels:
+        app: httpbin-v2
+    spec:
+      containers:
+        - name: httpbin
+          image: docker.io/mccutchen/go-httpbin:v2.6.0
+          imagePullPolicy: IfNotPresent
+          command: [go-httpbin]
+          args:
+            - "-port"
+            - "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi

--- a/kubernetes/kgateway/quickstart/manifests/routing/httpbin-v2-service.yaml
+++ b/kubernetes/kgateway/quickstart/manifests/routing/httpbin-v2-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin-v2
+  namespace: httpbin
+  labels:
+    app: httpbin-v2
+    app.kubernetes.io/name: kgateway-quickstart
+    app.kubernetes.io/component: routing
+spec:
+  selector:
+    app: httpbin-v2
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080


### PR DESCRIPTION
# 구현

kgateway quickstart 핸즈온 추가. 문서 7개와 manifest 15개로 구성하고 knowledge topic 1개 기록

- Gateway API v1.6.1과 kgateway v2.4.2의 CRD 스키마로 Gateway, HTTPRoute, TrafficPolicy, GatewayParameters 7개 전부 검증 통과

# 어려웠던 점

검색으로 나오는 kgateway AI 문서가 전부 v2.4에 존재하지 않는 설정을 가리킴

- helm values에 inferenceExtension 키가 없고 ClusterRole에도 inference.networking.k8s.io가 없어 제거로 판정하고 InferencePool을 범위에서 제외

# 리스크

클러스터 실행 없이 스키마 검증까지만 마침

- helm과 kind가 없는 환경이라 apply 이후 status 확인과 curl 결과는 첫 실행에서 확인 필요

Issue #699

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLx4htZX5oYN2XqgbrGV2Y)_