### PR TITLE
fix: restore akbun-makevideo UI and add error logs

### DIFF
--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.6.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.6.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -63,6 +63,12 @@ pub struct Settings {
     /// same code and make the preview and the render agree; the third is
     /// faster because frames never leave ffmpeg.
     pub compositor: String,
+    /// Empty uses the operating system's application log directory.
+    pub log_dir: String,
+    /// Maximum size of errors.log before it becomes errors.log.1.
+    pub log_rotation_size: u64,
+    /// "kb" or "mb".
+    pub log_rotation_unit: String,
 }
 
 impl Default for Settings {
@@ -79,6 +85,9 @@ impl Default for Settings {
             ffmpeg_dir: String::new(),
             render_acceleration: "auto".into(),
             compositor: "auto".into(),
+            log_dir: String::new(),
+            log_rotation_size: 5,
+            log_rotation_unit: "mb".into(),
         }
     }
 }
@@ -142,6 +151,7 @@ pub struct Bootstrap {
     pub settings: Settings,
     pub version: String,
     pub data_dir: String,
+    pub log_dir: String,
     /// The workspace root as actually resolved, so the page can show it whether
     /// or not the user has set one.
     pub workspace: String,
@@ -419,6 +429,9 @@ pub fn bootstrap(app: AppHandle, state: State<AppState>) -> Bootstrap {
     Bootstrap {
         version: app.package_info().version.to_string(),
         data_dir: crate::store::data_dir(&app),
+        log_dir: crate::store::log_dir(&app, &settings)
+            .to_string_lossy()
+            .to_string(),
         workspace: workspace_root(&app, &settings)
             .to_string_lossy()
             .to_string(),
@@ -492,6 +505,7 @@ pub fn save_settings(
     state: State<AppState>,
     settings: Settings,
 ) -> Result<Bootstrap, String> {
+    crate::store::prepare_log_dir(&app, &settings)?;
     apply_theme(&app, &settings.theme);
     crate::store::save_settings(&app, &settings)?;
     {
@@ -504,6 +518,17 @@ pub fn save_settings(
         *current = settings;
     }
     Ok(bootstrap(app, state))
+}
+
+#[tauri::command]
+pub fn report_error(
+    app: AppHandle,
+    state: State<AppState>,
+    source: String,
+    message: String,
+) -> Result<(), String> {
+    let settings = state.settings.lock().unwrap().clone();
+    crate::store::append_error(&app, &settings, &source, &message)
 }
 
 fn probe_asset(ffprobe: Option<&String>, path: &str) -> probe::Probed {

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap,
             commands::save_settings,
+            commands::report_error,
             commands::list_projects,
             commands::create_project,
             commands::import_assets,

--- a/product/akbun-makevideo/workspace/src-tauri/src/store.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/store.rs
@@ -5,8 +5,12 @@
 //! ~/Library/Application Support/io.akbun.makevideo on macOS.
 
 use crate::commands::Settings;
+use std::io::Write;
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager};
+
+const ERROR_LOG: &str = "errors.log";
 
 fn file_path(app: &AppHandle, name: &str) -> Result<PathBuf, String> {
     let dir = app
@@ -22,6 +26,74 @@ pub fn data_dir(app: &AppHandle) -> String {
         .app_config_dir()
         .map(|dir| dir.to_string_lossy().to_string())
         .unwrap_or_default()
+}
+
+pub fn log_dir(app: &AppHandle, settings: &Settings) -> PathBuf {
+    let configured = settings.log_dir.trim();
+    if configured.is_empty() {
+        return app
+            .path()
+            .app_log_dir()
+            .unwrap_or_else(|_| PathBuf::from("."));
+    }
+    if configured == "~" || configured.starts_with("~/") || configured.starts_with("~\\") {
+        if let Ok(home) = app.path().home_dir() {
+            return home.join(configured[1..].trim_start_matches(|ch| ch == '/' || ch == '\\'));
+        }
+    }
+    PathBuf::from(configured)
+}
+
+pub fn prepare_log_dir(app: &AppHandle, settings: &Settings) -> Result<PathBuf, String> {
+    let dir = log_dir(app, settings);
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| format!("cannot create log directory {dir:?}: {error}"))?;
+    Ok(dir)
+}
+
+fn rotation_bytes(settings: &Settings) -> u64 {
+    let multiplier = if settings.log_rotation_unit.eq_ignore_ascii_case("kb") {
+        1024
+    } else {
+        1024 * 1024
+    };
+    settings.log_rotation_size.max(1).saturating_mul(multiplier)
+}
+
+pub fn append_error(
+    app: &AppHandle,
+    settings: &Settings,
+    source: &str,
+    message: &str,
+) -> Result<(), String> {
+    let dir = prepare_log_dir(app, settings)?;
+    let active = dir.join(ERROR_LOG);
+    let archived = dir.join("errors.log.1");
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    let record = format!("[{timestamp}] {source}: {}\n", message.trim());
+    let current_size = active.metadata().map(|meta| meta.len()).unwrap_or(0);
+
+    if current_size > 0
+        && current_size.saturating_add(record.len() as u64) > rotation_bytes(settings)
+    {
+        if archived.exists() {
+            std::fs::remove_file(&archived)
+                .map_err(|error| format!("cannot remove old error log {archived:?}: {error}"))?;
+        }
+        std::fs::rename(&active, &archived)
+            .map_err(|error| format!("cannot rotate error log {active:?}: {error}"))?;
+    }
+
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&active)
+        .map_err(|error| format!("cannot open error log {active:?}: {error}"))?;
+    file.write_all(record.as_bytes())
+        .map_err(|error| format!("cannot write error log {active:?}: {error}"))
 }
 
 /// Write to a temp file and rename over the target. A crash halfway through a

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -1,5 +1,7 @@
 'use strict';
 
+(function () {
+
 // The only bridge between the page and the operating system.
 //
 // withGlobalTauri puts the Tauri APIs on window.__TAURI__, so this file needs no
@@ -64,10 +66,14 @@ if (!window.__TAURI__) {
         ffmpegDir: '',
         renderAcceleration: 'auto',
         compositor: 'auto',
+        logDir: '',
+        logRotationSize: 5,
+        logRotationUnit: 'mb',
       },
       workspace: '',
       version: '0.0.0-browser',
       dataDir: '',
+      logDir: '',
       ffmpeg: null,
       ffprobe: null,
       acceleration: { available: null, tried: [] },
@@ -81,6 +87,7 @@ if (!window.__TAURI__) {
       workspace: settings.workspaceDir || '',
       version: '0.0.0-browser',
       dataDir: '',
+      logDir: settings.logDir || '',
       ffmpeg: null,
       ffprobe: null,
       acceleration: { available: null, tried: [] },
@@ -134,6 +141,7 @@ if (!window.__TAURI__) {
     onCloseRequested: () => {},
     closeWindow: () => {},
     checkUpdate: async () => {},
+    reportError: async (source, text) => console.error(source, text),
   };
   throw new Error('not running under Tauri; using the browser fallback api');
 }
@@ -161,6 +169,9 @@ async function checkUpdate() {
     await update.downloadAndInstall();
     await relaunch();
   } catch (error) {
+    invoke('report_error', { source: 'update:check', message: String(error) }).catch((logError) => {
+      console.error('error-log', logError);
+    });
     await message(`Cannot check for updates.\n\n${error}`, {
       title: 'Update failed',
       kind: 'error',
@@ -195,6 +206,7 @@ window.api = {
 
   bootstrap: () => invoke('bootstrap'),
   saveSettings: (settings) => invoke('save_settings', { settings }),
+  reportError: (source, message) => invoke('report_error', { source, message }),
 
   pickMedia: () =>
     openDialog({ title: 'Import Media', multiple: true, filters: MEDIA_FILTERS }),
@@ -282,3 +294,22 @@ window.api = {
   closeWindow: () => getCurrentWindow().destroy(),
   checkUpdate,
 };
+
+function pageErrorText(error) {
+  if (error instanceof Error) return error.stack || error.message;
+  return String(error);
+}
+
+function reportPageError(error, source) {
+  window.api.reportError(source, pageErrorText(error)).catch((logError) => {
+    console.error('error-log', logError);
+  });
+}
+
+window.addEventListener('error', (event) => {
+  reportPageError(event.error || event.message, 'page');
+});
+window.addEventListener('unhandledrejection', (event) => {
+  reportPageError(event.reason, 'page:promise');
+});
+})();

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -302,6 +302,22 @@
         <input type="text" id="as-ffmpeg" placeholder="empty = look in the usual places" />
       </label>
       <p class="dim small-text" id="as-tools"></p>
+      <label class="row">Error log folder
+        <span class="row-input">
+          <input type="text" id="as-log-dir" placeholder="empty = operating system default" />
+          <button id="as-log-dir-pick" class="small" type="button">Choose…</button>
+        </span>
+      </label>
+      <p class="dim small-text" id="as-log-note"></p>
+      <label class="row">Rotate error log at
+        <span class="row-input compact">
+          <input type="number" id="as-log-size" min="1" max="1024" />
+          <select id="as-log-unit">
+            <option value="kb">KB</option>
+            <option value="mb">MB</option>
+          </select>
+        </span>
+      </label>
       <div class="sheet-actions">
         <button data-close="app-settings">Cancel</button>
         <button id="as-save" class="primary">Apply</button>
@@ -309,9 +325,9 @@
     </div>
   </div>
 
+  <script src="api.js"></script>
   <script src="time.js"></script>
   <script src="timeline.js"></script>
-  <script src="api.js"></script>
   <script src="quality.js"></script>
   <script src="preview.js"></script>
   <script src="renderer.js"></script>

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -1,5 +1,7 @@
 'use strict';
 
+(function () {
+
 // The preview: real media elements, stacked and driven by a clock.
 //
 // There is no compositor here and no decoding in Rust. One element per clip
@@ -524,3 +526,4 @@ if (typeof module !== 'undefined' && module.exports) {
 } else {
   globalThis.previewLib = { createPreview, QUALITY };
 }
+})();

--- a/product/akbun-makevideo/workspace/src/quality.js
+++ b/product/akbun-makevideo/workspace/src/quality.js
@@ -1,5 +1,7 @@
 'use strict';
 
+(function () {
+
 const DEFAULT_QUALITY_LIMITS = {
   frameIntervalP50Ms: Math.ceil(1000 / 30 * 1.25),
   frameIntervalP99Ms: Math.ceil(1000 / 30 * 2),
@@ -432,3 +434,4 @@ if (typeof module !== 'undefined' && module.exports) {
     createQualityHarness,
   };
 }
+})();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1,5 +1,7 @@
 'use strict';
 
+(function () {
+
 // The DOM. Everything that plays lives in preview.js and the arithmetic a
 // redraw needs lives in timeline.js; this file listens, sends commands, and
 // redraws from what comes back.
@@ -25,6 +27,23 @@ const SNAP_PX = 10;
 // How much timeline is kept past the end of the edit, so there is always
 // somewhere to drop the next clip.
 const TAIL_SECONDS = 10;
+
+const DEFAULT_SETTINGS = {
+  theme: 'system',
+  previewQuality: 'half',
+  previewMuteWhileScrubbing: true,
+  snap: true,
+  defaultWidth: 1920,
+  defaultHeight: 1080,
+  defaultRate: { num: 30, den: 1 },
+  workspaceDir: '',
+  ffmpegDir: '',
+  renderAcceleration: 'auto',
+  compositor: 'auto',
+  logDir: '',
+  logRotationSize: 5,
+  logRotationUnit: 'mb',
+};
 
 const el = (id) => document.getElementById(id);
 
@@ -79,8 +98,21 @@ const state = {
   // flag, which means undoing back to where the last save was leaves the
   // project clean again instead of permanently modified.
   savedRevision: 0,
-  settings: null,
-  boot: null,
+  settings: { ...DEFAULT_SETTINGS },
+  boot: {
+    settings: { ...DEFAULT_SETTINGS },
+    workspace: '',
+    version: '',
+    dataDir: '',
+    logDir: '',
+    ffmpeg: null,
+    ffprobe: null,
+    acceleration: { available: null, tried: [] },
+    compositor: { setting: 'auto', device: 'initializing', gpu: false, fellBack: true },
+    qualityProject: null,
+    qualityReport: null,
+    qualitySmoke: false,
+  },
   path: null,
   selectedClipId: null,
   selectedAssetId: null,
@@ -92,6 +124,19 @@ let preview = null;
 let qualityMonitor = null;
 
 // --- helpers ---------------------------------------------------------------
+
+function errorText(error) {
+  if (error instanceof Error) return error.stack || error.message;
+  return String(error);
+}
+
+function reportError(error, source) {
+  const message = errorText(error);
+  console.error(source, error);
+  Promise.resolve(window.api.reportError(source, message)).catch((logError) => {
+    console.error('error-log', logError);
+  });
+}
 
 function baseName(path) {
   return String(path).split(/[\\/]/).pop();
@@ -571,6 +616,7 @@ async function persistSettings(revert) {
     state.boot = await window.api.saveSettings(state.settings);
     state.settings = state.boot.settings;
   } catch (error) {
+    reportError(error, 'settings:persist');
     if (revert) revert();
     await window.api.message(`That setting could not be saved.\n\n${error}`, {
       title: 'Settings',
@@ -880,6 +926,7 @@ async function startRender(preset) {
     // this runs cannot half reach the file being written.
     await window.api.startRender(output, preset);
   } catch (error) {
+    reportError(error, 'render:start');
     state.rendering = false;
     dom.renderOverlay.hidden = true;
     await window.api.message(String(error), { title: 'Render failed', kind: 'error' });
@@ -928,6 +975,7 @@ function onRenderDone(payload) {
   } else {
     dom.renderTitle.textContent = payload.cancelled ? 'Render cancelled' : 'Render failed';
     dom.renderStatus.textContent = payload.message || '';
+    if (!payload.cancelled) reportError(payload.message || 'Render failed', 'render');
   }
 }
 
@@ -980,6 +1028,7 @@ async function createProjectFromSheet() {
     await window.api.saveProject(entry.path);
     updateTitle();
   } catch (failure) {
+    reportError(failure, 'project:create');
     error.textContent = String(failure);
     error.hidden = false;
   }
@@ -1021,6 +1070,7 @@ async function openProjectPath(path) {
     loadDocument(doc, path);
     return true;
   } catch (error) {
+    reportError(error, 'project:open');
     await window.api.message(String(error), { title: 'Cannot open', kind: 'error' });
     return false;
   }
@@ -1055,6 +1105,7 @@ async function saveProject(forcePicker) {
     updateTitle();
     return true;
   } catch (error) {
+    reportError(error, 'project:save');
     await window.api.message(String(error), { title: 'Cannot save', kind: 'error' });
     return false;
   }
@@ -1136,6 +1187,11 @@ function fillAppSheet() {
   el('as-tools').textContent = state.boot.ffmpeg
     ? `Found ffmpeg at ${state.boot.ffmpeg}`
     : 'ffmpeg was not found. Rendering is unavailable until it is.';
+  el('as-log-dir').value = state.settings.logDir;
+  el('as-log-size').value = state.settings.logRotationSize;
+  el('as-log-unit').value = state.settings.logRotationUnit;
+  const logDir = state.boot.logDir || 'the operating system application log folder';
+  el('as-log-note').textContent = `Only errors are written to ${logDir}/errors.log. The previous file is kept as errors.log.1.`;
 }
 
 function applySettings(next) {
@@ -1253,7 +1309,7 @@ function wireMenus() {
     if (!item) return;
     closeMenus();
     const run = actions[item.dataset.action];
-    if (run) run();
+    if (run) Promise.resolve().then(run).catch((error) => reportError(error, `menu:${item.dataset.action}`));
   });
   dom.menus.addEventListener('pointerover', (event) => {
     const title = event.target.closest('.menu-title');
@@ -1406,11 +1462,15 @@ function wireSheets() {
       renderAcceleration: el('as-accel').value,
       workspaceDir: el('as-workspace').value.trim(),
       ffmpegDir: el('as-ffmpeg').value.trim(),
+      logDir: el('as-log-dir').value.trim(),
+      logRotationSize: Math.max(1, Number(el('as-log-size').value) || 5),
+      logRotationUnit: el('as-log-unit').value,
     });
     closeSheet('app-settings');
     try {
       state.boot = await window.api.saveSettings(next);
     } catch (error) {
+      reportError(error, 'settings:save');
       await window.api.message(`Those settings could not be saved.\n\n${error}`, {
         title: 'Settings',
         kind: 'error',
@@ -1423,6 +1483,10 @@ function wireSheets() {
   el('as-workspace-pick').addEventListener('click', async () => {
     const folder = await window.api.pickFolder('Workspace folder');
     if (folder) el('as-workspace').value = folder;
+  });
+  el('as-log-dir-pick').addEventListener('click', async () => {
+    const folder = await window.api.pickFolder('Error log folder');
+    if (folder) el('as-log-dir').value = folder;
   });
   el('np-create').addEventListener('click', createProjectFromSheet);
   el('np-name').addEventListener('keydown', (event) => {
@@ -1521,9 +1585,15 @@ function updateToolWarning() {
   dom.toolWarning.hidden = Boolean(state.boot && state.boot.ffmpeg);
 }
 
+function subscribe(source, register, handler) {
+  try {
+    Promise.resolve(register(handler)).catch((error) => reportError(error, source));
+  } catch (error) {
+    reportError(error, source);
+  }
+}
+
 async function boot() {
-  state.boot = await window.api.bootstrap();
-  state.settings = state.boot.settings;
   state.pxPerSecond = zoomToPxPerSecond(dom.zoom.value);
 
   qualityMonitor = globalThis.qualityLib.createQualityMonitor({});
@@ -1549,10 +1619,6 @@ async function boot() {
     },
   });
 
-  // The app already has an empty document open, made from these same defaults
-  // when the window came up.
-  adopt(await window.api.editState());
-  state.savedRevision = state.doc.revision;
   applySettings(state.settings);
   globalThis.makevideoQuality = globalThis.qualityLib.createQualityHarness({
     monitor: qualityMonitor,
@@ -1573,11 +1639,13 @@ async function boot() {
   wireSheets();
   wireKeyboard();
 
-  window.api.onRenderProgress(onRenderProgress);
-  window.api.onRenderDone(onRenderDone);
-  window.api.onRenderFallback(onRenderFallback);
-  window.api.onFileDrop(handleOsDrop);
-  window.api.onCloseRequested(async (event) => {
+  subscribe('events:render-progress', window.api.onRenderProgress, onRenderProgress);
+  subscribe('events:render-done', window.api.onRenderDone, onRenderDone);
+  subscribe('events:render-fallback', window.api.onRenderFallback, onRenderFallback);
+  subscribe('events:file-drop', window.api.onFileDrop, (payload) => {
+    Promise.resolve(handleOsDrop(payload)).catch((error) => reportError(error, 'file-drop'));
+  });
+  subscribe('events:close-requested', window.api.onCloseRequested, async (event) => {
     if (isDirty()) {
       if (event && event.preventDefault) event.preventDefault();
       if (!(await confirmDiscard('Quit'))) return;
@@ -1588,6 +1656,28 @@ async function boot() {
 
   refresh();
   setPreviewSource('timeline');
+
+  try {
+    adopt(await window.api.editState());
+    state.savedRevision = state.doc.revision;
+    refresh();
+  } catch (error) {
+    reportError(error, 'edit-state');
+  }
+
+  try {
+    state.boot = await window.api.bootstrap();
+    state.settings = { ...DEFAULT_SETTINGS, ...state.boot.settings };
+    applySettings(state.settings);
+    updateToolWarning();
+    refresh();
+  } catch (error) {
+    reportError(error, 'bootstrap');
+    dom.toolWarning.hidden = false;
+    dom.toolWarning.textContent = 'Initialization failed';
+    dom.toolWarning.title = 'Open Settings to inspect the error log location';
+  }
+
   if (state.boot.qualityProject && state.boot.qualityReport) {
     window.setTimeout(async () => {
       if (!(await openProjectPath(state.boot.qualityProject))) return;
@@ -1609,4 +1699,5 @@ globalThis.makevideo = {
   lib: L,
 };
 
-boot();
+boot().catch((error) => reportError(error, 'ui-initialization'));
+})();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1463,7 +1463,10 @@ function wireSheets() {
       workspaceDir: el('as-workspace').value.trim(),
       ffmpegDir: el('as-ffmpeg').value.trim(),
       logDir: el('as-log-dir').value.trim(),
-      logRotationSize: Math.max(1, Number(el('as-log-size').value) || 5),
+      logRotationSize: Math.min(
+        1024,
+        Math.max(1, Math.floor(Number(el('as-log-size').value) || 5)),
+      ),
       logRotationUnit: el('as-log-unit').value,
     });
     closeSheet('app-settings');

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -793,7 +793,9 @@ button.icon.on {
 
 .sheet {
   width: min(460px, 90vw);
+  max-height: 90vh;
   padding: 18px 20px;
+  overflow-y: auto;
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -821,6 +823,20 @@ button.icon.on {
 .sheet .row input[type='number'],
 .sheet .row select {
   min-width: 190px;
+}
+
+.sheet .row .row-input.compact input {
+  flex: 0 1 140px;
+  min-width: 100px;
+}
+
+.sheet .row .row-input.compact {
+  justify-content: flex-start;
+}
+
+.sheet .row .row-input.compact select {
+  flex: 0 0 90px;
+  min-width: 90px;
 }
 
 .row-input {

--- a/product/akbun-makevideo/workspace/src/time.js
+++ b/product/akbun-makevideo/workspace/src/time.js
@@ -1,5 +1,7 @@
 'use strict';
 
+(function () {
+
 // Time, expressed once, as a count of frames on a rate. The page half of the
 // makevideo-time crate; the two have to agree because the project file passes
 // between them, so the tests on both sides check the same rates.
@@ -224,3 +226,4 @@ if (typeof module !== 'undefined' && module.exports) {
 } else {
   globalThis.timeLib = exported;
 }
+})();

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -1,5 +1,7 @@
 'use strict';
 
+(function () {
+
 // What the page needs in order to draw a project and to answer a pointer.
 //
 // This file used to own the project. It does not any more: the model lives in
@@ -236,3 +238,4 @@ if (typeof module !== 'undefined' && module.exports) {
 } else {
   globalThis.timelineLib = exported;
 }
+})();

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+test('classic page scripts do not leak conflicting declarations', () => {
+  const context = vm.createContext({});
+  for (const name of ['time.js', 'timeline.js', 'quality.js', 'preview.js']) {
+    const file = path.join(__dirname, '..', 'src', name);
+    vm.runInContext(fs.readFileSync(file, 'utf8'), context, { filename: file });
+  }
+
+  assert.ok(context.timeLib);
+  assert.ok(context.timelineLib);
+  assert.ok(context.qualityLib);
+  assert.ok(context.previewLib);
+});


### PR DESCRIPTION
# 구현

classic script 전역 격리, UI 이벤트 선연결, 오류 전용 로그 설정 추가
- Node 테스트 45개와 Cargo check 통과, 실제 macOS 앱에서 메뉴와 errors.log 기록 확인

# 어려웠던 점

UI 전체 무반응 원인이 독립 기능이 아닌 classic script 전역 선언 충돌
- Web Inspector에서 exported와 T 중복 선언 오류를 확인해 모든 classic script의 스코프 격리

# 리스크

운영체제 파일 드래그 앤 드롭의 자동화 회귀 검증 미포함
- 선언 충돌 회귀 테스트와 실제 메뉴 동작은 검증했으나 Finder 간 드래그 자동화는 좌표 제약으로 제외

Issue #710