### PR TITLE
fix: akbun-awsviewer UI 상호작용 복구

### DIFF
--- a/product/akbun-awsviewer/workspace/package-lock.json
+++ b/product/akbun-awsviewer/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-awsviewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-awsviewer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-awsviewer/workspace/package.json
+++ b/product/akbun-awsviewer/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-awsviewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "macOS desktop viewer for AWS resources: pick a profile from ~/.aws/config, log in with IAM Identity Center, and browse EC2 read-only",
   "author": "akbun",

--- a/product/akbun-awsviewer/workspace/src/index.html
+++ b/product/akbun-awsviewer/workspace/src/index.html
@@ -64,8 +64,6 @@
       <button id="login-button">Log in</button>
     </header>
 
-    <div id="error-banner" class="hidden"></div>
-
     <main>
       <!-- Instances tab -->
       <section id="tab-instances" class="tab active">
@@ -177,6 +175,17 @@
     </div>
     <div id="detail-body"></div>
   </aside>
+
+  <dialog id="error-dialog" aria-labelledby="error-title" aria-describedby="error-message">
+    <div class="error-dialog-header">
+      <h2 id="error-title">An error occurred</h2>
+      <button id="close-error-dialog" aria-label="Close error message">✕</button>
+    </div>
+    <p id="error-message"></p>
+    <div class="error-dialog-actions">
+      <button id="confirm-error-dialog">OK</button>
+    </div>
+  </dialog>
 
   <script src="lib.js"></script>
   <script src="api.js"></script>

--- a/product/akbun-awsviewer/workspace/src/lib.js
+++ b/product/akbun-awsviewer/workspace/src/lib.js
@@ -88,10 +88,10 @@ const exported = {
   sessionLabel,
 };
 
-// One export name for both worlds: require() for node --test, a single global
-// for the script tag. Individual top-level names would collide across tags.
+// Always publish the browser global. Some WebViews expose a CommonJS-like
+// `module` object even though scripts are loaded with script tags.
+globalThis.awsviewerLib = exported;
+
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = exported;
-} else {
-  globalThis.awsviewerLib = exported;
 }

--- a/product/akbun-awsviewer/workspace/src/renderer.js
+++ b/product/akbun-awsviewer/workspace/src/renderer.js
@@ -35,13 +35,15 @@ function dash(value) {
 // ---------------------------------------------------------------- errors
 
 function showError(message) {
-  const banner = $('#error-banner');
-  banner.textContent = message;
-  banner.classList.remove('hidden');
+  const dialog = $('#error-dialog');
+  $('#error-message').textContent = message;
+  if (!dialog.open) dialog.showModal();
+  $('#confirm-error-dialog').focus();
 }
 
 function clearError() {
-  $('#error-banner').classList.add('hidden');
+  const dialog = $('#error-dialog');
+  if (dialog.open) dialog.close();
 }
 
 /// Command failures arrive as { kind, message } from the backend, or as a
@@ -381,6 +383,14 @@ function switchTab(name) {
 }
 
 function wire() {
+  const errorDialog = $('#error-dialog');
+  const closeErrorDialog = () => errorDialog.close();
+  $('#close-error-dialog').addEventListener('click', closeErrorDialog);
+  $('#confirm-error-dialog').addEventListener('click', closeErrorDialog);
+  errorDialog.addEventListener('click', (event) => {
+    if (event.target === errorDialog) closeErrorDialog();
+  });
+
   for (const tabButton of document.querySelectorAll('#sidebar .tab-button')) {
     tabButton.addEventListener('click', () => switchTab(tabButton.dataset.tab));
   }

--- a/product/akbun-awsviewer/workspace/src/style.css
+++ b/product/akbun-awsviewer/workspace/src/style.css
@@ -366,14 +366,53 @@ th[aria-sort="descending"] .sort-arrow::after {
   color: var(--muted);
 }
 
-#error-banner {
-  margin: 10px 20px 0;
-  padding: 8px 12px;
+#error-dialog {
+  width: min(460px, calc(100vw - 40px));
+  padding: 0;
   border: 1px solid var(--danger-border);
-  border-radius: 6px;
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: 0 16px 48px rgb(0 0 0 / 24%);
+  color: var(--text);
+}
+
+#error-dialog::backdrop {
+  background: rgb(15 23 42 / 45%);
+}
+
+.error-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--danger-border);
   background: var(--danger-bg);
   color: var(--danger);
+}
+
+.error-dialog-header h2 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.error-dialog-header button {
+  padding: 3px 7px;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+#error-message {
+  margin: 0;
+  padding: 18px 16px;
   overflow-wrap: anywhere;
+}
+
+.error-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 16px 16px;
 }
 
 .settings-form {

--- a/product/akbun-awsviewer/workspace/test/lib.test.js
+++ b/product/akbun-awsviewer/workspace/test/lib.test.js
@@ -2,6 +2,8 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const vm = require('node:vm');
 const {
   filterInstances,
   sortInstances,
@@ -10,6 +12,15 @@ const {
   stateClass,
   sessionLabel,
 } = require('../src/lib.js');
+
+test('publishes the browser API when a CommonJS module global exists', () => {
+  const source = fs.readFileSync(require.resolve('../src/lib.js'), 'utf8');
+  const context = { module: { exports: {} } };
+
+  vm.runInNewContext(source, context);
+
+  assert.strictEqual(typeof context.awsviewerLib.filterInstances, 'function');
+});
 
 const instances = [
   { instanceId: 'i-0aaa', name: 'web-1', state: 'running', privateIp: '10.0.1.10' },


### PR DESCRIPTION
# 구현

WebView 전역 API 초기화 복구, 오류 모달 추가, 버전 0.1.1 갱신
- JavaScript 테스트 10개와 Rust 테스트 17개 통과

# 어려웠던 점

WebView 초기화 실패가 화면에 드러나지 않아 모든 컨트롤이 동시에 멈춘 것처럼 보이는 증상 재현
- CommonJS 호환 전역 존재 시 브라우저 API 게시가 누락되는 분기 확인

# 리스크

오류 모달 표시 중에는 배경 UI 조작 차단
- 확인, 닫기, 바깥 영역 클릭, Esc로 해제 가능

Issue #743