### PR TITLE
akbun-gitdesktop 자동 업데이트 추가와 stack 규칙 승격

### DIFF
--- a/.claude/rules/electron.md
+++ b/.claude/rules/electron.md
@@ -4,6 +4,31 @@
 
 데스크톱 앱의 기본은 [tauri.md](./tauri.md)다. Electron은 macOS나 Linux 빌드가 지금 필요할 때, 트레이·메뉴바가 앱의 주 화면일 때, Rust 대체재가 없는 node 라이브러리에 의존할 때, 그리고 이미 Electron으로 되어 있는 제품을 고칠 때 고른다. 아래 테마 규칙의 CSS 부분은 Tauri에도 그대로 적용된다.
 
+## 자동 업데이트는 기본 기능이다
+
+`product/`의 Electron 앱은 자동 업데이트를 처음부터 넣는다. 새로 만들 때도, 업데이트가 없는 기존 앱을 고칠 때도 마찬가지다. 매번 다시 판단하지 않고 [akbun-k8supgradeview](../../product/akbun-k8supgradeview/workspace/src/main/update.ts)의 구현을 포팅한다. 배경은 [knowledge/decisions/2026-07-unsigned-desktop-app-self-update.md](../../knowledge/decisions/2026-07-unsigned-desktop-app-self-update.md)에 있다.
+
+업데이트가 없으면 릴리스가 사용자에게 도달하지 않는다. 설치본을 손으로 다시 받는 사람은 없다. [product.md](./product.md)의 버전 규칙이 릴리스를 만드는 쪽이고, 이 규칙은 그 릴리스가 실제로 설치되는 쪽이다. 둘 중 하나가 빠지면 고친 코드는 master에만 남는다.
+
+포팅할 때 다음 여섯 가지를 그대로 유지한다.
+
+- GitHub Release API에서 `<제품명>-v` 접두사 tag를 찾고 `process.arch`에 맞는 dmg를 고른다. electron-builder는 arm64에만 접미사를 붙인다.
+- 버전은 문자열이 아니라 숫자로 비교하고, 기준은 `app.getVersion()`이다.
+- dmg를 임시 디렉터리로 스트리밍한 뒤 분리된 bash 스크립트를 띄우고 앱을 종료한다. 실행 중인 앱은 자기 자신을 덮어쓸 수 없다.
+- 임시 디렉터리 정리 지점 세 곳(내려받기 실패, 스크립트의 trap, 앱 시작 시 청소)을 모두 남긴다. 하나라도 사라지면 실패하는 테스트를 구현과 함께 포팅한다.
+- 설치 제안은 packaged 빌드의 macOS에서만 한다. 개발 모드는 교체 대상이 Electron.app이고, Windows와 Linux 빌드에는 받을 dmg가 없다. 두 경우는 릴리스 페이지를 여는 버튼만 보여 준다.
+- 진입점은 앱 메뉴나 트레이 컨텍스트 메뉴의 "Check for Updates…"다.
+
+Windows는 이 방식이 필요 없다. electron-updater가 `verifyUpdateCodeSignature`를 `false`로 두면 서명 없는 NSIS 빌드를 설치한다. macOS의 이유를 Windows로 옮기지 않는다.
+
+업데이트 모듈은 electron을 import하지 않는다. 그래야 앱 바이너리 없이 테스트가 돌고, PR의 verify job이 ubuntu에서 `ELECTRON_SKIP_BINARY_DOWNLOAD`로 끝난다. electron이 필요한 부분(`app.getVersion()`, `app.quit()`, dialog)은 호출하는 쪽인 main에 둔다.
+
+TypeScript 앱이면 빌드 산출물 대신 원본을 테스트한다. node가 타입만 벗겨 내고 `.ts`를 그대로 읽으므로 테스트 전에 빌드할 필요가 없다.
+
+```js
+const { cleanupTempDirs, SWAP_SCRIPT } = await import('../src/main/update.ts')
+```
+
 ## 테마
 
 dark mode와 light mode를 모두 지원하고, 기본값은 시스템 설정을 따른다.

--- a/.claude/rules/tauri.md
+++ b/.claude/rules/tauri.md
@@ -141,7 +141,11 @@ if let Some(window) = app.get_webview_window("main") {
 
 ## Updates
 
-Use the official updater plugin. Do not hand-roll one.
+**Self update is a default feature, not an optional one.** Every app under `product/` ships it from the first release, and an existing app that lacks it gets it the next time it is touched. A release nobody can install is a release that did not happen — nobody re-downloads an installer by hand. The version rule in [product.md](./product.md) is the half that produces the release; this is the half that delivers it.
+
+Use the official updater plugin. Do not hand-roll one. The dmg-swap implementation in [electron.md](./electron.md) exists only because Squirrel.Mac refuses unsigned builds; the plugin has no such limit, so do not port that code here.
+
+Reach the check from a menu item or a settings entry labelled "Check for Updates…", the same entry point as the Electron apps.
 
 - Set `bundle.createUpdaterArtifacts` to `true`. It defaults to `false`, and leaving it produces no `.sig` file, after which tauri-action **silently** skips uploading latest.json. The release looks fine and nobody can update.
 - `createUpdaterArtifacts: true` without a `plugins.updater` block is a hard CLI error. The two go together.

--- a/.github/workflows/gitdesktop-release.yml
+++ b/.github/workflows/gitdesktop-release.yml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - 'product/akbun-gitdesktop/**'
+  pull_request:
+    paths:
+      - 'product/akbun-gitdesktop/**'
 
 permissions:
   contents: write
@@ -15,7 +18,35 @@ defaults:
     working-directory: product/akbun-gitdesktop
 
 jobs:
+  # PR 검증용. electron 바이너리 없이 typecheck와 테스트만 돌린다.
+  # 업데이트 기능이 임시 파일을 남기지 않는지 확인하는 테스트가 여기서 돈다.
+  verify:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: product/akbun-gitdesktop/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
   release:
+    if: github.event_name != 'pull_request'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7

--- a/knowledge/decisions/2026-07-unsigned-desktop-app-self-update.md
+++ b/knowledge/decisions/2026-07-unsigned-desktop-app-self-update.md
@@ -17,6 +17,8 @@ product의 데스크톱 앱은 자동 업데이트를 electron-updater가 아니
 
 이 절차를 [.claude/commands/repo-product-create.md](../../.claude/commands/repo-product-create.md)의 Self update 항목으로 옮겨, 새 제품을 만들 때 매번 다시 판단하지 않게 했다.
 
+2026-08-04에 자리를 한 번 더 옮겼다. 자동 업데이트는 제품 생성 명령이 아니라 stack 규칙([.claude/rules/electron.md](../../.claude/rules/electron.md), [.claude/rules/tauri.md](../../.claude/rules/tauri.md))의 기본 요구사항이다. 생성 명령은 새 제품을 만들 때만 읽히므로, 이미 있는 앱에 업데이트가 빠져 있으면 아무도 그 사실을 만나지 않는다. akbun-gitdesktop이 릴리스를 두 번 냈는데 업데이트 경로가 없었던 것이 그 결과다.
+
 ## 이유
 
 유료 개발자 계정이 없어 빌드에 서명이 없다. electron-updater가 macOS에서 쓰는 Squirrel.Mac은 서명이 없는 업데이트의 설치를 거부하므로 기본 경로 자체가 막혀 있다.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,6 +3,7 @@
 ## 2026-08-04
 
 * **Creation**: [영상 편집 도구의 시간은 프레임 수와 두 정수 rate로 표현한다](decisions/2026-08-rational-time-model.md) 결정 기록. akbun-makevideo에 29.97과 23.976을 넣으려다 frame rate가 u32라 표현할 방법 자체가 없다는 것을 알게 되면서, 밀리초 왕복이 정확할 것이라 기대했다가 반 프레임 양자화를 다시 배운 것까지 함께 남긴다.
+* **Update**: [서명 없는 데스크톱 앱의 자동 업데이트는 dmg를 받아 번들을 교체한다](decisions/2026-07-unsigned-desktop-app-self-update.md)에 규칙의 자리를 옮긴 이유를 추가했다. akbun-gitdesktop에 업데이트를 넣으면서, 제품 생성 명령에만 있던 요구사항이 이미 있는 앱에는 한 번도 닿지 않는다는 것을 알게 되어 stack 규칙으로 올린다.
 
 ## 2026-08-03
 

--- a/product/akbun-gitdesktop/README.md
+++ b/product/akbun-gitdesktop/README.md
@@ -30,6 +30,7 @@ UI 언어는 영어다.
 - worktree를 외부 앱으로 열기
 - dark/light 테마 전환, 기본값은 시스템 설정을 따르는 system
 - Settings에서 git, gh CLI의 인식 여부와 버전, 경로, gh 로그인 상태 확인과 재검사
+- 앱 메뉴의 Check for Updates…로 새 버전 확인과 설치
 
 ## 테마
 
@@ -97,6 +98,12 @@ npm run dev
 npm run typecheck
 ```
 
+테스트. 업데이트 기능이 임시 파일을 남기지 않는지 확인한다. node가 TypeScript의 타입을 벗겨 내고 `src/main/update.ts`를 그대로 읽으므로 빌드 없이 돈다:
+
+```bash
+npm test
+```
+
 플랫폼별 설치 파일 빌드:
 
 ```bash
@@ -105,6 +112,22 @@ npm run dist:win
 npm run dist:linux
 ```
 
+## 업데이트
+
+앱 메뉴 akbun-gitdesktop > Check for Updates…가 GitHub Release API에서 gitdesktop-v 태그의 최신 버전을 찾아 현재 버전과 비교한다. 새 버전이 있으면 dmg를 임시 디렉터리에 받아 교체 스크립트를 분리 프로세스로 띄우고 앱을 종료하며, 스크립트가 .app 번들을 통째로 바꾸고 다시 실행한다.
+
+dmg에 서명이 없어 Squirrel.Mac 기반 자동 업데이트(electron-updater)를 쓸 수 없다. 앱이 fetch로 받은 파일에는 quarantine 속성이 붙지 않아 Gatekeeper를 거치지 않고 교체할 수 있다는 점을 이용한다. 배경은 [knowledge/decisions/2026-07-unsigned-desktop-app-self-update.md](../../knowledge/decisions/2026-07-unsigned-desktop-app-self-update.md)에 있다.
+
+교체는 macOS 패키지 빌드에서만 동작한다. 개발 모드(`npm run dev`)에서는 교체 대상이 Electron.app이고, Windows와 Linux 빌드에는 받을 dmg가 없다. 두 경우 모두 릴리즈 페이지를 여는 버튼만 보여 준다.
+
+용량이 큰 dmg를 다루므로 정리 지점을 세 곳에 둔다. 세 지점은 `test/update-disk-leak.test.js`가 검증하고 PR의 verify job에서 돈다.
+
+1. `downloadDmg`가 내려받기에 실패하면 만든 임시 디렉터리를 지운다.
+2. 교체 스크립트의 trap이 어느 단계에서 실패해도 작업 디렉터리와 mount를 지운다.
+3. 앱 시작 때 `cleanupTempDirs`가 강제 종료로 남은 임시 디렉터리를 지운다.
+
 ## 릴리즈
+
+PR에서는 같은 workflow의 verify job이 ubuntu에서 typecheck와 테스트만 돌린다. `ELECTRON_SKIP_BINARY_DOWNLOAD`로 electron 바이너리를 받지 않으므로 앱 없이 끝난다.
 
 master에 이 디렉터리 변경이 병합되면 GitHub Actions(gitdesktop-release.yml)가 릴리즈를 만든다. 버전은 기존 gitdesktop-v 태그 중 가장 높은 값의 patch를 +1 해서 정하므로, 매 실행마다 새 버전이 나오고 기존 릴리즈를 덮어쓰지 않는다. package.json의 version이 그보다 높으면 그 값을 쓰므로 major, minor는 package.json을 직접 올려서 바꾼다. 태그가 이미 있으면 workflow는 실패한다.

--- a/product/akbun-gitdesktop/package-lock.json
+++ b/product/akbun-gitdesktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-gitdesktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-gitdesktop",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.8",

--- a/product/akbun-gitdesktop/package.json
+++ b/product/akbun-gitdesktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-gitdesktop",
   "productName": "akbun-gitdesktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Git graph desktop viewer for local repositories and worktrees",
   "main": "out/main/index.js",
   "author": "akbun",
@@ -11,6 +11,7 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
+    "test": "node --test \"test/*.test.js\"",
     "start": "electron-vite preview",
     "dist": "electron-vite build && electron-builder --publish never",
     "dist:mac": "electron-vite build && electron-builder --mac --publish never",

--- a/product/akbun-gitdesktop/src/main/index.ts
+++ b/product/akbun-gitdesktop/src/main/index.ts
@@ -1,4 +1,6 @@
-import { app, BrowserWindow, dialog, ipcMain, nativeTheme, shell } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeTheme, shell } from 'electron'
+import type { MenuItemConstructorOptions } from 'electron'
+import { promises as fsp } from 'node:fs'
 import path from 'node:path'
 import type { GitResult, ThemePreference } from '../shared/types'
 import * as git from './git'
@@ -6,6 +8,7 @@ import * as github from './github'
 import { openInApp, listOpenerApps } from './openWith'
 import { addRepo, loadRepos, removeRepo } from './repoStore'
 import { loadSettings, saveTheme } from './settingsStore'
+import { checkUpdate, cleanupTempDirs, downloadDmg, spawnSwap } from './update'
 
 function createWindow(): void {
   const window = new BrowserWindow({
@@ -132,10 +135,129 @@ function registerIpcHandlers(): void {
   )
 }
 
+/** 실행 중인 .app 번들 경로. exe는 <앱>.app/Contents/MacOS/<실행파일>이다. */
+function appBundlePath(): string {
+  return path.resolve(app.getPath('exe'), '../../..')
+}
+
+/** 내려받기와 교체가 진행되는 동안 메뉴를 다시 눌러도 겹쳐 돌지 않게 막는다. */
+let updating = false
+
+/**
+ * dmg를 받아 교체 스크립트를 띄우고 앱을 끈다. 재실행은 스크립트가 한다.
+ * 스크립트를 띄우기 전에 실패하면 받아 둔 dmg를 지운다. 스크립트가 뜬 뒤에는
+ * 스크립트의 trap이 정리를 맡는다.
+ */
+async function installUpdate(dmgUrl: string): Promise<void> {
+  updating = true
+  let dmgPath: string | null = null
+  try {
+    dmgPath = await downloadDmg(dmgUrl)
+    await spawnSwap(appBundlePath(), dmgPath)
+    app.quit()
+  } catch (error) {
+    if (dmgPath) await fsp.rm(path.dirname(dmgPath), { recursive: true, force: true })
+    updating = false
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Failed to install the update',
+      detail: String(error)
+    })
+  }
+}
+
+/** 메뉴에서 업데이트 확인을 눌렀을 때의 흐름. GitHub Release의 최신 버전과 비교한다. */
+async function runUpdateCheck(): Promise<void> {
+  if (updating) return
+  try {
+    const result = await checkUpdate(app.getVersion())
+    if (!result.hasUpdate) {
+      await dialog.showMessageBox({
+        type: 'info',
+        message: 'You are on the latest version',
+        detail: `Current version ${result.current}`
+      })
+      return
+    }
+
+    // 개발 모드(npm run dev)에서는 교체 대상이 Electron.app이라 설치를 막는다.
+    // macOS 외의 빌드는 dmg 교체를 쓸 수 없으므로 릴리스 페이지만 연다.
+    const canInstall = app.isPackaged && process.platform === 'darwin' && result.dmgUrl !== null
+    const buttons = canInstall
+      ? ['Update now', 'Open release', 'Close']
+      : ['Open release', 'Close']
+    const detail = canInstall
+      ? `Current version ${result.current}. "Update now" downloads the dmg, replaces the app and restarts it.`
+      : `Current version ${result.current}. Download the installer from the release page.`
+
+    const answer = await dialog.showMessageBox({
+      type: 'info',
+      message: `Version ${result.latest} is available`,
+      detail,
+      buttons,
+      defaultId: 0,
+      cancelId: buttons.length - 1
+    })
+
+    if (canInstall && answer.response === 0) {
+      await installUpdate(result.dmgUrl!)
+      return
+    }
+    const openIndex = canInstall ? 1 : 0
+    if (answer.response === openIndex && result.url) await shell.openExternal(result.url)
+  } catch (error) {
+    await dialog.showMessageBox({
+      type: 'error',
+      message: 'Could not check for updates',
+      detail: String(error)
+    })
+  }
+}
+
+/**
+ * 업데이트 확인의 자리를 만들기 위한 메뉴다. macOS는 앱 이름 메뉴에 두고,
+ * 그 메뉴가 없는 Windows와 Linux는 Help 메뉴에 둔다.
+ * about과 hide는 macOS 전용 role이라 다른 플랫폼의 template에는 넣지 않는다.
+ */
+function buildMenu(): void {
+  const checkForUpdates: MenuItemConstructorOptions = {
+    label: 'Check for Updates…',
+    click: () => void runUpdateCheck()
+  }
+  const isMac = process.platform === 'darwin'
+  const template: MenuItemConstructorOptions[] = isMac
+    ? [
+        {
+          label: app.name,
+          submenu: [
+            { role: 'about' },
+            checkForUpdates,
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'quit' }
+          ]
+        },
+        { role: 'editMenu' },
+        { role: 'viewMenu' },
+        { role: 'windowMenu' }
+      ]
+    : [
+        { label: 'File', submenu: [{ role: 'quit' }] },
+        { role: 'editMenu' },
+        { role: 'viewMenu' },
+        { role: 'windowMenu' },
+        { label: 'Help', submenu: [checkForUpdates] }
+      ]
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template))
+}
+
 app.whenReady().then(async () => {
+  // 강제 종료로 남은 업데이트 임시 디렉터리를 지운다. 실패해도 앱 동작에는 지장 없다.
+  void cleanupTempDirs().catch(() => {})
   const settings = await loadSettings()
   nativeTheme.themeSource = settings.theme
   registerIpcHandlers()
+  buildMenu()
   createWindow()
 
   app.on('activate', () => {

--- a/product/akbun-gitdesktop/src/main/update.ts
+++ b/product/akbun-gitdesktop/src/main/update.ts
@@ -1,0 +1,184 @@
+/**
+ * GitHub Release로 배포한 최신 버전을 확인하고, 원하면 dmg를 받아 앱을 교체한다.
+ * 이 저장소의 release가 바이너리 저장소이고, tag는 gitdesktop-v{버전} 형식이다.
+ *
+ * 서명이 없어 Squirrel.Mac 자동 업데이트는 쓸 수 없다. 대신 dmg를 직접 받아
+ * .app 번들을 통째로 바꾼다. 앱이 fetch로 받은 파일에는 quarantine 속성이 붙지 않아
+ * Gatekeeper 검사를 거치지 않는다는 점을 이용한다.
+ * akbun-k8supgradeview의 업데이트 구현과 같은 구조다.
+ *
+ * 디스크 누수 방지가 핵심이다. 정리 지점은 세 곳이다.
+ * 1. downloadDmg: 내려받기 실패 시 만든 임시 디렉터리를 지운다.
+ * 2. 교체 스크립트의 trap: 교체가 어느 단계에서 실패해도 작업 디렉터리와 mount를 지운다.
+ * 3. cleanupTempDirs: 강제 종료로 남은 임시 디렉터리를 앱 시작 때 지운다.
+ *
+ * electron을 import하지 않는다. 그래야 node --test가 앱 바이너리 없이 이 파일을 읽는다.
+ */
+
+import { spawn } from 'node:child_process'
+import { createWriteStream } from 'node:fs'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { Readable } from 'node:stream'
+import { pipeline } from 'node:stream/promises'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+
+const RELEASES_API = 'https://api.github.com/repos/choisungwook/portfolio/releases'
+const TAG_PREFIX = 'gitdesktop-v'
+
+export interface UpdateCheck {
+  current: string
+  latest: string | null
+  url: string | null
+  /** 현재 아키텍처에 맞는 dmg 내려받기 주소. 없으면 null. */
+  dmgUrl: string | null
+  hasUpdate: boolean
+}
+
+/** "0.2.0" 형식 두 개를 비교한다. a가 크면 양수. */
+function compareVersion(a: string, b: string): number {
+  const left = a.split('.').map(Number)
+  const right = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if ((left[i] ?? 0) !== (right[i] ?? 0)) return (left[i] ?? 0) - (right[i] ?? 0)
+  }
+  return 0
+}
+
+/**
+ * 현재 아키텍처에 맞는 dmg를 고른다.
+ * electron-builder는 arm64에만 -arm64 접미사를 붙이고 x64는 접미사가 없다.
+ */
+function pickDmg(assets: { name: string; browser_download_url: string }[]): string | null {
+  const dmgs = assets.filter((asset) => asset.name.endsWith('.dmg'))
+  const wantArm = process.arch === 'arm64'
+  const match = dmgs.find((asset) => asset.name.includes('-arm64.') === wantArm)
+  return match?.browser_download_url ?? null
+}
+
+export async function checkUpdate(currentVersion: string): Promise<UpdateCheck> {
+  const response = await fetch(RELEASES_API, {
+    headers: { Accept: 'application/vnd.github+json' }
+  })
+  if (!response.ok) throw new Error(`GitHub API responded with ${response.status}`)
+
+  const releases = (await response.json()) as {
+    tag_name: string
+    html_url: string
+    assets: { name: string; browser_download_url: string }[]
+  }[]
+  const release = releases.find((entry) => entry.tag_name.startsWith(TAG_PREFIX))
+  if (!release) {
+    return { current: currentVersion, latest: null, url: null, dmgUrl: null, hasUpdate: false }
+  }
+
+  const latest = release.tag_name.slice(TAG_PREFIX.length)
+  return {
+    current: currentVersion,
+    latest,
+    url: release.html_url,
+    dmgUrl: pickDmg(release.assets),
+    hasUpdate: compareVersion(latest, currentVersion) > 0
+  }
+}
+
+/** 내려받기용 임시 디렉터리 접두사. 남은 디렉터리를 찾아 지울 때도 쓴다. */
+const TEMP_PREFIX = 'akbun-gitdesktop-update-'
+
+/**
+ * dmg를 임시 디렉터리로 받아 저장한 경로를 돌려준다.
+ * 받다가 실패하면 만든 디렉터리를 지운다. 용량이 큰 파일이므로
+ * 메모리에 통째로 올리지 않고 스트림으로 흘려 쓴다.
+ */
+export async function downloadDmg(dmgUrl: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), TEMP_PREFIX))
+  try {
+    const response = await fetch(dmgUrl)
+    if (!response.ok) throw new Error(`dmg download failed with ${response.status}`)
+    if (!response.body) throw new Error('dmg response body is empty')
+    const dmgPath = path.join(dir, path.basename(new URL(dmgUrl).pathname))
+    // fetch가 주는 DOM ReadableStream과 node:stream/web의 것은 이름만 같고 타입이 겹치지 않는다.
+    const body = response.body as unknown as NodeReadableStream
+    await pipeline(Readable.fromWeb(body), createWriteStream(dmgPath))
+    return dmgPath
+  } catch (error) {
+    await fs.rm(dir, { recursive: true, force: true })
+    throw error
+  }
+}
+
+/**
+ * 이전 시도가 중간에 끊겨 남은 임시 디렉터리를 지운다.
+ * 교체 스크립트가 자기 작업 디렉터리를 지우지만, 앱이나 스크립트가 강제 종료되면
+ * dmg가 그대로 남는다. 앱 시작 때 한 번 훑어 디스크에 쌓이지 않게 한다.
+ */
+export async function cleanupTempDirs(): Promise<void> {
+  const tmpDir = os.tmpdir()
+  const names = await fs.readdir(tmpDir)
+  await Promise.all(
+    names
+      .filter((name) => name.startsWith(TEMP_PREFIX))
+      .map((name) => fs.rm(path.join(tmpDir, name), { recursive: true, force: true }))
+  )
+}
+
+/**
+ * 앱이 종료되기를 기다렸다가 .app 번들을 교체하고 다시 실행하는 스크립트다.
+ * 실행 중인 자기 자신을 덮어쓸 수 없으므로 앱 밖에서 돌려야 한다.
+ * 교체에 실패하면 옮겨 둔 이전 번들을 되돌린다.
+ *
+ * mount 지점과 dmg를 담은 작업 디렉터리는 trap으로 지운다. 중간에 어느 단계가
+ * 실패해도 마운트가 남거나 dmg가 /tmp에 쌓이지 않게 하기 위함이다.
+ */
+export const SWAP_SCRIPT = `#!/bin/bash
+set -u
+APP="$1"; DMG="$2"; PID="$3"
+WORK=$(dirname "$DMG")
+MOUNT=""
+
+cleanup() {
+  if [ -n "$MOUNT" ]; then
+    hdiutil detach "$MOUNT" -quiet 2>/dev/null || hdiutil detach "$MOUNT" -force -quiet 2>/dev/null
+    rmdir "$MOUNT" 2>/dev/null
+  fi
+  # 실행 중인 이 스크립트도 WORK 안에 있다. 이미 열린 파일이라 지워도 계속 돈다.
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+while kill -0 "$PID" 2>/dev/null; do sleep 0.3; done
+
+MOUNT=$(mktemp -d) || exit 1
+hdiutil attach "$DMG" -nobrowse -quiet -mountpoint "$MOUNT" || exit 1
+NEW=$(find "$MOUNT" -maxdepth 1 -name '*.app' | head -1)
+[ -n "$NEW" ] || exit 1
+
+rm -rf "$APP.old"
+mv "$APP" "$APP.old" || exit 1
+if ditto "$NEW" "$APP"; then
+  rm -rf "$APP.old"
+else
+  rm -rf "$APP"
+  mv "$APP.old" "$APP"
+  exit 1
+fi
+
+# 앱이 직접 받은 파일이라 quarantine이 붙지 않지만, dmg에 남아 있던 속성을 확실히 지운다.
+xattr -cr "$APP"
+open "$APP"
+`
+
+/**
+ * 교체 스크립트를 앱과 분리된 프로세스로 띄운다.
+ * 호출한 쪽은 곧바로 app.quit()을 해야 스크립트가 교체를 시작한다.
+ */
+export async function spawnSwap(appPath: string, dmgPath: string): Promise<void> {
+  const scriptPath = path.join(path.dirname(dmgPath), 'swap.sh')
+  await fs.writeFile(scriptPath, SWAP_SCRIPT, { mode: 0o755 })
+  const child = spawn('/bin/bash', [scriptPath, appPath, dmgPath, String(process.pid)], {
+    detached: true,
+    stdio: 'ignore'
+  })
+  child.unref()
+}

--- a/product/akbun-gitdesktop/test/update-disk-leak.test.js
+++ b/product/akbun-gitdesktop/test/update-disk-leak.test.js
@@ -1,0 +1,107 @@
+/**
+ * 업데이트 기능이 임시 파일을 남기지 않는지 검증한다.
+ *
+ * 업데이트는 용량이 큰 dmg를 임시 디렉터리에 받는다. 정리가 한 군데라도
+ * 빠지면 실패할 때마다 디스크가 찬다. 정리 지점이 세 곳(교체 스크립트의 trap,
+ * 스크립트 실행 전 실패, 다음 실행 때 남은 디렉터리 청소)이라 손으로 확인하기
+ * 어려우므로, 업데이트 관련 코드를 고치면 이 테스트로 확인한다.
+ *
+ * 실행: npm test
+ *
+ * src/main/update.ts를 그대로 읽는다. node가 타입만 벗겨 내고 실행하므로
+ * 빌드 산출물이 필요 없다. update.ts가 electron을 import하지 않는 이유다.
+ *
+ * 교체 스크립트 테스트는 hdiutil이 없는 환경에서도 돈다. attach 단계에서
+ * 실패하는 것이 바로 검증 대상인 실패 경로이기 때문이다.
+ */
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const UPDATE_SOURCE = path.join(__dirname, '../src/main/update.ts')
+const MAIN_SOURCE = path.join(__dirname, '../src/main/index.ts')
+const TEMP_PREFIX = 'akbun-gitdesktop-update-'
+
+/** os.tmpdir()에 남아 있는 업데이트 임시 디렉터리 수. */
+function countTempDirs() {
+  return fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith(TEMP_PREFIX)).length
+}
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), TEMP_PREFIX))
+}
+
+function loadUpdateModule() {
+  return import('../src/main/update.ts')
+}
+
+test('cleanupTempDirs는 남은 업데이트 임시 디렉터리만 지운다', async () => {
+  const { cleanupTempDirs } = await loadUpdateModule()
+  const stale = makeTempDir()
+  fs.writeFileSync(path.join(stale, 'leftover.dmg'), 'x'.repeat(1024))
+  const unrelated = fs.mkdtempSync(path.join(os.tmpdir(), 'unrelated-'))
+
+  try {
+    assert.ok(countTempDirs() > 0, '테스트가 만든 디렉터리가 보여야 한다')
+    await cleanupTempDirs()
+
+    assert.strictEqual(countTempDirs(), 0, '업데이트 임시 디렉터리가 남았다')
+    assert.ok(fs.existsSync(unrelated), '무관한 디렉터리를 지우면 안 된다')
+  } finally {
+    fs.rmSync(unrelated, { recursive: true, force: true })
+  }
+})
+
+test('downloadDmg는 내려받기에 실패하면 만든 디렉터리를 지운다', async () => {
+  const { cleanupTempDirs, downloadDmg } = await loadUpdateModule()
+  await cleanupTempDirs()
+
+  // 연결이 거부되는 주소라 네트워크 없이도 즉시 실패한다.
+  await assert.rejects(() => downloadDmg('http://127.0.0.1:1/akbun-gitdesktop.dmg'))
+
+  assert.strictEqual(countTempDirs(), 0, '실패한 내려받기의 디렉터리가 남았다')
+})
+
+test('교체 스크립트는 실패해도 작업 디렉터리를 남기지 않는다', async () => {
+  const { SWAP_SCRIPT } = await loadUpdateModule()
+  const work = makeTempDir()
+  const scriptPath = path.join(work, 'swap.sh')
+  const dmgPath = path.join(work, 'fake.dmg')
+  fs.writeFileSync(scriptPath, SWAP_SCRIPT, { mode: 0o755 })
+  fs.writeFileSync(dmgPath, 'dmg 형식이 아니라 attach가 실패한다')
+
+  // 이미 끝난 프로세스의 pid를 주어 종료 대기 루프를 즉시 빠져나가게 한다.
+  const deadPid = spawnSync('/usr/bin/true').pid
+  const appPath = path.join(work, 'nonexistent.app')
+
+  const result = spawnSync('/bin/bash', [scriptPath, appPath, dmgPath, String(deadPid)], {
+    stdio: 'ignore',
+    timeout: 30_000
+  })
+
+  assert.notStrictEqual(result.status, 0, '잘못된 dmg인데 성공으로 끝났다')
+  assert.ok(!fs.existsSync(work), '실패한 교체의 작업 디렉터리가 남았다')
+})
+
+test('정리 지점이 세 곳 모두 코드에 남아 있다', async () => {
+  const { SWAP_SCRIPT } = await loadUpdateModule()
+  const source = fs.readFileSync(UPDATE_SOURCE, 'utf-8')
+  const mainSource = fs.readFileSync(MAIN_SOURCE, 'utf-8')
+
+  assert.match(SWAP_SCRIPT, /trap cleanup EXIT/, '교체 스크립트의 trap이 사라졌다')
+  assert.match(source, /cleanupTempDirs/, '남은 디렉터리 청소 함수가 사라졌다')
+  assert.match(mainSource, /cleanupTempDirs/, '앱 시작 때 청소를 부르지 않는다')
+  assert.match(mainSource, /fsp\.rm\(/, '설치 실패 시 dmg를 지우지 않는다')
+})
+
+test('tag 접두사와 임시 디렉터리 접두사가 이 제품의 것이다', () => {
+  const source = fs.readFileSync(UPDATE_SOURCE, 'utf-8')
+
+  // release workflow가 만드는 tag 형식과 어긋나면 업데이트가 영원히 안 뜬다.
+  assert.match(source, /TAG_PREFIX = 'gitdesktop-v'/, 'tag 접두사가 릴리스와 어긋난다')
+  assert.match(source, new RegExp(`TEMP_PREFIX = '${TEMP_PREFIX}'`), '임시 디렉터리 접두사가 바뀌었다')
+})


### PR DESCRIPTION
# 구현

akbun-k8supgradeview의 dmg 교체 업데이트를 포팅하고, electron과 tauri 규칙에 자동 업데이트를 기본 요구사항으로 명시

- typecheck, 테스트 5개, 빌드 통과. PR용 verify job이 ubuntu에서 같은 검증을 돌림

# 어려웠던 점

원본 테스트는 dist의 update.js를 읽지만 electron-vite는 main을 단일 번들로 묶어 모듈 하나만 따로 읽을 수 없음

- node의 타입 스트리핑으로 src/main/update.ts를 그대로 import해 빌드 없이 검증

# 리스크

앱에 커스텀 메뉴가 없어 메뉴를 새로 만들었고, 그만큼 기본 메뉴에 있던 항목이 template에 적은 것으로 한정됨

- editMenu, viewMenu, windowMenu role로 덮었으나 누락이 있으면 사용자가 단축키를 잃는 형태로 드러남

Issue #703

