### PR TITLE
akbun-openapiviewer 모바일 반응형 레이아웃과 Export JSON

### DIFF
--- a/product/akbun-openapiviewer/README.md
+++ b/product/akbun-openapiviewer/README.md
@@ -14,6 +14,7 @@ Deployed as a static Astro build on Cloudflare.
 | Search | The search bar filters live on every keystroke, no Enter needed. Ctrl/Cmd + K focuses it. Every word must match, over method, path, summary, operationId and tags |
 | Detail | Parameters as a table (path-level parameters merged in), request body and responses per content type, schemas as an indented tree with `$ref`s resolved in place, `*` marking required properties and circular refs cut off |
 | Restore | The spec is kept in `localStorage`, so a reload or a closed tab does not lose it |
+| Phone | Below 720px the API list becomes a drawer opened from the header, so an operation gets the whole screen, and each parameter reads down a card instead of across a table too wide to fit |
 
 ## Directory layout
 

--- a/product/akbun-openapiviewer/README.md
+++ b/product/akbun-openapiviewer/README.md
@@ -13,6 +13,7 @@ Deployed as a static Astro build on Cloudflare.
 | All APIs | The top item of the list. The right pane shows every operation as a card, 10 per page with Prev/Next, so a thousand-operation spec does not freeze the first paint |
 | Search | The search bar filters live on every keystroke, no Enter needed. Ctrl/Cmd + K focuses it. Every word must match, over method, path, summary, operationId and tags |
 | Detail | Parameters as a table (path-level parameters merged in), request body and responses per content type, schemas as an indented tree with `$ref`s resolved in place, `*` marking required properties and circular refs cut off |
+| Export JSON | The header button saves the loaded document as JSON, named from `info` (`petstore-sample-1.0.0.json`). Loading YAML and exporting is how a YAML spec comes back out as JSON |
 | Restore | The spec is kept in `localStorage`, so a reload or a closed tab does not lose it |
 | Phone | Below 720px the API list becomes a drawer opened from the header, so an operation gets the whole screen, and each parameter reads down a card instead of across a table too wide to fit |
 

--- a/product/akbun-openapiviewer/adr/2026-08-sidebar-drawer-on-phones.md
+++ b/product/akbun-openapiviewer/adr/2026-08-sidebar-drawer-on-phones.md
@@ -1,0 +1,11 @@
+# The sidebar becomes a drawer on phones, not a stacked pane
+
+## Decision
+
+Below 720px the left pane leaves the flow and becomes a fixed drawer over the detail pane, opened by a hamburger button in the header and closed by picking an operation, tapping the backdrop or pressing Escape. Above that width the two-pane split is unchanged. The parameter table restacks on a container query instead, not a media query: a card narrower than 33rem drops the header row and prints one labelled block per parameter. The app shell is measured in `dvh` and the document itself never scrolls; the drawer and the detail pane scroll inside themselves.
+
+## Reason
+
+The previous mobile rule stacked the two panes at 45vh and 55vh, which spent half a phone screen on a list nobody reads while reading an operation, and left the page with three nested scroll areas. A drawer gives the detail the whole screen and costs one boolean of state.
+
+The parameter table was the actual broken proportion: five columns cannot fit 375px, and with no scroll container it pushed the whole document sideways, so every card and the header went out of alignment. It restacks on the card rather than the viewport because the two do not agree — a 768px tablet holding the split gives a card 444px, less than the 573px the same card gets on a 600px phone where the list is a drawer. A media query would stack the wrong one of those. The `overflow-x` wrapper stays underneath as the fallback for a card that is wide enough to keep the table but still too narrow for one long description.

--- a/product/akbun-openapiviewer/adr/index.md
+++ b/product/akbun-openapiviewer/adr/index.md
@@ -9,3 +9,4 @@ Decision records for akbun-openapiviewer in "decision - reason" form. Filenames 
 * [The spec logic lives in a DOM free module](2026-08-dom-free-spec-module.md) - Parsing, search, paging and schema formatting are the failures worth testing, so they sit where node can test them without a browser.
 * [The all-APIs view renders 10 cards per page](2026-08-paged-all-view.md) - Full detail cards for every operation of a large spec make the first paint take seconds, and paging is smaller than virtualizing.
 * [Schemas render as a text tree, not a collapsible widget](2026-08-schema-as-text-tree.md) - One pure function covers every schema shape, the browser's find works on it, and it is testable by string.
+* [The sidebar becomes a drawer on phones, not a stacked pane](2026-08-sidebar-drawer-on-phones.md) - Stacking spent half a phone screen on a list nobody was reading, and the unwrapped parameter table pushed the whole document sideways.

--- a/product/akbun-openapiviewer/wiki/architecture.md
+++ b/product/akbun-openapiviewer/wiki/architecture.md
@@ -53,4 +53,6 @@ Text rather than a collapsible tree was deliberate. The output is greppable with
 
 `parseSpec` tries JSON when the text starts with `{`, because `JSON.parse` produces the better error message, and hands everything else to `js-yaml`, which accepts JSON anyway. It rejects documents without `openapi`/`swagger` or `paths` with a message saying which field is missing; that message lands in the loader dialog.
 
+Exporting runs the other way and starts from the parsed object rather than the stored text, which is what makes a YAML paste come back out as JSON. `specJson` and `specFileName` are both in `spec.js`, so the serialization and the name are testable without a browser; `main.js` keeps only the four lines of Blob, object URL, synthetic anchor and revoke. The name is built from `info` and reduced to lowercase words joined by hyphens, because a title is free text and can hold slashes. Dots survive so a version stays `1.0.0`.
+
 The raw text, not the parsed object, is kept in `localStorage` under one key and re-parsed on load. Storing the source keeps the stored form identical to what the user pasted and survives changes to the parsed shape. A quota failure is swallowed: the page still works, it just starts empty next time. A stored spec that no longer parses is dropped and the loader opens.

--- a/product/akbun-openapiviewer/wiki/architecture.md
+++ b/product/akbun-openapiviewer/wiki/architecture.md
@@ -29,6 +29,18 @@ The all view renders the same full detail card used for a single operation, for 
 
 Search and paging compose: the page is cut from the filtered list, and typing resets to page 1.
 
+## Layout across screen sizes
+
+There are two layouts and one breakpoint that matters, 720px. Above it the header, the sidebar and the detail pane sit side by side as they always have; 900px only shrinks the type and the sidebar's share.
+
+Below 720px the sidebar leaves the flow. It becomes a fixed drawer over the detail pane, the header grows a hamburger button, and a backdrop sits between the two. `main.js` holds the open flag in `state.drawer` and `syncDrawer` is the only function that touches the DOM for it: it toggles the class, shows the backdrop, sets `aria-expanded`, and marks the pane `inert` while it is off screen so nothing inside it takes focus or is read out. The breakpoint is written twice, as a media query in `global.css` and as a `matchMedia` in `main.js`, and the two have to be changed together. Widening past the breakpoint clears the flag, so a rotation never lands on an open drawer.
+
+Picking an operation, loading a spec and Escape all close the drawer. Ctrl/Cmd + K opens it first, because the search box lives inside it. The loader dialog does not focus its textarea on a phone, where that would throw the keyboard over the dialog before it has been read.
+
+The app shell is `100dvh`, not `100vh`, so the browser chrome does not cut off the bottom of the detail pane, and the document itself never scrolls: the drawer and the detail pane scroll inside themselves with `overscroll-behavior: contain`.
+
+The parameter table is the one piece that does not use the breakpoint. Five columns wide, it sits in a `.table-wrap` that scrolls sideways on its own, and `.op` is a query container so that a card narrower than 33rem drops the header row and turns each parameter into a labelled block, its cells printing their column name from `data-label`. It has to be a container query because card width and window width disagree: the split leaves a card 444px on a 768px tablet, while a 600px phone with the list in a drawer gives that same card 573px. Without the wrapper underneath it, the table pushed the whole document sideways and every other element inherited the misalignment.
+
 ## Schema rendering
 
 `schemaText` turns a schema into an indented text tree shown in a `<pre>`. `$ref`s are resolved in place and prefixed with their name (`Pet — object`), required properties carry `*`, scalars show their format and enum, and `allOf`/`oneOf`/`anyOf` become labelled lists. Two guards keep it finite: a ref already on the resolution path renders as `(circular)`, and depth past 6 becomes `…`.

--- a/product/akbun-openapiviewer/workspace/package-lock.json
+++ b/product/akbun-openapiviewer/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-openapiviewer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-openapiviewer",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "astro": "^7.1.6",
         "js-yaml": "^5.2.3"

--- a/product/akbun-openapiviewer/workspace/package-lock.json
+++ b/product/akbun-openapiviewer/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-openapiviewer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-openapiviewer",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "astro": "^7.1.6",
         "js-yaml": "^5.2.3"

--- a/product/akbun-openapiviewer/workspace/package.json
+++ b/product/akbun-openapiviewer/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-openapiviewer",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-openapiviewer/workspace/package.json
+++ b/product/akbun-openapiviewer/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-openapiviewer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-openapiviewer/workspace/src/lib/spec.js
+++ b/product/akbun-openapiviewer/workspace/src/lib/spec.js
@@ -49,6 +49,28 @@ export function specTitle(spec) {
 }
 
 /**
+ * The document re-serialized as JSON, two-space indented.
+ * Exporting this is how a YAML spec comes back out as JSON.
+ */
+export function specJson(spec) {
+  return `${JSON.stringify(spec, null, 2)}\n`;
+}
+
+/**
+ * File name for the export, built from `info`, e.g. `petstore-1.0.0.json`.
+ * A title is free text and can hold slashes, quotes or nothing usable, so it
+ * is reduced to lowercase words joined by hyphens before it reaches a disk.
+ * Dots survive, because a version reads worse as 1-0-0 than as 1.0.0.
+ */
+export function specFileName(spec) {
+  const info = spec?.info ?? {};
+  const parts = [info.title, info.version]
+    .map((part) => String(part ?? '').toLowerCase().replace(/[^a-z0-9.]+/g, '-').replace(/^[-.]+|[-.]+$/g, ''))
+    .filter(Boolean);
+  return `${parts.join('-') || 'openapi'}.json`;
+}
+
+/**
  * Flattens `paths` into one operation per method. Path-level parameters apply
  * to every operation under the path, so they are merged in here once and the
  * rest of the code never has to know they existed.

--- a/product/akbun-openapiviewer/workspace/src/pages/index.astro
+++ b/product/akbun-openapiviewer/workspace/src/pages/index.astro
@@ -27,7 +27,17 @@ import '../styles/global.css';
       <h1>akbun openapi viewer</h1>
       <p id="spec-title">Import an OpenAPI file or paste the spec. Nothing leaves the browser.</p>
     </div>
-    <button id="open-loader" type="button">Load spec</button>
+    <div class="header-actions">
+      <button id="export-json" class="icon-button ghost" type="button" disabled
+              title="Export JSON" aria-label="Export the spec as JSON">
+        <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 3v9m0 0 3.5-3.5M10 12 6.5 8.5M3.5 14v1.5a1.5 1.5 0 0 0 1.5 1.5h10a1.5 1.5 0 0 0 1.5-1.5V14"></path>
+        </svg>
+        <span class="icon-button-label">Export JSON</span>
+      </button>
+      <button id="open-loader" type="button">Load spec</button>
+    </div>
   </header>
 
   <main class="split">

--- a/product/akbun-openapiviewer/workspace/src/pages/index.astro
+++ b/product/akbun-openapiviewer/workspace/src/pages/index.astro
@@ -29,7 +29,7 @@ import '../styles/global.css';
     </div>
     <div class="header-actions">
       <button id="export-json" class="icon-button ghost" type="button" disabled
-              title="Export JSON" aria-label="Export the spec as JSON">
+              title="Export JSON">
         <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"
              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
           <path d="M10 3v9m0 0 3.5-3.5M10 12 6.5 8.5M3.5 14v1.5a1.5 1.5 0 0 0 1.5 1.5h10a1.5 1.5 0 0 0 1.5-1.5V14"></path>

--- a/product/akbun-openapiviewer/workspace/src/pages/index.astro
+++ b/product/akbun-openapiviewer/workspace/src/pages/index.astro
@@ -6,7 +6,7 @@ import '../styles/global.css';
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>akbun openapi viewer</title>
   <meta name="description" content="Import an OpenAPI file or paste the spec as JSON or YAML, browse the API list on the left and read each operation on the right. Runs entirely in the browser.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -15,6 +15,14 @@ import '../styles/global.css';
 </head>
 <body>
   <header class="app-header">
+    <button id="toggle-list" class="nav-toggle ghost" type="button"
+            aria-controls="pane-left" aria-expanded="false">
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" aria-hidden="true">
+        <path d="M3 5h14M3 10h14M3 15h14"></path>
+      </svg>
+      <span class="nav-toggle-label">APIs</span>
+    </button>
     <div class="app-title">
       <h1>akbun openapi viewer</h1>
       <p id="spec-title">Import an OpenAPI file or paste the spec. Nothing leaves the browser.</p>
@@ -23,7 +31,8 @@ import '../styles/global.css';
   </header>
 
   <main class="split">
-    <aside class="pane-left">
+    <div id="pane-backdrop" class="pane-backdrop" hidden></div>
+    <aside id="pane-left" class="pane-left">
       <div class="search-box">
         <input id="search" type="search" placeholder="Search APIs (Ctrl/Cmd + K)"
                autocomplete="off" spellcheck="false" aria-label="Search APIs">

--- a/product/akbun-openapiviewer/workspace/src/scripts/main.js
+++ b/product/akbun-openapiviewer/workspace/src/scripts/main.js
@@ -3,6 +3,8 @@
 import {
   parseSpec,
   specTitle,
+  specJson,
+  specFileName,
   listOperations,
   filterOperations,
   pageSlice,
@@ -23,6 +25,7 @@ const loader = document.getElementById('loader');
 const specInput = document.getElementById('spec-input');
 const loadStatus = document.getElementById('load-status');
 const fileInput = document.getElementById('file-input');
+const exportButton = document.getElementById('export-json');
 const paneLeft = document.getElementById('pane-left');
 const paneBackdrop = document.getElementById('pane-backdrop');
 const toggleList = document.getElementById('toggle-list');
@@ -218,6 +221,22 @@ function render() {
   renderDetail();
 }
 
+// ===== Export =====
+
+// Exports the parsed document, not the pasted text, so a YAML spec comes back
+// out as JSON. The object URL is revoked once the click has been handed off,
+// or the whole document stays in memory for the life of the tab.
+function exportJson() {
+  if (!state.spec) return;
+  const blob = new Blob([specJson(state.spec)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = specFileName(state.spec);
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
 // ===== Loading =====
 
 function loadSpec(text) {
@@ -229,6 +248,7 @@ function loadSpec(text) {
   setDrawer(false);
   searchInput.value = '';
   specTitleEl.textContent = `${specTitle(spec)} · ${state.ops.length} APIs`;
+  exportButton.disabled = false;
 
   // A spec near the localStorage quota is not worth failing the load over.
   try {
@@ -265,6 +285,7 @@ function tryLoadFromInput() {
 // ===== Wiring =====
 
 document.getElementById('open-loader').addEventListener('click', openLoader);
+exportButton.addEventListener('click', exportJson);
 document.getElementById('close-loader').addEventListener('click', closeLoader);
 document.getElementById('load-spec').addEventListener('click', tryLoadFromInput);
 document.getElementById('load-sample').addEventListener('click', () => {

--- a/product/akbun-openapiviewer/workspace/src/scripts/main.js
+++ b/product/akbun-openapiviewer/workspace/src/scripts/main.js
@@ -23,6 +23,13 @@ const loader = document.getElementById('loader');
 const specInput = document.getElementById('spec-input');
 const loadStatus = document.getElementById('load-status');
 const fileInput = document.getElementById('file-input');
+const paneLeft = document.getElementById('pane-left');
+const paneBackdrop = document.getElementById('pane-backdrop');
+const toggleList = document.getElementById('toggle-list');
+
+// Below this width the sidebar is a drawer, not a pane. The same number lives
+// in global.css; the two have to move together.
+const drawerQuery = window.matchMedia('(max-width: 720px)');
 
 // view is either the paginated all-APIs view or one selected operation.
 const state = {
@@ -30,6 +37,7 @@ const state = {
   ops: [],
   query: '',
   view: { kind: 'all', page: 1 },
+  drawer: false,
 };
 
 function esc(value) {
@@ -40,6 +48,25 @@ function esc(value) {
 
 function visibleOps() {
   return filterOperations(state.ops, state.query);
+}
+
+// ===== Drawer =====
+
+// The drawer only exists below the breakpoint. Above it the pane is always
+// there, so the open flag is ignored and the pane must never be inert.
+function syncDrawer() {
+  const isDrawer = drawerQuery.matches;
+  if (!isDrawer) state.drawer = false;
+  const open = isDrawer && state.drawer;
+  paneLeft.classList.toggle('open', open);
+  paneLeft.inert = isDrawer && !open;
+  paneBackdrop.hidden = !open;
+  toggleList.setAttribute('aria-expanded', String(open));
+}
+
+function setDrawer(open) {
+  state.drawer = open;
+  syncDrawer();
 }
 
 // ===== Sidebar =====
@@ -91,22 +118,26 @@ function operationHtml(op) {
     .map((param) => (param && param.$ref ? resolveRef(spec, param.$ref) : param))
     .filter((param) => param && typeof param === 'object');
   if (params.length) {
+    // data-label carries the column header for the phone layout, where the
+    // header row is hidden and each cell prints its own label.
     const rows = params
       .map((param) => `
         <tr>
-          <td><code>${esc(param.name)}</code></td>
-          <td>${esc(param.in)}</td>
-          <td>${param.required ? '✓' : ''}</td>
-          <td><code>${esc(schemaText(spec, param.schema).split('\n')[0])}</code></td>
-          <td>${esc(param.description ?? '')}</td>
+          <td data-label="Name"><code>${esc(param.name)}</code></td>
+          <td data-label="In">${esc(param.in)}</td>
+          <td data-label="Required">${param.required ? '✓' : ''}</td>
+          <td data-label="Type"><code>${esc(schemaText(spec, param.schema).split('\n')[0])}</code></td>
+          <td data-label="Description">${esc(param.description ?? '')}</td>
         </tr>`)
       .join('');
     parts.push(`
       <h3>Parameters</h3>
-      <table class="params">
-        <thead><tr><th>Name</th><th>In</th><th>Required</th><th>Type</th><th>Description</th></tr></thead>
-        <tbody>${rows}</tbody>
-      </table>`);
+      <div class="table-wrap">
+        <table class="params">
+          <thead><tr><th>Name</th><th>In</th><th>Required</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`);
   }
 
   const body = operation.requestBody?.$ref
@@ -195,6 +226,7 @@ function loadSpec(text) {
   state.ops = listOperations(spec);
   state.query = '';
   state.view = { kind: 'all', page: 1 };
+  setDrawer(false);
   searchInput.value = '';
   specTitleEl.textContent = `${specTitle(spec)} · ${state.ops.length} APIs`;
 
@@ -211,7 +243,9 @@ function openLoader() {
   loadStatus.textContent = '';
   loadStatus.classList.remove('error');
   loader.classList.add('open');
-  specInput.focus();
+  // Focusing the textarea throws the on-screen keyboard over the dialog before
+  // the reader has seen what it is asking for, so phones open it untouched.
+  if (!drawerQuery.matches) specInput.focus();
 }
 
 function closeLoader() {
@@ -247,8 +281,13 @@ fileInput.addEventListener('change', async () => {
   tryLoadFromInput();
 });
 
+toggleList.addEventListener('click', () => setDrawer(!state.drawer));
+paneBackdrop.addEventListener('click', () => setDrawer(false));
+drawerQuery.addEventListener('change', syncDrawer);
+
 allButton.addEventListener('click', () => {
   state.view = { kind: 'all', page: 1 };
+  setDrawer(false);
   render();
 });
 
@@ -256,6 +295,7 @@ opList.addEventListener('click', (event) => {
   const item = event.target.closest('.op-item');
   if (!item) return;
   state.view = { kind: 'op', id: item.dataset.id };
+  setDrawer(false);
   render();
 });
 
@@ -275,16 +315,23 @@ searchInput.addEventListener('input', () => {
 document.addEventListener('keydown', (event) => {
   if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
     event.preventDefault();
+    // The search box lives in the drawer, so it has to be on screen first.
+    setDrawer(true);
     searchInput.focus();
     searchInput.select();
     return;
   }
-  if (event.key === 'Escape' && loader.classList.contains('open') && state.spec) {
-    closeLoader();
+  if (event.key !== 'Escape') return;
+  if (loader.classList.contains('open')) {
+    if (state.spec) closeLoader();
+    return;
   }
+  setDrawer(false);
 });
 
 // ===== Start =====
+
+syncDrawer();
 
 const saved = localStorage.getItem(STORAGE_KEY);
 if (saved) {

--- a/product/akbun-openapiviewer/workspace/src/styles/global.css
+++ b/product/akbun-openapiviewer/workspace/src/styles/global.css
@@ -684,8 +684,20 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
 /* Below this the header name and every button label cannot share a line, so
    the two icon buttons drop their labels and keep only the glyph. */
 @media (max-width: 520px) {
-  .nav-toggle-label, .icon-button-label { display: none; }
-  .nav-toggle, .icon-button { padding: 0.4rem 0.55rem; }
+  /* Hidden from the eye, kept in the accessibility tree. display:none would
+     drop it, and the glyph beside it is aria-hidden, so the button would be
+     left with no accessible name at all. */
+  .nav-toggle-label, .icon-button-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+  .nav-toggle, .icon-button { position: relative; padding: 0.4rem 0.55rem; }
 }
 
 @media (max-width: 400px) {

--- a/product/akbun-openapiviewer/workspace/src/styles/global.css
+++ b/product/akbun-openapiviewer/workspace/src/styles/global.css
@@ -23,8 +23,16 @@
   --m-other: #6B6560;
 }
 
-html { font-size: 16px; -webkit-font-smoothing: antialiased; }
-html, body { height: 100%; }
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  /* iOS inflates text when a phone is turned sideways unless this is pinned. */
+  -webkit-text-size-adjust: 100%;
+}
+
+/* dvh keeps the app shell out from under the mobile browser chrome. The vh
+   line above it is the fallback for browsers that do not know dvh. */
+html, body { height: 100vh; height: 100dvh; }
 
 body {
   font-family: var(--font-body);
@@ -45,23 +53,30 @@ body {
   justify-content: space-between;
   gap: 1rem;
   padding: 0 1.25rem;
+  padding-left: max(1.25rem, env(safe-area-inset-left));
+  padding-right: max(1.25rem, env(safe-area-inset-right));
   border-bottom: 3px solid var(--text);
   background: var(--surface);
 }
 
 .app-title {
+  flex: 1 1 auto;
   display: flex;
   align-items: baseline;
   gap: 0.8rem;
   min-width: 0;
 }
 
+/* The title is the only part of the header allowed to shrink, so a narrow
+   screen truncates the name instead of pushing the buttons off the edge. */
 .app-title h1 {
   font-family: var(--font-title);
   font-size: 1.7rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .app-title p {
@@ -73,6 +88,7 @@ body {
 }
 
 button {
+  flex-shrink: 0;
   margin: 0;
   padding: 0.45rem 0.95rem;
   color: #fff;
@@ -99,6 +115,25 @@ button.ghost {
 }
 button.ghost:hover { background: #F1EEE7; border-color: var(--text-sub); }
 button.ghost:disabled:hover { background: var(--surface); border-color: var(--divider); }
+
+/* Opens the API list on phones, where the list is a drawer instead of a pane.
+   Hidden until the drawer breakpoint, where the pane stops being visible. */
+.nav-toggle {
+  display: none;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.85rem;
+}
+.nav-toggle svg { display: block; width: 1.1rem; height: 1.1rem; }
+
+.pane-backdrop {
+  display: none;
+  position: fixed;
+  inset: var(--header-height) 0 0 0;
+  z-index: 14;
+  background: rgba(45, 42, 38, 0.45);
+}
 
 /* ===== Split layout ===== */
 .split {
@@ -181,6 +216,7 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   display: flex;
   flex-direction: column;
 }
@@ -246,6 +282,7 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 1.25rem 1.5rem 3rem;
 }
 
@@ -284,7 +321,12 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   color: var(--text-sub);
 }
 
+/* A query container, so the parameter table can restack on how much room the
+   card actually got rather than on how wide the window is. The two differ:
+   a tablet holding the split gives a card no more room than a phone does. */
 .op {
+  container-type: inline-size;
+  container-name: opcard;
   margin-bottom: 1rem;
   padding: 1rem 1.25rem;
   background: var(--surface);
@@ -362,9 +404,16 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   text-transform: none;
 }
 
+/* Five columns of parameter never fit a narrow card. The wrapper keeps the
+   overflow inside the card so the page itself never scrolls sideways. */
+.table-wrap {
+  margin-top: 0.4rem;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
 .params {
   width: 100%;
-  margin-top: 0.4rem;
   border-collapse: collapse;
   font-size: 0.85rem;
 }
@@ -385,6 +434,56 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
 }
 .params code { font-family: var(--font-mono); font-size: 0.8rem; }
 
+/* Narrow card: the table stops being a table and each parameter becomes one
+   labelled block. Five columns below this width are unreadable whether they
+   are squeezed or scrolled, and reading down beats scrolling sideways. */
+@container opcard (max-width: 33rem) {
+  .table-wrap { overflow-x: visible; }
+
+  /* Kept in the DOM, off screen, so a screen reader still reads the columns
+     once. Parked to the left rather than clipped in place, or the cells keep
+     a layout box out past the right edge. */
+  .params thead {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  .params, .params tbody, .params tr, .params td { display: block; width: 100%; }
+
+  .params tr {
+    margin-bottom: 0.4rem;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--divider);
+    border-radius: 8px;
+    background: var(--bg);
+  }
+
+  .params td {
+    display: flex;
+    gap: 0.6rem;
+    padding: 0.1rem 0;
+    border: none;
+    overflow-wrap: anywhere;
+  }
+  .params td::before {
+    content: attr(data-label);
+    flex: 0 0 5.5rem;
+    white-space: nowrap;
+    font-family: var(--font-title);
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.9;
+    color: var(--text-sub);
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+  /* An unset "required" or a parameter with no description prints nothing. */
+  .params td:empty { display: none; }
+}
+
 .media { margin-top: 0.4rem; }
 .media-type code {
   font-family: var(--font-mono);
@@ -403,6 +502,7 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   font-size: 0.8rem;
   line-height: 1.55;
   overflow-x: auto;
+  overscroll-behavior-x: contain;
 }
 
 .response { margin-top: 0.6rem; }
@@ -485,18 +585,105 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   flex-wrap: wrap;
 }
 
+/* ===== Tablet: the split holds, the chrome around it shrinks ===== */
 @media (max-width: 900px) {
-  body { overflow: auto; }
-  .app-header { height: auto; flex-wrap: wrap; padding: 0.7rem 1rem; }
-  .app-title { flex-direction: column; gap: 0.15rem; }
+  :root { --header-height: 64px; }
+  .app-header { gap: 0.75rem; padding: 0 1rem; }
+  .app-title { gap: 0.6rem; }
+  .app-title h1 { font-size: 1.3rem; }
+  .app-title p { font-size: 0.85rem; }
+  .pane-left { width: 38%; min-width: 240px; }
+  .detail { padding: 1rem 1rem 2.5rem; }
+  .op { padding: 0.9rem 1rem; }
+}
+
+/* ===== Phone: the list becomes a drawer over the detail pane =====
+   Two panes side by side stop being readable somewhere around here, and
+   stacking them costs half the screen to a list nobody is reading while
+   they read an operation. The drawer gives the detail the whole screen. */
+@media (max-width: 720px) {
+  :root { --header-height: 56px; }
+
+  .app-header { gap: 0.5rem; padding: 0 0.75rem; }
+  .app-title h1 { font-size: 1.05rem; }
   .app-title p { display: none; }
-  .split { flex-direction: column; }
+  .nav-toggle { display: inline-flex; }
+  .pane-backdrop:not([hidden]) { display: block; }
+
+  .app-header button { min-height: 40px; }
+
   .pane-left {
-    width: 100%;
+    position: fixed;
+    z-index: 15;
+    top: var(--header-height);
+    bottom: 0;
+    left: 0;
+    width: min(86vw, 340px);
+    min-width: 0;
     max-width: none;
-    height: 45vh;
-    border-right: none;
-    border-bottom: 2px solid var(--divider);
+    padding-left: env(safe-area-inset-left);
+    border-right: 2px solid var(--text);
+    box-shadow: 0 0 24px rgba(45, 42, 38, 0.25);
+    transform: translateX(-101%);
+    transition: transform 0.2s ease;
   }
-  .pane-right { min-height: 55vh; }
+  .pane-left.open { transform: none; }
+
+  #search { min-height: 42px; font-size: 16px; }
+  .all-item { min-height: 48px; }
+  .op-item { min-height: 48px; justify-content: center; }
+  .op-list { padding-bottom: env(safe-area-inset-bottom); }
+
+  .detail {
+    padding: 0.85rem 0.85rem 3rem;
+    padding-bottom: calc(3rem + env(safe-area-inset-bottom));
+  }
+  .all-head h2 { font-size: 1.1rem; }
+  .pager button { min-height: 40px; }
+
+  .op { padding: 0.8rem 0.85rem; border-radius: 8px; }
+  .op-head .method { font-size: 0.78rem; }
+  .op-url { font-size: 0.95rem; }
+  .op-title { font-size: 1rem; }
+  .schema { padding: 0.6rem 0.7rem; font-size: 0.75rem; }
+
+  /* The loader fills the screen instead of floating in a phone-sized gap. */
+  .loader { padding: 0; align-items: stretch; }
+  .loader-card {
+    width: 100%;
+    height: 100%;
+    max-height: none;
+    overflow-y: auto;
+    padding: 1rem;
+    padding-top: max(1rem, env(safe-area-inset-top));
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+    border: none;
+    border-radius: 0;
+  }
+  .loader-card h2 { font-size: 1.15rem; }
+  #spec-input { min-height: 10rem; font-size: 16px; }
+  .loader-actions button { flex: 1 1 7rem; min-height: 44px; }
+}
+
+/* Below this the header name and both button labels cannot share a line. */
+@media (max-width: 400px) {
+  .nav-toggle-label { display: none; }
+  .nav-toggle { padding: 0.4rem 0.55rem; }
+  .app-title h1 { font-size: 0.95rem; }
+  .app-header button { padding: 0.4rem 0.7rem; font-size: 0.85rem; }
+}
+
+/* A phone on its side is wider than the drawer breakpoint, so it keeps the
+   split. What it has no room for is chrome and a wide sidebar. */
+@media (max-height: 480px) and (orientation: landscape) {
+  :root { --header-height: 48px; }
+  .app-title h1 { font-size: 1rem; }
+  .pane-left { width: 32%; min-width: 200px; }
+  .loader { padding: 0.5rem; }
+  .loader-card { padding: 0.6rem 1rem; }
+  #spec-input { min-height: 6rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pane-left { transition: none; }
 }

--- a/product/akbun-openapiviewer/workspace/src/styles/global.css
+++ b/product/akbun-openapiviewer/workspace/src/styles/global.css
@@ -127,6 +127,22 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
 }
 .nav-toggle svg { display: block; width: 1.1rem; height: 1.1rem; }
 
+.header-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.85rem;
+}
+.icon-button svg { display: block; width: 1.1rem; height: 1.1rem; }
+
 .pane-backdrop {
   display: none;
   position: fixed;
@@ -665,12 +681,18 @@ button.ghost:disabled:hover { background: var(--surface); border-color: var(--di
   .loader-actions button { flex: 1 1 7rem; min-height: 44px; }
 }
 
-/* Below this the header name and both button labels cannot share a line. */
+/* Below this the header name and every button label cannot share a line, so
+   the two icon buttons drop their labels and keep only the glyph. */
+@media (max-width: 520px) {
+  .nav-toggle-label, .icon-button-label { display: none; }
+  .nav-toggle, .icon-button { padding: 0.4rem 0.55rem; }
+}
+
 @media (max-width: 400px) {
-  .nav-toggle-label { display: none; }
-  .nav-toggle { padding: 0.4rem 0.55rem; }
   .app-title h1 { font-size: 0.95rem; }
+  .header-actions { gap: 0.35rem; }
   .app-header button { padding: 0.4rem 0.7rem; font-size: 0.85rem; }
+  .app-header .icon-button { padding: 0.4rem 0.5rem; }
 }
 
 /* A phone on its side is wider than the drawer breakpoint, so it keeps the

--- a/product/akbun-openapiviewer/workspace/test/spec.test.js
+++ b/product/akbun-openapiviewer/workspace/test/spec.test.js
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import {
   parseSpec,
   specTitle,
+  specJson,
+  specFileName,
   listOperations,
   filterOperations,
   pageCount,
@@ -65,6 +67,26 @@ test('parseSpec caps YAML alias expansion', () => {
 test('specTitle joins title and version with fallbacks', () => {
   assert.equal(specTitle(MINIMAL), 'T 2');
   assert.equal(specTitle({}), 'OpenAPI');
+});
+
+test('specJson round-trips a YAML spec into indented JSON', () => {
+  const yaml = 'openapi: "3.0.3"\ninfo:\n  title: T\n  version: "2"\npaths:\n  /a:\n    get: {}\n';
+  const json = specJson(parseSpec(yaml));
+
+  assert.deepEqual(JSON.parse(json), parseSpec(yaml));
+  // one indent step per level, so top-level keys sit at 2 and info.title at 4
+  assert.match(json, /\n {2}"openapi": "3\.0\.3"/);
+  assert.match(json, /\n {4}"title": "T"/);
+  assert.ok(json.endsWith('\n'));
+});
+
+test('specFileName reduces the title to something a disk accepts', () => {
+  assert.equal(specFileName(MINIMAL), 't-2.json');
+  assert.equal(specFileName(parseSpec(SAMPLE_SPEC)), 'petstore-sample-1.0.0.json');
+  assert.equal(specFileName({ info: { title: 'Orders / Billing API!', version: 'v2' } }), 'orders-billing-api-v2.json');
+  assert.equal(specFileName({ info: { title: 'T' } }), 't.json');
+  assert.equal(specFileName({ info: { title: '///' } }), 'openapi.json');
+  assert.equal(specFileName({}), 'openapi.json');
 });
 
 test('listOperations flattens methods and merges path-level parameters', () => {


### PR DESCRIPTION
# 구현

720px 미만 sidebar를 drawer로 전환, parameter table을 카드 폭 기준으로 재배치, app shell을 dvh로 측정, 헤더에 Export JSON 추가

- 320, 375, 390, 520, 560, 700, 740x360, 768, 1440px 실측에서 가로 오버플로 0. 단위 테스트 12개와 브라우저 검사 33개 통과

# 어려웠던 점

parameter table 재배치 기준을 창 폭으로 잡으면 태블릿이 어긋남

- 768px 태블릿은 split 때문에 카드가 444px인데 600px 폰은 목록이 drawer라 같은 카드가 573px이라, media query를 버리고 container query로 바꿈

# 리스크

breakpoint 720px이 global.css의 media query와 main.js의 matchMedia 두 곳에 나뉘어 있어 한쪽만 고치면 drawer 상태와 화면이 어긋남

- CSS 변수를 JS가 읽을 수 없어 중복이 불가피함. 값을 바꿀 때 두 파일을 함께 고침

Issue #726
