### PR TITLE
akbun-makevideo macOS viewport 빌드 수정과 업데이트 서명 불일치 판정

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-07
 
+* **Creation**: [move 클로저가 필드 이름을 대면 Send는 wrapper에 남고 클로저는 필드만 가져간다](topics/move-closure-captures-the-field-not-the-wrapper.md) topic 기록. akbun-makevideo의 release 빌드가 unsafe impl Send를 붙여 둔 wrapper를 두고 안쪽 NonNull을 지목하며 실패해, 원인이 wrapper가 아니라 edition 2021의 캡처 단위였다는 것을 남긴다.
+* **Creation**: [업데이트 서명 불일치는 서명과 pubkey의 key ID를 뽑아 갈라낸다](topics/tauri-updater-key-id-mismatch.md) topic 기록. akbun-makevideo의 업데이트 실패를 짐작으로 재배포하지 않고 판정하려다, 읽을 수 없는 secret을 두고도 minisign key ID로 서명한 키와 신뢰하는 키를 비교할 수 있다는 것을 알게 되어 남긴다.
 * **Creation**: [늦은 프레임은 그리지 않고 건너뛰며, 디코더를 되돌리지 않는다](decisions/2026-08-late-frames-are-skipped-not-drawn.md) 결정 기록. akbun-makevideo의 프레임 소스와 오디오 클럭을 화면에 잇는 단계에서, 판정을 하네스에만 맡긴 덕에 눈으로는 찾지 못했을 결함 세 가지를 찾은 것을 함께 남긴다.
 * **Creation**: [재생 시각의 기준은 오디오 출력이고 영상이 그것을 따라간다](decisions/2026-08-audio-is-the-master-clock.md) 결정 기록. akbun-makevideo에 오디오 엔진을 넣으면서, seek가 함수 호출이 아니라 메시지라 요청 직후에도 링버퍼는 이전 위치로 가득 차 있다는 것과, 링버퍼를 비울 수 있는 쪽이 소비자뿐이라 seek가 정리되는 동안에도 재생 쪽이 계속 버퍼를 요청해야 한다는 것을 함께 남긴다.
 

--- a/knowledge/topics/index.md
+++ b/knowledge/topics/index.md
@@ -8,3 +8,5 @@
 * [Electron 메뉴바 앱은 창 정리와 메뉴바 공간에서 조용히 실패한다](electron-menubar-silent-failures.md) - 앱이 살아 있는데 아무것도 안 보일 때 원인을 코드와 환경으로 갈라내는 방법.
 * [macOS 메뉴바 status item은 넓은 자리 차지로만 가릴 수 있고, 노치 뒤에서는 좌표가 있어도 그려지지 않는다](macos-menubar-status-items.md) - 다른 앱의 메뉴바 아이콘을 다루는 세 제약과 실측으로 검증한 우회 방법.
 * [hidden 속성으로 감추는 패널은 자기 display 규칙에 조용히 진다](hidden-attribute-loses-to-display.md) - el.hidden이 true인데 패널이 그대로 보일 때의 판정 방법과 시트 한 줄 해결.
+* [move 클로저가 필드 이름을 대면 Send는 wrapper에 남고 클로저는 필드만 가져간다](move-closure-captures-the-field-not-the-wrapper.md) - unsafe impl Send를 붙였는데도 스레드 경계를 못 넘을 때 캡처 단위를 올려 고치는 방법.
+* [업데이트 서명 불일치는 서명과 pubkey의 key ID를 뽑아 갈라낸다](tauri-updater-key-id-mismatch.md) - 읽을 수 없는 secret을 두고 서명한 키와 신뢰하는 키가 같은지 판정하는 방법.

--- a/knowledge/topics/move-closure-captures-the-field-not-the-wrapper.md
+++ b/knowledge/topics/move-closure-captures-the-field-not-the-wrapper.md
@@ -1,0 +1,41 @@
+---
+type: Topic
+title: move 클로저가 필드 이름을 대면 Send는 wrapper에 남고 클로저는 필드만 가져간다
+description: 포인터를 Send wrapper로 감쌌는데도 스레드 경계를 못 넘을 때, 원인이 wrapper가 아니라 클로저의 캡처 단위라는 것과 필드 접근을 메서드로 바꿔 고치는 방법.
+tags: [rust, tauri, objc2, macos]
+timestamp: 2026-08-07T00:00:00Z
+---
+
+## 증상
+
+`!Send`인 원시 포인터를 tuple struct로 감싸고 `unsafe impl Send`를 붙인다. 흔한 관용구다. 그런데 그 wrapper를 `move` 클로저에 넘기면 컴파일러가 wrapper가 아니라 안쪽 타입 이름을 대며 거절한다.
+
+```
+error[E0277]: `NonNull<NSView>` cannot be sent between threads safely
+```
+
+`unsafe impl Send for Handle`은 분명히 있는데 에러는 `Handle`이 아니라 `NonNull<NSView>`를 말한다. wrapper를 의심하게 되지만 wrapper는 멀쩡하다.
+
+## 원인
+
+edition 2021의 disjoint capture다. 클로저는 자기가 실제로 쓰는 경로만 캡처한다. 본문에 `handle.0`이라고 적혀 있으면 캡처 대상은 `handle`이 아니라 `handle.0`이고, `move`니까 그 필드가 값으로 넘어간다. `Send`는 `Handle`에만 붙어 있으므로 넘어간 `NonNull`에는 아무 보증이 없다.
+
+즉 wrapper는 필드를 직접 만지지 않는 동안에만 wrapper다. 에러 메시지가 안쪽 타입을 가리키는 것은 정확한 신고다.
+
+## 고치는 법
+
+클로저가 wrapper 전체를 잡게 만든다. 필드 접근을 `self`를 값으로 받는 메서드 하나로 감싸면 그 호출이 wrapper 전체를 요구하므로 캡처 단위가 올라간다.
+
+```rust
+impl Handle {
+    fn ptr(self) -> NonNull<NSView> {
+        self.0
+    }
+}
+```
+
+클로저 첫 줄에 `let handle = handle;`을 넣어도 같은 효과지만, 쓰는 자리마다 반복되고 지우면 조용히 되돌아간다. 메서드는 필드를 쓰는 경로가 하나로 모여서 다음 사람이 `.0`을 다시 적을 자리가 줄어든다.
+
+## 어디서 다시 만나는가
+
+포인터를 스레드 사이로 옮기는 코드 전부다. 특히 AppKit처럼 "주소는 아무 데서나 들고 있어도 되지만 메시지는 메인 스레드에서만"인 API가 이 관용구를 강제한다. 컴파일러가 안쪽 타입을 지목하면 wrapper 정의가 아니라 클로저 본문의 점 뒤를 먼저 본다.

--- a/knowledge/topics/tauri-updater-key-id-mismatch.md
+++ b/knowledge/topics/tauri-updater-key-id-mismatch.md
@@ -1,0 +1,34 @@
+---
+type: Topic
+title: 업데이트 서명 불일치는 서명과 pubkey의 key ID를 뽑아 갈라낸다
+description: Tauri 업데이터가 서명을 거부할 때 secret의 private key와 conf의 pubkey가 딴 키인지 확인하는 방법과, 확인된 뒤 남는 선택지.
+tags: [tauri, release, github-actions]
+timestamp: 2026-08-07T00:00:00Z
+---
+
+## 왜 갈라내야 하는가
+
+업데이터가 서명을 거부하면 원인 후보가 둘이다. 서명 파일이 깨졌거나, 서명한 키와 앱이 신뢰하는 키가 애초에 다른 키다. 둘의 처방이 정반대라 짐작으로 재배포하면 같은 실패를 반복한다.
+
+private key는 GitHub secret에 들어가면 다시 읽을 수 없으므로 키를 꺼내서 비교하는 길은 없다. 대신 minisign 형식이 양쪽에 key ID를 박아 둔다.
+
+## 비교 방법
+
+두 값 모두 base64 안에 minisign 텍스트가 들어 있고, 그 두 번째 줄을 다시 base64 디코딩하면 앞 2바이트가 알고리즘, 이어지는 8바이트가 리틀엔디언 key ID다.
+
+- 서명: 릴리스의 latest.json에서 platforms 아래 signature
+- pubkey: tauri.conf.json의 plugins.updater.pubkey
+
+```python
+import base64, binascii
+raw = base64.b64decode(base64.b64decode(value).decode().splitlines()[1])
+print(binascii.hexlify(raw[2:10][::-1]).decode().upper())
+```
+
+두 ID가 다르면 secret의 키와 conf의 pubkey가 딴 키다. 알고리즘 자리가 서명은 ED, pubkey는 Ed로 갈리는 것은 정상이다. 서명이 prehashed라서 그렇지 불일치가 아니다.
+
+## 갈렸다면
+
+conf의 pubkey에 맞는 private key가 손에 없다면 되돌릴 방법이 없다. 새 키쌍을 만들어 secret과 conf를 함께 갱신하는 것이 유일한 진행 방향이고, 이미 설치된 사용자는 옛 pubkey를 들고 있으므로 어느 쪽으로도 자동 업데이트가 닿지 않는다. 그들에게는 설치본을 다시 받는 안내가 필요하다.
+
+secret 갱신과 conf 갱신은 반드시 같이 간다. 한쪽만 바꾸면 릴리스는 초록불로 끝나고 불일치만 새 키로 옮겨 간다. 그래서 private key 파일은 secret 말고 다른 곳에도 남겨 둔다. secret은 백업이 아니다.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -24,7 +24,7 @@
 
 use super::Place;
 use objc2::rc::Retained;
-use objc2::MainThreadMarker;
+use objc2::{MainThreadMarker, MainThreadOnly};
 use objc2_app_kit::{NSView, NSWindow, NSWindowOrderingMode};
 use objc2_foundation::{NSPoint, NSRect, NSSize};
 use raw_window_handle::{
@@ -53,6 +53,19 @@ struct Handle(NonNull<NSView>);
 // wgpu, which attaches a layer and then talks to Metal.
 unsafe impl Send for Handle {}
 unsafe impl Sync for Handle {}
+
+impl Handle {
+    /// The address, taken through the whole handle.
+    ///
+    /// Every closure below reaches the pointer through this rather than through
+    /// `.0`. A `move` closure that names the field captures the `NonNull`
+    /// alone, and a `NonNull` is not `Send` — the `unsafe impl` above is on
+    /// `Handle`, so the closure has to capture the `Handle`. Calling a method
+    /// that takes `self` is what makes it do that.
+    fn ptr(self) -> NonNull<NSView> {
+        self.0
+    }
+}
 
 /// What wgpu is given. Separate from [`Inner`] because a surface target has to
 /// be owned and `'static`, and because it must not carry the window with it.
@@ -111,7 +124,7 @@ pub fn attach(window: &tauri::WebviewWindow, place: Place) -> Result<Inner, Stri
     let handle = window.clone();
     let view = on_main(window, move |main| {
         let content = content_view(&handle)?;
-        let view = unsafe { NSView::initWithFrame(NSView::alloc(main), rect(&content, place)) };
+        let view = NSView::initWithFrame(NSView::alloc(main), rect(&content, place));
         // Metal draws into this view's layer, so it has to have one. wgpu
         // replaces it with a CAMetalLayer when it makes the surface; without
         // this the view is not layer backed and there is nothing to replace.
@@ -119,9 +132,7 @@ pub fn attach(window: &tauri::WebviewWindow, place: Place) -> Result<Inner, Stri
         // Over the webview. A `None` sibling with `Above` means "over all of
         // them", which is the front. The page hides it before drawing anything
         // on top; see the note in mod.rs for why it is not the other way round.
-        unsafe {
-            content.addSubview_positioned_relativeTo(&view, NSWindowOrderingMode::Above, None)
-        };
+        content.addSubview_positioned_relativeTo(&view, NSWindowOrderingMode::Above, None);
         // Retained past the end of this block on purpose: the `Viewport` owns
         // it now and `detach` is what releases it.
         let pointer = NonNull::new(Retained::into_raw(view))
@@ -141,8 +152,10 @@ pub fn place(inner: &Inner, at: Place) {
     // window nobody is looking at.
     let _ = on_main(&inner.window, move |_| {
         let content = content_view(&handle)?;
-        let view = unsafe { view.0.as_ref() };
-        unsafe { view.setFrame(rect(&content, at)) };
+        // SAFETY: messaged on the main thread, and the view is alive until
+        // `detach` releases it.
+        let view = unsafe { view.ptr().as_ref() };
+        view.setFrame(rect(&content, at));
         Ok(())
     });
 }
@@ -152,7 +165,7 @@ pub fn set_visible(inner: &Inner, visible: bool) {
     let _ = on_main(&inner.window, move |_| {
         // SAFETY: messaged on the main thread, and the view is alive until
         // `detach` releases it.
-        unsafe { view.0.as_ref().setHidden(!visible) };
+        unsafe { view.ptr().as_ref().setHidden(!visible) };
         Ok(())
     });
 }
@@ -162,9 +175,9 @@ pub fn detach(inner: &Inner) {
     let _ = on_main(&inner.window, move |_| {
         // SAFETY: the pointer came from `Retained::into_raw` in `attach` and is
         // released exactly once, here.
-        let view: Retained<NSView> = unsafe { Retained::from_raw(view.0.as_ptr()) }
+        let view: Retained<NSView> = unsafe { Retained::from_raw(view.ptr().as_ptr()) }
             .ok_or("the monitor view was already gone")?;
-        unsafe { view.removeFromSuperview() };
+        view.removeFromSuperview();
         Ok(())
     });
 }
@@ -187,7 +200,9 @@ fn content_view(window: &tauri::WebviewWindow) -> Result<Retained<NSView>, Strin
     let ns_window: Retained<NSWindow> = unsafe {
         Retained::retain(ns_window.cast::<NSWindow>()).ok_or("the native window went away")?
     };
-    unsafe { ns_window.contentView() }.ok_or_else(|| "the window has no content view".to_string())
+    ns_window
+        .contentView()
+        .ok_or_else(|| "the window has no content view".to_string())
 }
 
 /// The page's rectangle as AppKit's.
@@ -217,7 +232,7 @@ fn backing_scale(content: &NSView) -> f64 {
     if bounds.size.width <= 0.0 {
         return 1.0;
     }
-    let backing = unsafe { content.convertRectToBacking(bounds) };
+    let backing = content.convertRectToBacking(bounds);
     let scale = backing.size.width / bounds.size.width;
     if scale.is_finite() && scale > 0.0 {
         scale


### PR DESCRIPTION
# 구현

macOS viewport의 컴파일 실패 두 종류 제거, 업데이트 서명 불일치 판정 방법을 knowledge에 기록
- cargo check -p akbun-makevideo 통과, 경고 0개

# 어려웠던 점

unsafe impl Send가 붙은 wrapper를 두고 컴파일러가 안쪽 NonNull을 지목해 wrapper 정의를 먼저 의심함
- edition 2021에서 move 클로저가 handle.0을 적으면 wrapper가 아니라 그 필드를 캡처하므로, 신고 대상이 정확했고 고칠 자리는 클로저 본문이었음

# 리스크

이미 설치된 0.10.0은 이 PR 이후에도 자동 업데이트가 닿지 않음
- 그쪽이 신뢰하는 pubkey의 private key가 남아 있지 않아, 키쌍을 새로 만들어도 설치본을 다시 받는 것 말고는 경로가 없음

Issue #763