### PR TITLE
llm-d quickstart 핸즈온 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 88. Java heap dump 자동 수집과 분석 핸즈온 (OOM 증거 남기기) (26.7.18) - [링크](./computer_science/java/heapdump/)
 89. git credential helper 원리와 CodeBuild connection 핸즈온 (26.7.26) - [링크](./computer_science/git/git_credential_helper/)
 90. ECS quickstart (26.8.2) - [링크](./aws/ecs/quickstart/)
+91. llm-d quickstart (GPU 1장 노드와 맥 kind 두 환경) (26.8.4) - [링크](./kubernetes/llm-d/)
 
 ## 직접 만든 제품
 

--- a/knowledge/decisions/2026-08-inference-sim-for-gpuless-handson.md
+++ b/knowledge/decisions/2026-08-inference-sim-for-gpuless-handson.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: GPU 없는 환경의 추론 인프라 핸즈온은 simulator를 model server 자리에 넣는다
+description: llm-d 같은 추론 라우팅 계층을 배울 때 GPU를 조달하지 않고 inference simulator로 model server를 대체하기로 한 결정과 그 한계.
+tags: [kubernetes, ai, handson, llmd]
+timestamp: 2026-08-04T00:00:00Z
+---
+
+## 결정
+
+추론 인프라 계층(라우팅, 스케줄링, 오토스케일링)을 배우는 핸즈온에서는 model server 자리에 simulator를 넣는다. GPU는 그 계층이 아니라 그 아래 계층을 배울 때 조달한다.
+
+llm-d quickstart 핸즈온의 경우 맥 kind 클러스터에 llm-d-inference-sim을 4 replica로 띄우고, GPU 1장짜리 노드에는 실제 vLLM을 2 replica로 띄워 두 문서로 나눈다.
+
+## 이유
+
+배우려는 대상이 요청을 어디로 보내는가일 때, 그 판단의 입력은 pod의 큐 길이와 KV cache 사용률과 prefix 이력이다. simulator가 vLLM의 OpenAI API와 Prometheus 메트릭 이름을 그대로 내보내면 라우터 입장에서 진짜와 구분되지 않는다.
+
+반대로 GPU를 넣으면 배우려는 것과 무관한 비용이 앞에 붙는다. 모델 가중치 다운로드, CUDA graph capture, GPU 메모리 배분이 실패 지점이 되고, 라우팅 동작을 보기 전에 지친다.
+
+결정적으로 라우팅은 replica가 여러 개여야 관찰된다. GPU 1장으로 replica를 2개 이상 만들려면 time-slicing이 필요하고, time-slicing은 시간만 나누고 메모리는 나누지 않아서 vLLM의 gpu-memory-utilization을 손으로 낮춰야 한다. simulator는 이 제약 자체가 없다.
+
+## 한계
+
+simulator로 확인되지 않는 것을 문서에 명시하고, 그 부분은 GPU 환경으로 넘긴다.
+
+- 추론 품질과 실제 토큰 처리량. simulator의 응답은 미리 정의된 문장이다.
+- 실제 KV cache의 eviction. simulator를 쓰든 안 쓰든 근사 prefix scorer는 추정만 하지만, 추정이 언제 틀리는지는 실제 엔진에서만 보인다.
+- GPU 메모리 압력에서 오는 장애. OOM으로 replica가 죽는 상황은 simulator에서 재현되지 않는다.

--- a/knowledge/decisions/index.md
+++ b/knowledge/decisions/index.md
@@ -22,3 +22,4 @@
 * [Tauri 앱의 썸네일은 webview가 그리고 Rust는 바이트만 저장한다](2026-08-thumbnails-in-the-webview.md) - akbun-folderview의 썸네일 캐시를 Rust 이미지 라이브러리 없이 canvas로 생성하기로 한 결정.
 * [핸즈온은 terraform으로 기반까지만 만들고 학습 대상은 console에서 조작한다](2026-08-handson-terraform-base-console-operation.md) - terraform 범위를 기반 리소스로 한정하는 결정과 state 밖 리소스가 만드는 비용.
 * [화살표 선분은 둥근 마감을 쓰지 않고 머리 길이를 화살표 길이로 제한한다](2026-08-arrow-shaft-square-cap.md) - 화살표 끝에 구슬 같은 점이 붙던 현상을 두 product에서 같은 방식으로 없앤 결정.
+* [GPU 없는 환경의 추론 인프라 핸즈온은 simulator를 model server 자리에 넣는다](2026-08-inference-sim-for-gpuless-handson.md) - llm-d 라우팅 학습에서 GPU 조달 대신 inference simulator를 쓰기로 한 결정과 그 한계.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-04
+
+* **Creation**: [GPU 없는 환경의 추론 인프라 핸즈온은 simulator를 model server 자리에 넣는다](decisions/2026-08-inference-sim-for-gpuless-handson.md) 결정 기록. llm-d quickstart 핸즈온을 만들며 맥과 GPU 1장짜리 노드로 환경을 나누다가, 라우팅 관찰에는 GPU가 필요 없고 오히려 GPU가 관찰을 방해한다는 것을 확인하면서 남긴다.
+
 ## 2026-08-03
 
 * **Creation**: [화살표 선분은 둥근 마감을 쓰지 않고 머리 길이를 화살표 길이로 제한한다](decisions/2026-08-arrow-shaft-square-cap.md) 결정 기록. akbun-makepresentation에서 화살표 끝에 점이 붙는다는 보고를 받고 고치다가, 같은 판단이 akbun-screenshot Issue #617의 ADR에만 남아 있어 두 번째로 만난 것을 알게 되면서 남긴다.

--- a/kubernetes/llm-d/README.md
+++ b/kubernetes/llm-d/README.md
@@ -1,0 +1,41 @@
+# llm-d quickstart 핸즈온
+
+[llm-d](https://llm-d.ai/)는 Kubernetes 위에서 vLLM 같은 추론 엔진을 여러 개 띄우고, 요청마다 어느 replica로 보낼지 결정하는 계층이다. 추론 엔진을 대체하지 않고 그 앞에 붙는다.
+
+이 핸즈온은 llm-d를 처음 켜 보고 EPP의 라우팅 결정을 눈으로 확인하는 데까지를 다룬다. GPU가 없는 맥과 GPU가 1장인 노드, 두 환경을 모두 준비했다.
+
+## 문서
+
+| 문서 | 내용 |
+|---|---|
+| [1-architecture.md](./docs/1-architecture.md) | llm-d 구성요소, 요청 흐름, scorer가 보는 것 |
+| [2-setup-kind-mac.md](./docs/2-setup-kind-mac.md) | 실습환경 1. 맥 kind 클러스터 + inference simulator |
+| [3-setup-gpu-node.md](./docs/3-setup-gpu-node.md) | 실습환경 2. GPU 1장짜리 노드 + kind + 실제 vLLM |
+| [4-routing.md](./docs/4-routing.md) | 라우팅 동작 관찰. 어느 pod으로 갔는지 세어 본다 |
+
+manifest와 helm values는 [manifests/](./manifests/README.md)에 있고, 고정한 버전도 거기 정리해 뒀다.
+
+## 두 환경을 나눈 이유
+
+| | 맥 kind | GPU 노드 |
+|---|---|---|
+| model server | llm-d-inference-sim | vLLM |
+| replica | 4개 | 2개 (GPU 1장을 time-slicing) |
+| 볼 수 있는 것 | 라우팅 결정, scorer 동작 | 실제 추론, GPU 메모리 점유 |
+| 볼 수 없는 것 | 실제 추론 품질과 처리량 | replica를 늘린 라우팅 분포 |
+
+- 라우팅 자체를 이해하는 데는 GPU가 필요 없다. simulator가 vLLM의 OpenAI API와 Prometheus 메트릭을 그대로 흉내 내므로 EPP 입장에서는 구분되지 않는다.
+- GPU가 1장이면 replica를 여러 개 만들 방법이 time-slicing뿐이고, 그때 메모리는 나뉘지 않는다는 제약이 따라온다. 그 부분은 [3-setup-gpu-node.md](./docs/3-setup-gpu-node.md)에 정리했다.
+
+## 시작 순서
+
+1. [1-architecture.md](./docs/1-architecture.md)로 구성요소를 먼저 본다. 설치 명령이 무엇을 만드는지 알고 시작하는 편이 낫다.
+2. 가진 장비에 맞는 setup 문서로 환경을 만든다.
+3. [4-routing.md](./docs/4-routing.md)로 라우팅을 관찰한다.
+
+## 참고자료
+
+- llm-d 공식 quickstart: <https://llm-d.ai/docs/guide/Installation/quickstart>
+- llm-d well-lit path 가이드: <https://github.com/llm-d/llm-d/tree/main/guides>
+- llm-d-inference-sim: <https://github.com/llm-d/llm-d-inference-sim>
+- Gateway API Inference Extension: <https://github.com/kubernetes-sigs/gateway-api-inference-extension>

--- a/kubernetes/llm-d/docs/1-architecture.md
+++ b/kubernetes/llm-d/docs/1-architecture.md
@@ -1,0 +1,76 @@
+# llm-d 구성요소와 요청 흐름
+
+## llm-d가 푸는 문제
+
+- vLLM은 노드 하나에서 모델 하나를 잘 돌린다. replica가 여러 개가 되는 순간부터는 "어느 replica로 보낼 것인가"가 성능을 결정한다.
+- llm-d는 이 선택을 하는 계층이다. 추론 엔진을 새로 만들지 않고 vLLM, SGLang, TensorRT-LLM 앞에 붙는다.
+
+일반적인 Kubernetes Service 로드밸런싱이 LLM에서 잘 안 맞는 이유는 세 가지다.
+
+- 요청마다 처리 시간이 수십 배 차이 난다. prompt 100 token과 100k token이 같은 큐를 쓴다.
+- 직전 요청의 KV cache가 그 pod에 남아 있다. 같은 prefix를 가진 요청은 그 pod에서 prefill을 건너뛴다. 다른 pod으로 보내면 처음부터 다시 계산한다.
+- pod마다 대기 큐 길이와 KV cache 사용률이 다르다. round-robin은 이 상태를 모른다.
+
+## 구성요소
+
+| 구성요소 | 역할 | 실체 |
+|---|---|---|
+| model server | 실제 추론 | vLLM 등의 Deployment |
+| InferencePool | 하나의 모델을 서빙하는 pod 집합 정의 | Gateway API Inference Extension CRD |
+| EPP (Endpoint Picker) | 요청마다 어느 pod으로 보낼지 결정 | gRPC ext_proc 서버 |
+| proxy | EPP가 고른 pod으로 요청 전달 | Envoy |
+
+- InferencePool은 `selector.matchLabels`로 pod을 고르고 `targetPorts`로 포트를 지정한다. Service가 아니라 CRD다.
+- EPP는 pod을 직접 watch하고 각 pod의 `/metrics`를 주기적으로 긁어 큐 길이와 KV cache 사용률을 안다.
+- proxy는 Envoy의 ORIGINAL_DST cluster를 쓴다. 목적지를 EPP가 응답 헤더 `x-gateway-destination-endpoint`로 알려 주고 Envoy가 그 주소로 그대로 보낸다. 그래서 pod 앞에 Service가 필요 없다.
+
+## 요청 흐름
+
+curl 한 번이 지나가는 경로다.
+
+```mermaid
+sequenceDiagram
+  participant C as client
+  participant E as Envoy proxy
+  participant P as EPP
+  participant V as vLLM pod
+
+  C->>E: POST /v1/completions
+  E->>P: ext_proc gRPC (header + body)
+  P->>P: InferencePool pod 목록에 scorer 적용
+  P-->>E: x-gateway-destination-endpoint: 10.244.1.7:8000
+  E->>V: 요청 전달 (ORIGINAL_DST)
+  V-->>E: 응답 스트리밍
+  E-->>C: 응답
+```
+
+- EPP는 트래픽을 직접 나르지 않는다. 판단만 하고 주소를 돌려준다. EPP가 죽어도 `failureMode: FailOpen`이면 Envoy가 그냥 흘린다.
+- 그래서 EPP 장애가 서비스 장애로 바로 이어지지 않는다. 대신 그 시간 동안 라우팅 품질만 떨어진다.
+
+## 배포 모드
+
+- standalone 모드: Envoy가 EPP pod 안에 sidecar로 들어간다. Gateway 리소스가 필요 없다. 이 핸즈온이 쓰는 모드다.
+- gateway 모드: 클러스터의 Gateway(kgateway, Istio, agentgateway 등)에 InferencePool을 붙인다. 이미 Gateway API를 쓰고 있으면 이쪽이다.
+
+standalone 모드를 먼저 보는 이유는 Gateway 구현체 설치라는 변수를 빼고 EPP 동작만 보기 위해서다.
+
+## scorer
+
+EPP는 플러그인 여러 개의 점수를 가중합해 pod을 고른다. 이 핸즈온이 쓰는 조합은 llm-d v0.8.1의 optimized-baseline과 같다.
+
+| plugin | weight | 무엇을 본다 |
+|---|---|---|
+| prefix-cache-scorer | 3 | prompt를 블록 단위로 해시해 그 prefix를 최근에 처리한 pod을 추정 |
+| queue-scorer | 2 | pod의 대기 큐 길이 |
+| kv-cache-utilization-scorer | 2 | pod의 KV cache 사용률 |
+| no-hit-lru-scorer | 2 | prefix hit이 없을 때 가장 오래 안 쓴 pod으로 분산 |
+
+- prefix-cache-scorer의 weight가 가장 크다. prefill을 건너뛰는 이득이 큐를 조금 더 기다리는 손해보다 크다는 판단이다.
+- 이 가중치는 정답이 아니라 upstream이 H100 기준으로 벤치마크한 출발점이다. 요청 길이 분포가 다르면 값도 달라진다.
+- 여기 쓴 prefix-cache-scorer는 근사값이다. EPP가 자기가 보낸 요청을 기억해 추정한다. vLLM의 실제 KV cache 상태를 ZMQ 이벤트로 받아 정확히 아는 방식은 별도 가이드(precise prefix cache routing)다.
+
+## 다음 문서
+
+- 맥에서 GPU 없이 시작: [2-setup-kind-mac.md](./2-setup-kind-mac.md)
+- GPU 1장짜리 노드: [3-setup-gpu-node.md](./3-setup-gpu-node.md)
+- 라우팅 동작 관찰: [4-routing.md](./4-routing.md)

--- a/kubernetes/llm-d/docs/2-setup-kind-mac.md
+++ b/kubernetes/llm-d/docs/2-setup-kind-mac.md
@@ -1,0 +1,97 @@
+# 실습환경 1 - 맥 kind 클러스터 (GPU 없음)
+
+맥에는 CUDA GPU가 없다. vLLM 대신 [llm-d-inference-sim](https://github.com/llm-d/llm-d-inference-sim)을 model server 자리에 넣는다. OpenAI 호환 API와 vLLM Prometheus 메트릭을 그대로 흉내 내므로 EPP 입장에서는 vLLM과 구분되지 않는다.
+
+- 이 환경에서 확인할 수 있는 것: InferencePool, EPP scorer, 라우팅 결정
+- 확인할 수 없는 것: 실제 추론 품질, 토큰 처리량, GPU 메모리
+
+명령은 모두 `kubernetes/llm-d/`에서 실행한다.
+
+## 사전 준비
+
+- Docker Desktop 또는 colima. CPU 4개, 메모리 8GB 이상을 컨테이너 런타임에 할당한다.
+- kind v0.32.0, kubectl, helm v3, jq
+
+homebrew로 클라이언트 도구를 설치한다.
+
+```bash
+brew install kind kubectl helm jq
+```
+
+## up
+
+kind 클러스터를 만든다. worker 2개를 두는 이유는 model server replica가 노드에 흩어지는 것을 보기 위해서다.
+
+```bash
+kind create cluster --config manifests/kind/kind-mac.yaml
+```
+
+llm-d가 쓰는 InferencePool CRD를 설치한다. Gateway API Inference Extension 프로젝트가 배포한다.
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml
+```
+
+namespace를 만든다.
+
+```bash
+kubectl create namespace llm-d
+```
+
+router를 설치한다. EPP와 Envoy sidecar, InferencePool이 함께 만들어진다.
+
+```bash
+helm install quickstart oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
+  --version v0.9.0 \
+  -f manifests/router/router.values.yaml \
+  -n llm-d
+```
+
+model server를 배포한다.
+
+```bash
+kubectl apply -f manifests/sim/vllm-sim-deployment.yaml -n llm-d
+```
+
+pod이 모두 Ready가 될 때까지 기다린다. sim은 모델 가중치를 받지 않으므로 십여 초면 끝난다.
+
+```bash
+kubectl wait --for=condition=Ready pod --all -n llm-d --timeout=300s
+```
+
+## 확인
+
+InferencePool이 pod 4개를 잡았는지 본다.
+
+```bash
+kubectl get inferencepool quickstart -n llm-d -o yaml
+kubectl get pod -n llm-d -l llm-d.ai/inference-serving=true -o wide
+```
+
+EPP service를 로컬로 연결한다.
+
+```bash
+kubectl port-forward -n llm-d svc/quickstart-epp 8080:80
+```
+
+다른 터미널에서 요청을 보낸다. 응답이 오면 client에서 EPP를 거쳐 sim까지 경로가 이어진 것이다.
+
+```bash
+curl -s http://localhost:8080/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "Qwen/Qwen3-0.6B", "prompt": "llm-d quickstart", "max_tokens": 20}' | jq
+```
+
+## 자주 막히는 지점
+
+- pod이 Pending에서 안 움직이면 EPP의 resource requests 때문이다. upstream 기본값은 CPU 4개, 메모리 8Gi다. [router.values.yaml](../manifests/router/router.values.yaml)에서 줄여 뒀지만 컨테이너 런타임 할당량이 더 작으면 여전히 안 뜬다.
+- EPP 로그에 pod을 못 찾는다는 메시지가 나오면 label을 확인한다. InferencePool의 `selector.matchLabels`와 Deployment `template.metadata.labels`가 둘 다 `llm-d.ai/inference-serving: "true"`여야 한다. Deployment 최상단 label만 붙이면 안 잡힌다.
+- sim이 CrashLoopBackOff면 HuggingFace에서 tokenizer를 못 받은 경우다. `--model`에 실재하지 않는 이름(예: `dummy-model`)을 주면 내장 정규식 tokenizer를 쓰므로 네트워크 없이 뜬다. 대신 요청 body의 `model` 값도 같이 바꾼다.
+
+## down
+
+실습이 끝나면 클러스터째 지운다.
+
+```bash
+kind delete cluster --name llm-d
+```

--- a/kubernetes/llm-d/docs/3-setup-gpu-node.md
+++ b/kubernetes/llm-d/docs/3-setup-gpu-node.md
@@ -1,0 +1,128 @@
+# 실습환경 2 - GPU 1장짜리 노드
+
+NVIDIA GPU가 1장 달린 Linux 노드에서 실제 vLLM을 띄운다. 클러스터는 맥과 똑같이 kind로 만든다. 관리형 클러스터를 빌리지 않고 노드 한 대로 끝내기 위해서다.
+
+- 이 환경에서 확인할 수 있는 것: 실제 추론 응답, GPU 메모리 점유, vLLM 메트릭 기반 scorer 동작
+- GPU가 1장이므로 replica 2개가 같은 GPU를 나눠 쓴다. time-slicing으로 나눈다.
+
+명령은 모두 `kubernetes/llm-d/`에서 실행한다.
+
+## 사전 준비
+
+- NVIDIA 드라이버가 설치되어 `nvidia-smi`가 동작하는 Linux 노드
+- docker, [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- kind v0.32.0, kubectl, helm v3
+- GPU 메모리 16GB 이상 권장. Qwen3-0.6B 기준으로 replica 2개가 각각 35%를 잡는다.
+
+## GPU를 kind 노드에 넣기
+
+kind 노드는 컨테이너다. 그 컨테이너 안에서 GPU가 보이려면 docker의 기본 런타임이 nvidia여야 한다.
+
+```bash
+sudo nvidia-ctk runtime configure --runtime=docker --set-as-default
+sudo systemctl restart docker
+```
+
+device plugin이 GPU를 pod에 붙이는 방식을 volume mount로 바꾼다. kind 노드 안의 containerd는 nvidia 런타임을 모르기 때문에 환경변수 방식이 동작하지 않는다.
+
+```bash
+sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place
+sudo systemctl restart docker
+```
+
+이 두 설정이 kind에서 GPU를 쓰는 핵심이다. 호스트 docker가 kind 노드 컨테이너에 드라이버와 `/dev/nvidia*`를 넣어 주고, 노드 안의 pod은 device plugin이 만든 volume mount로 그것을 물려받는다.
+
+## up
+
+kind 클러스터를 만든다. 노드가 컨테이너 하나이므로 GPU도 하나다.
+
+```bash
+kind create cluster --config manifests/kind/kind-gpu-node.yaml
+```
+
+kind 노드 안에서 GPU가 보이는지 먼저 확인한다. 여기서 안 보이면 다음 단계는 전부 실패한다.
+
+```bash
+docker exec -it llm-d-gpu-control-plane nvidia-smi
+```
+
+NVIDIA device plugin을 time-slicing 설정과 함께 설치한다.
+
+```bash
+helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
+helm repo update
+helm upgrade -i nvdp nvdp/nvidia-device-plugin \
+  --namespace nvidia-device-plugin --create-namespace \
+  --version 0.19.3 \
+  --set deviceListStrategy=volume-mounts \
+  --set config.default=default \
+  --set-file config.map.default=manifests/gpu/time-slicing-config.yaml
+```
+
+노드가 GPU를 4개로 광고하는지 확인한다. 물리 GPU는 1장이지만 `nvidia.com/gpu: 4`로 보이면 성공이다.
+
+```bash
+kubectl get node -o jsonpath='{.items[0].status.capacity.nvidia\.com/gpu}'
+```
+
+여기부터는 맥 환경과 같다. CRD, namespace, router를 설치한다.
+
+```bash
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/v1-manifests.yaml
+kubectl create namespace llm-d
+helm install quickstart oci://ghcr.io/llm-d/charts/llm-d-router-standalone \
+  --version v0.9.0 \
+  -f manifests/router/router.values.yaml \
+  -n llm-d
+```
+
+vLLM model server를 배포한다.
+
+```bash
+kubectl apply -f manifests/gpu/vllm-deployment.yaml -n llm-d
+```
+
+모델 다운로드와 CUDA graph capture 때문에 첫 기동은 몇 분 걸린다.
+
+```bash
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=vllm-decode -n llm-d --timeout=1200s
+```
+
+## 확인
+
+GPU 메모리를 두 pod이 나눠 쓰고 있는지 본다.
+
+```bash
+docker exec -it llm-d-gpu-control-plane nvidia-smi
+```
+
+요청을 보낸다. sim과 달리 진짜 생성 결과가 온다.
+
+```bash
+kubectl port-forward -n llm-d svc/quickstart-epp 8080:80
+curl -s http://localhost:8080/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "Qwen/Qwen3-0.6B", "prompt": "쿠버네티스가 무엇인지 한 문장으로 설명해줘.", "max_tokens": 100}' | jq
+```
+
+## time-slicing이 나누지 않는 것
+
+- time-slicing은 GPU 시간만 나눈다. 메모리는 나누지 않는다. 두 pod이 같은 GPU 메모리를 그냥 같이 쓴다.
+- 그래서 [vllm-deployment.yaml](../manifests/gpu/vllm-deployment.yaml)에서 `--gpu-memory-utilization=0.35`를 준다. vLLM은 기본값 0.9로 KV cache를 미리 잡으므로, 이 값을 안 낮추면 먼저 뜬 pod이 GPU를 다 먹고 두 번째 pod은 CUDA OOM으로 죽는다.
+- 격리도 없다. 한 pod이 GPU를 오래 점유하면 다른 pod의 지연이 그대로 늘어난다. 프로덕션에서 격리가 필요하면 MIG나 물리적 분리를 쓴다.
+- 실습에서 이 방식을 고른 이유는 GPU 1장으로 replica를 2개 이상 만들어야 라우팅 동작을 볼 수 있기 때문이다. replica가 1개면 EPP가 고를 대상이 없다.
+
+## 자주 막히는 지점
+
+- pod이 Pending이고 이벤트에 `Insufficient nvidia.com/gpu`가 뜨면 device plugin이 GPU를 못 찾은 것이다. `kubectl logs -n nvidia-device-plugin -l app.kubernetes.io/name=nvidia-device-plugin`을 본다.
+- pod은 떴는데 컨테이너 안에서 `nvidia-smi`가 없으면 `accept-nvidia-visible-devices-as-volume-mounts` 설정이 빠졌거나 docker를 재시작하지 않은 것이다.
+- 두 번째 replica만 CUDA OOM으로 죽으면 `--gpu-memory-utilization` 값을 더 낮춘다.
+- gated 모델을 쓰려면 `llm-d-hf-token` secret을 만들고 Deployment에 `HF_TOKEN` 환경변수를 추가한다. Qwen3-0.6B는 공개 모델이라 필요 없다.
+
+## down
+
+클러스터째 지운다. device plugin과 nvidia 런타임 설정은 호스트에 남으므로 다음 실습에서 다시 쓸 수 있다.
+
+```bash
+kind delete cluster --name llm-d-gpu
+```

--- a/kubernetes/llm-d/docs/4-routing.md
+++ b/kubernetes/llm-d/docs/4-routing.md
@@ -1,0 +1,100 @@
+# 라우팅 동작 관찰
+
+EPP가 요청을 어디로 보내는지 눈으로 확인한다. [2-setup-kind-mac.md](./2-setup-kind-mac.md) 또는 [3-setup-gpu-node.md](./3-setup-gpu-node.md)로 환경을 먼저 만든다. 아래는 replica가 4개인 sim 환경 기준이고, GPU 환경은 replica가 2개라 같은 경향이 더 작은 숫자로 보인다.
+
+## 준비
+
+port-forward를 켜 둔다.
+
+```bash
+kubectl port-forward -n llm-d svc/quickstart-epp 8080:80
+```
+
+다른 터미널에서 공통 prefix와 요청 함수를 만든다. prefix를 길게 잡는 이유는 prefix-cache-scorer가 블록 단위로 해시하기 때문이다. 짧은 prompt는 블록이 하나뿐이라 차이가 안 난다.
+
+```bash
+PREFIX=$(yes "llm-d prefix cache routing handson document." | head -n 100 | tr '\n' ' ')
+
+ask() {
+  jq -nc --arg p "$2" --argjson m "$1" \
+    '{model:"Qwen/Qwen3-0.6B", prompt:$p, max_tokens:$m}' \
+  | curl -s http://localhost:8080/v1/completions \
+      -H 'Content-Type: application/json' -d @- > /dev/null
+}
+```
+
+어느 pod이 요청을 받았는지는 model server 로그로 센다. label로 로그를 모을 때 kubectl은 pod마다 마지막 10줄만 가져오므로 `--tail=-1`이 필요하다.
+
+```bash
+count_by_pod() {
+  kubectl logs -n llm-d -l app.kubernetes.io/name=vllm-sim \
+    --prefix --tail=-1 --since="$1" \
+    | grep '/v1/completions' \
+    | awk '{print $1}' | sort | uniq -c | sort -rn
+}
+```
+
+## 실험 1 - 같은 prefix는 같은 pod으로 간다
+
+같은 prefix에 꼬리만 바꾼 요청 10개를 순차로 보낸다.
+
+```bash
+for i in $(seq 1 10); do ask 10 "$PREFIX question $i"; done
+count_by_pod 60s
+```
+
+- 첫 요청은 아무 pod에나 간다. 그 pod이 prefix를 처리했다는 사실을 EPP가 기억한다.
+- 이후 요청은 대부분 그 pod으로 몰린다. prefix-cache-scorer의 weight가 3으로 가장 크기 때문이다.
+- 완전히 한 pod에만 가지는 않는다. queue-scorer와 kv-cache-utilization-scorer가 반대 방향으로 밀기 때문이다. 가중합이라 항상 한 요소가 이기지 않는다.
+
+## 실험 2 - prefix가 다르면 흩어진다
+
+매번 다른 prefix로 10개를 보낸다.
+
+```bash
+for i in $(seq 1 10); do
+  UNIQ=$(yes "unrelated topic $i padding sentence." | head -n 100 | tr '\n' ' ')
+  ask 10 "$UNIQ question"
+done
+count_by_pod 60s
+```
+
+- pod 4개에 고르게 퍼진다. prefix hit이 없으므로 no-hit-lru-scorer가 가장 오래 안 쓴 pod을 고른다.
+- 이 scorer가 없으면 hit이 없는 요청이 큐가 가장 짧은 pod 한 곳으로 쏠려 캐시가 한 pod에만 쌓인다.
+
+## 실험 3 - 큐가 차면 prefix affinity를 포기한다
+
+같은 prefix로 12개를 동시에 던진다. sim은 `--max-num-seqs 2`라 pod 하나가 동시에 2개만 처리한다.
+
+```bash
+for i in $(seq 1 12); do ask 200 "$PREFIX burst $i" & done
+wait
+count_by_pod 60s
+```
+
+- 실험 1과 달리 여러 pod으로 갈라진다. 캐시가 있는 pod의 큐가 길어지면서 queue-scorer 점수가 떨어졌기 때문이다.
+- 이것이 prefix cache aware 라우팅과 sticky 라우팅의 차이다. sticky는 큐 길이와 무관하게 같은 곳으로 계속 보내서 그 pod만 막힌다.
+
+## EPP가 남긴 판단 근거 보기
+
+router values에서 EPP 로그 레벨을 `v: 2`로 켜 뒀다. 요청마다 후보 pod과 선택 결과가 남는다.
+
+```bash
+kubectl logs -n llm-d deploy/quickstart-epp -c epp --since=2m | tail -40
+```
+
+EPP가 pod 상태를 어떻게 보고 있는지는 메트릭으로 확인한다.
+
+```bash
+kubectl port-forward -n llm-d svc/quickstart-epp 9090:9090
+curl -s http://localhost:9090/metrics | grep -i inference
+```
+
+- EPP는 각 pod의 `/metrics`를 주기적으로 긁어 큐 길이와 KV cache 사용률을 읽는다. sim이 vLLM의 메트릭 이름을 그대로 내보내기 때문에 sim 환경에서도 같은 경로로 동작한다.
+- 반대로 말하면 model server가 vLLM 메트릭을 안 내보내면 queue-scorer와 kv-cache-utilization-scorer는 판단 근거가 없다.
+
+## 정리하면서 남는 질문
+
+- 여기서 쓴 prefix-cache-scorer는 EPP가 자기가 보낸 요청 이력으로 추정한 근사값이다. vLLM이 실제로 캐시를 evict하면 EPP는 모른다. 정확히 맞추려면 vLLM의 KV cache 이벤트를 받아야 하고 그것이 precise prefix cache routing 가이드다.
+- scorer 가중치는 요청 길이 분포에 따라 달라진다. prompt가 짧고 생성이 긴 워크로드에서는 prefix affinity의 이득이 작아 weight를 낮추는 게 맞을 수 있다.
+- replica가 1개면 이 문서의 실험은 전부 무의미하다. llm-d는 replica가 여러 개일 때부터 의미가 생긴다.

--- a/kubernetes/llm-d/manifests/README.md
+++ b/kubernetes/llm-d/manifests/README.md
@@ -1,0 +1,26 @@
+# llm-d quickstart manifests
+
+llm-d quickstart 핸즈온에서 사용하는 파일이다. 사용 순서와 명령어는 [docs/](../docs/)에 있다.
+
+## 인덱스
+
+| 디렉터리/파일 | 설명 |
+|---|---|
+| `kind/kind-mac.yaml` | 맥 실습용 kind 클러스터 정의. control-plane 1개 + worker 2개 |
+| `kind/kind-gpu-node.yaml` | GPU 노드 실습용 kind 클러스터 정의. 단일 노드 |
+| `router/router.values.yaml` | llm-d-router-standalone helm chart values. EPP 플러그인 구성과 InferencePool selector |
+| `sim/vllm-sim-deployment.yaml` | llm-d-inference-sim model server 4 replica. GPU 없이 라우팅만 관찰할 때 사용 |
+| `gpu/vllm-deployment.yaml` | vLLM model server 2 replica. GPU 1장을 time-slicing으로 나눠 쓴다 |
+| `gpu/time-slicing-config.yaml` | NVIDIA device plugin의 time-slicing 설정. Kubernetes 리소스가 아니라 helm에 넘기는 설정 파일 |
+
+## 고정한 버전
+
+| 대상 | 버전 |
+|---|---|
+| llm-d guide | v0.8.1 |
+| llm-d-router-standalone chart, EPP 이미지 | v0.9.0 |
+| Gateway API Inference Extension CRD | v1.5.0 |
+| llm-d-inference-sim | v0.10.2 |
+| vLLM | v0.23.0 |
+| kind, kind node 이미지 | v0.32.0, v1.36.1 |
+| NVIDIA device plugin | v0.19.3 |

--- a/kubernetes/llm-d/manifests/gpu/time-slicing-config.yaml
+++ b/kubernetes/llm-d/manifests/gpu/time-slicing-config.yaml
@@ -1,0 +1,9 @@
+version: v1
+flags:
+  migStrategy: none
+sharing:
+  timeSlicing:
+    resources:
+      # GPU 1장을 nvidia.com/gpu 4개로 광고한다. 메모리는 나누지 않고 시간만 나눈다.
+      - name: nvidia.com/gpu
+        replicas: 4

--- a/kubernetes/llm-d/manifests/gpu/vllm-deployment.yaml
+++ b/kubernetes/llm-d/manifests/gpu/vllm-deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-decode
+  labels:
+    app.kubernetes.io/name: vllm-decode
+    llm-d.ai/inference-serving: "true"
+spec:
+  # GPU 1장을 time-slicing으로 4등분했으므로 replica 2개가 같은 GPU에 올라간다.
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm-decode
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vllm-decode
+        # InferencePool의 selector와 같은 label이다. sim 환경과 값을 맞춰 둔다.
+        llm-d.ai/inference-serving: "true"
+    spec:
+      containers:
+        - name: modelserver
+          image: vllm/vllm-openai:v0.23.0
+          imagePullPolicy: IfNotPresent
+          command: ["vllm", "serve"]
+          args:
+            - "Qwen/Qwen3-0.6B"
+            - "--port=8000"
+            - "--tensor-parallel-size=1"
+            - "--max-model-len=8192"
+            # time-slicing은 메모리를 나누지 않는다. 이 값을 안 낮추면 먼저 뜬 pod이 GPU 메모리를 다 잡는다.
+            - "--gpu-memory-utilization=0.35"
+            - "--disable-access-log-for-endpoints=/health,/metrics,/v1/models"
+          env:
+            # vLLM v0.20.0+ (torch 2.11)에서 HOME 계산이 실패하는 것을 우회한다.
+            - name: USER
+              value: llm-d
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "2"
+              memory: 8Gi
+              nvidia.com/gpu: 1
+            limits:
+              cpu: "4"
+              memory: 16Gi
+              nvidia.com/gpu: 1
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: shm
+            - mountPath: /.cache
+              name: cache
+            - mountPath: /.triton
+              name: triton-cache
+            - mountPath: /.config
+              name: vllm-config
+          # 모델 다운로드와 CUDA graph capture까지 최대 20분 기다린다.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 120
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: http
+            periodSeconds: 5
+      volumes:
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Gi
+        - name: cache
+          emptyDir: {}
+        - name: triton-cache
+          emptyDir: {}
+        - name: vllm-config
+          emptyDir: {}

--- a/kubernetes/llm-d/manifests/kind/kind-gpu-node.yaml
+++ b/kubernetes/llm-d/manifests/kind/kind-gpu-node.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: llm-d-gpu
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5

--- a/kubernetes/llm-d/manifests/kind/kind-mac.yaml
+++ b/kubernetes/llm-d/manifests/kind/kind-mac.yaml
@@ -1,0 +1,10 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: llm-d
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  - role: worker
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  - role: worker
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5

--- a/kubernetes/llm-d/manifests/router/router.values.yaml
+++ b/kubernetes/llm-d/manifests/router/router.values.yaml
@@ -1,0 +1,90 @@
+## llm-d-router-standalone chart v0.9.0 values
+## 노드 1개짜리 kind 클러스터 기준으로 upstream 기본값을 축소한 값이다.
+## upstream 원본: llm-d v0.8.1의 guides/recipes/router/base.values.yaml + guides/optimized-baseline/router/optimized-baseline.values.yaml
+
+router:
+  epp:
+    replicas: 1
+
+    # chart 기본값은 llm-d-router-endpoint-picker-dev:main + pullPolicy Always다.
+    # 재현 가능한 실습을 위해 release 이미지의 고정 tag를 쓴다.
+    image:
+      registry: ghcr.io/llm-d
+      repository: llm-d-router-endpoint-picker
+      tag: v0.9.0
+      pullPolicy: IfNotPresent
+
+    # v=2면 요청마다 선택한 endpoint와 scorer 점수가 로그에 남는다.
+    flags:
+      v: 2
+
+    pluginsConfigFile: "quickstart-plugins.yaml"
+    pluginsCustomConfig:
+      quickstart-plugins.yaml: |
+        apiVersion: llm-d.ai/v1alpha1
+        kind: EndpointPickerConfig
+        plugins:
+        - type: queue-scorer
+        - type: kv-cache-utilization-scorer
+        - type: prefix-cache-scorer
+        - type: no-hit-lru-scorer
+        schedulingProfiles:
+        - name: default
+          plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
+          - pluginRef: no-hit-lru-scorer
+            weight: 2
+
+    # upstream 기본값은 requests cpu 4 / memory 8Gi다. 노트북 kind에서는 pending으로 멈춘다.
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+
+  # EPP가 죽어도 proxy가 트래픽을 그대로 흘린다.
+  inferencePool:
+    failureMode: "FailOpen"
+
+  # InferencePool이 model server pod을 고르는 기준이다.
+  # sim과 GPU vLLM 모두 이 label을 달아 둬서 values 파일 하나로 두 환경을 쓴다.
+  modelServers:
+    protocol: http
+    targetPorts:
+      - number: 8000
+    matchLabels:
+      llm-d.ai/inference-serving: "true"
+
+  # 8081은 proxy의 listener 포트다. 80으로 노출해 port-forward를 단순하게 만든다.
+  extraServicePorts:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8081
+
+  proxy:
+    enabled: true
+    proxyType: envoy
+    mode: sidecar
+    args:
+      - "--service-node"
+      - "envoy-sidecar"
+      - "--log-level"
+      - "warn"
+      # 지정하지 않으면 Envoy가 호스트 코어 수만큼 worker thread를 만든다.
+      - "--concurrency"
+      - "2"
+      - "-c"
+      - "/etc/envoy/envoy.yaml"
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/llm-d/manifests/sim/vllm-sim-deployment.yaml
+++ b/kubernetes/llm-d/manifests/sim/vllm-sim-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-sim
+  labels:
+    app.kubernetes.io/name: vllm-sim
+    llm-d.ai/inference-serving: "true"
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vllm-sim
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vllm-sim
+        # InferencePool의 selector와 같은 label이다. 이게 없으면 EPP가 pod을 못 찾는다.
+        llm-d.ai/inference-serving: "true"
+    spec:
+      containers:
+        - name: vllm-sim
+          image: ghcr.io/llm-d/llm-d-inference-sim:v0.10.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--model"
+            - "Qwen/Qwen3-0.6B"
+            - "--port"
+            - "8000"
+            # 동시 처리 2개. 3번째 요청부터 대기 큐에 쌓여 queue-scorer 점수가 벌어진다.
+            - "--max-num-seqs"
+            - "2"
+            - "--max-model-len"
+            - "8192"
+            - "--mode"
+            - "random"
+            - "--latency-calculator"
+            - "constant"
+            - "--time-to-first-token"
+            - "500ms"
+            - "--inter-token-latency"
+            - "20ms"
+            # 동시 요청이 max-num-seqs에 가까워지면 응답 시간을 2배까지 늘린다.
+            - "--time-factor-under-load"
+            - "2.0"
+            # 어느 pod이 어떤 요청을 받았는지 로그로 확인하기 위해 켠다.
+            - "--log-http"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5


### PR DESCRIPTION
# 구현

kubernetes/llm-d에 llm-d quickstart 핸즈온 추가. 구성요소 문서 1개, 실습환경 문서 2개, 라우팅 관찰 문서 1개와 manifest 6개

- 버전은 llm-d v0.8.1 기준으로 전부 고정. router chart와 EPP v0.9.0, GAIE CRD v1.5.0, inference-sim v0.10.2, vLLM v0.23.0

# 어려웠던 점

upstream quickstart를 그대로 쓰면 두 실습환경 어디에서도 안 뜸

- 기본값이 Qwen3-32B 8 replica에 GPU 16장, EPP 혼자 CPU 4개와 메모리 8Gi 요구라 노트북과 GPU 1장 환경 양쪽에서 Pending

llm-d main과 v0.8.1의 EPP 플러그인 이름이 서로 다름

- main은 prefix-cache-affinity-filter 계열, v0.8.1은 prefix-cache-scorer 계열이라 chart 버전에 맞는 쪽으로 맞춤

# 리스크

GPU 환경은 time-slicing이라 pod 간 메모리 격리가 없음

- gpu-memory-utilization 0.35 고정이라 더 큰 모델로 바꾸면 두 번째 replica가 CUDA OOM으로 죽음. 모델을 바꿀 때 이 값을 같이 조정해야 함

Issue #701


---
_Generated by [Claude Code](https://claude.ai/code/session_01MvXZz28DFAYL9x1GcbQ8rH)_