### PR TITLE
akbun-makevideo: 타임라인 오디오 파형

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-asset-waveform-cache.md
+++ b/product/akbun-makevideo/adr/2026-08-asset-waveform-cache.md
@@ -1,0 +1,20 @@
+# Asset waveform cache
+
+## Decision
+
+- 오디오가 있는 asset마다 초당 100개의 최소·최대 진폭 쌍 생성
+- 프로젝트의 `waveforms/` 폴더에 원본 경로·수정 시각과 함께 JSON 저장
+- ffmpeg 디코딩과 축약은 백그라운드 worker에서 실행
+- audio clip 내부 canvas에서 trim 구간만 다시 표본화
+
+## Reason
+
+- 같은 asset을 자르거나 옮겨도 오디오 재계산 불필요
+- 원본 경로 또는 수정 시각 변경 시 기존 파형 무효화
+- 확대 배율과 무관하게 clip source 구간과 파형 구간 일치
+
+## Tradeoffs
+
+- 계산 완료 전 이름만 표시해 편집 흐름 유지
+- 긴 오디오일수록 프로젝트 파생 파일과 IPC payload 증가
+- canvas 내부 폭을 4096px로 제한해 극단적 확대에서 세부 정보 축약

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -20,4 +20,5 @@
 | [2026-08-audio-is-the-master-clock.md](./2026-08-audio-is-the-master-clock.md) | The audio output is the master clock and the picture follows it |
 | [2026-08-native-viewport-and-skip-late-frames.md](./2026-08-native-viewport-and-skip-late-frames.md) | The monitor draws on a native surface, and a late frame is skipped |
 | [2026-08-playback-proxies.md](./2026-08-playback-proxies.md) | 4K playback uses validated 1280px proxies while export keeps originals |
+| [2026-08-asset-waveform-cache.md](./2026-08-asset-waveform-cache.md) | Audio waveforms are cached per asset and clips draw only their source interval |
 | [2026-08-native-project-trash.md](./2026-08-native-project-trash.md) | Windows and macOS move validated project targets with native trash APIs |

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",
@@ -16,6 +16,7 @@
     "test:audio": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-audio",
     "test:nodevice": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-audio --no-default-features",
     "test:present": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-present",
+    "test:waveform": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-waveform",
     "test:nosurface": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-present --no-default-features",
     "quality:media": "bash scripts/generate-quality-media.sh",
     "quality:supply": "cargo run --release --manifest-path src-tauri/Cargo.toml -p makevideo-compositor --bin supply-soak --",

--- a/product/akbun-makevideo/workspace/src-tauri/Cargo.lock
+++ b/product/akbun-makevideo/workspace/src-tauri/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "makevideo-present",
  "makevideo-proxy",
  "makevideo-render",
+ "makevideo-waveform",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -2135,6 +2136,15 @@ dependencies = [
 name = "makevideo-time"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "makevideo-waveform"
+version = "0.1.0"
+dependencies = [
+ "makevideo-edit",
  "serde",
  "serde_json",
 ]

--- a/product/akbun-makevideo/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-makevideo/workspace/src-tauri/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/audio",
   "crates/present",
   "crates/proxy",
+  "crates/waveform",
 ]
 
 [package]
@@ -52,6 +53,7 @@ makevideo-present = { path = "crates/present" }
 # something reached through the present crate.
 makevideo-audio = { path = "crates/audio" }
 makevideo-proxy = { path = "crates/proxy" }
+makevideo-waveform = { path = "crates/waveform" }
 # protocol-asset is what makes asset_protocol_scope() exist. Without the
 # feature the preview shows broken media with no error anywhere.
 tauri = { version = "2", features = ["protocol-asset"] }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/waveform/Cargo.toml
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/waveform/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "makevideo-waveform"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+makevideo-edit = { path = "../edit" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/product/akbun-makevideo/workspace/src-tauri/crates/waveform/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/waveform/src/lib.rs
@@ -117,10 +117,8 @@ impl PeakBuilder {
         if self.samples == 0 {
             return;
         }
-        self.peaks.push([
-            self.min as f32 / i16::MAX as f32,
-            self.max as f32 / i16::MAX as f32,
-        ]);
+        self.peaks
+            .push([self.min as f32 / 32_768.0, self.max as f32 / 32_768.0]);
         self.samples = 0;
         self.min = i16::MAX;
         self.max = i16::MIN;
@@ -181,6 +179,15 @@ mod tests {
         assert_eq!(peaks.len(), 1);
         assert!((peaks[0][0] + 0.5).abs() < 0.001);
         assert!((peaks[0][1] - 0.25).abs() < 0.001);
+    }
+
+    #[test]
+    fn peak_builder_keeps_full_scale_samples_in_range() {
+        let mut builder = PeakBuilder::new();
+        builder.push(i16::MIN);
+        builder.push(i16::MAX);
+        let peaks = builder.finish();
+        assert_eq!(peaks, vec![[-1.0, 32_767.0 / 32_768.0]]);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/waveform/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/waveform/src/lib.rs
@@ -1,0 +1,209 @@
+use makevideo_edit::{Asset, AssetKind};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+pub const FOLDER: &str = "waveforms";
+pub const SAMPLE_RATE: usize = 8_000;
+pub const BUCKETS_PER_SECOND: usize = 100;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Waveform {
+    pub source_path: String,
+    pub source_modified_ms: u64,
+    pub buckets_per_second: u32,
+    pub peaks: Vec<[f32; 2]>,
+}
+
+pub fn needs_waveform(asset: &Asset) -> bool {
+    asset.kind == AssetKind::Audio || (asset.kind == AssetKind::Video && asset.has_audio)
+}
+
+pub fn waveform_dir(project_path: &str) -> Result<PathBuf, String> {
+    Path::new(project_path)
+        .parent()
+        .map(|parent| parent.join(FOLDER))
+        .ok_or_else(|| "the project needs a folder before waveforms can be made".into())
+}
+
+pub fn waveform_path(project_path: &str, asset_id: &str) -> Result<PathBuf, String> {
+    Ok(waveform_dir(project_path)?.join(format!("{asset_id}.json")))
+}
+
+pub fn source_modified_ms(path: &str) -> Option<u64> {
+    Path::new(path)
+        .metadata()
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis() as u64)
+}
+
+pub fn read_valid(project_path: &str, asset: &Asset) -> Option<Waveform> {
+    let path = waveform_path(project_path, &asset.id).ok()?;
+    let waveform: Waveform = serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
+    let modified = source_modified_ms(&asset.path)?;
+    (waveform.source_path == asset.path && waveform.source_modified_ms == modified)
+        .then_some(waveform)
+}
+
+pub fn write(project_path: &str, asset: &Asset, peaks: Vec<[f32; 2]>) -> Result<Waveform, String> {
+    let source_modified_ms = source_modified_ms(&asset.path)
+        .ok_or_else(|| format!("cannot read the modification time of {}", asset.path))?;
+    let waveform = Waveform {
+        source_path: asset.path.clone(),
+        source_modified_ms,
+        buckets_per_second: BUCKETS_PER_SECOND as u32,
+        peaks,
+    };
+    let path = waveform_path(project_path, &asset.id)?;
+    let text = serde_json::to_string(&waveform).map_err(|error| error.to_string())?;
+    std::fs::write(&path, text).map_err(|error| format!("cannot write {path:?}: {error}"))?;
+    Ok(waveform)
+}
+
+pub fn ffmpeg_args(asset: &Asset) -> Vec<String> {
+    vec![
+        "-hide_banner".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-i".into(),
+        asset.path.clone(),
+        "-map".into(),
+        "0:a:0".into(),
+        "-vn".into(),
+        "-ac".into(),
+        "1".into(),
+        "-ar".into(),
+        SAMPLE_RATE.to_string(),
+        "-f".into(),
+        "s16le".into(),
+        "pipe:1".into(),
+    ]
+}
+
+pub struct PeakBuilder {
+    samples_per_bucket: usize,
+    samples: usize,
+    min: i16,
+    max: i16,
+    peaks: Vec<[f32; 2]>,
+}
+
+impl PeakBuilder {
+    pub fn new() -> Self {
+        Self {
+            samples_per_bucket: SAMPLE_RATE / BUCKETS_PER_SECOND,
+            samples: 0,
+            min: i16::MAX,
+            max: i16::MIN,
+            peaks: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, sample: i16) {
+        self.min = self.min.min(sample);
+        self.max = self.max.max(sample);
+        self.samples += 1;
+        if self.samples == self.samples_per_bucket {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.samples == 0 {
+            return;
+        }
+        self.peaks.push([
+            self.min as f32 / i16::MAX as f32,
+            self.max as f32 / i16::MAX as f32,
+        ]);
+        self.samples = 0;
+        self.min = i16::MAX;
+        self.max = i16::MIN;
+    }
+
+    pub fn finish(mut self) -> Vec<[f32; 2]> {
+        self.flush();
+        self.peaks
+    }
+}
+
+impl Default for PeakBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn asset(kind: AssetKind) -> Asset {
+        Asset {
+            id: "as1".into(),
+            path: "/media/original.mov".into(),
+            name: "original.mov".into(),
+            kind,
+            duration_ms: 1_000,
+            width: 1920,
+            height: 1080,
+            has_audio: true,
+        }
+    }
+
+    #[test]
+    fn audio_and_video_with_audio_need_waveforms() {
+        assert!(needs_waveform(&asset(AssetKind::Audio)));
+        assert!(needs_waveform(&asset(AssetKind::Video)));
+        let mut silent = asset(AssetKind::Video);
+        silent.has_audio = false;
+        assert!(!needs_waveform(&silent));
+        assert!(!needs_waveform(&asset(AssetKind::Image)));
+    }
+
+    #[test]
+    fn peak_builder_keeps_minimum_and_maximum_for_each_bucket() {
+        let mut builder = PeakBuilder::new();
+        for sample in 0..80 {
+            builder.push(if sample == 20 {
+                -16_384
+            } else if sample == 40 {
+                8_192
+            } else {
+                0
+            });
+        }
+        let peaks = builder.finish();
+        assert_eq!(peaks.len(), 1);
+        assert!((peaks[0][0] + 0.5).abs() < 0.001);
+        assert!((peaks[0][1] - 0.25).abs() < 0.001);
+    }
+
+    #[test]
+    fn ffmpeg_decodes_first_audio_stream_to_mono_pcm() {
+        let args = ffmpeg_args(&asset(AssetKind::Video));
+        assert!(args.windows(2).any(|pair| pair == ["-map", "0:a:0"]));
+        assert!(args.windows(2).any(|pair| pair == ["-f", "s16le"]));
+        assert_eq!(args.last().map(String::as_str), Some("pipe:1"));
+    }
+
+    #[test]
+    fn cache_is_valid_only_for_the_same_path_and_modification_time() {
+        let root = std::env::temp_dir().join(format!("makevideo-waveform-{}", std::process::id()));
+        let project = root.join("project.akbunvideo");
+        let source = root.join("source.wav");
+        std::fs::create_dir_all(root.join(FOLDER)).unwrap();
+        std::fs::write(&source, b"source").unwrap();
+        let mut media = asset(AssetKind::Audio);
+        media.path = source.to_string_lossy().to_string();
+        write(project.to_str().unwrap(), &media, vec![[-0.5, 0.5]]).unwrap();
+        assert!(read_valid(project.to_str().unwrap(), &media).is_some());
+        media.path = root.join("other.wav").to_string_lossy().to_string();
+        assert!(read_valid(project.to_str().unwrap(), &media).is_none());
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -139,12 +139,30 @@ pub struct AppState {
     pub playback: Mutex<Option<Session>>,
     pub proxies: Arc<Mutex<ProxyState>>,
     pub proxy_workers: Mutex<Vec<JoinHandle<()>>>,
+    pub waveforms: Arc<Mutex<WaveformState>>,
+    pub waveform_workers: Mutex<Vec<JoinHandle<()>>>,
 }
 
 #[derive(Debug, Default)]
 pub struct ProxyState {
     project_path: String,
     entries: HashMap<String, ProxyStatus>,
+}
+
+#[derive(Debug, Default)]
+pub struct WaveformState {
+    project_path: String,
+    entries: HashMap<String, WaveformStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WaveformStatus {
+    asset_id: String,
+    state: String,
+    buckets_per_second: u32,
+    peaks: Vec<[f32; 2]>,
+    message: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -166,6 +184,17 @@ fn proxy_statuses(proxies: &ProxyState) -> Vec<ProxyStatus> {
 fn emit_proxy_status(app: &AppHandle, proxies: &Arc<Mutex<ProxyState>>) {
     let statuses = proxy_statuses(&proxies.lock().unwrap());
     let _ = app.emit("proxy:status", statuses);
+}
+
+fn waveform_statuses(waveforms: &WaveformState) -> Vec<WaveformStatus> {
+    let mut statuses: Vec<WaveformStatus> = waveforms.entries.values().cloned().collect();
+    statuses.sort_by(|a, b| a.asset_id.cmp(&b.asset_id));
+    statuses
+}
+
+fn emit_waveform_status(app: &AppHandle, waveforms: &Arc<Mutex<WaveformState>>) {
+    let statuses = waveform_statuses(&waveforms.lock().unwrap());
+    let _ = app.emit("waveform:status", statuses);
 }
 
 fn ready_proxy_paths(proxies: &ProxyState) -> HashMap<String, String> {
@@ -499,6 +528,16 @@ fn stop_proxy_workers(app: &AppHandle, state: &State<AppState>) {
     }
 }
 
+fn detach_waveform_workers(app: &AppHandle, state: &State<AppState>) {
+    {
+        let mut waveforms = state.waveforms.lock().unwrap();
+        waveforms.project_path.clear();
+        waveforms.entries.clear();
+    }
+    emit_waveform_status(app, &state.waveforms);
+    state.waveform_workers.lock().unwrap().clear();
+}
+
 fn move_to_trash(path: &Path) -> Result<(), String> {
     let mut context = trash::TrashContext::default();
     #[cfg(target_os = "macos")]
@@ -534,6 +573,7 @@ pub fn delete_project(
     let session = state.playback.lock().unwrap().take();
     drop(session);
     stop_proxy_workers(&app, &state);
+    detach_waveform_workers(&app, &state);
     move_to_trash(&target)
 }
 
@@ -917,6 +957,233 @@ pub fn start_proxies(
     Ok(proxy_statuses(&state.proxies.lock().unwrap()))
 }
 
+fn set_waveform_status(
+    app: &AppHandle,
+    waveforms: &Arc<Mutex<WaveformState>>,
+    project_path: &str,
+    status: WaveformStatus,
+) -> bool {
+    let mut current = waveforms.lock().unwrap();
+    if current.project_path != project_path {
+        return false;
+    }
+    current.entries.insert(status.asset_id.clone(), status);
+    drop(current);
+    emit_waveform_status(app, waveforms);
+    true
+}
+
+fn decode_waveform(ffmpeg_path: &str, asset: &Asset) -> Result<Vec<[f32; 2]>, String> {
+    let mut child = Command::new(ffmpeg_path)
+        .args(makevideo_waveform::ffmpeg_args(asset))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("cannot start ffmpeg: {error}"))?;
+    let mut output = child.stdout.take().ok_or("ffmpeg did not provide audio")?;
+    let mut buffer = [0_u8; 16_384];
+    let mut pending = None;
+    let mut peaks = makevideo_waveform::PeakBuilder::new();
+    loop {
+        let read = output
+            .read(&mut buffer)
+            .map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        let mut at = 0;
+        if let Some(low) = pending.take() {
+            peaks.push(i16::from_le_bytes([low, buffer[0]]));
+            at = 1;
+        }
+        while at + 1 < read {
+            peaks.push(i16::from_le_bytes([buffer[at], buffer[at + 1]]));
+            at += 2;
+        }
+        if at < read {
+            pending = Some(buffer[at]);
+        }
+    }
+    let status = child.wait().map_err(|error| error.to_string())?;
+    if !status.success() {
+        return Err("ffmpeg could not decode the waveform".into());
+    }
+    Ok(peaks.finish())
+}
+
+#[tauri::command]
+pub fn waveform_status(state: State<AppState>) -> Vec<WaveformStatus> {
+    waveform_statuses(&state.waveforms.lock().unwrap())
+}
+
+#[tauri::command]
+pub fn start_waveforms(
+    app: AppHandle,
+    state: State<AppState>,
+    project_path: String,
+) -> Result<Vec<WaveformStatus>, String> {
+    start_waveforms_inner(app, &state, project_path)
+}
+
+fn start_waveforms_inner(
+    app: AppHandle,
+    state: &AppState,
+    project_path: String,
+) -> Result<Vec<WaveformStatus>, String> {
+    let configured = state.settings.lock().unwrap().ffmpeg_dir.clone();
+    let ffmpeg_path = find_tool(&app, "ffmpeg", &configured)
+        .ok_or("ffmpeg was not found, so waveforms cannot be created")?;
+    let project = state.document.lock().unwrap().project().clone();
+    let mut jobs = Vec::new();
+    {
+        let mut waveforms = state.waveforms.lock().unwrap();
+        if waveforms.project_path != project_path {
+            waveforms.project_path = project_path.clone();
+            waveforms.entries.clear();
+        }
+        let wanted: HashSet<String> = project
+            .assets
+            .iter()
+            .filter(|asset| makevideo_waveform::needs_waveform(asset))
+            .map(|asset| asset.id.clone())
+            .collect();
+        waveforms.entries.retain(|id, _| wanted.contains(id));
+        for asset in project
+            .assets
+            .iter()
+            .filter(|asset| wanted.contains(&asset.id))
+        {
+            if let Some(waveform) = makevideo_waveform::read_valid(&project_path, asset) {
+                waveforms.entries.insert(
+                    asset.id.clone(),
+                    WaveformStatus {
+                        asset_id: asset.id.clone(),
+                        state: "ready".into(),
+                        buckets_per_second: waveform.buckets_per_second,
+                        peaks: waveform.peaks,
+                        message: String::new(),
+                    },
+                );
+            } else if !matches!(
+                waveforms
+                    .entries
+                    .get(&asset.id)
+                    .map(|status| status.state.as_str()),
+                Some("queued" | "generating")
+            ) {
+                waveforms.entries.insert(
+                    asset.id.clone(),
+                    WaveformStatus {
+                        asset_id: asset.id.clone(),
+                        state: "queued".into(),
+                        buckets_per_second: makevideo_waveform::BUCKETS_PER_SECOND as u32,
+                        peaks: Vec::new(),
+                        message: String::new(),
+                    },
+                );
+                jobs.push(asset.clone());
+            }
+        }
+    }
+    emit_waveform_status(&app, &state.waveforms);
+
+    if !jobs.is_empty() {
+        let waveforms = Arc::clone(&state.waveforms);
+        let worker = std::thread::spawn(move || {
+            let dir = match makevideo_waveform::waveform_dir(&project_path) {
+                Ok(dir) => dir,
+                Err(message) => {
+                    for asset in jobs {
+                        set_waveform_status(
+                            &app,
+                            &waveforms,
+                            &project_path,
+                            WaveformStatus {
+                                asset_id: asset.id,
+                                state: "failed".into(),
+                                buckets_per_second: 0,
+                                peaks: Vec::new(),
+                                message: message.clone(),
+                            },
+                        );
+                    }
+                    return;
+                }
+            };
+            if let Err(error) = std::fs::create_dir_all(dir) {
+                for asset in jobs {
+                    set_waveform_status(
+                        &app,
+                        &waveforms,
+                        &project_path,
+                        WaveformStatus {
+                            asset_id: asset.id,
+                            state: "failed".into(),
+                            buckets_per_second: 0,
+                            peaks: Vec::new(),
+                            message: error.to_string(),
+                        },
+                    );
+                }
+                return;
+            }
+            for asset in jobs {
+                if !set_waveform_status(
+                    &app,
+                    &waveforms,
+                    &project_path,
+                    WaveformStatus {
+                        asset_id: asset.id.clone(),
+                        state: "generating".into(),
+                        buckets_per_second: makevideo_waveform::BUCKETS_PER_SECOND as u32,
+                        peaks: Vec::new(),
+                        message: String::new(),
+                    },
+                ) {
+                    return;
+                }
+                let result = decode_waveform(&ffmpeg_path, &asset)
+                    .and_then(|peaks| makevideo_waveform::write(&project_path, &asset, peaks));
+                match result {
+                    Ok(waveform) => {
+                        set_waveform_status(
+                            &app,
+                            &waveforms,
+                            &project_path,
+                            WaveformStatus {
+                                asset_id: asset.id,
+                                state: "ready".into(),
+                                buckets_per_second: waveform.buckets_per_second,
+                                peaks: waveform.peaks,
+                                message: String::new(),
+                            },
+                        );
+                    }
+                    Err(message) => {
+                        set_waveform_status(
+                            &app,
+                            &waveforms,
+                            &project_path,
+                            WaveformStatus {
+                                asset_id: asset.id,
+                                state: "failed".into(),
+                                buckets_per_second: 0,
+                                peaks: Vec::new(),
+                                message,
+                            },
+                        );
+                    }
+                }
+            }
+        });
+        let mut workers = state.waveform_workers.lock().unwrap();
+        workers.retain(|worker| !worker.is_finished());
+        workers.push(worker);
+    }
+    Ok(waveform_statuses(&state.waveforms.lock().unwrap()))
+}
+
 // --- the edit ---------------------------------------------------------------
 
 /// What the page redraws from, right now.
@@ -995,11 +1262,15 @@ pub fn open_project(
     for asset in &project.assets {
         allow_asset_file(&app, &asset.path);
     }
-    let mut document = state.document.lock().unwrap();
-    // Opening starts a fresh history: undo goes back through this session, not
-    // through the sessions that wrote the file.
-    *document = Document::opened(project);
-    Ok(document.state())
+    let opened = {
+        let mut document = state.document.lock().unwrap();
+        // Opening starts a fresh history: undo goes back through this session, not
+        // through the sessions that wrote the file.
+        *document = Document::opened(project);
+        document.state()
+    };
+    let _ = start_waveforms_inner(app, &state, path);
+    Ok(opened)
 }
 
 /// Writes the project file and nothing else. In particular it does not copy a
@@ -1009,7 +1280,7 @@ pub fn open_project(
 /// What gets written is the document, not something the page sent along with
 /// the request: there is one copy of the edit and this is the one that saves.
 #[tauri::command]
-pub fn save_project(state: State<AppState>, path: String) -> Result<(), String> {
+pub fn save_project(app: AppHandle, state: State<AppState>, path: String) -> Result<(), String> {
     let text = {
         let document = state.document.lock().unwrap();
         serde_json::to_string_pretty(document.project()).map_err(|error| error.to_string())?
@@ -1020,7 +1291,9 @@ pub fn save_project(state: State<AppState>, path: String) -> Result<(), String> 
         std::fs::create_dir_all(parent)
             .map_err(|error| format!("cannot create {parent:?}: {error}"))?;
     }
-    std::fs::write(&path, text).map_err(|error| format!("cannot write {path}: {error}"))
+    std::fs::write(&path, text).map_err(|error| format!("cannot write {path}: {error}"))?;
+    let _ = start_waveforms_inner(app, &state, path);
+    Ok(())
 }
 
 #[derive(Clone, Serialize)]

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -192,9 +192,8 @@ fn waveform_statuses(waveforms: &WaveformState) -> Vec<WaveformStatus> {
     statuses
 }
 
-fn emit_waveform_status(app: &AppHandle, waveforms: &Arc<Mutex<WaveformState>>) {
-    let statuses = waveform_statuses(&waveforms.lock().unwrap());
-    let _ = app.emit("waveform:status", statuses);
+fn emit_waveform_status(app: &AppHandle, status: WaveformStatus) {
+    let _ = app.emit("waveform:status", vec![status]);
 }
 
 fn ready_proxy_paths(proxies: &ProxyState) -> HashMap<String, String> {
@@ -528,14 +527,17 @@ fn stop_proxy_workers(app: &AppHandle, state: &State<AppState>) {
     }
 }
 
-fn detach_waveform_workers(app: &AppHandle, state: &State<AppState>) {
+fn stop_waveform_workers(app: &AppHandle, state: &State<AppState>) {
     {
         let mut waveforms = state.waveforms.lock().unwrap();
         waveforms.project_path.clear();
         waveforms.entries.clear();
     }
-    emit_waveform_status(app, &state.waveforms);
-    state.waveform_workers.lock().unwrap().clear();
+    let _ = app.emit("waveform:status", Vec::<WaveformStatus>::new());
+    let workers = std::mem::take(&mut *state.waveform_workers.lock().unwrap());
+    for worker in workers {
+        let _ = worker.join();
+    }
 }
 
 fn move_to_trash(path: &Path) -> Result<(), String> {
@@ -573,7 +575,7 @@ pub fn delete_project(
     let session = state.playback.lock().unwrap().take();
     drop(session);
     stop_proxy_workers(&app, &state);
-    detach_waveform_workers(&app, &state);
+    stop_waveform_workers(&app, &state);
     move_to_trash(&target)
 }
 
@@ -967,9 +969,11 @@ fn set_waveform_status(
     if current.project_path != project_path {
         return false;
     }
-    current.entries.insert(status.asset_id.clone(), status);
+    current
+        .entries
+        .insert(status.asset_id.clone(), status.clone());
     drop(current);
-    emit_waveform_status(app, waveforms);
+    emit_waveform_status(app, status);
     true
 }
 
@@ -1086,8 +1090,6 @@ fn start_waveforms_inner(
             }
         }
     }
-    emit_waveform_status(&app, &state.waveforms);
-
     if !jobs.is_empty() {
         let waveforms = Arc::clone(&state.waveforms);
         let worker = std::thread::spawn(move || {

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -50,6 +50,8 @@ pub fn run() {
                 playback: Mutex::new(None),
                 proxies: Arc::new(Mutex::new(commands::ProxyState::default())),
                 proxy_workers: Mutex::new(Vec::new()),
+                waveforms: Arc::new(Mutex::new(commands::WaveformState::default())),
+                waveform_workers: Mutex::new(Vec::new()),
             });
             Ok(())
         })
@@ -63,6 +65,8 @@ pub fn run() {
             commands::import_assets,
             commands::proxy_status,
             commands::start_proxies,
+            commands::waveform_status,
+            commands::start_waveforms,
             commands::edit_state,
             commands::edit_apply,
             commands::edit_undo,

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -135,6 +135,8 @@ if (!window.__TAURI__) {
     importAssets: async () => [],
     proxyStatus: async () => [],
     startProxies: async () => [],
+    waveformStatus: async () => [],
+    startWaveforms: async () => [],
     editState: async () => emptyDocument(),
     editApply: async () => emptyDocument(),
     editUndo: async () => emptyDocument(),
@@ -150,6 +152,7 @@ if (!window.__TAURI__) {
     onRenderDone: () => {},
     onRenderFallback: () => {},
     onProxyStatus: () => {},
+    onWaveformStatus: () => {},
     onFileDrop: () => {},
     message: async (text) => alert(text),
     ask: async (text) => confirm(text),
@@ -289,6 +292,8 @@ window.api = {
   importAssets: (paths) => invoke('import_assets', { paths }),
   proxyStatus: () => invoke('proxy_status'),
   startProxies: (projectPath) => invoke('start_proxies', { projectPath }),
+  waveformStatus: () => invoke('waveform_status'),
+  startWaveforms: (projectPath) => invoke('start_waveforms', { projectPath }),
 
   // The edit. Every one of these hands back the whole document state, and the
   // page draws that rather than its own idea of what just happened.
@@ -316,6 +321,7 @@ window.api = {
   // The hardware encoder failed on this file and the CPU is taking over.
   onRenderFallback: (handler) => listen('render:fallback', (event) => handler(event.payload)),
   onProxyStatus: (handler) => listen('proxy:status', (event) => handler(event.payload)),
+  onWaveformStatus: (handler) => listen('waveform:status', (event) => handler(event.payload)),
   onFileDrop: (handler) => getCurrentWebview().onDragDropEvent(dedupeDrops(handler)),
 
   message: (text, options) => message(text, options),

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -124,6 +124,7 @@ const state = {
     qualitySmoke: false,
   },
   path: null,
+  waveforms: {},
   selectedClipId: null,
   selectedAssetId: null,
   pxPerSecond: 30,
@@ -250,7 +251,7 @@ async function edit(...commands) {
     for (const clip of track.clips) if (!before.has(clip.id)) made.push(clip.id);
   }
   refresh();
-  if (sent.some((command) => command.op === 'addAssets')) prepareProxies();
+  if (sent.some((command) => command.op === 'addAssets')) prepareDerivedMedia();
   return made;
 }
 
@@ -349,6 +350,25 @@ async function prepareProxies() {
   }
 }
 
+function adoptWaveformStatuses(statuses) {
+  state.waveforms = Object.fromEntries((statuses || []).map((status) => [status.assetId, status]));
+  renderLanes();
+}
+
+async function prepareWaveforms() {
+  if (!state.path || !window.api.available) return;
+  try {
+    adoptWaveformStatuses(await window.api.startWaveforms(state.path));
+  } catch (error) {
+    reportError(error, 'waveform:start');
+  }
+}
+
+function prepareDerivedMedia() {
+  prepareProxies();
+  prepareWaveforms();
+}
+
 function onProxyStatus(statuses) {
   const becameReady = (statuses || []).some((status) => {
     const before = state.proxies[status.assetId];
@@ -359,6 +379,10 @@ function onProxyStatus(statuses) {
     preview.redraw();
     if (preview.usesNativeMonitor()) attachMonitor(true);
   }
+}
+
+function onWaveformStatus(statuses) {
+  adoptWaveformStatuses(statuses);
 }
 
 function renderAssets() {
@@ -490,7 +514,8 @@ function clipElement(track, clip) {
   node.className = `clip ${track.kind}`;
   node.dataset.clipId = clip.id;
   node.style.left = `${L.framesToPx(clip.start, rate(), state.pxPerSecond)}px`;
-  node.style.width = `${Math.max(2, L.framesToPx(L.clipDuration(clip), rate(), state.pxPerSecond))}px`;
+  const width = Math.max(2, L.framesToPx(L.clipDuration(clip), rate(), state.pxPerSecond));
+  node.style.width = `${width}px`;
   if (clip.id === state.selectedClipId) node.classList.add('selected');
   if (clip.linkGroup) {
     node.classList.add('linked');
@@ -505,8 +530,49 @@ function clipElement(track, clip) {
   left.className = 'handle left';
   const right = document.createElement('span');
   right.className = 'handle right';
+  if (track.kind === 'audio' && asset) {
+    const waveform = state.waveforms[asset.id];
+    if (waveform && waveform.state === 'ready' && waveform.peaks.length) {
+      const canvas = document.createElement('canvas');
+      canvas.className = 'clip-waveform';
+      drawWaveform(canvas, clip, waveform, width);
+      node.appendChild(canvas);
+    }
+  }
   node.append(left, label, right);
   return node;
+}
+
+function drawWaveform(canvas, clip, waveform, cssWidth) {
+  const ratio = Math.min(window.devicePixelRatio || 1, 2);
+  const width = Math.max(1, Math.min(4096, Math.ceil(cssWidth * ratio)));
+  const height = Math.ceil(32 * ratio);
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  const { first, last } = L.waveformBucketRange(clip, rate(), waveform.bucketsPerSecond);
+  const span = Math.max(1, last - first);
+  context.strokeStyle = getComputedStyle(document.documentElement)
+    .getPropertyValue('--waveform')
+    .trim() || '#205f42';
+  context.lineWidth = Math.max(1, ratio);
+  context.beginPath();
+  for (let x = 0; x < width; x += 1) {
+    const from = Math.max(0, Math.floor(first + (x / width) * span));
+    const to = Math.min(
+      waveform.peaks.length,
+      Math.max(from + 1, Math.ceil(first + ((x + 1) / width) * span))
+    );
+    let min = 0;
+    let max = 0;
+    for (let index = from; index < to; index += 1) {
+      min = Math.min(min, waveform.peaks[index][0]);
+      max = Math.max(max, waveform.peaks[index][1]);
+    }
+    context.moveTo(x + 0.5, ((1 - max) * height) / 2);
+    context.lineTo(x + 0.5, ((1 - min) * height) / 2);
+  }
+  context.stroke();
 }
 
 function renderLanes() {
@@ -1134,12 +1200,13 @@ function loadDocument(doc, path) {
   state.selectedClipId = null;
   state.selectedAssetId = null;
   state.proxies = {};
+  state.waveforms = {};
   preview.clear();
   preview.showTimeline();
   setPreviewSource('timeline');
   for (const asset of state.project.assets) hydrateDuration(asset);
   refresh();
-  prepareProxies();
+  prepareDerivedMedia();
   // A monitor is built for the project it draws — the output size and the
   // clips are read when the frame source is made — so opening a different one
   // means a new session rather than a reused one.
@@ -1240,7 +1307,7 @@ async function saveProject(forcePicker) {
   try {
     await window.api.saveProject(path);
     state.path = path;
-    prepareProxies();
+    prepareDerivedMedia();
     // What is on disk is this revision, which is what makes the dot go away —
     // and come back the moment anything else is done.
     state.savedRevision = state.doc.revision;
@@ -1951,6 +2018,7 @@ async function boot() {
   subscribe('events:render-done', window.api.onRenderDone, onRenderDone);
   subscribe('events:render-fallback', window.api.onRenderFallback, onRenderFallback);
   subscribe('events:proxy-status', window.api.onProxyStatus, onProxyStatus);
+  subscribe('events:waveform-status', window.api.onWaveformStatus, onWaveformStatus);
   subscribe('events:file-drop', window.api.onFileDrop, (payload) => {
     Promise.resolve(handleOsDrop(payload)).catch((error) => reportError(error, 'file-drop'));
   });

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -382,7 +382,12 @@ function onProxyStatus(statuses) {
 }
 
 function onWaveformStatus(statuses) {
-  adoptWaveformStatuses(statuses);
+  if (!(statuses || []).length) {
+    state.waveforms = {};
+  } else {
+    for (const status of statuses) state.waveforms[status.assetId] = status;
+  }
+  renderLanes();
 }
 
 function renderAssets() {
@@ -550,6 +555,7 @@ function drawWaveform(canvas, clip, waveform, cssWidth) {
   canvas.width = width;
   canvas.height = height;
   const context = canvas.getContext('2d');
+  if (!context) return;
   const { first, last } = L.waveformBucketRange(clip, rate(), waveform.bucketsPerSecond);
   const span = Math.max(1, last - first);
   context.strokeStyle = getComputedStyle(document.documentElement)
@@ -558,14 +564,16 @@ function drawWaveform(canvas, clip, waveform, cssWidth) {
   context.lineWidth = Math.max(1, ratio);
   context.beginPath();
   for (let x = 0; x < width; x += 1) {
-    const from = Math.max(0, Math.floor(first + (x / width) * span));
+    const from = Math.min(
+      waveform.peaks.length - 1,
+      Math.max(0, Math.floor(first + (x / width) * span))
+    );
     const to = Math.min(
       waveform.peaks.length,
       Math.max(from + 1, Math.ceil(first + ((x + 1) / width) * span))
     );
-    let min = 0;
-    let max = 0;
-    for (let index = from; index < to; index += 1) {
+    let [min, max] = waveform.peaks[from];
+    for (let index = from + 1; index < to; index += 1) {
       min = Math.min(min, waveform.peaks[index][0]);
       max = Math.max(max, waveform.peaks[index][1]);
     }

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -724,6 +724,16 @@ button.icon.on {
   color: #0f2a1a;
 }
 
+.clip-waveform {
+  position: absolute;
+  inset: 50% 8px auto;
+  width: calc(100% - 16px);
+  height: 32px;
+  transform: translateY(-50%);
+  opacity: 0.72;
+  pointer-events: none;
+}
+
 @media (prefers-color-scheme: dark) {
   .clip.video,
   .clip.audio {
@@ -750,6 +760,8 @@ button.icon.on {
 }
 
 .clip-name {
+  position: relative;
+  z-index: 1;
   padding: 0 10px;
   font-size: 11px;
   white-space: nowrap;

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -202,6 +202,14 @@ function pxToFrames(px, rate, pxPerSecond) {
   return T.secondsToFrames(px / pxPerSecond, rate);
 }
 
+function waveformBucketRange(clip, rate, bucketsPerSecond) {
+  const secondsPerFrame = rate.den / rate.num;
+  return {
+    first: clip.in * secondsPerFrame * bucketsPerSecond,
+    last: clip.out * secondsPerFrame * bucketsPerSecond,
+  };
+}
+
 /** h:mm:ss:ff. The frames field is what makes a two frame trim visible, which
  *  a fraction of a second never was. */
 function formatTimecode(frames, rate) {
@@ -258,6 +266,7 @@ const exported = {
   snapClipStart,
   framesToPx,
   pxToFrames,
+  waveformBucketRange,
   formatTimecode,
   formatRulerLabel,
   tickStepFrames,

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -219,6 +219,14 @@ test('pixels and frames convert both ways', () => {
   assert.strictEqual(L.pxToFrames(100, rate, 50), 60);
 });
 
+test('a trimmed clip reads only its source interval from the waveform', () => {
+  const media = clip('c1', 'v', 900, 150, 450);
+  assert.deepStrictEqual(L.waveformBucketRange(media, T.fps(30), 100), {
+    first: 500,
+    last: 1500,
+  });
+});
+
 test('a clip with nothing left of it has no negative length', () => {
   assert.strictEqual(L.clipDuration(clip('c1', 'v', 0, 30, 10)), 0);
   assert.strictEqual(L.clipEnd(clip('c1', 'v', 100, 30, 10)), 100);


### PR DESCRIPTION
# 구현

asset 단위 파형 캐시와 audio clip canvas 구간 렌더링 추가
- 페이지 테스트 66개, waveform 테스트 4개, edit 테스트 42개, 전체 Tauri compile 통과

# 어려웠던 점

긴 오디오 전체를 메모리에 올리지 않는 PCM min/max 축약
- 8kHz mono PCM을 80 sample 단위로 읽어 초당 100개 최소·최대 쌍 생성

# 리스크

긴 asset이 많으면 waveform IPC payload 증가
- canvas 내부 폭은 4096px로 제한했지만 ready 상태의 peak 배열은 페이지로 전달

Issue #766
