### PR TITLE
akbun-awsviewer 클릭 불능 근본 수정과 로그인 모달, spot 필터, 오류 로그

### DIFF
--- a/.claude/rules/tauri.md
+++ b/.claude/rules/tauri.md
@@ -65,7 +65,7 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 ```
 
-A script tag makes that file's top level names globals on the page, so destructuring them in another script fails with `Identifier has already been declared`. Keep the exports behind one name.
+A script tag makes that file's top level names globals on the page, so destructuring them in another script fails with `Identifier has already been declared`. Keep the exports behind one name, and consume them through that name too — `const lib = globalThis.myAppLib`, never a top-level destructure of the same function names. The collision is a parse error that kills the consuming file before it wires a single listener, so the symptom is every control dead at once; akbun-awsviewer shipped two frozen releases this way. When the whole page is dead, read the webview console before changing any code.
 
 ## Returning state
 

--- a/product/akbun-awsviewer/README.md
+++ b/product/akbun-awsviewer/README.md
@@ -1,6 +1,6 @@
 # akbun-awsviewer
 
-macOS desktop viewer for AWS resources. Pick a profile from ~/.aws/config, sign in with IAM Identity Center in a dialog window, and browse EC2 instances read-only — list, filter by id or Name tag, and open console-style Details / Network / Storage / Security tabs.
+macOS desktop viewer for AWS resources. Pick a profile from ~/.aws/config in the AWS login dialog, sign in with IAM Identity Center, and browse EC2 instances read-only — list with an Age column, filter by id, Name tag, or spot only, and open console-style Details / Network / Storage / Security tabs.
 
 No access keys: the app reads no ~/.aws/credentials and calls only list/describe APIs through the official AWS SDK for Rust.
 

--- a/product/akbun-awsviewer/wiki/architecture.md
+++ b/product/akbun-awsviewer/wiki/architecture.md
@@ -20,16 +20,21 @@ The page owns the instance array; filtering and sorting run in lib.js on every k
 
 | Command | Does |
 |---|---|
-| get_snapshot | profiles + settings + session status + version, one round trip |
+| get_snapshot | profiles + settings + session status + version + log dir, one round trip |
 | select_profile | persists the choice, clears the credential cache, returns a snapshot |
 | set_insecure_tls | persists the TLS toggle, returns a snapshot |
 | sso_login | whole device flow: opens the login window, polls, writes the token cache |
 | list_instances | DescribeInstances for the selected profile's region |
 | instance_detail | one instance joined with its volumes and security groups |
+| open_log_dir | reveals the error log folder in Finder |
 
 Errors cross the boundary as `{ kind, message }`. The page treats `login_required` as "show the login hint", not as an error dump.
 
+api.js loads first and registers window `error`/`unhandledrejection` hooks before anything that can fail; together with the log plugin they append every uncaught page error — including a parse error in a later script — to a file under app_log_dir (~/Library/Logs/io.akbun.awsviewer). A log that has the startup line but no page errors and still misbehaves points at the webview, not the backend.
+
 ## Login flow
+
+The AWS login button in the topbar opens a profile picker dialog listing the SSO-capable profiles. Picking one selects it and, when the cached session is not already valid, starts this flow. The AWS Profile tab is a read-only listing.
 
 1. `sso_login` registers a public OIDC client and starts device authorization (both unsigned calls, this is how a client without credentials gets its first token).
 2. The verification URL opens in a separate `sso-login` window. That window is not in capabilities/default.json, so the remote identity page gets no IPC.

--- a/product/akbun-awsviewer/workspace/package-lock.json
+++ b/product/akbun-awsviewer/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-awsviewer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-awsviewer",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-awsviewer/workspace/package.json
+++ b/product/akbun-awsviewer/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-awsviewer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "macOS desktop viewer for AWS resources: pick a profile from ~/.aws/config, log in with IAM Identity Center, and browse EC2 read-only",
   "author": "akbun",

--- a/product/akbun-awsviewer/workspace/src-tauri/Cargo.lock
+++ b/product/akbun-awsviewer/workspace/src-tauri/Cargo.lock
@@ -22,10 +22,13 @@ name = "akbun-awsviewer"
 version = "0.1.0"
 dependencies = [
  "awsviewer-core",
+ "log",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
+ "tauri-plugin-log",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
@@ -44,6 +47,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -1427,6 +1447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2802,6 +2841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,6 +3537,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4444,6 +4516,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.19",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "toml 1.1.4+spec-1.1.0",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6792296e6f389268016c77db21ebae1fc0568f2fccf88b1ec7e2ea71330afb4c"
+dependencies = [
+ "android_logger",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "tauri-plugin-process"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4671,7 +4806,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/product/akbun-awsviewer/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-awsviewer/workspace/src-tauri/Cargo.toml
@@ -28,6 +28,11 @@ tauri-build = { version = "2", features = [] }
 # WebKit on the runner.
 awsviewer-core = { path = "crates/core" }
 tauri = { version = "2", features = [] }
+tauri-plugin-dialog = "2"
+# Page and backend errors go to a file under app_log_dir, so a dead-on-arrival
+# window still leaves something to debug from.
+tauri-plugin-log = "2"
+log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/product/akbun-awsviewer/workspace/src-tauri/capabilities/default.json
+++ b/product/akbun-awsviewer/workspace/src-tauri/capabilities/default.json
@@ -5,6 +5,9 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "dialog:allow-message",
+    "dialog:allow-ask",
+    "log:default",
     "updater:allow-check",
     "updater:allow-download-and-install",
     "process:allow-restart"

--- a/product/akbun-awsviewer/workspace/src-tauri/crates/core/src/ec2.rs
+++ b/product/akbun-awsviewer/workspace/src-tauri/crates/core/src/ec2.rs
@@ -20,6 +20,8 @@ pub struct InstanceSummary {
     pub private_ip: Option<String>,
     pub public_ip: Option<String>,
     pub launch_time: Option<String>,
+    /// "spot" for spot instances; the API omits it for on-demand.
+    pub lifecycle: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -239,6 +241,9 @@ pub fn map_summary(instance: &Instance) -> InstanceSummary {
         launch_time: instance.launch_time().and_then(|t| {
             t.fmt(aws_smithy_types::date_time::Format::DateTime).ok()
         }),
+        lifecycle: instance
+            .instance_lifecycle()
+            .map(|l| l.as_str().to_string()),
     }
 }
 
@@ -453,6 +458,17 @@ mod tests {
         assert_eq!(summary.state.as_deref(), Some("running"));
         assert_eq!(summary.instance_type.as_deref(), Some("t4g.small"));
         assert_eq!(summary.availability_zone.as_deref(), Some("ap-northeast-2a"));
+        assert_eq!(summary.lifecycle, None);
+    }
+
+    #[test]
+    fn summary_marks_spot_lifecycle() {
+        let instance = Instance::builder()
+            .instance_id("i-spot")
+            .instance_lifecycle(aws_sdk_ec2::types::InstanceLifecycleType::Spot)
+            .build();
+        let summary = map_summary(&instance);
+        assert_eq!(summary.lifecycle.as_deref(), Some("spot"));
     }
 
     #[test]

--- a/product/akbun-awsviewer/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-awsviewer/workspace/src-tauri/src/commands.rs
@@ -39,6 +39,7 @@ pub struct Snapshot {
     pub settings: Settings,
     pub session: Option<SessionStatus>,
     pub version: String,
+    pub log_dir: String,
 }
 
 fn io_error(message: String) -> CoreError {
@@ -106,12 +107,33 @@ fn snapshot(app: &AppHandle, state: &State<'_, AppState>) -> Result<Snapshot, Co
         settings,
         session,
         version: app.package_info().version.to_string(),
+        log_dir: log_dir(app)
+            .map(|dir| dir.display().to_string())
+            .unwrap_or_default(),
     })
 }
 
 #[tauri::command]
 pub fn get_snapshot(app: AppHandle, state: State<'_, AppState>) -> Result<Snapshot, CoreError> {
     snapshot(&app, &state)
+}
+
+fn log_dir(app: &AppHandle) -> Result<PathBuf, CoreError> {
+    app.path()
+        .app_log_dir()
+        .map_err(|error| io_error(format!("no log directory: {error}")))
+}
+
+/// Reveals the error log folder in Finder. The bundle only targets macOS
+/// (app/dmg), so `open` is enough.
+#[tauri::command]
+pub fn open_log_dir(app: AppHandle) -> Result<(), CoreError> {
+    let dir = log_dir(&app)?;
+    std::process::Command::new("open")
+        .arg(&dir)
+        .spawn()
+        .map_err(|error| io_error(format!("cannot open {dir:?}: {error}")))?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/product/akbun-awsviewer/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-awsviewer/workspace/src-tauri/src/lib.rs
@@ -8,7 +8,19 @@ use std::sync::Mutex;
 use tauri::Manager;
 
 pub fn run() {
-    let mut builder = tauri::Builder::default();
+    let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .targets([
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::LogDir {
+                        file_name: None,
+                    }),
+                ])
+                .level(log::LevelFilter::Info)
+                .build(),
+        );
 
     // One window only. The updater restarts the app while the installer may
     // also be starting it, and the second launch lands here instead of
@@ -39,6 +51,10 @@ pub fn run() {
                 window.open_devtools();
             }
 
+            // One line per launch: a log file that starts here but has no
+            // page activity after it points at the webview, not the backend.
+            log::info!("akbun-awsviewer {} starting", app.package_info().version);
+
             let handle = app.handle();
             app.manage(AppState {
                 settings: Mutex::new(store::load_settings(handle)),
@@ -53,6 +69,7 @@ pub fn run() {
             commands::sso_login,
             commands::list_instances,
             commands::instance_detail,
+            commands::open_log_dir,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/product/akbun-awsviewer/workspace/src/api.js
+++ b/product/akbun-awsviewer/workspace/src/api.js
@@ -6,21 +6,51 @@
 // no bundler and the app keeps its no-build-step property. Every AWS call is
 // a command in commands.rs; the page never talks to the network itself.
 
+// Loaded first, hooks registered before anything that can fail: an uncaught
+// error anywhere on the page — including a parse error in a later script —
+// lands in the log file under app_log_dir. v0.1.0 shipped a page that died
+// before wiring a single listener and left no evidence anywhere; this is the
+// evidence.
+function reportError(message) {
+  try {
+    window.__TAURI__?.log?.error(String(message));
+  } catch (_) {
+    // Logging must never take the page down with it.
+  }
+}
+window.addEventListener('error', (event) => {
+  reportError(`${event.message} (${event.filename}:${event.lineno})`);
+});
+window.addEventListener('unhandledrejection', (event) => {
+  reportError(`unhandled rejection: ${event.reason?.message || event.reason}`);
+});
+
 const { invoke } = window.__TAURI__.core;
 
-async function checkUpdate(onStatus) {
+async function checkUpdate() {
+  const { message, ask } = window.__TAURI__.dialog;
   const { check } = window.__TAURI__.updater;
   const { relaunch } = window.__TAURI__.process;
-  onStatus('Checking…');
-  const update = await check();
-  if (!update) {
-    onStatus('You are on the latest version.');
-    return;
+  try {
+    const update = await check();
+    if (!update) {
+      await message('You are on the latest version.', { title: 'akbun-awsviewer' });
+      return;
+    }
+    const install = await ask(
+      `Version ${update.version} is available. Download and install it now?`,
+      { title: 'Update available', kind: 'info' },
+    );
+    if (!install) return;
+    await update.downloadAndInstall();
+    await relaunch();
+  } catch (error) {
+    reportError(`update check: ${error}`);
+    await message(`Cannot check for updates.\n\n${error}`, {
+      title: 'Update failed',
+      kind: 'error',
+    });
   }
-  onStatus(`Downloading ${update.version}…`);
-  await update.downloadAndInstall();
-  onStatus('Restarting…');
-  await relaunch();
 }
 
 globalThis.awsviewerApi = {
@@ -30,5 +60,6 @@ globalThis.awsviewerApi = {
   ssoLogin: () => invoke('sso_login'),
   listInstances: () => invoke('list_instances'),
   instanceDetail: (instanceId) => invoke('instance_detail', { instanceId }),
+  openLogDir: () => invoke('open_log_dir'),
   checkUpdate,
 };

--- a/product/akbun-awsviewer/workspace/src/api.js
+++ b/product/akbun-awsviewer/workspace/src/api.js
@@ -28,10 +28,10 @@ window.addEventListener('unhandledrejection', (event) => {
 const { invoke } = window.__TAURI__.core;
 
 async function checkUpdate() {
-  const { message, ask } = window.__TAURI__.dialog;
-  const { check } = window.__TAURI__.updater;
-  const { relaunch } = window.__TAURI__.process;
   try {
+    const { message, ask } = window.__TAURI__.dialog;
+    const { check } = window.__TAURI__.updater;
+    const { relaunch } = window.__TAURI__.process;
     const update = await check();
     if (!update) {
       await message('You are on the latest version.', { title: 'akbun-awsviewer' });
@@ -45,8 +45,11 @@ async function checkUpdate() {
     await update.downloadAndInstall();
     await relaunch();
   } catch (error) {
-    reportError(`update check: ${error}`);
-    await message(`Cannot check for updates.\n\n${error}`, {
+    const detail = error?.message || String(error);
+    reportError(`update check: ${detail}`);
+    // Optional chained: when the dialog plugin itself is what is missing,
+    // the log line above is the only reporting channel left.
+    await window.__TAURI__?.dialog?.message?.(`Cannot check for updates.\n\n${detail}`, {
       title: 'Update failed',
       kind: 'error',
     });

--- a/product/akbun-awsviewer/workspace/src/index.html
+++ b/product/akbun-awsviewer/workspace/src/index.html
@@ -61,7 +61,8 @@
         <span id="current-profile">none</span>
         <span id="session-badge" class="session-badge logged-out">Not logged in</span>
       </div>
-      <button id="login-button">Log in</button>
+      <button id="update-button" title="Check for a newer version">Updates</button>
+      <button id="login-button">AWS login</button>
     </header>
 
     <main>
@@ -70,6 +71,10 @@
         <div class="toolbar">
           <input id="instance-filter" type="text"
             placeholder="Filter by instance id or Name tag" />
+          <label class="toolbar-check">
+            <input id="spot-only" type="checkbox" />
+            Spot only
+          </label>
           <button id="refresh-instances">Refresh</button>
         </div>
         <p class="help">Click a header to sort by that column; click it again to flip the direction. Click a row for details.</p>
@@ -97,22 +102,26 @@
               <th class="sortable" data-sort-key="publicIp" tabindex="0" role="button" aria-sort="none">
                 Public IP<span class="sort-arrow"></span>
               </th>
+              <th class="sortable" data-sort-key="launchTime" tabindex="0" role="button" aria-sort="none">
+                Age<span class="sort-arrow"></span>
+              </th>
             </tr>
           </thead>
           <tbody></tbody>
         </table>
         <p id="instance-empty" class="empty hidden">No instances.</p>
         <p id="instance-login-hint" class="empty hidden">
-          Log in with the button in the top right to list instances.
+          Use AWS login in the top right to list instances.
         </p>
       </section>
 
       <!-- AWS Profile tab -->
       <section id="tab-profile" class="tab">
         <p class="help">
-          Profiles come from ~/.aws/config. This app signs in through IAM
-          Identity Center only; profiles without SSO configuration are listed
-          but cannot be used.
+          Profiles come from ~/.aws/config, read-only. This app signs in
+          through IAM Identity Center only; profiles without SSO configuration
+          are listed but cannot be signed in to. Sign in and switch profiles
+          with AWS login in the top right.
         </p>
         <table id="profile-table">
           <thead>
@@ -150,9 +159,18 @@
         <h2>Updates</h2>
         <div class="settings-form">
           <button id="check-updates">Check for Updates…</button>
-          <span id="update-status" class="help"></span>
         </div>
         <p class="help">Version <span id="app-version">-</span></p>
+
+        <h2>Error log</h2>
+        <div class="settings-form">
+          <button id="open-log-dir">Open Log Folder</button>
+          <span id="log-dir" class="help"></span>
+        </div>
+        <p class="help">
+          Page and backend errors are appended to a file in this folder.
+          Attach it when reporting a bug.
+        </p>
       </section>
     </main>
   </div>
@@ -176,6 +194,22 @@
     <div id="detail-body"></div>
   </aside>
 
+  <!-- AWS login: pick the profile first, then the SSO flow starts. -->
+  <dialog id="login-dialog" aria-labelledby="login-dialog-title">
+    <div class="login-dialog-header">
+      <h2 id="login-dialog-title">AWS login</h2>
+      <button id="close-login-dialog" aria-label="Close login">✕</button>
+    </div>
+    <p class="help">
+      Pick the profile to sign in with. Only IAM Identity Center profiles
+      from ~/.aws/config are listed.
+    </p>
+    <ul id="login-profile-list"></ul>
+    <p id="login-profile-empty" class="empty hidden">
+      No IAM Identity Center profiles in ~/.aws/config.
+    </p>
+  </dialog>
+
   <dialog id="error-dialog" aria-labelledby="error-title" aria-describedby="error-message">
     <div class="error-dialog-header">
       <h2 id="error-title">An error occurred</h2>
@@ -187,8 +221,10 @@
     </div>
   </dialog>
 
-  <script src="lib.js"></script>
+  <!-- api.js first: its window error hooks catch failures in the other two,
+       including parse errors that would otherwise vanish without a trace. -->
   <script src="api.js"></script>
+  <script src="lib.js"></script>
   <script src="renderer.js"></script>
 </body>
 </html>

--- a/product/akbun-awsviewer/workspace/src/lib.js
+++ b/product/akbun-awsviewer/workspace/src/lib.js
@@ -75,7 +75,7 @@ function stateClass(state) {
 // The single largest unit is enough for a glance; sorting uses the raw
 // launchTime, not this label. Months and years are calendar approximations
 // (30 and 365 days), fine for a viewer.
-function formatAge(launchTime, nowMs) {
+function formatAge(launchTime, nowMs = Date.now()) {
   if (!launchTime) {
     return null;
   }

--- a/product/akbun-awsviewer/workspace/src/lib.js
+++ b/product/akbun-awsviewer/workspace/src/lib.js
@@ -4,12 +4,15 @@
 // DOM, so node --test runs this file as is. Search never asks the backend —
 // it runs over the array the page already has, on every keystroke.
 
-function filterInstances(instances, query) {
+function filterInstances(instances, query, spotOnly) {
+  const pool = spotOnly
+    ? instances.filter((instance) => instance.lifecycle === 'spot')
+    : instances;
   const q = (query || '').trim().toLowerCase();
   if (!q) {
-    return instances.slice();
+    return pool.slice();
   }
-  return instances.filter(
+  return pool.filter(
     (instance) =>
       (instance.instanceId || '').toLowerCase().includes(q) ||
       (instance.name || '').toLowerCase().includes(q),
@@ -69,6 +72,28 @@ function stateClass(state) {
   return '';
 }
 
+// The single largest unit is enough for a glance; sorting uses the raw
+// launchTime, not this label. Months and years are calendar approximations
+// (30 and 365 days), fine for a viewer.
+function formatAge(launchTime, nowMs) {
+  if (!launchTime) {
+    return null;
+  }
+  const launched = Date.parse(launchTime);
+  if (Number.isNaN(launched)) {
+    return null;
+  }
+  const minutes = Math.floor((nowMs - launched) / 60_000);
+  if (minutes < 1) return '<1m';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  if (days < 365) return `${Math.floor(days / 30)}mo`;
+  return `${Math.floor(days / 365)}y`;
+}
+
 function sessionLabel(session) {
   if (!session || !session.loggedIn) {
     return 'Not logged in';
@@ -84,6 +109,7 @@ const exported = {
   sortInstances,
   formatProtocol,
   formatPortRange,
+  formatAge,
   stateClass,
   sessionLabel,
 };

--- a/product/akbun-awsviewer/workspace/src/renderer.js
+++ b/product/akbun-awsviewer/workspace/src/renderer.js
@@ -108,6 +108,7 @@ function renderInstances() {
 
   const body = $('#instance-table tbody');
   body.replaceChildren();
+  const nowMs = Date.now();
   for (const instance of rows) {
     const tr = document.createElement('tr');
     tr.dataset.instanceId = instance.instanceId;
@@ -120,7 +121,7 @@ function renderInstances() {
       el('td', null, dash(instance.availabilityZone)),
       el('td', null, dash(instance.privateIp)),
       el('td', null, dash(instance.publicIp)),
-      el('td', null, dash(lib.formatAge(instance.launchTime, Date.now()))),
+      el('td', null, dash(lib.formatAge(instance.launchTime, nowMs))),
     );
     tr.addEventListener('click', () => openDetail(instance.instanceId));
     body.append(tr);
@@ -363,6 +364,7 @@ function renderLoginDialog() {
   for (const profile of profiles) {
     const item = document.createElement('li');
     const button = el('button', 'login-profile-row');
+    button.type = 'button';
     const name = el('span', null, profile.name);
     if (profile.name === current) {
       name.append(' ', el('span', 'badge current', 'current'));

--- a/product/akbun-awsviewer/workspace/src/renderer.js
+++ b/product/akbun-awsviewer/workspace/src/renderer.js
@@ -5,14 +5,18 @@
 // an AWS call. Data changes only on Refresh, profile switch, and login.
 
 const api = globalThis.awsviewerApi;
-const { filterInstances, sortInstances, formatProtocol, formatPortRange, stateClass, sessionLabel } =
-  globalThis.awsviewerLib;
+// Accessed through the namespace only. Classic scripts share one global
+// scope, so a top-level `const { filterInstances } = …` here collides with
+// lib.js's function declarations and kills this whole file with a parse
+// error before a single listener is wired. That was the v0.1.0/v0.1.1 bug.
+const lib = globalThis.awsviewerLib;
 
 const state = {
   snapshot: null,
   instances: [],
   loaded: false,
   filter: '',
+  spotOnly: false,
   sort: { key: 'name', direction: 'asc' },
   selectedId: null,
   detail: null,
@@ -57,9 +61,10 @@ function errorInfo(error) {
 
 function handleError(error) {
   const info = errorInfo(error);
+  reportError(`${info.kind}: ${info.message}`);
   if (info.kind === 'login_required') {
     setLoginHint(true);
-    showError('The session for this profile is missing or expired. Log in from the top right.');
+    showError('The session for this profile is missing or expired. Use AWS login in the top right.');
   } else if (info.kind === 'cancelled') {
     clearError();
   } else {
@@ -75,7 +80,7 @@ function renderTopbar() {
   const session = state.snapshot?.session || null;
   $('#current-profile').textContent = settings.profile || 'none';
   const badge = $('#session-badge');
-  badge.textContent = sessionLabel(session);
+  badge.textContent = lib.sessionLabel(session);
   badge.classList.toggle('logged-in', Boolean(session?.loggedIn));
   badge.classList.toggle('logged-out', !session?.loggedIn);
 }
@@ -87,8 +92,8 @@ function setLoginHint(visible) {
 }
 
 function renderInstances() {
-  const rows = sortInstances(
-    filterInstances(state.instances, state.filter),
+  const rows = lib.sortInstances(
+    lib.filterInstances(state.instances, state.filter, state.spotOnly),
     state.sort.key,
     state.sort.direction,
   );
@@ -110,11 +115,12 @@ function renderInstances() {
     tr.append(
       el('td', null, dash(instance.name)),
       el('td', null, instance.instanceId),
-      el('td', stateClass(instance.state) || null, dash(instance.state)),
+      el('td', lib.stateClass(instance.state) || null, dash(instance.state)),
       el('td', null, dash(instance.instanceType)),
       el('td', null, dash(instance.availabilityZone)),
       el('td', null, dash(instance.privateIp)),
       el('td', null, dash(instance.publicIp)),
+      el('td', null, dash(lib.formatAge(instance.launchTime, Date.now()))),
     );
     tr.addEventListener('click', () => openDetail(instance.instanceId));
     body.append(tr);
@@ -163,8 +169,8 @@ function ruleTable(rules) {
   for (const rule of rules) {
     const tr = document.createElement('tr');
     tr.append(
-      el('td', null, formatProtocol(rule.protocol)),
-      el('td', null, formatPortRange(rule.fromPort, rule.toPort)),
+      el('td', null, lib.formatProtocol(rule.protocol)),
+      el('td', null, lib.formatPortRange(rule.fromPort, rule.toPort)),
       el('td', null, rule.sources.length ? rule.sources.join(', ') : '-'),
     );
     body.append(tr);
@@ -290,6 +296,8 @@ function closeDetail() {
 
 // ---------------------------------------------------------------- profiles
 
+// Read-only listing; signing in to a profile happens in the AWS login
+// dialog, not here.
 function renderProfiles() {
   const profiles = state.snapshot?.profiles || [];
   const current = state.snapshot?.settings?.profile || null;
@@ -301,10 +309,6 @@ function renderProfiles() {
     const action = el('td');
     if (profile.name === current) {
       action.append(el('span', 'badge current', 'current'));
-    } else {
-      const button = el('button', 'select-profile', 'Use');
-      button.addEventListener('click', () => useProfile(profile.name));
-      action.append(button);
     }
     tr.append(
       el('td', null, profile.name),
@@ -325,6 +329,7 @@ function applySnapshot(snapshot) {
   renderProfiles();
   $('#insecure-tls').checked = Boolean(snapshot.settings.insecureTls);
   $('#app-version').textContent = snapshot.version;
+  $('#log-dir').textContent = snapshot.logDir || '';
 }
 
 async function useProfile(name) {
@@ -348,12 +353,60 @@ async function useProfile(name) {
 
 // ---------------------------------------------------------------- login
 
-async function login() {
-  const button = $('#login-button');
-  if (!state.snapshot?.settings?.profile) {
-    showError('Pick a profile in the AWS Profile tab first.');
+// The dialog lists only profiles the SSO flow can use; the AWS Profile tab
+// keeps showing everything.
+function renderLoginDialog() {
+  const profiles = (state.snapshot?.profiles || []).filter((profile) => profile.sso);
+  const current = state.snapshot?.settings?.profile || null;
+  const list = $('#login-profile-list');
+  list.replaceChildren();
+  for (const profile of profiles) {
+    const item = document.createElement('li');
+    const button = el('button', 'login-profile-row');
+    const name = el('span', null, profile.name);
+    if (profile.name === current) {
+      name.append(' ', el('span', 'badge current', 'current'));
+    }
+    const meta = [profile.region, profile.sso.accountId, profile.sso.roleName]
+      .filter(Boolean)
+      .join(' · ');
+    button.append(name, el('span', 'login-profile-meta', meta));
+    button.addEventListener('click', () => loginWithProfile(profile.name));
+    item.append(button);
+    list.append(item);
+  }
+  $('#login-profile-empty').classList.toggle('hidden', profiles.length > 0);
+}
+
+async function openLoginDialog() {
+  // Re-read ~/.aws/config on every open so a profile added while the app is
+  // running shows up without a restart.
+  try {
+    applySnapshot(await api.getSnapshot());
+  } catch (error) {
+    handleError(error);
     return;
   }
+  renderLoginDialog();
+  $('#login-dialog').showModal();
+}
+
+function closeLoginDialog() {
+  const dialog = $('#login-dialog');
+  if (dialog.open) dialog.close();
+}
+
+async function loginWithProfile(name) {
+  closeLoginDialog();
+  await useProfile(name);
+  // Selection failed (already reported) — do not sign in to the old profile.
+  if (state.snapshot?.settings?.profile !== name) return;
+  if (state.snapshot?.session?.loggedIn) return;
+  await login();
+}
+
+async function login() {
+  const button = $('#login-button');
   button.disabled = true;
   button.textContent = 'Waiting for sign-in…';
   try {
@@ -366,7 +419,7 @@ async function login() {
     handleError(error);
   } finally {
     button.disabled = false;
-    button.textContent = 'Log in';
+    button.textContent = 'AWS login';
     renderTopbar();
   }
 }
@@ -395,10 +448,20 @@ function wire() {
     tabButton.addEventListener('click', () => switchTab(tabButton.dataset.tab));
   }
 
-  $('#login-button').addEventListener('click', login);
+  const loginDialog = $('#login-dialog');
+  $('#close-login-dialog').addEventListener('click', closeLoginDialog);
+  loginDialog.addEventListener('click', (event) => {
+    if (event.target === loginDialog) closeLoginDialog();
+  });
+
+  $('#login-button').addEventListener('click', openLoginDialog);
   $('#refresh-instances').addEventListener('click', loadInstances);
   $('#instance-filter').addEventListener('input', (event) => {
     state.filter = event.target.value;
+    renderInstances();
+  });
+  $('#spot-only').addEventListener('change', (event) => {
+    state.spotOnly = event.target.checked;
     renderInstances();
   });
 
@@ -446,19 +509,21 @@ function wire() {
     }
   });
 
-  $('#check-updates').addEventListener('click', async () => {
-    const status = $('#update-status');
-    const button = $('#check-updates');
-    button.disabled = true;
-    try {
-      await api.checkUpdate((text) => {
-        status.textContent = text;
-      });
-    } catch (error) {
-      status.textContent = `Update failed: ${errorInfo(error).message}`;
-    } finally {
-      button.disabled = false;
-    }
+  // Two entry points, one flow: the topbar button mirrors the Settings one so
+  // an update is reachable without knowing the Settings tab exists.
+  for (const button of [$('#update-button'), $('#check-updates')]) {
+    button.addEventListener('click', async () => {
+      button.disabled = true;
+      try {
+        await api.checkUpdate();
+      } finally {
+        button.disabled = false;
+      }
+    });
+  }
+
+  $('#open-log-dir').addEventListener('click', () => {
+    api.openLogDir().catch(handleError);
   });
 }
 

--- a/product/akbun-awsviewer/workspace/src/style.css
+++ b/product/akbun-awsviewer/workspace/src/style.css
@@ -191,7 +191,8 @@ body {
   background: var(--surface-muted);
 }
 
-#login-button {
+/* Pushes itself and the login button to the right edge. */
+#update-button {
   margin-left: auto;
 }
 
@@ -222,6 +223,13 @@ main {
   max-width: 100%;
 }
 
+.toolbar-check {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
 button {
   padding: 6px 12px;
   border: 1px solid var(--border);
@@ -241,15 +249,13 @@ button:disabled {
   cursor: default;
 }
 
-#login-button,
-.select-profile {
+#login-button {
   border-color: var(--accent);
   background: var(--accent);
   color: var(--accent-fg);
 }
 
-#login-button:hover,
-.select-profile:hover {
+#login-button:hover {
   filter: brightness(1.08);
   background: var(--accent);
 }
@@ -373,11 +379,74 @@ th[aria-sort="descending"] .sort-arrow::after {
   border-radius: 10px;
   background: var(--surface);
   box-shadow: 0 16px 48px rgb(0 0 0 / 24%);
-  color: var(--text);
+  color: var(--fg);
 }
 
-#error-dialog::backdrop {
+#error-dialog::backdrop,
+#login-dialog::backdrop {
   background: rgb(15 23 42 / 45%);
+}
+
+#login-dialog {
+  width: min(520px, calc(100vw - 40px));
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: 0 16px 48px rgb(0 0 0 / 24%);
+  color: var(--fg);
+}
+
+.login-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--surface-muted);
+}
+
+.login-dialog-header h2 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.login-dialog-header button {
+  padding: 3px 7px;
+  border: none;
+  background: transparent;
+  color: inherit;
+}
+
+#login-dialog .help,
+#login-dialog .empty {
+  margin: 10px 16px;
+}
+
+#login-profile-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 8px 16px 16px;
+  max-height: 380px;
+  overflow-y: auto;
+}
+
+.login-profile-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+}
+
+.login-profile-meta {
+  color: var(--muted);
+  overflow-wrap: anywhere;
+  text-align: right;
 }
 
 .error-dialog-header {

--- a/product/akbun-awsviewer/workspace/test/lib.test.js
+++ b/product/akbun-awsviewer/workspace/test/lib.test.js
@@ -9,6 +9,7 @@ const {
   sortInstances,
   formatProtocol,
   formatPortRange,
+  formatAge,
   stateClass,
   sessionLabel,
 } = require('../src/lib.js');
@@ -22,9 +23,51 @@ test('publishes the browser API when a CommonJS module global exists', () => {
   assert.strictEqual(typeof context.awsviewerLib.filterInstances, 'function');
 });
 
+// The page loads its scripts as classic script tags, so every top-level
+// declaration lands in one shared global scope. A `const` in one file named
+// like a function in another is a SyntaxError that kills the whole file
+// before it wires a single listener — v0.1.0 and v0.1.1 shipped frozen
+// because of exactly that. Run the files in one context the way the page
+// does; missing browser globals (window, document) are expected and fine,
+// a redeclaration is not.
+test('page scripts share one global scope without redeclaring names', () => {
+  // Just enough of a DOM that the wiring code runs to completion; every
+  // element answers every call with a no-op. Runtime errors from the missing
+  // Tauri bridge are expected and fine — only a SyntaxError is the bug.
+  const element = new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (prop === 'classList') return { toggle() {}, add() {}, remove() {} };
+        if (prop === 'dataset') return {};
+        if (prop === 'open' || prop === 'disabled' || prop === 'checked') return false;
+        if (prop === 'textContent') return '';
+        return () => {};
+      },
+      set: () => true,
+    },
+  );
+  const context = vm.createContext({
+    window: { addEventListener() {} },
+    document: { querySelector: () => element, querySelectorAll: () => [] },
+  });
+  const load = (name) => fs.readFileSync(require.resolve(`../src/${name}`), 'utf8');
+  for (const name of ['api.js', 'lib.js', 'renderer.js']) {
+    try {
+      vm.runInContext(load(name), context, { filename: name });
+    } catch (error) {
+      assert.notStrictEqual(
+        error.name,
+        'SyntaxError',
+        `${name} breaks the shared global scope: ${error.message}`,
+      );
+    }
+  }
+});
+
 const instances = [
   { instanceId: 'i-0aaa', name: 'web-1', state: 'running', privateIp: '10.0.1.10' },
-  { instanceId: 'i-0bbb', name: 'batch', state: 'stopped', privateIp: '10.0.1.2' },
+  { instanceId: 'i-0bbb', name: 'batch', state: 'stopped', privateIp: '10.0.1.2', lifecycle: 'spot' },
   { instanceId: 'i-0ccc', name: null, state: 'running', privateIp: null },
 ];
 
@@ -42,6 +85,24 @@ test('empty filter returns a copy of everything', () => {
   const found = filterInstances(instances, '  ');
   assert.deepStrictEqual(found, instances);
   assert.notStrictEqual(found, instances);
+});
+
+test('spot only keeps spot instances and composes with the query', () => {
+  const spot = filterInstances(instances, '', true);
+  assert.deepStrictEqual(spot.map((i) => i.instanceId), ['i-0bbb']);
+  assert.deepStrictEqual(filterInstances(instances, 'web', true), []);
+});
+
+test('age renders the single largest unit', () => {
+  const now = Date.parse('2026-08-07T12:00:00Z');
+  assert.strictEqual(formatAge('2026-08-07T11:59:40Z', now), '<1m');
+  assert.strictEqual(formatAge('2026-08-07T11:30:00Z', now), '30m');
+  assert.strictEqual(formatAge('2026-08-07T05:00:00Z', now), '7h');
+  assert.strictEqual(formatAge('2026-08-01T12:00:00Z', now), '6d');
+  assert.strictEqual(formatAge('2026-05-07T12:00:00Z', now), '3mo');
+  assert.strictEqual(formatAge('2024-08-07T12:00:00Z', now), '2y');
+  assert.strictEqual(formatAge(null, now), null);
+  assert.strictEqual(formatAge('not a date', now), null);
 });
 
 test('sort is ascending then reversible', () => {


### PR DESCRIPTION
# 구현

UI 클릭 불능 근본 수정, AWS login 모달, spot 필터와 Age 칼럼, 오류 로그 파일, 업데이트 확인 대화상자
- JavaScript 테스트 13개와 Rust 테스트 18개 통과, 브라우저와 dev 앱 실행으로 클릭 복구와 로그 파일 기록 확인

# 어려웠던 점

증상 재현 없이 두 번 배포된 클릭 불능의 원인 규명
- v0.1.1의 수정은 lib module 분기 오진, 실제 원인은 renderer의 전역 재선언 SyntaxError로 webview 콘솔에서 확인, 같은 방식의 vm 회귀 테스트 추가

# 리스크

verify job은 core crate만 테스트하므로 앱 crate의 새 플러그인 연결은 머지 후 release 빌드에서 처음 CI 컴파일
- dev 빌드로 로컬 컴파일과 실행은 확인, 머지 후 release job 결과 확인 필요

Issue #747