### PR TITLE
akbun-makevideo: 링크된 오디오와 비디오 클립

### DIFF
--- a/product/akbun-makevideo/README.md
+++ b/product/akbun-makevideo/README.md
@@ -9,7 +9,7 @@ Desktop video editor: a multi track timeline, a live preview, and a render to FH
 - Assets panel: drop files from Finder or import them, with kind, length and size read by ffprobe. **Importing references the file where it is — media is never copied into the project**
 - Program monitor: the render's own compositor draws straight onto a surface in the window, and the audio clock decides when each frame is shown. Playing and stopped are the same picture, so what is on screen is what will be in the file
 - The older preview — stacked media elements, with the composited frame swapped in when the playhead stops — is still there as a setting and as the automatic fallback when the monitor cannot start
-- Timeline: up to four video and four audio tracks, drag to move, drag an edge to trim
+- Timeline: up to four video and four audio tracks, linked picture and sound from video assets, drag to move, drag an edge to trim
 - Frame rates including the broadcast ones — 23.976, 29.97 and 59.94 are held as the exact ratios they are, so a camera file stays in step with itself. The clock reads in timecode and the arrow keys step a frame at a time
 - Split at the playhead, from the toolbar button or Cmd+B
 - Undo and redo across everything: moves, trims, splits, imports, track changes and the timebase. A drop that imports three files and lays down three clips comes back on one press

--- a/product/akbun-makevideo/wiki/architecture/timeline.md
+++ b/product/akbun-makevideo/wiki/architecture/timeline.md
@@ -28,10 +28,13 @@ Checked after every command, against the whole project:
 
 - a clip has a length, its in point is not negative, and it does not reach past the end of its source
 - clips on a track do not overlap, and none starts before the timeline does
+- a link group has one video clip and one audio clip from the same asset, with matching timeline and source ranges
 
 A broken one does not show on the timeline. A zero length clip draws as nothing and an out point past the end of a file draws as the last frame; both surface as an ffmpeg failure or a black stretch part way through a render that has been running for ten minutes.
 
 Opening a file is the exception: `Project::repair` pulls a clip back to the nearest state that keeps the rules rather than refusing to open. A project written by an older build, or one whose media has been re-encoded to a slightly different length since it was imported, has to keep opening.
+
+Moving, trimming, splitting, deleting, and ripple deleting one linked clip expands to its whole group. A linked move uses the same delta on both tracks and fails as one edit if either destination is occupied. Splitting keeps the left pair in its group and gives the right pair a new group, so the two halves can be edited independently.
 
 ## The revision
 

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
@@ -122,6 +122,7 @@ mod tests {
         Clip {
             id: id.into(),
             asset_id: asset_id.into(),
+            link_group: None,
             start,
             in_point,
             out_point,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
@@ -865,6 +865,7 @@ pub(crate) mod tests {
         Clip {
             id: id.into(),
             asset_id: asset_id.into(),
+            link_group: None,
             start,
             in_point,
             out_point,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
@@ -88,6 +88,7 @@ fn clip(id: &str, asset_id: &str, start: i64, in_point: i64, out_point: i64, vol
     Clip {
         id: id.into(),
         asset_id: asset_id.into(),
+        link_group: None,
         start,
         in_point,
         out_point,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -814,6 +814,7 @@ mod tests {
         Clip {
             id: id.into(),
             asset_id: asset_id.into(),
+            link_group: None,
             start,
             in_point,
             out_point,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
@@ -438,6 +438,7 @@ mod tests {
                 clips: vec![Clip {
                     id: "c1".into(),
                     asset_id: "a1".into(),
+                    link_group: None,
                     start: 0,
                     in_point: 0,
                     out_point: 60,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
@@ -119,6 +119,7 @@ fn clip(id: &str, asset_id: &str, start: i64, out_point: i64) -> Clip {
     Clip {
         id: id.into(),
         asset_id: asset_id.into(),
+        link_group: None,
         start,
         in_point: 0,
         out_point,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -29,6 +29,7 @@
 
 use crate::{min_clip_frames, Asset, Clip, Project, ProjectSettings, Rate, Track, TrackKind};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Which end of a clip a trim is dragging.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -105,6 +106,8 @@ pub enum Command {
         start: i64,
         #[serde(default)]
         id: Option<String>,
+        #[serde(default)]
+        link_group: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
     MoveClip {
@@ -131,9 +134,19 @@ pub enum Command {
         /// produces the same clips rather than new ones.
         #[serde(default)]
         ids: Vec<String>,
+        #[serde(default)]
+        link_groups: Vec<Option<String>>,
     },
     #[serde(rename_all = "camelCase")]
     RemoveClip { clip_id: String },
+    #[serde(rename_all = "camelCase")]
+    LinkClips {
+        clip_ids: Vec<String>,
+        #[serde(default)]
+        link_group: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    UnlinkClips { clip_id: String },
     /// Delete and close the gap: everything after it on the same track moves
     /// left by its length. Destructive, and only reasonable now that there is
     /// an undo to take it back.
@@ -205,7 +218,12 @@ impl Ids {
     /// there.
     pub fn observe(&mut self, id: &str) {
         let digits: String = id.chars().skip_while(|c| !c.is_ascii_digit()).collect();
-        if !digits.is_empty() && id.chars().take_while(|c| !c.is_ascii_digit()).all(char::is_alphabetic) {
+        if !digits.is_empty()
+            && id
+                .chars()
+                .take_while(|c| !c.is_ascii_digit())
+                .all(char::is_alphabetic)
+        {
             if let Ok(value) = digits.parse::<u64>() {
                 self.next = self.next.max(value);
             }
@@ -248,6 +266,8 @@ impl Command {
             Command::TrimClip { .. } => "Trim clip",
             Command::SplitAt { .. } => "Split",
             Command::RemoveClip { .. } | Command::DropClips { .. } => "Delete clip",
+            Command::LinkClips { .. } => "Link clips",
+            Command::UnlinkClips { .. } => "Unlink clips",
             Command::RippleDelete { .. } => "Ripple delete",
             Command::SetClipGain { .. } => "Clip levels",
             Command::SetSettings { .. } => "Project settings",
@@ -284,7 +304,8 @@ impl Command {
                 asset_id,
                 start,
                 id,
-            } => add_clip(project, ids, track_id, asset_id, start, id),
+                link_group,
+            } => add_clip(project, ids, track_id, asset_id, start, id, link_group),
             Command::MoveClip {
                 clip_id,
                 track_id,
@@ -299,8 +320,14 @@ impl Command {
                 frame,
                 clip_id,
                 ids: given,
-            } => Ok(split_at(project, ids, frame, clip_id, given)),
+                link_groups,
+            } => Ok(split_at(project, ids, frame, clip_id, given, link_groups)),
             Command::RemoveClip { clip_id } => remove_clip(project, clip_id),
+            Command::LinkClips {
+                clip_ids,
+                link_group,
+            } => link_clips(project, ids, clip_ids, link_group),
+            Command::UnlinkClips { clip_id } => unlink_clips(project, clip_id),
             Command::RippleDelete { clip_id } => ripple_delete(project, clip_id),
             Command::SetClipGain {
                 clip_id,
@@ -508,6 +535,7 @@ fn add_clip(
     asset_id: String,
     start: i64,
     id: Option<String>,
+    link_group: Option<String>,
 ) -> Result<Applied, String> {
     let rate = project.rate();
     let asset = project
@@ -526,6 +554,7 @@ fn add_clip(
     track.clips.push(Clip {
         id: id.clone(),
         asset_id: asset_id.clone(),
+        link_group: link_group.clone(),
         start,
         in_point: 0,
         out_point: duration,
@@ -539,10 +568,9 @@ fn add_clip(
             asset_id,
             start,
             id: Some(id.clone()),
+            link_group,
         },
-        inverse: Command::DropClips {
-            clip_ids: vec![id],
-        },
+        inverse: Command::DropClips { clip_ids: vec![id] },
     })
 }
 
@@ -555,6 +583,9 @@ fn move_clip(
     let was = project
         .placement(&clip_id)
         .ok_or("that clip is not on the timeline")?;
+    if was.clip.link_group.is_some() {
+        return move_linked_clips(project, clip_id, track_id, start);
+    }
     let asset = project.asset(&was.clip.asset_id).cloned();
     let target = project
         .track_index(&track_id)
@@ -563,8 +594,11 @@ fn move_clip(
         // A clip whose asset has gone is still draggable; there is nothing left
         // to say which tracks would take it, so it stays on the kind it is on.
         Some(asset) if !project.tracks[target].accepts(&asset) => {
-            return Err(format!("a {:?} track will not take that", project.tracks[target].kind)
-                .to_lowercase())
+            return Err(format!(
+                "a {:?} track will not take that",
+                project.tracks[target].kind
+            )
+            .to_lowercase())
         }
         None if project.tracks[target].kind != project.track(&was.track_id).unwrap().kind => {
             return Err("that clip has lost its file, so it can only move on its own kind".into())
@@ -591,21 +625,125 @@ fn move_clip(
     })
 }
 
+fn move_linked_clips(
+    project: &mut Project,
+    clip_id: String,
+    track_id: String,
+    start: i64,
+) -> Result<Applied, String> {
+    let selected = project
+        .placement(&clip_id)
+        .ok_or("that clip is not on the timeline")?;
+    let placements = project.linked_placements(&clip_id);
+    let delta = start - selected.clip.start;
+    let ignored: Vec<&str> = placements
+        .iter()
+        .map(|entry| entry.clip.id.as_str())
+        .collect();
+    let mut targets = Vec::with_capacity(placements.len());
+
+    for entry in &placements {
+        let destination = if entry.clip.id == clip_id {
+            track_id.as_str()
+        } else {
+            entry.track_id.as_str()
+        };
+        let target = project
+            .track(destination)
+            .ok_or("that track is not in this project")?;
+        let asset = project
+            .asset(&entry.clip.asset_id)
+            .ok_or("that linked clip has lost its file")?;
+        if !target.accepts(asset) {
+            return Err(format!("a {:?} track will not take that", target.kind).to_lowercase());
+        }
+        let wanted = entry.clip.start + delta;
+        if wanted < 0 {
+            return Err("linked clips would start before the timeline does".into());
+        }
+        let duration = entry.clip.duration_frames();
+        let occupied = target.clips.iter().any(|other| {
+            !ignored.contains(&other.id.as_str())
+                && wanted < other.end_frame()
+                && other.start < wanted + duration
+        });
+        if occupied {
+            return Err("there is no room to move every linked clip together".into());
+        }
+        targets.push((entry.clip.id.clone(), destination.to_string(), wanted));
+    }
+
+    for track in &mut project.tracks {
+        track
+            .clips
+            .retain(|clip| !ignored.contains(&clip.id.as_str()));
+    }
+    for (id, destination, wanted) in &targets {
+        let mut clip = placements
+            .iter()
+            .find(|entry| entry.clip.id == *id)
+            .expect("planned from this set")
+            .clip
+            .clone();
+        clip.start = *wanted;
+        project
+            .track_mut(destination)
+            .expect("destination was checked")
+            .clips
+            .push(clip);
+    }
+    for track in &mut project.tracks {
+        track.sort();
+    }
+    Ok(Applied {
+        resolved: Command::MoveClip {
+            clip_id,
+            track_id,
+            start,
+        },
+        inverse: Command::RestoreClips {
+            entries: placements,
+        },
+    })
+}
+
 fn trim_clip(
     project: &mut Project,
     clip_id: String,
     edge: Edge,
     frame: i64,
 ) -> Result<Applied, String> {
+    let entries = project.linked_placements(&clip_id);
+    if entries.is_empty() {
+        return Err("that clip is not on the timeline".into());
+    }
+    let mut selected_frame = frame;
+    for entry in &entries {
+        let at = trim_one(project, &entry.clip.id, edge, frame)?;
+        if entry.clip.id == clip_id {
+            selected_frame = at;
+        }
+    }
+    Ok(Applied {
+        resolved: Command::TrimClip {
+            clip_id,
+            edge,
+            frame: selected_frame,
+        },
+        inverse: Command::RestoreClips { entries },
+    })
+}
+
+fn trim_one(project: &mut Project, clip_id: &str, edge: Edge, frame: i64) -> Result<i64, String> {
     let rate = project.rate();
     let shortest = min_clip_frames(rate);
-    let was = project
-        .placement(&clip_id)
+    let clip = project
+        .clip(clip_id)
         .ok_or("that clip is not on the timeline")?;
     let limit = project
-        .asset(&was.clip.asset_id)
+        .asset(&clip.asset_id)
         .and_then(|asset| asset.source_limit_frames(rate));
-    let (track_index, clip_index) = project.locate(&clip_id).expect("just found it");
+    let (track_index, clip_index) = project.locate(clip_id).expect("just found it");
     let track = &project.tracks[track_index];
 
     // A trim may not run into the neighbour: overlapping clips are a state the
@@ -644,14 +782,7 @@ fn trim_clip(
         }
     };
     project.tracks[track_index].sort();
-    Ok(Applied {
-        resolved: Command::TrimClip {
-            clip_id,
-            edge,
-            frame: at,
-        },
-        inverse: Command::RestoreClips { entries: vec![was] },
-    })
+    Ok(at)
 }
 
 fn split_at(
@@ -660,18 +791,29 @@ fn split_at(
     frame: i64,
     clip_id: Option<String>,
     given: Vec<String>,
+    given_groups: Vec<Option<String>>,
 ) -> Applied {
     let shortest = min_clip_frames(project.rate());
     let mut made = Vec::new();
     let mut originals = Vec::new();
     let mut given = given.into_iter();
+    let mut given_groups = given_groups.into_iter();
+    let selected_group = clip_id
+        .as_deref()
+        .and_then(|id| project.clip(id))
+        .and_then(|clip| clip.link_group.clone());
+    let mut split_groups = HashMap::new();
+    let mut made_groups = Vec::new();
 
     for track in &mut project.tracks {
         let mut created = Vec::new();
         for clip in &mut track.clips {
             if let Some(only) = clip_id.as_deref() {
                 if clip.id != only {
-                    continue;
+                    match selected_group.as_deref() {
+                        Some(group) if clip.link_group.as_deref() == Some(group) => {}
+                        _ => continue,
+                    }
                 }
             }
             if frame <= clip.start || frame >= clip.end_frame() {
@@ -687,9 +829,18 @@ fn split_at(
                 clip: clip.clone(),
             });
             let id = given.next().unwrap_or_else(|| ids.make('c'));
+            let link_group = given_groups.next().unwrap_or_else(|| {
+                clip.link_group.as_ref().map(|group| {
+                    split_groups
+                        .entry(group.clone())
+                        .or_insert_with(|| ids.make('g'))
+                        .clone()
+                })
+            });
             created.push(Clip {
                 id: id.clone(),
                 asset_id: clip.asset_id.clone(),
+                link_group: link_group.clone(),
                 start: frame,
                 in_point: clip.in_point + offset,
                 out_point: clip.out_point,
@@ -697,6 +848,7 @@ fn split_at(
                 opacity: clip.opacity,
             });
             made.push(id);
+            made_groups.push(link_group);
             clip.out_point = clip.in_point + offset;
         }
         if !created.is_empty() {
@@ -716,6 +868,7 @@ fn split_at(
             frame,
             clip_id,
             ids: made.clone(),
+            link_groups: made_groups,
         },
         inverse: Command::Transaction {
             commands: vec![
@@ -727,15 +880,83 @@ fn split_at(
 }
 
 fn remove_clip(project: &mut Project, clip_id: String) -> Result<Applied, String> {
-    let was = project
-        .placement(&clip_id)
-        .ok_or("that clip is not on the timeline")?;
+    let entries = project.linked_placements(&clip_id);
+    if entries.is_empty() {
+        return Err("that clip is not on the timeline".into());
+    }
+    let ids: Vec<&str> = entries.iter().map(|entry| entry.clip.id.as_str()).collect();
     for track in &mut project.tracks {
-        track.clips.retain(|clip| clip.id != clip_id);
+        track.clips.retain(|clip| !ids.contains(&clip.id.as_str()));
     }
     Ok(Applied {
         resolved: Command::RemoveClip { clip_id },
-        inverse: Command::RestoreClips { entries: vec![was] },
+        inverse: Command::RestoreClips { entries },
+    })
+}
+
+fn link_clips(
+    project: &mut Project,
+    ids: &mut Ids,
+    clip_ids: Vec<String>,
+    link_group: Option<String>,
+) -> Result<Applied, String> {
+    if clip_ids.len() != 2 || clip_ids[0] == clip_ids[1] {
+        return Err("link exactly one video clip and one audio clip".into());
+    }
+    let entries: Vec<ClipAt> = clip_ids
+        .iter()
+        .map(|id| {
+            project
+                .placement(id)
+                .ok_or("that clip is not on the timeline")
+        })
+        .collect::<Result<_, _>>()?;
+    let first_track = project
+        .track(&entries[0].track_id)
+        .expect("placement has a track");
+    let second_track = project
+        .track(&entries[1].track_id)
+        .expect("placement has a track");
+    let first = &entries[0].clip;
+    let second = &entries[1].clip;
+    if first_track.kind == second_track.kind
+        || first.asset_id != second.asset_id
+        || first.start != second.start
+        || first.in_point != second.in_point
+        || first.out_point != second.out_point
+    {
+        return Err("only synchronized video and audio clips from one asset can be linked".into());
+    }
+    if first.link_group.is_some() || second.link_group.is_some() {
+        return Err("unlink those clips before linking them again".into());
+    }
+    let group = link_group.unwrap_or_else(|| ids.make('g'));
+    for id in &clip_ids {
+        let (track, clip) = project.locate(id).expect("just found it");
+        project.tracks[track].clips[clip].link_group = Some(group.clone());
+    }
+    Ok(Applied {
+        resolved: Command::LinkClips {
+            clip_ids,
+            link_group: Some(group),
+        },
+        inverse: Command::RestoreClips { entries },
+    })
+}
+
+fn unlink_clips(project: &mut Project, clip_id: String) -> Result<Applied, String> {
+    let entries = project.linked_placements(&clip_id);
+    if entries.len() < 2 {
+        return Err("that clip is not linked".into());
+    }
+    let ids: Vec<String> = entries.iter().map(|entry| entry.clip.id.clone()).collect();
+    for id in ids {
+        let (track, clip) = project.locate(&id).expect("just found it");
+        project.tracks[track].clips[clip].link_group = None;
+    }
+    Ok(Applied {
+        resolved: Command::UnlinkClips { clip_id },
+        inverse: Command::RestoreClips { entries },
     })
 }
 
@@ -743,27 +964,30 @@ fn remove_clip(project: &mut Project, clip_id: String) -> Result<Applied, String
 /// by exactly the length that went, so the order and the spacing of what is
 /// left are untouched and nothing can end up overlapping.
 fn ripple_delete(project: &mut Project, clip_id: String) -> Result<Applied, String> {
-    let was = project
-        .placement(&clip_id)
-        .ok_or("that clip is not on the timeline")?;
-    let (track_index, _) = project.locate(&clip_id).expect("just found it");
-    let gap = was.clip.duration_frames();
-    let after = was.clip.end_frame();
-    let track_id = project.tracks[track_index].id.clone();
-
-    let mut restore = vec![was];
-    let track = &mut project.tracks[track_index];
-    track.clips.retain(|clip| clip.id != clip_id);
-    for clip in &mut track.clips {
-        if clip.start >= after {
-            restore.push(ClipAt {
-                track_id: track_id.clone(),
-                clip: clip.clone(),
-            });
-            clip.start = (clip.start - gap).max(0);
-        }
+    let removed = project.linked_placements(&clip_id);
+    if removed.is_empty() {
+        return Err("that clip is not on the timeline".into());
     }
-    track.sort();
+    let removed_ids: Vec<&str> = removed.iter().map(|entry| entry.clip.id.as_str()).collect();
+    let mut restore = removed.clone();
+    for entry in &removed {
+        let track = project
+            .track_mut(&entry.track_id)
+            .expect("placement has a track");
+        track
+            .clips
+            .retain(|clip| !removed_ids.contains(&clip.id.as_str()));
+        for clip in &mut track.clips {
+            if clip.start >= entry.clip.end_frame() {
+                restore.push(ClipAt {
+                    track_id: entry.track_id.clone(),
+                    clip: clip.clone(),
+                });
+                clip.start = (clip.start - entry.clip.duration_frames()).max(0);
+            }
+        }
+        track.sort();
+    }
     Ok(Applied {
         resolved: Command::RippleDelete { clip_id },
         inverse: Command::RestoreClips { entries: restore },
@@ -872,9 +1096,7 @@ fn restore_clips(project: &mut Project, entries: Vec<ClipAt>) -> Applied {
         resolved: Command::RestoreClips { entries },
         inverse: Command::Transaction {
             commands: vec![
-                Command::DropClips {
-                    clip_ids: invented,
-                },
+                Command::DropClips { clip_ids: invented },
                 Command::RestoreClips { entries: previous },
             ],
         },
@@ -938,7 +1160,9 @@ fn drop_assets(project: &mut Project, asset_ids: Vec<String>) -> Applied {
             })
         })
         .collect();
-    project.assets.retain(|asset| !asset_ids.contains(&asset.id));
+    project
+        .assets
+        .retain(|asset| !asset_ids.contains(&asset.id));
     Applied {
         resolved: Command::DropAssets { asset_ids },
         inverse: Command::RestoreAssets { entries: previous },
@@ -970,7 +1194,9 @@ fn drop_tracks(project: &mut Project, track_ids: Vec<String>) -> Applied {
             })
         })
         .collect();
-    project.tracks.retain(|track| !track_ids.contains(&track.id));
+    project
+        .tracks
+        .retain(|track| !track_ids.contains(&track.id));
     Applied {
         resolved: Command::DropTracks { track_ids },
         inverse: Command::RestoreTracks { entries: previous },

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -549,7 +549,11 @@ fn add_clip(
         return Err(format!("a {:?} track will not take that", track.kind).to_lowercase());
     }
     let duration = asset.initial_clip_frames(rate);
-    let start = track.free_start(start, duration, None);
+    let free_start = track.free_start(start, duration, None);
+    if link_group.is_some() && free_start != start {
+        return Err("there is no room to add every linked clip together".into());
+    }
+    let start = free_start;
     let id = id.unwrap_or_else(|| ids.make('c'));
     track.clips.push(Clip {
         id: id.clone(),

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -69,6 +69,9 @@ impl Document {
             ids.observe(&track.id);
             for clip in &track.clips {
                 ids.observe(&clip.id);
+                if let Some(group) = &clip.link_group {
+                    ids.observe(group);
+                }
             }
         }
         Document {
@@ -105,8 +108,16 @@ impl Document {
             revision: self.revision,
             can_undo: self.can_undo(),
             can_redo: self.can_redo(),
-            undo_label: self.undo.last().map(|entry| entry.label.into()).unwrap_or_default(),
-            redo_label: self.redo.last().map(|entry| entry.label.into()).unwrap_or_default(),
+            undo_label: self
+                .undo
+                .last()
+                .map(|entry| entry.label.into())
+                .unwrap_or_default(),
+            redo_label: self
+                .redo
+                .last()
+                .map(|entry| entry.label.into())
+                .unwrap_or_default(),
         }
     }
 
@@ -238,9 +249,7 @@ impl Document {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        Asset, AssetKind, Clip, Command, Edge, ProjectSettings, Rate, TrackKind,
-    };
+    use crate::{Asset, AssetKind, Clip, Command, Edge, ProjectSettings, Rate, TrackKind};
 
     fn asset(id: &str, kind: AssetKind, duration_ms: u64) -> Asset {
         Asset {
@@ -284,6 +293,7 @@ mod tests {
                 asset_id: "v".into(),
                 start,
                 id: None,
+                link_group: None,
             })
             .unwrap();
         document
@@ -297,6 +307,37 @@ mod tests {
             .expect("the clip that was just added")
     }
 
+    fn add_linked(document: &mut Document, start: i64) -> (String, String) {
+        let video = video_track(document);
+        let audio = audio_track(document);
+        document
+            .apply_all(vec![
+                Command::AddClip {
+                    track_id: video.clone(),
+                    asset_id: "v".into(),
+                    start,
+                    id: None,
+                    link_group: Some("g1".into()),
+                },
+                Command::AddClip {
+                    track_id: audio.clone(),
+                    asset_id: "v".into(),
+                    start,
+                    id: None,
+                    link_group: Some("g1".into()),
+                },
+            ])
+            .unwrap();
+        (
+            document.project().track(&video).unwrap().clips[0]
+                .id
+                .clone(),
+            document.project().track(&audio).unwrap().clips[0]
+                .id
+                .clone(),
+        )
+    }
+
     fn clips(document: &Document) -> Vec<Clip> {
         document.project().tracks[0].clips.clone()
     }
@@ -307,7 +348,10 @@ mod tests {
         add(&mut document, 75);
         let clips = clips(&document);
         assert_eq!(clips.len(), 1);
-        assert_eq!((clips[0].start, clips[0].in_point, clips[0].out_point), (75, 0, 300));
+        assert_eq!(
+            (clips[0].start, clips[0].in_point, clips[0].out_point),
+            (75, 0, 300)
+        );
     }
 
     #[test]
@@ -325,6 +369,7 @@ mod tests {
                 asset_id: "still".into(),
                 start: 0,
                 id: None,
+                link_group: None,
             })
             .unwrap_err();
         assert!(error.contains("will not take"), "{error}");
@@ -355,14 +400,27 @@ mod tests {
     fn redo_reproduces_the_same_clips_rather_than_new_ones() {
         let mut document = document();
         add(&mut document, 0);
-        document.apply(Command::SplitAt { frame: 150, clip_id: None, ids: Vec::new() }).unwrap();
-        let after_split: Vec<String> = clips(&document).iter().map(|clip| clip.id.clone()).collect();
+        document
+            .apply(Command::SplitAt {
+                frame: 150,
+                clip_id: None,
+                ids: Vec::new(),
+                link_groups: Vec::new(),
+            })
+            .unwrap();
+        let after_split: Vec<String> = clips(&document)
+            .iter()
+            .map(|clip| clip.id.clone())
+            .collect();
         assert_eq!(after_split.len(), 2);
 
         document.undo().unwrap();
         assert_eq!(clips(&document).len(), 1);
         document.redo().unwrap();
-        let again: Vec<String> = clips(&document).iter().map(|clip| clip.id.clone()).collect();
+        let again: Vec<String> = clips(&document)
+            .iter()
+            .map(|clip| clip.id.clone())
+            .collect();
         assert_eq!(again, after_split, "redo has to hand back the same ids");
         // And the cut is still where it was, on both halves.
         assert_eq!(clips(&document)[0].out_point, 150);
@@ -380,7 +438,9 @@ mod tests {
                 frame: 200,
             })
             .unwrap();
-        document.apply(Command::RemoveClip { clip_id: clip }).unwrap();
+        document
+            .apply(Command::RemoveClip { clip_id: clip })
+            .unwrap();
         assert!(clips(&document).is_empty());
 
         let mut steps = 0;
@@ -396,7 +456,10 @@ mod tests {
             document.redo().unwrap();
         }
         assert_eq!(document.project().assets.len(), 1);
-        assert!(clips(&document).is_empty(), "and forward to after the delete");
+        assert!(
+            clips(&document).is_empty(),
+            "and forward to after the delete"
+        );
     }
 
     #[test]
@@ -419,9 +482,14 @@ mod tests {
                 frame: 100_000,
                 clip_id: None,
                 ids: Vec::new(),
+                link_groups: Vec::new(),
             })
             .unwrap();
-        assert_eq!(document.revision(), before, "nothing happened, so nothing to undo");
+        assert_eq!(
+            document.revision(),
+            before,
+            "nothing happened, so nothing to undo"
+        );
     }
 
     #[test]
@@ -430,12 +498,32 @@ mod tests {
         let first = add(&mut document, 0);
         add(&mut document, 300);
         add(&mut document, 600);
-        assert_eq!(clips(&document).iter().map(|clip| clip.start).collect::<Vec<_>>(), [0, 300, 600]);
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.start)
+                .collect::<Vec<_>>(),
+            [0, 300, 600]
+        );
 
-        document.apply(Command::RippleDelete { clip_id: first }).unwrap();
-        assert_eq!(clips(&document).iter().map(|clip| clip.start).collect::<Vec<_>>(), [0, 300]);
+        document
+            .apply(Command::RippleDelete { clip_id: first })
+            .unwrap();
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.start)
+                .collect::<Vec<_>>(),
+            [0, 300]
+        );
         document.undo().unwrap();
-        assert_eq!(clips(&document).iter().map(|clip| clip.start).collect::<Vec<_>>(), [0, 300, 600]);
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.start)
+                .collect::<Vec<_>>(),
+            [0, 300, 600]
+        );
     }
 
     #[test]
@@ -488,6 +576,7 @@ mod tests {
                     clip: Clip {
                         id: clip,
                         asset_id: "v".into(),
+                        link_group: None,
                         start: 0,
                         in_point: 0,
                         out_point: 9_000,
@@ -561,7 +650,11 @@ mod tests {
 
         document.undo().unwrap();
         assert_eq!(document.project().rate(), Rate::fps(30));
-        assert_eq!(clips(&document)[0].out_point, 150, "and exactly back, not near it");
+        assert_eq!(
+            clips(&document)[0].out_point,
+            150,
+            "and exactly back, not near it"
+        );
     }
 
     #[test]
@@ -569,7 +662,11 @@ mod tests {
         let mut document = document();
         add(&mut document, 0);
         add(&mut document, 300);
-        document.apply(Command::RemoveAsset { asset_id: "v".into() }).unwrap();
+        document
+            .apply(Command::RemoveAsset {
+                asset_id: "v".into(),
+            })
+            .unwrap();
         assert!(document.project().assets.is_empty());
         assert!(clips(&document).is_empty());
 
@@ -587,20 +684,34 @@ mod tests {
                 id: None,
             })
             .unwrap();
-        let second = document.project().tracks_of(TrackKind::Video).nth(1).unwrap().id.clone();
+        let second = document
+            .project()
+            .tracks_of(TrackKind::Video)
+            .nth(1)
+            .unwrap()
+            .id
+            .clone();
         document
             .apply(Command::AddClip {
                 track_id: second.clone(),
                 asset_id: "v".into(),
                 start: 0,
                 id: None,
+                link_group: None,
             })
             .unwrap();
-        document.apply(Command::RemoveTrack { track_id: second.clone() }).unwrap();
+        document
+            .apply(Command::RemoveTrack {
+                track_id: second.clone(),
+            })
+            .unwrap();
         assert!(document.project().track(&second).is_none());
 
         document.undo().unwrap();
-        let back = document.project().track(&second).expect("the track is back");
+        let back = document
+            .project()
+            .track(&second)
+            .expect("the track is back");
         assert_eq!(back.clips.len(), 1, "and so are the clips that were on it");
         assert_eq!(document.project().tracks[2].id, second, "in the same place");
     }
@@ -609,14 +720,20 @@ mod tests {
     fn only_the_last_track_of_a_kind_can_go() {
         let mut document = document();
         let first = video_track(&document);
-        assert!(document.apply(Command::RemoveTrack { track_id: first.clone() }).is_err());
+        assert!(document
+            .apply(Command::RemoveTrack {
+                track_id: first.clone()
+            })
+            .is_err());
         document
             .apply(Command::AddTrack {
                 track_kind: TrackKind::Video,
                 id: None,
             })
             .unwrap();
-        assert!(document.apply(Command::RemoveTrack { track_id: first }).is_err());
+        assert!(document
+            .apply(Command::RemoveTrack { track_id: first })
+            .is_err());
     }
 
     #[test]
@@ -650,18 +767,166 @@ mod tests {
                     asset_id: "v".into(),
                     start: 0,
                     id: None,
+                    link_group: None,
                 },
                 Command::AddClip {
                     track_id: track,
                     asset_id: "v".into(),
                     start: 300,
                     id: None,
+                    link_group: None,
                 },
             ])
             .unwrap();
         assert_eq!(clips(&document).len(), 2);
         document.undo().unwrap();
         assert!(clips(&document).is_empty(), "both went, on one undo");
+    }
+
+    #[test]
+    fn linked_clips_are_added_moved_and_undone_as_one_edit() {
+        let mut document = document();
+        let (video, audio) = add_linked(&mut document, 0);
+        document
+            .apply(Command::MoveClip {
+                clip_id: video.clone(),
+                track_id: video_track(&document),
+                start: 60,
+            })
+            .unwrap();
+        assert_eq!(document.project().clip(&video).unwrap().start, 60);
+        assert_eq!(document.project().clip(&audio).unwrap().start, 60);
+
+        document.undo().unwrap();
+        assert_eq!(document.project().clip(&video).unwrap().start, 0);
+        assert_eq!(document.project().clip(&audio).unwrap().start, 0);
+        document.undo().unwrap();
+        assert!(document.project().clip(&video).is_none());
+        assert!(document.project().clip(&audio).is_none());
+        document.redo().unwrap();
+        assert_eq!(
+            document
+                .project()
+                .clip(&video)
+                .unwrap()
+                .link_group
+                .as_deref(),
+            Some("g1")
+        );
+        assert_eq!(
+            document
+                .project()
+                .clip(&audio)
+                .unwrap()
+                .link_group
+                .as_deref(),
+            Some("g1")
+        );
+    }
+
+    #[test]
+    fn a_linked_move_fails_whole_when_either_track_is_occupied() {
+        let mut document = document();
+        let (video, audio) = add_linked(&mut document, 0);
+        document
+            .apply(Command::AddClip {
+                track_id: audio_track(&document),
+                asset_id: "v".into(),
+                start: 600,
+                id: None,
+                link_group: None,
+            })
+            .unwrap();
+        let error = document
+            .apply(Command::MoveClip {
+                clip_id: video.clone(),
+                track_id: video_track(&document),
+                start: 600,
+            })
+            .unwrap_err();
+        assert!(error.contains("no room"), "{error}");
+        assert_eq!(document.project().clip(&video).unwrap().start, 0);
+        assert_eq!(document.project().clip(&audio).unwrap().start, 0);
+    }
+
+    #[test]
+    fn trim_split_and_delete_keep_linked_pairs_together() {
+        let mut document = document();
+        let (video, audio) = add_linked(&mut document, 0);
+        document
+            .apply(Command::TrimClip {
+                clip_id: video.clone(),
+                edge: Edge::End,
+                frame: 240,
+            })
+            .unwrap();
+        assert_eq!(document.project().clip(&video).unwrap().out_point, 240);
+        assert_eq!(document.project().clip(&audio).unwrap().out_point, 240);
+
+        document
+            .apply(Command::SplitAt {
+                frame: 120,
+                clip_id: Some(video),
+                ids: Vec::new(),
+                link_groups: Vec::new(),
+            })
+            .unwrap();
+        let right_video = document
+            .project()
+            .track(&video_track(&document))
+            .unwrap()
+            .clips[1]
+            .clone();
+        let right_audio = document
+            .project()
+            .track(&audio_track(&document))
+            .unwrap()
+            .clips[1]
+            .clone();
+        assert_eq!(right_video.link_group, right_audio.link_group);
+        assert_ne!(right_video.link_group.as_deref(), Some("g1"));
+
+        document
+            .apply(Command::RemoveClip {
+                clip_id: right_video.id.clone(),
+            })
+            .unwrap();
+        assert!(document.project().clip(&right_video.id).is_none());
+        assert!(document.project().clip(&right_audio.id).is_none());
+        document.undo().unwrap();
+        assert!(document.project().clip(&right_video.id).is_some());
+        assert!(document.project().clip(&right_audio.id).is_some());
+    }
+
+    #[test]
+    fn unlink_allows_one_side_to_move_and_link_restores_group_editing() {
+        let mut document = document();
+        let (video, audio) = add_linked(&mut document, 0);
+        document
+            .apply(Command::UnlinkClips {
+                clip_id: video.clone(),
+            })
+            .unwrap();
+        document
+            .apply(Command::MoveClip {
+                clip_id: video.clone(),
+                track_id: video_track(&document),
+                start: 30,
+            })
+            .unwrap();
+        assert_eq!(document.project().clip(&video).unwrap().start, 30);
+        assert_eq!(document.project().clip(&audio).unwrap().start, 0);
+        document.undo().unwrap();
+        document
+            .apply(Command::LinkClips {
+                clip_ids: vec![video.clone(), audio.clone()],
+                link_group: None,
+            })
+            .unwrap();
+        assert_eq!(
+            document.project().clip(&video).unwrap().link_group,
+            document.project().clip(&audio).unwrap().link_group
+        );
     }
 
     #[test]
@@ -693,10 +958,14 @@ mod tests {
                 asset_id: "v".into(),
                 start: 120,
                 id: None,
+                link_group: None,
             })
             .unwrap();
         let made = &document.project().tracks[0].clips[1].id;
-        assert_ne!(made, "c9", "a new clip may not land on an id already in use");
+        assert_ne!(
+            made, "c9",
+            "a new clip may not land on an id already in use"
+        );
         assert_eq!(made, "c10");
     }
 
@@ -739,14 +1008,14 @@ mod tests {
         assert_eq!(serde_json::to_string(&command).unwrap(), text);
 
         // The fields the page leaves out are the ones the apply fills in.
-        let split: Command =
-            serde_json::from_str(r#"{"op":"splitAt","frame":10}"#).unwrap();
+        let split: Command = serde_json::from_str(r#"{"op":"splitAt","frame":10}"#).unwrap();
         assert_eq!(
             split,
             Command::SplitAt {
                 frame: 10,
                 clip_id: None,
-                ids: Vec::new()
+                ids: Vec::new(),
+                link_groups: Vec::new()
             }
         );
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -825,6 +825,56 @@ mod tests {
     }
 
     #[test]
+    fn linked_add_fails_whole_when_either_track_is_occupied() {
+        let mut document = document();
+        document
+            .apply(Command::AddClip {
+                track_id: audio_track(&document),
+                asset_id: "v".into(),
+                start: 0,
+                id: None,
+                link_group: None,
+            })
+            .unwrap();
+
+        let error = document
+            .apply_all(vec![
+                Command::AddClip {
+                    track_id: video_track(&document),
+                    asset_id: "v".into(),
+                    start: 0,
+                    id: None,
+                    link_group: Some("g1".into()),
+                },
+                Command::AddClip {
+                    track_id: audio_track(&document),
+                    asset_id: "v".into(),
+                    start: 0,
+                    id: None,
+                    link_group: Some("g1".into()),
+                },
+            ])
+            .unwrap_err();
+
+        assert!(error.contains("no room"), "{error}");
+        assert!(document
+            .project()
+            .track(&video_track(&document))
+            .unwrap()
+            .clips
+            .is_empty());
+        assert_eq!(
+            document
+                .project()
+                .track(&audio_track(&document))
+                .unwrap()
+                .clips
+                .len(),
+            1
+        );
+    }
+
+    #[test]
     fn a_linked_move_fails_whole_when_either_track_is_occupied() {
         let mut document = document();
         let (video, audio) = add_linked(&mut document, 0);

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -26,9 +26,10 @@ pub mod migrate;
 
 pub use command::{ClipAt, Command, Edge};
 pub use document::{Document, DocumentState};
-pub use makevideo_time::{RationalTime, Rate};
+pub use makevideo_time::{Rate, RationalTime};
 
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 /// What `version` a project file written today holds. Version 1 measured
 /// everything in whole milliseconds; `migrate` turns one of those into this on
@@ -284,6 +285,8 @@ impl Track {
 pub struct Clip {
     pub id: String,
     pub asset_id: String,
+    #[serde(default)]
+    pub link_group: Option<String>,
     /// Where the clip sits on the timeline, in frames of the project rate.
     pub start: i64,
     /// The span taken out of the source, in frames too. `out` is exclusive.
@@ -388,6 +391,26 @@ impl Project {
         Some(&self.tracks[track].clips[clip])
     }
 
+    pub fn linked_placements(&self, clip_id: &str) -> Vec<ClipAt> {
+        let Some(clip) = self.clip(clip_id) else {
+            return Vec::new();
+        };
+        let Some(group) = clip.link_group.as_deref() else {
+            return self.placement(clip_id).into_iter().collect();
+        };
+        self.tracks
+            .iter()
+            .flat_map(|track| {
+                track.clips.iter().filter_map(move |clip| {
+                    (clip.link_group.as_deref() == Some(group)).then(|| ClipAt {
+                        track_id: track.id.clone(),
+                        clip: clip.clone(),
+                    })
+                })
+            })
+            .collect()
+    }
+
     /// The track a clip is on, and a clone of the clip: what an inverse needs
     /// to put the thing back exactly where it was.
     pub fn placement(&self, clip_id: &str) -> Option<ClipAt> {
@@ -426,8 +449,7 @@ impl Project {
 
     /// How far into its source a clip may reach, when anything knows.
     fn source_limit(&self, clip: &Clip) -> Option<i64> {
-        self.asset(&clip.asset_id)?
-            .source_limit_frames(self.rate())
+        self.asset(&clip.asset_id)?.source_limit_frames(self.rate())
     }
 
     /// Everything a clip has to satisfy for the rest of the app to be able to
@@ -441,6 +463,7 @@ impl Project {
     /// out at the edit costs a rejected drag; finding out at the render costs
     /// the render.
     pub fn validate(&self) -> Result<(), String> {
+        let mut links: HashMap<&str, Vec<(&Track, &Clip)>> = HashMap::new();
         for track in &self.tracks {
             let mut previous_end = i64::MIN;
             for clip in &track.clips {
@@ -456,13 +479,35 @@ impl Project {
                 }
                 if let Some(limit) = self.source_limit(clip) {
                     if clip.out_point > limit {
-                        return Err(format!("clip {name} would reach past the end of its source"));
+                        return Err(format!(
+                            "clip {name} would reach past the end of its source"
+                        ));
                     }
                 }
                 if clip.start < previous_end {
                     return Err(format!("clip {name} would overlap the clip before it"));
                 }
+                if let Some(group) = clip.link_group.as_deref() {
+                    links.entry(group).or_default().push((track, clip));
+                }
                 previous_end = clip.end_frame();
+            }
+        }
+        for (group, entries) in links {
+            if entries.len() != 2 {
+                return Err(format!(
+                    "link group {group} must contain one video and one audio clip"
+                ));
+            }
+            let (first_track, first) = entries[0];
+            let (second_track, second) = entries[1];
+            if first_track.kind == second_track.kind
+                || first.asset_id != second.asset_id
+                || first.start != second.start
+                || first.in_point != second.in_point
+                || first.out_point != second.out_point
+            {
+                return Err(format!("link group {group} is out of sync"));
             }
         }
         Ok(())
@@ -503,6 +548,47 @@ impl Project {
                 end = clip.end_frame();
             }
         }
+        let mut groups: HashMap<String, Vec<(TrackKind, String, i64, i64, i64)>> = HashMap::new();
+        for track in &self.tracks {
+            for clip in &track.clips {
+                if let Some(group) = &clip.link_group {
+                    groups.entry(group.clone()).or_default().push((
+                        track.kind,
+                        clip.asset_id.clone(),
+                        clip.start,
+                        clip.in_point,
+                        clip.out_point,
+                    ));
+                }
+            }
+        }
+        let valid: HashSet<String> = groups
+            .into_iter()
+            .filter_map(|(group, entries)| {
+                if entries.len() != 2 {
+                    return None;
+                }
+                let first = &entries[0];
+                let second = &entries[1];
+                (first.0 != second.0
+                    && first.1 == second.1
+                    && first.2 == second.2
+                    && first.3 == second.3
+                    && first.4 == second.4)
+                    .then_some(group)
+            })
+            .collect();
+        for track in &mut self.tracks {
+            for clip in &mut track.clips {
+                if clip
+                    .link_group
+                    .as_ref()
+                    .is_some_and(|group| !valid.contains(group))
+                {
+                    clip.link_group = None;
+                }
+            }
+        }
     }
 }
 
@@ -527,6 +613,7 @@ mod tests {
         Clip {
             id: id.into(),
             asset_id: "v".into(),
+            link_group: None,
             start,
             in_point,
             out_point,
@@ -627,6 +714,9 @@ mod tests {
         project.repair();
         assert!(project.validate().is_ok(), "{:?}", project.tracks[0].clips);
         assert_eq!(project.tracks[0].clips[0].start, 0);
-        assert!(project.tracks[0].clips.iter().all(|clip| clip.out_point <= 300));
+        assert!(project.tracks[0]
+            .clips
+            .iter()
+            .all(|clip| clip.out_point <= 300));
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
@@ -63,6 +63,8 @@ struct WireTrack {
 struct WireClip {
     id: String,
     asset_id: String,
+    #[serde(default)]
+    link_group: Option<String>,
     start: Option<i64>,
     #[serde(rename = "in")]
     in_point: Option<i64>,
@@ -125,6 +127,7 @@ impl From<WireProject> for Project {
                         .map(|clip| Clip {
                             id: clip.id,
                             asset_id: clip.asset_id,
+                            link_group: clip.link_group,
                             start: frames(clip.start, clip.start_ms, rate),
                             in_point: frames(clip.in_point, clip.in_ms, rate),
                             out_point: frames(clip.out_point, clip.out_ms, rate),
@@ -185,7 +188,7 @@ mod tests {
             "version": 2,
             "settings": {"width": 1080, "height": 1920, "rate": {"num": 24000, "den": 1001}},
             "tracks": [{"id": "V1", "kind": "video", "clips": [
-                {"id": "c1", "assetId": "a1", "start": 12, "in": 3, "out": 48, "volume": 0.5}
+                {"id": "c1", "assetId": "a1", "linkGroup": "g1", "start": 12, "in": 3, "out": 48, "volume": 0.5}
             ]}]
         }"#;
         let project: Project = serde_json::from_str(text).unwrap();
@@ -193,6 +196,7 @@ mod tests {
         let clip = &project.tracks[0].clips[0];
         assert_eq!((clip.start, clip.in_point, clip.out_point), (12, 3, 48));
         assert_eq!(clip.volume, 0.5);
+        assert_eq!(clip.link_group.as_deref(), Some("g1"));
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -514,6 +514,7 @@ mod tests {
                 clips: vec![Clip {
                     id: "c1".into(),
                     asset_id: "a1".into(),
+                    link_group: None,
                     start: 0,
                     in_point: 0,
                     out_point: 300,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
@@ -664,6 +664,7 @@ mod tests {
                 clips: vec![Clip {
                     id: "c1".into(),
                     asset_id: "a1".into(),
+                    link_group: None,
                     start: 0,
                     in_point: 0,
                     out_point: 300,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
@@ -244,6 +244,7 @@ mod tests {
                 clips: vec![Clip {
                     id: "c1".into(),
                     asset_id: "a1".into(),
+                    link_group: None,
                     start: 0,
                     in_point: 0,
                     out_point: 300,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
@@ -703,6 +703,7 @@ mod tests {
         Clip {
             id: id.into(),
             asset_id: asset_id.into(),
+            link_group: None,
             start,
             in_point,
             out_point,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
@@ -307,6 +307,7 @@ mod tests {
         Clip {
             id: id.into(),
             asset_id: asset_id.into(),
+            link_group: None,
             start,
             in_point,
             out_point,

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -160,6 +160,7 @@
         <button id="btn-ripple" class="icon" title="Delete the selected clip and close the gap (⇧Delete)">
           <svg viewBox="0 0 20 20"><use href="#icon-ripple" /></svg>
         </button>
+        <button id="btn-link" class="small" title="Link or unlink synchronized audio and video clips">Link Clips</button>
         <span class="sep-v"></span>
         <button id="btn-add-video" class="small">+ Video track</button>
         <button id="btn-add-audio" class="small">+ Audio track</button>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -79,6 +79,7 @@ const dom = {
   btnMagnet: el('btn-magnet'),
   btnDelete: el('btn-delete'),
   btnRipple: el('btn-ripple'),
+  btnLink: el('btn-link'),
   btnAddVideo: el('btn-add-video'),
   btnAddAudio: el('btn-add-audio'),
   zoom: el('zoom'),
@@ -491,6 +492,10 @@ function clipElement(track, clip) {
   node.style.left = `${L.framesToPx(clip.start, rate(), state.pxPerSecond)}px`;
   node.style.width = `${Math.max(2, L.framesToPx(L.clipDuration(clip), rate(), state.pxPerSecond))}px`;
   if (clip.id === state.selectedClipId) node.classList.add('selected');
+  if (clip.linkGroup) {
+    node.classList.add('linked');
+    node.title = 'Linked audio and video clip';
+  }
 
   const label = document.createElement('span');
   label.className = 'clip-name';
@@ -557,6 +562,7 @@ function renderTimeline() {
   dom.btnMagnet.classList.toggle('on', Boolean(state.settings && state.settings.snap));
   dom.btnAddVideo.disabled = L.tracksOf(state.project, 'video').length >= L.MAX_TRACKS_PER_KIND;
   dom.btnAddAudio.disabled = L.tracksOf(state.project, 'audio').length >= L.MAX_TRACKS_PER_KIND;
+  updateLinkUi();
   updateHistoryUi();
   scheduleExactFrame();
   if (preview) preview.redraw();
@@ -644,6 +650,14 @@ function selectClip(clipId) {
   for (const node of dom.lanes.querySelectorAll('.clip')) {
     node.classList.toggle('selected', node.dataset.clipId === clipId);
   }
+  updateLinkUi();
+}
+
+function updateLinkUi() {
+  const selected = liveSelection();
+  const found = selected && L.findClip(state.project, selected);
+  dom.btnLink.disabled = !found || (!found.clip.linkGroup && !L.relinkCandidate(state.project, selected));
+  dom.btnLink.textContent = found && found.clip.linkGroup ? 'Unlink Clips' : 'Link Clips';
 }
 
 function selectAsset(assetId) {
@@ -680,6 +694,20 @@ async function deleteSelected(ripple) {
   // gets back is a success that made no clips, and it is not null.
   const done = await edit({ op: ripple ? 'rippleDelete' : 'removeClip', clipId });
   if (done) state.selectedClipId = null;
+}
+
+async function toggleClipLink() {
+  const clipId = liveSelection();
+  if (!clipId) return;
+  const found = L.findClip(state.project, clipId);
+  if (!found) return;
+  if (found.clip.linkGroup) {
+    await edit({ op: 'unlinkClips', clipId });
+    return;
+  }
+  const candidate = L.relinkCandidate(state.project, clipId);
+  if (!candidate) return;
+  await edit({ op: 'linkClips', clipIds: [clipId, candidate.clip.id] });
 }
 
 /** Persist a setting changed from a toolbar or the transport, where there is no
@@ -850,9 +878,22 @@ function beginScrub(event) {
 function dropCommands(trackId, assets, atFrame) {
   const track = L.findTrack(state.project, trackId);
   if (!track) return [];
-  return assets
-    .filter((asset) => L.canAccept(track, asset))
-    .map((asset) => ({ op: 'addClip', trackId, assetId: asset.id, start: atFrame }));
+  const commands = [];
+  for (const asset of assets.filter((asset) => L.canAccept(track, asset))) {
+    if (track.kind === 'video' && asset.kind === 'video' && asset.hasAudio) {
+      const videoIndex = L.tracksOf(state.project, 'video').findIndex((item) => item.id === trackId);
+      const audio = L.tracksOf(state.project, 'audio')[videoIndex];
+      if (!audio) return null;
+      const linkGroup = `g${crypto.randomUUID()}`;
+      commands.push(
+        { op: 'addClip', trackId, assetId: asset.id, start: atFrame, linkGroup },
+        { op: 'addClip', trackId: audio.id, assetId: asset.id, start: atFrame, linkGroup }
+      );
+      continue;
+    }
+    commands.push({ op: 'addClip', trackId, assetId: asset.id, start: atFrame });
+  }
+  return commands;
 }
 
 function laneAtPoint(x, y) {
@@ -924,7 +965,14 @@ async function endAssetDrag(event) {
   const lane = laneAtPoint(event.clientX, event.clientY);
   if (!lane) return;
   const at = L.snapTime(state.project, frameAtClientX(event.clientX), snapTolerance());
-  const made = await edit(...dropCommands(lane.dataset.trackId, [current.asset], at));
+  const commands = dropCommands(lane.dataset.trackId, [current.asset], at);
+  if (!commands) {
+    await window.api.message('Add the matching audio track before placing this video.', {
+      title: 'Linked clip needs an audio track',
+    });
+    return;
+  }
+  const made = await edit(...commands);
   if (made && made.length) selectClip(made[made.length - 1]);
 }
 
@@ -955,9 +1003,16 @@ async function handleOsDrop(payload) {
   // The import and the clips it turns into are one thing the user did, so they
   // go over as one transaction and come back on one press of undo.
   const at = L.snapTime(state.project, frameAtClientX(x), snapTolerance());
+  const commands = lane ? dropCommands(lane.dataset.trackId, found, at) : [];
+  if (lane && !commands) {
+    await window.api.message('Add the matching audio track before placing this video.', {
+      title: 'Linked clip needs an audio track',
+    });
+    return;
+  }
   const made = await edit(
     { op: 'addAssets', assets: found },
-    ...(lane ? dropCommands(lane.dataset.trackId, found, at) : [])
+    ...commands
   );
   if (made && made.length) selectClip(made[made.length - 1]);
   for (const asset of found) hydrateDuration(asset);
@@ -1554,6 +1609,7 @@ function wireTimeline() {
   dom.btnMagnet.addEventListener('click', toggleSnap);
   dom.btnDelete.addEventListener('click', () => deleteSelected(false));
   dom.btnRipple.addEventListener('click', () => deleteSelected(true));
+  dom.btnLink.addEventListener('click', toggleClipLink);
   dom.btnAddVideo.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'video' }));
   dom.btnAddAudio.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'audio' }));
 

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -736,6 +736,14 @@ button.icon.on {
   outline-offset: -2px;
 }
 
+.clip.linked::after {
+  content: "⌁";
+  position: absolute;
+  right: 8px;
+  font-weight: 700;
+  pointer-events: none;
+}
+
 .clip.missing {
   background: repeating-linear-gradient(45deg, #b1443a, #b1443a 6px, #8f342c 6px, #8f342c 12px);
   color: #fff;

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -69,6 +69,36 @@ function findAsset(project, assetId) {
   return project.assets.find((asset) => asset.id === assetId) || null;
 }
 
+function linkedClips(project, clipId) {
+  const found = findClip(project, clipId);
+  if (!found || !found.clip.linkGroup) return found ? [found] : [];
+  const linked = [];
+  for (const track of project.tracks) {
+    for (const clip of track.clips) {
+      if (clip.linkGroup === found.clip.linkGroup) linked.push({ track, clip });
+    }
+  }
+  return linked;
+}
+
+function relinkCandidate(project, clipId) {
+  const found = findClip(project, clipId);
+  if (!found || found.clip.linkGroup) return null;
+  for (const track of project.tracks) {
+    if (track.kind === found.track.kind) continue;
+    const clip = track.clips.find(
+      (candidate) =>
+        !candidate.linkGroup &&
+        candidate.assetId === found.clip.assetId &&
+        candidate.start === found.clip.start &&
+        candidate.in === found.clip.in &&
+        candidate.out === found.clip.out
+    );
+    if (clip) return { track, clip };
+  }
+  return null;
+}
+
 /** What a track will take. A video with sound can go on an audio track, which
  *  is how you use the sound of a take without its picture. Asked while a clip
  *  is being dragged, to decide whether a lane lights up as a target. */
@@ -215,6 +245,8 @@ const exported = {
   findTrack,
   findClip,
   findAsset,
+  linkedClips,
+  relinkCandidate,
   canAccept,
   clipDuration,
   clipEnd,

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -18,8 +18,8 @@ const SILENT = { id: 's', path: '/m/s.mp4', name: 's.mp4', kind: 'video', durati
 const SOUND = { id: 'm', path: '/m/m.mp3', name: 'm.mp3', kind: 'audio', durationMs: 30000, width: 0, height: 0, hasAudio: true };
 const STILL = { id: 'p', path: '/m/p.png', name: 'p.png', kind: 'image', durationMs: 0, width: 800, height: 600, hasAudio: false };
 
-function clip(id, assetId, start, inPoint, outPoint) {
-  return { id, assetId, start, in: inPoint, out: outPoint, volume: 1, opacity: 1 };
+function clip(id, assetId, start, inPoint, outPoint, linkGroup) {
+  return { id, assetId, start, in: inPoint, out: outPoint, volume: 1, opacity: 1, linkGroup: linkGroup || null };
 }
 
 function track(id, kind, name, clips) {
@@ -155,6 +155,22 @@ test('finding by id reaches into every track', () => {
   assert.strictEqual(L.findTrack(project, 't1').name, 'V1');
   assert.strictEqual(L.findAsset(project, 'm').kind, 'audio');
   assert.deepStrictEqual(L.tracksOf(project, 'video').map((each) => each.id), ['t1']);
+});
+
+test('linked clips and a relink candidate are found across track kinds', () => {
+  const video = clip('c1', 'v', 0, 0, 300, 'g1');
+  const audio = clip('c2', 'v', 0, 0, 300, 'g1');
+  const project = projectOf(
+    [VIDEO],
+    [track('t1', 'video', 'V1', [video]), track('t2', 'audio', 'A1', [audio])]
+  );
+  assert.deepStrictEqual(L.linkedClips(project, 'c1').map((entry) => entry.clip.id), ['c1', 'c2']);
+  assert.strictEqual(L.relinkCandidate(project, 'c1'), null, 'already linked');
+  video.linkGroup = null;
+  audio.linkGroup = null;
+  assert.strictEqual(L.relinkCandidate(project, 'c1').clip.id, 'c2');
+  audio.start = 1;
+  assert.strictEqual(L.relinkCandidate(project, 'c1'), null, 'out of sync');
 });
 
 test('a project on a broadcast rate counts its own frames', () => {


### PR DESCRIPTION
# 구현

오디오 포함 영상의 링크 배치와 그룹 단위 이동·트림·분할·삭제·해제 추가
- Node 65개, 편집 41개, 렌더 95개, GPU 없는 합성 37개, 오디오 59개, 프레젠트 38개 통과 및 번들 앱에서 V1/A1 동시 배치와 단독 편집 확인

# 어려웠던 점

링크 그룹의 부분 적용과 undo·redo 시 새 그룹 ID 생성 방지
- 프로젝트 전체 불변식 검증과 transaction rollback, resolved command의 clip·group ID 보존으로 처리

# 리스크

비디오 트랙과 같은 순번의 오디오 트랙이 없으면 오디오 포함 영상 배치 거절
- 그림만 조용히 배치해 소리가 빠지는 결과보다 명시적 실패를 우선한 선택

Issue #765
