### PR TITLE
akbun-rendermermaid 이름, 화면, preview 조작 정리

### DIFF
--- a/product/akbun-rendermermaid/README.md
+++ b/product/akbun-rendermermaid/README.md
@@ -9,13 +9,15 @@ Deployed at [mermaid.akbun.com](https://mermaid.akbun.com).
 | Feature | How it works |
 |---|---|
 | Render | The diagram redraws 400 ms after you stop typing. Ctrl or Cmd + Enter and the Render button skip the wait |
+| Refresh | Throws the drawn diagram away and renders it again from the code, back at the fitted zoom. The button next to Render |
+| Zoom | The preview zooms with its own buttons, with Ctrl or Cmd and +, - or 0, and with Ctrl or Cmd and the wheel. Fit re-fits it to the pane |
 | Errors | A failed parse leaves the last good diagram on screen and prints the mermaid message, with its line and caret, under the editor. Nothing flashes away while you are mid-edit |
-| Save PNG | Rasterizes the rendered SVG at 2x onto a white background and downloads it as `mermaid-<type>-<date>-<time>.png`. A diagram too wide for a canvas is exported at a lower scale instead of failing |
+| Save PNG | Rasterizes the rendered SVG at 2x onto a white background and downloads it as `mermaid-<type>-<date>-<time>.png`. The export is the diagram's own size whatever the preview zoom is, and a diagram too wide for a canvas is exported at a lower scale instead of failing |
 | Large view | Opens the diagram full screen, scaled to fill the window rather than left at its original size. Zoom with the buttons, +/-/0, or Ctrl and the wheel; drag to pan; Escape closes |
-| Grid | A 20 px grid behind the preview, for lining diagrams up by eye. It is a background of the pane, so it never appears in an exported PNG. The setting is remembered |
+| Dots | A 22 px dot grid behind the preview, for lining diagrams up by eye. It is a background of the pane, so it never appears in an exported PNG. The setting is remembered |
 | Restore | The code is kept in `localStorage`, so a reload or a closed tab does not lose the diagram |
 
-The preview shows the diagram at its natural size and scales it down only when it is wider than the pane. Under 900 px the two panes stack.
+The toolbar sits above the preview at the inner edge, next to the code, rather than in the far corner of the window. The preview opens at the zoom that fits the diagram in the pane, never larger than its natural size, and stays where you put it once you zoom by hand. Under 900 px the two panes stack.
 
 ## Directory layout
 

--- a/product/akbun-rendermermaid/adr/2026-08-preview-zoom-by-element-size.md
+++ b/product/akbun-rendermermaid/adr/2026-08-preview-zoom-by-element-size.md
@@ -1,0 +1,17 @@
+# The preview zoom sets the element size, the large view transforms
+
+## Decision
+
+The preview zoom multiplies the diagram's pixel size and writes it into the SVG's inline width and height. The large view keeps its CSS transform. The PNG export serializes a clone with those two inline properties removed.
+
+## Reason
+
+The two zooms look like one feature and sit on different constraints.
+
+The large view owns the whole window and its stage exists to be panned, so a transform is right there: it is cheap, it does not reflow, and the wrapper is given the scaled box by hand to give the stage something to scroll over.
+
+The preview is a pane in a split layout that already scrolls. A transform there scales the paint and leaves the layout box alone, so at 300% the pane believes the diagram is still its original size, the scrollbars stay put, and the three quarters of the diagram now outside the pane cannot be reached. Setting the element's size makes the overflow real and the existing `overflow: auto` does the rest. The same reasoning moved the pane's centring from `align-items: center` to `margin: auto` on the child, which is the arrangement that does not clip the overflow at the top and the left.
+
+The cost is that the zoom now lives in the inline style, and an inline width beats the width attribute `withExplicitSize` pins on for the export. Left alone, a diagram zoomed to 150% exported into a canvas sized for 100%, drawn at 150%, and came out clipped. So the export works from a clone with the inline size stripped, and a PNG is the diagram's own size whatever the screen is showing.
+
+Zoom is not persisted. It is a reading position rather than a preference, and a page that reopens at yesterday's 340% is a page that reopens broken. It is pinned only within a session: renders re-fit the diagram until the reader zooms by hand, after which the chosen value survives the next keystroke.

--- a/product/akbun-rendermermaid/adr/index.md
+++ b/product/akbun-rendermermaid/adr/index.md
@@ -7,4 +7,5 @@ Decision records for akbun-rendermermaid in "decision - reason" form. Filenames 
 * [An Astro static page on Cloudflare Pages](2026-08-astro-static-on-cloudflare.md) - The deployment was picked first and copied from the envelope simulator, so there is no release job, no tag and no version to bump.
 * [Mermaid is bundled, not loaded from a CDN](2026-08-bundled-mermaid-over-cdn.md) - A CDN tag would delete the build step and hand a page that promises to run in your browser a dependency on somebody else's uptime.
 * [PNG export through a canvas](2026-08-png-export-through-canvas.md) - PNG is where the diagrams end up, and getting one out of a browser means HTML labels off, system fonts, an explicit size and a scale cap.
+* [The preview zoom sets the element size, the large view transforms](2026-08-preview-zoom-by-element-size.md) - A transform does not change layout size, so in a pane that scrolls it puts most of a zoomed diagram out of reach.
 * [The arithmetic lives in a DOM free module](2026-08-dom-free-module-for-tests.md) - The failures worth testing are sizing and zoom, so they sit where node can test them without a browser; the wiring is checked by hand.

--- a/product/akbun-rendermermaid/wiki/architecture.md
+++ b/product/akbun-rendermermaid/wiki/architecture.md
@@ -23,11 +23,21 @@ Each render takes a sequence number. `mermaid.render` is asynchronous, so a slow
 
 `mermaid.parse` runs before `mermaid.render` because it is the call that produces the readable error, with the offending line and a caret. On failure the preview is left untouched and only the status bar changes, so an unfinished line does not blank the diagram you are working from.
 
+The status bar under the editor is the only place the error goes. A toast in the corner of the preview was tried and removed: the message was already on screen a few centimetres away, under the code that caused it, and a second copy of it is noise rather than a second chance to notice.
+
 Mermaid builds a hidden measuring node under `body` while rendering and leaves it behind when the render throws. The `finally` block removes it. Left alone these accumulate one per failed keystroke.
 
 ## Sizing, and why the preview borrows the export code
 
-Mermaid emits `<svg width="100%" style="max-width: 752px">`. Dropped into a box that shrinks to fit its content, `width="100%"` resolves against nothing and the diagram collapses to a fraction of its size. So the render reads the true size out of the `viewBox` and rewrites the markup with explicit pixel width and height, using the same `withExplicitSize` the PNG export uses. CSS then caps it at `max-width: 100%` with `height: auto`, which is what scales an oversized diagram down to the pane.
+Mermaid emits `<svg width="100%" style="max-width: 752px">`. Dropped into a box that shrinks to fit its content, `width="100%"` resolves against nothing and the diagram collapses to a fraction of its size. So the render reads the true size out of the `viewBox` and rewrites the markup with explicit pixel width and height, using the same `withExplicitSize` the PNG export uses.
+
+## Preview zoom
+
+The zoom multiplies that size and writes the result into the SVG's inline width and height. A CSS transform would have been shorter, and it is what the large view uses, but a transform does not change layout size and the preview is a scrolling pane: at 300% there would be nothing to scroll over and three quarters of the diagram would be unreachable. Setting the element's size instead makes the overflow real. That is also why the pane centres its child with `margin: auto` rather than `align-items`, which is the flexbox arrangement that leaves the overflow scrollable on all four sides.
+
+Zoom starts at whatever fits the diagram into the pane, capped at 100%, and every render re-fits until the reader touches the zoom. From that point the value is pinned and survives the next keystroke, because having zoomed into one corner of a large diagram to edit it, the last thing wanted is the fit being restored 400 ms later. Refresh unpins it.
+
+This is also the reason the PNG export works from a clone with the inline width and height stripped. An inline style beats an attribute, so `withExplicitSize` would pin 261 px onto the tag while the style still said 392 px, and the canvas would be sized for one and drawn with the other. The export is the diagram's own size at any zoom.
 
 ## PNG export
 
@@ -53,4 +63,8 @@ Fit scales up as well as down. SVG is vector, so filling the window costs nothin
 
 ## Storage
 
-`localStorage` holds two keys, the code and the grid setting. There is no history, no named documents and no sharing. Anything more would be the point at which this stops being a page you open and paste into.
+`localStorage` holds two keys, the code and the dot background setting. The zoom is not one of them: it is a reading position, not a preference, and a page that opens at yesterday's 340% is a page that opens broken.
+
+That setting used to be called the grid, so the reader is read from the new key and falls back to the old one. A rename is not a reason to hand somebody back a background they had turned off.
+
+There is no history, no named documents and no sharing. Anything more would be the point at which this stops being a page you open and paste into.

--- a/product/akbun-rendermermaid/wiki/development.md
+++ b/product/akbun-rendermermaid/wiki/development.md
@@ -35,7 +35,7 @@ The build warns that a chunk is over 500 kB. That chunk is mermaid, it is expect
 
 ## Deploy
 
-Cloudflare Pages builds on push to master. There is no GitHub Actions release job, no tag and no version to bump; the version in `package.json` exists only to name the package.
+Cloudflare Pages builds on push to master. There is no GitHub Actions release job and no tag, so nothing breaks when the version in `package.json` stands still. It is bumped anyway, by the repository rule that a change under `workspace/` carries one, and it reads as a note about how far the page has moved rather than as something a build looks at.
 
 First time setup, once:
 

--- a/product/akbun-rendermermaid/workspace/package-lock.json
+++ b/product/akbun-rendermermaid/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-rendermermaid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-rendermermaid",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "astro": "^7.1.6",
         "mermaid": "^11.16.0"

--- a/product/akbun-rendermermaid/workspace/package.json
+++ b/product/akbun-rendermermaid/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-rendermermaid",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-rendermermaid/workspace/src/lib/diagram.js
+++ b/product/akbun-rendermermaid/workspace/src/lib/diagram.js
@@ -3,6 +3,7 @@
 
 export const ZOOM_MIN = 0.2;
 export const ZOOM_MAX = 8;
+export const ZOOM_STEP = 1.25;
 
 // Browsers refuse to allocate a canvas beyond a few thousand pixels per side.
 // 8192 is the smallest limit still in the field, so exports stay under it.
@@ -90,6 +91,52 @@ export function fitZoom(viewportWidth, viewportHeight, diagramWidth, diagramHeig
   const usableWidth = Math.max(1, viewportWidth - padding * 2);
   const usableHeight = Math.max(1, viewportHeight - padding * 2);
   return clampZoom(Math.min(usableWidth / diagramWidth, usableHeight / diagramHeight));
+}
+
+/**
+ * One zoom step away from the current value. `direction` is positive to zoom
+ * in and negative to zoom out, so a button and a wheel share one code path.
+ */
+export function stepZoom(current, direction, step = ZOOM_STEP) {
+  const base = Number.isFinite(current) && current > 0 ? current : 1;
+  return clampZoom(direction >= 0 ? base * step : base / step);
+}
+
+/**
+ * Zoom that fits the diagram in the pane but never enlarges it past its
+ * natural size. The preview is the place you read the code next to, so a small
+ * diagram blown up to fill the pane would only lie about its real size. The
+ * large view is where `fitZoom` scales up.
+ */
+export function shrinkToFitZoom(viewportWidth, viewportHeight, diagramWidth, diagramHeight, padding = 24) {
+  return Math.min(1, fitZoom(viewportWidth, viewportHeight, diagramWidth, diagramHeight, padding));
+}
+
+/**
+ * Maps a pressed key to a zoom action, or null when the key is not one.
+ * `withModifier` is whether Ctrl or Cmd was held; the caller decides whether
+ * that is required, because the large view takes the bare keys too.
+ */
+export function zoomAction(key, withModifier = true) {
+  if (!withModifier) return null;
+  if (key === '+' || key === '=' || key === 'Add') return 'in';
+  if (key === '-' || key === '_' || key === 'Subtract') return 'out';
+  if (key === '0') return 'reset';
+  return null;
+}
+
+/** The message to show for a thrown value, whatever shape it arrived in. */
+export function errorText(error) {
+  if (error == null) return 'Unknown error.';
+  if (typeof error === 'string') return error.trim() || 'Unknown error.';
+
+  const message = typeof error.message === 'string' ? error.message.trim() : '';
+  if (message) return message;
+
+  // `String(new Error(''))` is just `Error`, which tells a reader nothing.
+  const text = String(error).trim();
+  if (!text || text === '[object Object]' || /^\w*Error$/.test(text)) return 'Unknown error.';
+  return text;
 }
 
 /**

--- a/product/akbun-rendermermaid/workspace/src/pages/index.astro
+++ b/product/akbun-rendermermaid/workspace/src/pages/index.astro
@@ -7,8 +7,8 @@ import '../styles/global.css';
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Mermaid Renderer</title>
-  <meta name="description" content="Write mermaid code on the left, see the diagram on the right. Save it as PNG, open it large, toggle the grid. Runs entirely in the browser.">
+  <title>akbun mermaid render</title>
+  <meta name="description" content="Write mermaid code on the left, see the diagram on the right. Zoom it, save it as PNG, open it large. Runs entirely in the browser.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Outfit:wght@400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
@@ -16,15 +16,8 @@ import '../styles/global.css';
 <body>
   <header class="app-header">
     <div class="app-title">
-      <h1>Mermaid Renderer</h1>
+      <h1>akbun mermaid render</h1>
       <p>Write on the left, read the diagram on the right. Nothing leaves the browser.</p>
-    </div>
-
-    <div class="toolbar">
-      <button id="render" type="button" title="Render now (Ctrl/Cmd + Enter)">Render</button>
-      <button id="save-png" class="ghost" type="button" disabled>Save PNG</button>
-      <button id="large" class="ghost" type="button" disabled>Large view</button>
-      <button id="grid" class="ghost" type="button" aria-pressed="true">Grid</button>
     </div>
   </header>
 
@@ -36,8 +29,25 @@ import '../styles/global.css';
     </section>
 
     <section class="pane-right">
-      <div class="pane-head"><span>Preview</span></div>
-      <div id="preview" class="preview grid-on">
+      <!-- The toolbar sits at the inner edge of the preview, next to the code
+           you were just reading, rather than in the far corner of the window. -->
+      <div class="pane-head toolbar-bar">
+        <button id="render" type="button" title="Render now (Ctrl/Cmd + Enter)">Render</button>
+        <button id="refresh" class="ghost" type="button" title="Clear the preview and draw it again">Refresh</button>
+        <button id="save-png" class="ghost" type="button" disabled>Save PNG</button>
+        <button id="large" class="ghost" type="button" disabled>Large view</button>
+        <button id="dots" class="ghost" type="button" aria-pressed="true">Dots</button>
+
+        <div class="zoom-group" role="group" aria-label="Preview zoom">
+          <button id="preview-zoom-out" class="ghost" type="button" aria-label="Zoom out" title="Zoom out (Ctrl/Cmd + -)">−</button>
+          <span id="preview-zoom-level" class="zoom-level">100%</span>
+          <button id="preview-zoom-in" class="ghost" type="button" aria-label="Zoom in" title="Zoom in (Ctrl/Cmd + +)">+</button>
+          <button id="preview-zoom-fit" class="ghost" type="button">Fit</button>
+          <button id="preview-zoom-reset" class="ghost" type="button" title="Back to 100% (Ctrl/Cmd + 0)">Reset</button>
+        </div>
+      </div>
+
+      <div id="preview" class="preview dots-on">
         <div id="diagram" class="is-empty"></div>
       </div>
     </section>
@@ -45,11 +55,11 @@ import '../styles/global.css';
 
   <div id="large-view" class="large-view" role="dialog" aria-modal="true" aria-label="Large view">
     <div class="large-bar">
-      <button id="zoom-out" class="ghost" type="button" aria-label="Zoom out">-</button>
+      <button id="zoom-out" class="ghost" type="button" aria-label="Zoom out">−</button>
       <span id="zoom-level" class="zoom-level">100%</span>
       <button id="zoom-in" class="ghost" type="button" aria-label="Zoom in">+</button>
       <button id="zoom-fit" class="ghost" type="button">Fit</button>
-      <button id="zoom-reset" class="ghost" type="button">100%</button>
+      <button id="zoom-reset" class="ghost" type="button">Reset</button>
       <button id="close-large" type="button">Close</button>
     </div>
     <div id="large-stage" class="large-stage">

--- a/product/akbun-rendermermaid/workspace/src/scripts/main.js
+++ b/product/akbun-rendermermaid/workspace/src/scripts/main.js
@@ -2,18 +2,24 @@ import mermaid from 'mermaid';
 
 import {
   clampZoom,
+  errorText,
   exportScale,
   fitZoom,
   isBlank,
   pngFileName,
   readSvgSize,
+  shrinkToFitZoom,
+  stepZoom,
   withExplicitSize,
+  zoomAction,
 } from '../lib/diagram.js';
 
 const STORAGE_CODE = 'akbun-rendermermaid.code';
-const STORAGE_GRID = 'akbun-rendermermaid.grid';
+const STORAGE_DOTS = 'akbun-rendermermaid.dots';
+// The toggle used to be called the grid, and a reader's setting outlives a rename.
+const STORAGE_GRID_LEGACY = 'akbun-rendermermaid.grid';
 const RENDER_DELAY_MS = 400;
-const ZOOM_STEP = 1.25;
+const RESIZE_DELAY_MS = 150;
 
 const SAMPLE = `flowchart LR
   A[Write mermaid] --> B{Valid?}
@@ -27,9 +33,11 @@ const diagramEl = document.querySelector('#diagram');
 const previewEl = document.querySelector('#preview');
 const statusEl = document.querySelector('#status');
 const renderBtn = document.querySelector('#render');
+const refreshBtn = document.querySelector('#refresh');
 const pngBtn = document.querySelector('#save-png');
 const largeBtn = document.querySelector('#large');
-const gridBtn = document.querySelector('#grid');
+const dotsBtn = document.querySelector('#dots');
+const previewZoomLabel = document.querySelector('#preview-zoom-level');
 const largeView = document.querySelector('#large-view');
 const largeStage = document.querySelector('#large-stage');
 const largeCanvas = document.querySelector('#large-canvas');
@@ -52,15 +60,27 @@ mermaid.initialize({
 
 let renderSeq = 0;
 let renderTimer = null;
+let resizeTimer = null;
 let zoom = 1;
 let largeSize = { width: 0, height: 0 };
 let launcher = null;
+
+let previewZoom = 1;
+let previewSize = { width: 0, height: 0 };
+// Until the reader touches the zoom, every render re-fits the diagram. After
+// that the chosen zoom survives the next keystroke, which is the whole point
+// of having zoomed in on a corner of a big diagram.
+let previewZoomPinned = false;
 
 /* ===== Rendering ===== */
 
 function setStatus(message, isError = false) {
   statusEl.textContent = message;
   statusEl.classList.toggle('error', isError);
+}
+
+function reportError(error) {
+  setStatus(errorText(error), true);
 }
 
 function setDiagramActions(enabled) {
@@ -71,8 +91,39 @@ function setDiagramActions(enabled) {
 function showEmpty() {
   diagramEl.classList.add('is-empty');
   diagramEl.textContent = 'Type mermaid code on the left.';
+  previewSize = { width: 0, height: 0 };
   setDiagramActions(false);
   setStatus('Waiting for input.');
+}
+
+/**
+ * Sizes the rendered SVG for the current preview zoom. The size goes on the
+ * element rather than into a transform, so the pane has something to scroll
+ * over once the diagram is larger than it.
+ */
+function applyPreviewZoom() {
+  previewZoomLabel.textContent = `${Math.round(previewZoom * 100)}%`;
+
+  const svg = diagramEl.querySelector('svg');
+  if (!svg || previewSize.width <= 0) return;
+
+  svg.style.width = `${previewSize.width * previewZoom}px`;
+  svg.style.height = `${previewSize.height * previewZoom}px`;
+}
+
+function setPreviewZoom(value, { pin = true } = {}) {
+  previewZoom = clampZoom(value);
+  if (pin) previewZoomPinned = true;
+  applyPreviewZoom();
+}
+
+function previewFitZoom() {
+  return shrinkToFitZoom(
+    previewEl.clientWidth,
+    previewEl.clientHeight,
+    previewSize.width,
+    previewSize.height,
+  );
 }
 
 async function render() {
@@ -92,16 +143,18 @@ async function render() {
 
     // Mermaid emits `width="100%"` with a max-width style. Inside a box that
     // shrinks to fit, that collapses the diagram to its minimum width, so the
-    // preview gets the same explicit size the PNG export uses. CSS then scales
-    // it down when it is wider than the pane.
+    // preview gets the same explicit size the PNG export uses. The zoom then
+    // scales it from there.
     const size = readSvgSize(svg);
     diagramEl.classList.remove('is-empty');
     diagramEl.innerHTML = withExplicitSize(svg, size.width, size.height);
+    previewSize = size;
+    setPreviewZoom(previewZoomPinned ? previewZoom : previewFitZoom(), { pin: false });
     setDiagramActions(true);
     setStatus('Rendered.');
   } catch (error) {
     if (seq !== renderSeq) return;
-    setStatus(error?.message ?? String(error), true);
+    reportError(error);
   } finally {
     // A failed render leaves its measuring node behind in the body.
     document.querySelector(`#d${id}`)?.remove();
@@ -115,6 +168,17 @@ function scheduleRender() {
 
 function renderNow() {
   window.clearTimeout(renderTimer);
+  render();
+}
+
+/** Throws the drawn diagram away and starts over, back at the fitted zoom. */
+function refresh() {
+  window.clearTimeout(renderTimer);
+  diagramEl.replaceChildren();
+  diagramEl.classList.add('is-empty');
+  diagramEl.textContent = 'Rendering…';
+  setDiagramActions(false);
+  previewZoomPinned = false;
   render();
 }
 
@@ -140,12 +204,25 @@ function download(blob, name) {
   window.setTimeout(() => URL.revokeObjectURL(url), 1000);
 }
 
+/**
+ * The preview zoom lives in the SVG's inline style, and an inline width beats
+ * the width attribute the export pins on. So the export works from a copy with
+ * those two properties removed, and the PNG is the diagram's real size at any
+ * zoom.
+ */
+function exportableMarkup(svg) {
+  const copy = svg.cloneNode(true);
+  copy.style.removeProperty('width');
+  copy.style.removeProperty('height');
+  return new XMLSerializer().serializeToString(copy);
+}
+
 async function savePng() {
   const svg = diagramEl.querySelector('svg');
   if (!svg) return;
 
   pngBtn.disabled = true;
-  const markup = new XMLSerializer().serializeToString(svg);
+  const markup = exportableMarkup(svg);
   const { width, height } = readSvgSize(markup);
   const scale = exportScale(width, height);
   const source = URL.createObjectURL(
@@ -174,7 +251,7 @@ async function savePng() {
     download(blob, pngFileName(codeEl.value, new Date()));
     setStatus(`Saved PNG at ${canvas.width}x${canvas.height}.`);
   } catch (error) {
-    setStatus(error?.message ?? String(error), true);
+    reportError(error);
   } finally {
     URL.revokeObjectURL(source);
     pngBtn.disabled = false;
@@ -202,14 +279,18 @@ function setZoom(value) {
   applyZoom();
 }
 
+function largeFitZoom() {
+  return fitZoom(largeStage.clientWidth, largeStage.clientHeight, largeSize.width, largeSize.height);
+}
+
 function openLargeView() {
   const svg = diagramEl.querySelector('svg');
   if (!svg) return;
 
+  largeSize = readSvgSize(exportableMarkup(svg));
   largeCanvas.replaceChildren(svg.cloneNode(true));
-  largeSize = readSvgSize(new XMLSerializer().serializeToString(svg));
   largeView.classList.add('open');
-  setZoom(fitZoom(largeStage.clientWidth, largeStage.clientHeight, largeSize.width, largeSize.height));
+  setZoom(largeFitZoom());
 
   // The overlay claims to be a modal, so the keyboard has to go into it.
   // Without this, tabbing walks the toolbar hidden behind the backdrop.
@@ -259,9 +340,10 @@ function restore() {
   const saved = window.localStorage.getItem(STORAGE_CODE);
   codeEl.value = saved ?? SAMPLE;
 
-  const gridOn = window.localStorage.getItem(STORAGE_GRID) !== 'off';
-  previewEl.classList.toggle('grid-on', gridOn);
-  gridBtn.setAttribute('aria-pressed', String(gridOn));
+  const stored = window.localStorage.getItem(STORAGE_DOTS) ?? window.localStorage.getItem(STORAGE_GRID_LEGACY);
+  const dotsOn = stored !== 'off';
+  previewEl.classList.toggle('dots-on', dotsOn);
+  dotsBtn.setAttribute('aria-pressed', String(dotsOn));
 }
 
 codeEl.addEventListener('input', () => {
@@ -277,35 +359,70 @@ codeEl.addEventListener('keydown', (event) => {
 });
 
 renderBtn.addEventListener('click', renderNow);
+refreshBtn.addEventListener('click', refresh);
 pngBtn.addEventListener('click', savePng);
 largeBtn.addEventListener('click', openLargeView);
 
-gridBtn.addEventListener('click', () => {
-  const gridOn = previewEl.classList.toggle('grid-on');
-  gridBtn.setAttribute('aria-pressed', String(gridOn));
-  window.localStorage.setItem(STORAGE_GRID, gridOn ? 'on' : 'off');
+dotsBtn.addEventListener('click', () => {
+  const dotsOn = previewEl.classList.toggle('dots-on');
+  dotsBtn.setAttribute('aria-pressed', String(dotsOn));
+  window.localStorage.setItem(STORAGE_DOTS, dotsOn ? 'on' : 'off');
 });
 
-document.querySelector('#zoom-in').addEventListener('click', () => setZoom(zoom * ZOOM_STEP));
-document.querySelector('#zoom-out').addEventListener('click', () => setZoom(zoom / ZOOM_STEP));
+document.querySelector('#preview-zoom-in').addEventListener('click', () => setPreviewZoom(stepZoom(previewZoom, 1)));
+document.querySelector('#preview-zoom-out').addEventListener('click', () => setPreviewZoom(stepZoom(previewZoom, -1)));
+document.querySelector('#preview-zoom-reset').addEventListener('click', () => setPreviewZoom(1));
+document.querySelector('#preview-zoom-fit').addEventListener('click', () => setPreviewZoom(previewFitZoom()));
+
+previewEl.addEventListener('wheel', (event) => {
+  if (!event.ctrlKey && !event.metaKey) return;
+  event.preventDefault();
+  setPreviewZoom(stepZoom(previewZoom, event.deltaY < 0 ? 1 : -1));
+}, { passive: false });
+
+document.querySelector('#zoom-in').addEventListener('click', () => setZoom(stepZoom(zoom, 1)));
+document.querySelector('#zoom-out').addEventListener('click', () => setZoom(stepZoom(zoom, -1)));
 document.querySelector('#zoom-reset').addEventListener('click', () => setZoom(1));
-document.querySelector('#zoom-fit').addEventListener('click', () => {
-  setZoom(fitZoom(largeStage.clientWidth, largeStage.clientHeight, largeSize.width, largeSize.height));
-});
+document.querySelector('#zoom-fit').addEventListener('click', () => setZoom(largeFitZoom()));
 closeLargeBtn.addEventListener('click', closeLargeView);
 
 largeStage.addEventListener('wheel', (event) => {
   if (!event.ctrlKey && !event.metaKey) return;
   event.preventDefault();
-  setZoom(zoom * (event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP));
+  setZoom(stepZoom(zoom, event.deltaY < 0 ? 1 : -1));
 }, { passive: false });
 
 document.addEventListener('keydown', (event) => {
-  if (!largeView.classList.contains('open')) return;
-  if (event.key === 'Escape') closeLargeView();
-  if (event.key === '+' || event.key === '=') setZoom(zoom * ZOOM_STEP);
-  if (event.key === '-') setZoom(zoom / ZOOM_STEP);
-  if (event.key === '0') setZoom(1);
+  const modifier = event.metaKey || event.ctrlKey;
+
+  if (largeView.classList.contains('open')) {
+    if (event.key === 'Escape') closeLargeView();
+    // The overlay is the whole window, so it answers the bare keys as well.
+    const action = zoomAction(event.key, true);
+    if (!action) return;
+    event.preventDefault();
+    if (action === 'in') setZoom(stepZoom(zoom, 1));
+    if (action === 'out') setZoom(stepZoom(zoom, -1));
+    if (action === 'reset') setZoom(1);
+    return;
+  }
+
+  // In the page the bare keys belong to the editor, so zooming needs Ctrl or
+  // Cmd. preventDefault is what keeps the browser from zooming the page too.
+  const action = zoomAction(event.key, modifier);
+  if (!action) return;
+  event.preventDefault();
+  if (action === 'in') setPreviewZoom(stepZoom(previewZoom, 1));
+  if (action === 'out') setPreviewZoom(stepZoom(previewZoom, -1));
+  if (action === 'reset') setPreviewZoom(1);
+});
+
+window.addEventListener('resize', () => {
+  window.clearTimeout(resizeTimer);
+  resizeTimer = window.setTimeout(() => {
+    if (previewZoomPinned || previewSize.width <= 0) return;
+    setPreviewZoom(previewFitZoom(), { pin: false });
+  }, RESIZE_DELAY_MS);
 });
 
 dragToPan();

--- a/product/akbun-rendermermaid/workspace/src/styles/global.css
+++ b/product/akbun-rendermermaid/workspace/src/styles/global.css
@@ -10,11 +10,12 @@
   --divider: #D6D0C4;
   --danger: #b3261e;
   --danger-bg: #FDECEA;
-  --grid-line: #E3DED2;
+  --danger-border: #F3C7C2;
+  --dot: #CFC8B8;
   --font-title: 'Sora', sans-serif;
   --font-body: 'Outfit', sans-serif;
   --font-mono: 'Fira Code', monospace;
-  --header-height: 60px;
+  --header-height: 76px;
 }
 
 html { font-size: 16px; -webkit-font-smoothing: antialiased; }
@@ -36,7 +37,6 @@ body {
   height: var(--header-height);
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
   padding: 0 1.25rem;
   border-bottom: 3px solid var(--text);
@@ -46,44 +46,38 @@ body {
 .app-title {
   display: flex;
   align-items: baseline;
-  gap: 0.65rem;
+  gap: 0.8rem;
   min-width: 0;
 }
 
 .app-title h1 {
   font-family: var(--font-title);
-  font-size: 1.15rem;
+  font-size: 1.95rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   white-space: nowrap;
 }
 
 .app-title p {
-  font-size: 0.8rem;
+  font-size: 1.05rem;
   color: var(--text-sub);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.toolbar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-shrink: 0;
-}
-
 button {
   margin: 0;
-  padding: 0.42rem 0.85rem;
+  padding: 0.45rem 0.95rem;
   color: #fff;
   background: var(--accent);
   border: 2px solid var(--accent);
-  border-radius: 8px;
+  border-radius: 9px;
   cursor: pointer;
   font-family: var(--font-mono);
-  font-size: 0.78rem;
+  font-size: 1.05rem;
   font-weight: 500;
+  line-height: 1.35;
   transition: all 0.15s;
   user-select: none;
   white-space: nowrap;
@@ -139,11 +133,36 @@ button.ghost[aria-pressed='true'] {
   padding: 0.5rem 0.9rem;
   border-bottom: 1px solid var(--divider);
   font-family: var(--font-title);
-  font-size: 0.82rem;
+  font-size: 1.15rem;
   font-weight: 600;
   color: var(--text-sub);
   letter-spacing: 0.02em;
   text-transform: uppercase;
+}
+
+/* The editor side keeps its original scale; only the reading side grew. */
+.pane-left .pane-head { font-size: 0.82rem; }
+
+.toolbar-bar {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  padding: 0.55rem 0.9rem;
+  background: var(--surface);
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+/* A pill rather than a separator, because the toolbar wraps on a narrow
+   window and a separator left dangling at the end of a row reads as an error. */
+.zoom-group {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.35rem;
+  border: 1px solid var(--divider);
+  border-radius: 12px;
+  background: var(--bg);
 }
 
 #code {
@@ -179,7 +198,7 @@ button.ghost[aria-pressed='true'] {
 .status.error {
   color: var(--danger);
   background: var(--danger-bg);
-  border-top-color: #F3C7C2;
+  border-top-color: var(--danger-border);
 }
 
 /* ===== Preview ===== */
@@ -187,19 +206,17 @@ button.ghost[aria-pressed='true'] {
   flex: 1;
   min-height: 0;
   overflow: auto;
+  /* Centring with `margin: auto` on the child rather than `align-items`, so a
+     diagram larger than the pane can still be scrolled to on every side. */
   display: flex;
-  align-items: center;
-  justify-content: center;
   padding: 1.5rem;
   background: var(--bg);
 }
 
-/* The grid is a background of the pane, so it never lands in an exported PNG. */
-.preview.grid-on {
-  background-image:
-    linear-gradient(to right, var(--grid-line) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--grid-line) 1px, transparent 1px);
-  background-size: 20px 20px;
+/* The dots are a background of the pane, so they never land in an exported PNG. */
+.preview.dots-on {
+  background-image: radial-gradient(circle at 1px 1px, var(--dot) 1.6px, transparent 0);
+  background-size: 22px 22px;
 }
 
 #diagram {
@@ -209,11 +226,12 @@ button.ghost[aria-pressed='true'] {
   border: 1px solid var(--divider);
   border-radius: 10px;
 }
-#diagram svg { display: block; max-width: 100%; height: auto; }
+/* The script sets the zoomed pixel size on the SVG, so no CSS cap here. */
+#diagram svg { display: block; max-width: none; }
 #diagram.is-empty {
   color: var(--text-sub);
   font-family: var(--font-mono);
-  font-size: 0.82rem;
+  font-size: 1.1rem;
   padding: 2rem;
 }
 
@@ -240,10 +258,10 @@ button.ghost[aria-pressed='true'] {
 }
 
 .zoom-level {
-  min-width: 4.2rem;
+  min-width: 4.6rem;
   text-align: center;
   font-family: var(--font-mono);
-  font-size: 0.8rem;
+  font-size: 1.05rem;
   color: var(--text-sub);
 }
 
@@ -274,8 +292,8 @@ button.ghost[aria-pressed='true'] {
 @media (max-width: 900px) {
   body { overflow: auto; }
   .app-header { height: auto; flex-wrap: wrap; padding: 0.7rem 1rem; }
+  .app-title { flex-direction: column; gap: 0.15rem; }
   .app-title p { display: none; }
-  .toolbar { flex-wrap: wrap; }
   .split { flex-direction: column; }
   .pane-left {
     width: 100%;

--- a/product/akbun-rendermermaid/workspace/test/diagram.test.js
+++ b/product/akbun-rendermermaid/workspace/test/diagram.test.js
@@ -5,14 +5,19 @@ import {
   MAX_CANVAS_EDGE,
   ZOOM_MAX,
   ZOOM_MIN,
+  ZOOM_STEP,
   clampZoom,
   diagramType,
+  errorText,
   exportScale,
   fitZoom,
   isBlank,
   pngFileName,
   readSvgSize,
+  shrinkToFitZoom,
+  stepZoom,
   withExplicitSize,
+  zoomAction,
 } from '../src/lib/diagram.js';
 
 test('readSvgSize prefers the viewBox over a percentage width', () => {
@@ -84,6 +89,57 @@ test('fitZoom enlarges a diagram smaller than the viewport', () => {
 
 test('fitZoom keeps its result inside the zoom range', () => {
   assert.equal(fitZoom(4000, 4000, 1, 1), ZOOM_MAX);
+});
+
+test('stepZoom moves one step in each direction', () => {
+  assert.equal(stepZoom(1, 1), ZOOM_STEP);
+  assert.equal(stepZoom(1, -1), 1 / ZOOM_STEP);
+});
+
+test('stepZoom stops at the ends of the range', () => {
+  assert.equal(stepZoom(ZOOM_MAX, 1), ZOOM_MAX);
+  assert.equal(stepZoom(ZOOM_MIN, -1), ZOOM_MIN);
+});
+
+test('stepZoom recovers from a broken current value', () => {
+  assert.equal(stepZoom(Number.NaN, 1), ZOOM_STEP);
+  assert.equal(stepZoom(0, 1), ZOOM_STEP);
+});
+
+test('shrinkToFitZoom scales an oversized diagram down', () => {
+  assert.equal(shrinkToFitZoom(1048, 800, 2000, 500, 24), 1000 / 2000);
+});
+
+test('shrinkToFitZoom leaves a small diagram at its own size', () => {
+  assert.equal(shrinkToFitZoom(1200, 900, 300, 200), 1);
+});
+
+test('zoomAction maps the keys the shortcut accepts', () => {
+  assert.equal(zoomAction('+', true), 'in');
+  assert.equal(zoomAction('=', true), 'in');
+  assert.equal(zoomAction('-', true), 'out');
+  assert.equal(zoomAction('_', true), 'out');
+  assert.equal(zoomAction('0', true), 'reset');
+});
+
+test('zoomAction ignores everything else, and every key without the modifier', () => {
+  assert.equal(zoomAction('a', true), null);
+  assert.equal(zoomAction('1', true), null);
+  assert.equal(zoomAction('+', false), null);
+});
+
+test('errorText reads the message of an Error', () => {
+  assert.equal(errorText(new Error('Parse error on line 2')), 'Parse error on line 2');
+});
+
+test('errorText takes a thrown string as it is', () => {
+  assert.equal(errorText('something broke'), 'something broke');
+});
+
+test('errorText falls back when there is no message to show', () => {
+  assert.equal(errorText(null), 'Unknown error.');
+  assert.equal(errorText(new Error('')), 'Unknown error.');
+  assert.equal(errorText({}), 'Unknown error.');
 });
 
 test('diagramType reads the first meaningful keyword', () => {


### PR DESCRIPTION
# 구현

이름 변경, dot 배경, preview zoom, Refresh, 툴바 위치, 폰트 확대 6건 반영
- 단위 테스트 30건 통과, Chromium으로 zoom과 단축키, dot 토글, PNG 저장, 900px 미만 레이아웃 확인

# 어려웠던 점

zoom을 transform으로 걸면 확대한 diagram의 바깥쪽이 scroll로 닿지 않음
- inline width와 height로 크기를 직접 바꾸고, pane 중앙정렬을 align-items에서 margin auto로 교체

# 리스크

zoom 값이 SVG inline style에 남아, export가 clone에서 그 두 속성을 지우는 데 의존
- 렌더 경로나 export 코드를 손대면 zoom 배율만큼 잘린 PNG로 되돌아감. 저장 후 크기 확인이 점검 방법

Issue #719
