### PR TITLE
akbun-openapiviewer PR 734 리뷰 코멘트 반영

### DIFF
--- a/product/akbun-openapiviewer/README.md
+++ b/product/akbun-openapiviewer/README.md
@@ -19,6 +19,9 @@ Deployed as a static Astro build on Cloudflare.
 | Restore | The spec is kept in `localStorage`, so a reload or a closed tab does not lose it |
 | Phone | Below 720px the API list becomes a drawer opened from the header, so an operation gets the whole screen, and each parameter reads down a card instead of across a table too wide to fit |
 
+## Directory layout
+
+| Directory | Description |
 |---|---|
 | `workspace/src/pages/` | The single Astro page: the sidebar, the detail pane, the loader dialog |
 | `workspace/src/scripts/` | The DOM side. Rendering, event wiring, `localStorage` |

--- a/product/akbun-openapiviewer/workspace/package-lock.json
+++ b/product/akbun-openapiviewer/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-openapiviewer",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-openapiviewer",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "dependencies": {
         "astro": "^7.1.6",
         "js-yaml": "^5.2.3"

--- a/product/akbun-openapiviewer/workspace/package.json
+++ b/product/akbun-openapiviewer/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-openapiviewer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-openapiviewer/workspace/src/lib/spec.js
+++ b/product/akbun-openapiviewer/workspace/src/lib/spec.js
@@ -240,19 +240,19 @@ export function schemaExample(spec, schema, seen = [], depth = 0) {
 
   if (schema.$ref) {
     if (seen.includes(schema.$ref)) return null;
-    return schemaExample(spec, resolveRef(spec, schema.$ref), [...seen, schema.$ref], depth);
+    return schemaExample(spec, resolveRef(spec, schema.$ref), [...seen, schema.$ref], depth + 1);
   }
 
   // allOf is a merge, so the parts are combined; oneOf/anyOf is a choice, so the
   // first branch is shown rather than an object that satisfies none of them.
   if (Array.isArray(schema.allOf)) {
     return schema.allOf.reduce(
-      (acc, part) => Object.assign(acc, schemaExample(spec, part, seen, depth) ?? {}),
+      (acc, part) => Object.assign(acc, schemaExample(spec, part, seen, depth + 1) ?? {}),
       {},
     );
   }
   for (const key of ['oneOf', 'anyOf']) {
-    if (Array.isArray(schema[key])) return schemaExample(spec, schema[key][0], seen, depth);
+    if (Array.isArray(schema[key])) return schemaExample(spec, schema[key][0], seen, depth + 1);
   }
 
   if (Array.isArray(schema.enum)) return schema.enum[0] ?? null;

--- a/product/akbun-openapiviewer/workspace/src/scripts/main.js
+++ b/product/akbun-openapiviewer/workspace/src/scripts/main.js
@@ -351,7 +351,7 @@ allButton.addEventListener('click', () => {
 });
 
 opList.addEventListener('click', (event) => {
-  const item = event.target.closest('.op-item');
+  const item = event.target.closest?.('.op-item');
   if (!item) return;
   state.view = { kind: 'op', id: item.dataset.id };
   setDrawer(false);
@@ -359,21 +359,21 @@ opList.addEventListener('click', (event) => {
 });
 
 detail.addEventListener('click', (event) => {
-  const lang = event.target.closest('[data-lang]');
+  const lang = event.target.closest?.('[data-lang]');
   if (lang) {
     state.lang = lang.dataset.lang;
     refreshCodeBoxes();
     return;
   }
 
-  const pretty = event.target.closest('[data-pretty]');
+  const pretty = event.target.closest?.('[data-pretty]');
   if (pretty) {
     state.pretty = pretty.dataset.pretty === '1';
     refreshCodeBoxes();
     return;
   }
 
-  const copy = event.target.closest('[data-copy]');
+  const copy = event.target.closest?.('[data-copy]');
   if (copy) {
     const code = copy.closest('.code-box').querySelector('.snippet').textContent;
     // No clipboard on an insecure origin, and the user can still select the
@@ -384,7 +384,7 @@ detail.addEventListener('click', (event) => {
     return;
   }
 
-  const button = event.target.closest('[data-page]');
+  const button = event.target.closest?.('[data-page]');
   if (!button || button.disabled) return;
   state.view = { kind: 'all', page: Number(button.dataset.page) };
   renderDetail();

--- a/product/akbun-openapiviewer/workspace/test/spec.test.js
+++ b/product/akbun-openapiviewer/workspace/test/spec.test.js
@@ -149,7 +149,7 @@ test('serverUrl takes the first server without its trailing slash', () => {
   assert.equal(serverUrl({}), 'https://api.example.com');
 });
 
-test('schemaExample fills a body and stops at circles', () => {
+test('schemaExample fills a body and stops at cycles', () => {
   assert.deepEqual(schemaExample(SAMPLE, { $ref: '#/components/schemas/Pet' }), {
     id: 0,
     name: 'string',
@@ -163,6 +163,20 @@ test('schemaExample fills a body and stops at circles', () => {
   });
   assert.equal(schemaExample({}, { type: 'boolean' }), true);
   assert.deepEqual(schemaExample({}, { allOf: [{ properties: { a: { type: 'string' } } }, { properties: { b: { type: 'boolean' } } }] }), { a: 'string', b: true });
+});
+
+test('schemaExample stops descending a chain of distinct $refs', () => {
+  // Every ref is a different name, so the cycle guard never fires and the depth
+  // limit is the only thing that can stop the descent.
+  const schemas = { S9: { type: 'string' } };
+  for (let i = 0; i < 9; i += 1) {
+    schemas[`S${i}`] = { type: 'object', properties: { next: { $ref: `#/components/schemas/S${i + 1}` } } };
+  }
+  const chain = { components: { schemas } };
+
+  assert.deepEqual(schemaExample(chain, { $ref: '#/components/schemas/S0' }), {
+    next: { next: { next: null } },
+  });
 });
 
 test('curl carries method, headers and body, on one line or several', () => {


### PR DESCRIPTION
# 구현

README 표 헤더 복구, schemaExample 깊이 제한 교정, closest 호출 5곳 방어, 버전 0.4.1
- 테스트 21개 통과, 신규 1개는 수정 전 실패하고 수정 후 통과함을 확인

# 어려웠던 점

깊이 제한 회귀 테스트의 기대 중첩 단수가 실제보다 한 단 깊었음
- ref 하강과 property 하강이 각각 depth를 1씩 소비해 한 단계가 두 칸이었고, 실측으로 3단이 맞음을 확인

# 리스크

ref가 depth를 소비하게 되어 예전보다 얕은 문서에서 요청 body 예시가 null로 끊길 수 있음
- MAX_DEPTH 6 고정이므로 실제로 잘리는 spec을 만나면 상수 상향

Issue #741