### PR TITLE
akbun-awsviewer 릴리스 서명 키쌍 재생성

### DIFF
--- a/product/akbun-awsviewer/wiki/development.md
+++ b/product/akbun-awsviewer/wiki/development.md
@@ -38,6 +38,28 @@ Secrets: TAURI_SIGNING_PRIVATE_KEY_AWSVIEWER and TAURI_SIGNING_PRIVATE_KEY_AWSVI
 
 After merging, confirm with `gh release list` that the new version actually shipped; a green PR is not a release.
 
+## Updater signing key (one-time setup)
+
+The build fails without the private key, because tauri.conf.json carries a pubkey and createUpdaterArtifacts is on. Generate the pair with the tauri CLI:
+
+```bash
+cd workspace && npx @tauri-apps/cli signer generate -w ~/.tauri/akbun-awsviewer.key -p ""
+```
+
+Put the private half and its password in the two repository secrets the workflow reads (run from the repository root):
+
+```bash
+gh secret set TAURI_SIGNING_PRIVATE_KEY_AWSVIEWER < ~/.tauri/akbun-awsviewer.key
+```
+
+```bash
+printf '' | gh secret set TAURI_SIGNING_PRIVATE_KEY_AWSVIEWER_PASSWORD
+```
+
+Then paste the contents of ~/.tauri/akbun-awsviewer.key.pub into plugins.updater.pubkey in src-tauri/tauri.conf.json — the key contents, not a path. The pubkey and the secret are one pair: regenerating the key without updating the config produces a signed release that installed copies refuse.
+
+Keep ~/.tauri/akbun-awsviewer.key somewhere that outlives this laptop. A repository secret cannot be read back, and losing the key means installed copies can never update again.
+
 ## Caveats
 
 - The SSO login window label is fixed (`sso-login`); a second login replaces it. Closing that window is the cancel path — the poll loop checks the window handle.

--- a/product/akbun-awsviewer/workspace/src-tauri/tauri.conf.json
+++ b/product/akbun-awsviewer/workspace/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
       "endpoints": [
         "https://github.com/choisungwook/portfolio/releases/download/akbun-awsviewer-updater/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUzNTk3MDQxQzgwNDhCNzAKUldSd2l3VElRWEJaNDFvVm9Pd0xFL2ZRck5ESndpeWRpdDVKcm9GMmd5WUNMZm5rWExSYUUweHcK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFERkExMjY5MzZFNEREMzQKUldRMDNlUTJhUkw2SGFJNDJIcG1LVEZoZEFvYW5kVHpFSk5KRlpZUVJ0Ny9MWHZkaThyWFpzamUK"
     }
   }
 }


### PR DESCRIPTION
# 구현

tauri.conf.json의 updater pubkey를 새로 만든 키쌍의 공개키로 교체하고, 키 발급과 secret 등록 절차를 wiki에 추가
- 기존 pubkey는 키 ID E3597041C8048B70, 새 pubkey는 1DFA126936E4DD34

# 어려웠던 점

증상이 workflow 문제로 보였으나 실제 실패 지점은 서명 한 곳
- 빌드 14분 33초와 dmg 번들까지 통과한 뒤 failed to decode secret key로 종료

# 리스크

이번 변경을 push하기 전에 실패한 run을 재실행하면 옛 pubkey로 서명된 릴리스가 나감
- 설치본이 서명 검증에 실패해 업데이트를 거부하므로, 이 PR 머지 후의 run만 유효함

Issue #735