### PR TITLE
akbun-makevideo Visual Item 공통 모델

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-common-visual-item-model.md
+++ b/product/akbun-makevideo/adr/2026-08-common-visual-item-model.md
@@ -1,0 +1,21 @@
+# Common visual item model
+
+## Decision
+
+- Keep every element drawn over a clip as one `VisualItem`; distinguish text, shape, image and video overlay in `content`
+- Store position and size in project pixels, rotation in degrees and opacity in the shared transform
+- Store start and duration as frame counts on the project rate
+- Place items on video tracks and order them by track position first, then item `zIndex`
+- Keep selection outlines, handles and guides outside the project model
+
+## Reason
+
+- Program Monitor and export can consume one stored shape without converting display coordinates
+- Selection and Inspector can edit one transform regardless of content kind
+- Frame-based time follows the same exact timebase as clips
+- Editor-only decorations cannot leak into an exported frame
+
+## Tradeoffs
+
+- Content-specific properties arrive with each content feature rather than expanding the common transform
+- Items may overlap in time, so ordering must stay explicit and deterministic

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -22,3 +22,4 @@
 | [2026-08-playback-proxies.md](./2026-08-playback-proxies.md) | 4K playback uses validated 1280px proxies while export keeps originals |
 | [2026-08-asset-waveform-cache.md](./2026-08-asset-waveform-cache.md) | Audio waveforms are cached per asset and clips draw only their source interval |
 | [2026-08-native-project-trash.md](./2026-08-native-project-trash.md) | Windows and macOS move validated project targets with native trash APIs |
+| [2026-08-common-visual-item-model.md](./2026-08-common-visual-item-model.md) | Text, shape, image and video overlays share one timed transform model |

--- a/product/akbun-makevideo/wiki/architecture/project-model.md
+++ b/product/akbun-makevideo/wiki/architecture/project-model.md
@@ -10,20 +10,26 @@ project
   assets[] { id, path, name, kind,         kind is video | audio | image
              durationMs, width, height, hasAudio }
   tracks[] { id, kind, name, muted, hidden,
-             clips[] { id, assetId, start, in, out, volume, opacity } }
+             clips[] { id, assetId, start, in, out, volume, opacity },
+             visualItems[] { id, start, duration, zIndex,
+               transform { x, y, width, height, rotation, opacity },
+               content { kind, ... } } }
 ```
 
 - `start`, `in` and `out` are frame indexes on `settings.rate`. `start` is the position on the timeline; `in`/`out` are the span taken out of the source, so a clip's length is `out - in` and its end is `start + (out - in)`. No division appears anywhere in that, which is the point — see [rational time](../../adr/2026-08-rational-time.md).
 - `durationMs` on an asset is the one time left in milliseconds. It is what ffprobe measured about a file rather than a position on the timeline, and it becomes frames the moment a clip is made from it.
 - An asset's `id` is a hash of its path, so importing the same file twice updates one row instead of adding a second, and a project reopened next week still points its clips at the same assets.
 - Video tracks composite in array order: track 1 is the bottom layer. The timeline draws them reversed so V1 sits at the bottom of the screen, which is where every other editor puts it.
+- Visual items belong to video tracks. Their coordinates and size are project pixels, not Program Monitor pixels. Items on one track draw by ascending `zIndex`; track array order remains the primary layer order.
+- `content.kind` is `text`, `shape`, `image` or `videoOverlay`. Image and video overlay content names an asset; content-specific fields stay inside `content`, not beside the shared transform.
+- Selection borders, transform handles and guides are editor state and never appear in `visualItems`.
 - `hidden` on a video track removes it from the preview, the render **and** the timeline length. `muted` silences a track but keeps its picture.
 
 ## Versions
 
 Version 1 was the first format: every time in whole milliseconds (`startMs`, `inMs`, `outMs`) and `settings.fps` as a single integer. Version 2 is the shape above.
 
-A version 1 file still opens. `crates/edit/src/migrate.rs` converts it once as it is read, and what gets written back is version 2 only, with the millisecond keys gone rather than carried along beside the frame counts that replaced them. Which format a clip is in is read off the clip rather than taken from the header, because the two use different keys and a header can be wrong.
+A version 1 file still opens. `crates/edit/src/migrate.rs` converts it once as it is read, and what gets written back is version 2 only, with the millisecond keys gone rather than carried along beside the frame counts that replaced them. Which format a clip is in is read off the clip rather than taken from the header, because the two use different keys and a header can be wrong. A version 2 track without `visualItems` opens with an empty list.
 
 A version 1 file whose `fps` says `29.97` opens on 30000/1001, because that is what the number meant. Believing the decimal is how the approximation gets back in.
 

--- a/product/akbun-makevideo/wiki/architecture/project-model.md
+++ b/product/akbun-makevideo/wiki/architecture/project-model.md
@@ -20,7 +20,7 @@ project
 - `durationMs` on an asset is the one time left in milliseconds. It is what ffprobe measured about a file rather than a position on the timeline, and it becomes frames the moment a clip is made from it.
 - An asset's `id` is a hash of its path, so importing the same file twice updates one row instead of adding a second, and a project reopened next week still points its clips at the same assets.
 - Video tracks composite in array order: track 1 is the bottom layer. The timeline draws them reversed so V1 sits at the bottom of the screen, which is where every other editor puts it.
-- Visual items belong to video tracks. Their coordinates and size are project pixels, not Program Monitor pixels. Items on one track draw by ascending `zIndex`; track array order remains the primary layer order.
+- Visual items belong to video tracks. Their coordinates and size are project pixels, not Program Monitor pixels. Items on one track draw by ascending `zIndex`, then `id`; track array order remains the primary layer order.
 - `content.kind` is `text`, `shape`, `image` or `videoOverlay`. Image and video overlay content names an asset; content-specific fields stay inside `content`, not beside the shared transform.
 - Selection borders, transform handles and guides are editor state and never appear in `visualItems`.
 - `hidden` on a video track removes it from the preview, the render **and** the timeline length. `muted` silences a track but keeps its picture.

--- a/product/akbun-makevideo/wiki/architecture/timeline.md
+++ b/product/akbun-makevideo/wiki/architecture/timeline.md
@@ -22,6 +22,8 @@ Undo stores the inverse rather than a copy of the project. Trimming one clip sto
 
 Commands that create something — `addClip`, `splitAt` — arrive without ids and are stored in the history *with* the ids they were given, so redo reproduces the same clips rather than new ones that merely resemble them.
 
+Visual items follow the same command boundary. Add, transform, timing, order, content and remove commands each store an inverse; the page never edits `visualItems` directly.
+
 ## The invariants
 
 Checked after every command, against the whole project:
@@ -29,6 +31,7 @@ Checked after every command, against the whole project:
 - a clip has a length, its in point is not negative, and it does not reach past the end of its source
 - clips on a track do not overlap, and none starts before the timeline does
 - a link group has one video clip and one audio clip from the same asset, with matching timeline and source ranges
+- a visual item belongs to a video track, has positive time and area, finite project-space geometry and opacity from zero through one
 
 A broken one does not show on the timeline. A zero length clip draws as nothing and an out point past the end of a file draws as the last frame; both surface as an ffmpeg failure or a black stretch part way through a render that has been running for ten minutes.
 

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
@@ -150,6 +150,7 @@ mod tests {
             kind: TrackKind::Audio,
             name: id.into(),
             clips,
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
@@ -880,6 +880,7 @@ pub(crate) mod tests {
             kind: TrackKind::Audio,
             name: id.into(),
             clips,
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         }
@@ -1409,6 +1410,7 @@ pub(crate) mod tests {
             kind: TrackKind::Video,
             name: "V1".into(),
             clips: vec![clip("v1", "silent", 0, 0, 30)],
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         });

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
@@ -103,6 +103,7 @@ fn audio_track(id: &str, clips: Vec<Clip>) -> Track {
         kind: TrackKind::Audio,
         name: id.into(),
         clips,
+        visual_items: Vec::new(),
         muted: false,
         hidden: false,
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -842,6 +842,7 @@ mod tests {
             kind: TrackKind::Video,
             name: id.into(),
             clips,
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
@@ -445,6 +445,7 @@ mod tests {
                     volume: 1.0,
                     opacity: 1.0,
                 }],
+                visual_items: Vec::new(),
                 muted: false,
                 hidden: false,
             }],

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
@@ -134,6 +134,7 @@ fn track(id: &str, kind: TrackKind, clips: Vec<Clip>) -> Track {
         kind,
         name: id.into(),
         clips,
+        visual_items: Vec::new(),
         muted: false,
         hidden: false,
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -1141,13 +1141,16 @@ fn add_visual_item(
     id: Option<String>,
 ) -> Result<Applied, String> {
     validate_visual_content(project, &content)?;
-    let track = project
-        .track_mut(&track_id)
+    let track_index = project
+        .track_index(&track_id)
         .ok_or("that track is not in this project")?;
-    if track.kind != TrackKind::Video {
+    if project.tracks[track_index].kind != TrackKind::Video {
         return Err("visual items belong on video tracks".into());
     }
     let id = id.unwrap_or_else(|| ids.make('i'));
+    if project.visual_item(&id).is_some() {
+        return Err("that visual item id is already in this project".into());
+    }
     let item = VisualItem {
         id: id.clone(),
         start,
@@ -1156,7 +1159,7 @@ fn add_visual_item(
         z_index,
         content: content.clone(),
     };
-    track.visual_items.push(item);
+    project.tracks[track_index].visual_items.push(item);
     Ok(Applied {
         resolved: Command::AddVisualItem {
             track_id,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -27,7 +27,10 @@
 //! applied edit is the state nobody can reason about: the user cannot tell how
 //! many times to press undo, and neither can the app.
 
-use crate::{min_clip_frames, Asset, Clip, Project, ProjectSettings, Rate, Track, TrackKind};
+use crate::{
+    min_clip_frames, Asset, Clip, Project, ProjectSettings, Rate, Track, TrackKind, VisualContent,
+    VisualItem, VisualTransform,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -46,6 +49,13 @@ pub enum Edge {
 pub struct ClipAt {
     pub track_id: String,
     pub clip: Clip,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualItemAt {
+    pub track_id: String,
+    pub item: VisualItem,
 }
 
 /// An asset and where it sat in the library, so undoing an import does not
@@ -160,6 +170,37 @@ pub enum Command {
         #[serde(default)]
         opacity: Option<f32>,
     },
+    #[serde(rename_all = "camelCase")]
+    AddVisualItem {
+        track_id: String,
+        content: VisualContent,
+        start: i64,
+        duration: i64,
+        transform: VisualTransform,
+        z_index: i32,
+        #[serde(default)]
+        id: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetVisualTransform {
+        item_id: String,
+        transform: VisualTransform,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetVisualTiming {
+        item_id: String,
+        start: i64,
+        duration: i64,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetVisualZIndex { item_id: String, z_index: i32 },
+    #[serde(rename_all = "camelCase")]
+    SetVisualContent {
+        item_id: String,
+        content: VisualContent,
+    },
+    #[serde(rename_all = "camelCase")]
+    RemoveVisualItem { item_id: String },
     /// Resolution and timebase. Changing the rate carries the edit with it, so
     /// a cut stays where it was in time rather than where it was in frames.
     #[serde(rename_all = "camelCase")]
@@ -181,6 +222,10 @@ pub enum Command {
     RestoreTracks { entries: Vec<TrackAt> },
     #[serde(rename_all = "camelCase")]
     DropTracks { track_ids: Vec<String> },
+    #[serde(rename_all = "camelCase")]
+    RestoreVisualItems { entries: Vec<VisualItemAt> },
+    #[serde(rename_all = "camelCase")]
+    DropVisualItems { item_ids: Vec<String> },
 
     /// One undo step made of several commands, all or nothing.
     #[serde(rename_all = "camelCase")]
@@ -270,10 +315,19 @@ impl Command {
             Command::UnlinkClips { .. } => "Unlink clips",
             Command::RippleDelete { .. } => "Ripple delete",
             Command::SetClipGain { .. } => "Clip levels",
+            Command::AddVisualItem { .. } => "Add visual item",
+            Command::SetVisualTransform { .. } => "Transform visual item",
+            Command::SetVisualTiming { .. } => "Time visual item",
+            Command::SetVisualZIndex { .. } => "Reorder visual item",
+            Command::SetVisualContent { .. } => "Edit visual item",
+            Command::RemoveVisualItem { .. } | Command::DropVisualItems { .. } => {
+                "Delete visual item"
+            }
             Command::SetSettings { .. } => "Project settings",
             Command::RestoreClips { .. } => "Restore clips",
             Command::RestoreAssets { .. } | Command::DropAssets { .. } => "Assets",
             Command::RestoreTracks { .. } => "Restore track",
+            Command::RestoreVisualItems { .. } => "Restore visual items",
             Command::Transaction { commands } => commands
                 .iter()
                 .find(|command| !command.is_nothing())
@@ -334,6 +388,32 @@ impl Command {
                 volume,
                 opacity,
             } => set_clip_gain(project, clip_id, volume, opacity),
+            Command::AddVisualItem {
+                track_id,
+                content,
+                start,
+                duration,
+                transform,
+                z_index,
+                id,
+            } => add_visual_item(
+                project, ids, track_id, content, start, duration, transform, z_index, id,
+            ),
+            Command::SetVisualTransform { item_id, transform } => {
+                set_visual_transform(project, item_id, transform)
+            }
+            Command::SetVisualTiming {
+                item_id,
+                start,
+                duration,
+            } => set_visual_timing(project, item_id, start, duration),
+            Command::SetVisualZIndex { item_id, z_index } => {
+                set_visual_z_index(project, item_id, z_index)
+            }
+            Command::SetVisualContent { item_id, content } => {
+                set_visual_content(project, item_id, content)
+            }
+            Command::RemoveVisualItem { item_id } => remove_visual_item(project, item_id),
             Command::SetSettings { settings } => Ok(set_settings(project, settings)),
             Command::RestoreClips { entries } => Ok(restore_clips(project, entries)),
             Command::DropClips { clip_ids } => Ok(drop_clips(project, clip_ids)),
@@ -341,6 +421,8 @@ impl Command {
             Command::DropAssets { asset_ids } => Ok(drop_assets(project, asset_ids)),
             Command::RestoreTracks { entries } => Ok(restore_tracks(project, entries)),
             Command::DropTracks { track_ids } => Ok(drop_tracks(project, track_ids)),
+            Command::RestoreVisualItems { entries } => Ok(restore_visual_items(project, entries)),
+            Command::DropVisualItems { item_ids } => Ok(drop_visual_items(project, item_ids)),
             Command::Transaction { commands } => transaction(project, ids, commands),
         }
     }
@@ -414,6 +496,7 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
         .ok_or("that asset is not in this project")?;
     let asset = project.assets.remove(index);
     let mut orphans = Vec::new();
+    let mut orphan_items = Vec::new();
     for track in &mut project.tracks {
         for clip in &track.clips {
             if clip.asset_id == asset_id {
@@ -424,6 +507,17 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
             }
         }
         track.clips.retain(|clip| clip.asset_id != asset_id);
+        for item in &track.visual_items {
+            if item.content.asset_id() == Some(asset_id.as_str()) {
+                orphan_items.push(VisualItemAt {
+                    track_id: track.id.clone(),
+                    item: item.clone(),
+                });
+            }
+        }
+        track
+            .visual_items
+            .retain(|item| item.content.asset_id() != Some(asset_id.as_str()));
     }
     Ok(Applied {
         resolved: Command::RemoveAsset { asset_id },
@@ -433,6 +527,9 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
                     entries: vec![AssetAt { index, asset }],
                 },
                 Command::RestoreClips { entries: orphans },
+                Command::RestoreVisualItems {
+                    entries: orphan_items,
+                },
             ],
         },
     })
@@ -457,6 +554,7 @@ fn add_track(
         kind,
         name: kind.name_for(existing),
         clips: Vec::new(),
+        visual_items: Vec::new(),
         muted: false,
         hidden: false,
     });
@@ -1030,6 +1128,177 @@ fn set_clip_gain(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+fn add_visual_item(
+    project: &mut Project,
+    ids: &mut Ids,
+    track_id: String,
+    content: VisualContent,
+    start: i64,
+    duration: i64,
+    transform: VisualTransform,
+    z_index: i32,
+    id: Option<String>,
+) -> Result<Applied, String> {
+    validate_visual_content(project, &content)?;
+    let track = project
+        .track_mut(&track_id)
+        .ok_or("that track is not in this project")?;
+    if track.kind != TrackKind::Video {
+        return Err("visual items belong on video tracks".into());
+    }
+    let id = id.unwrap_or_else(|| ids.make('i'));
+    let item = VisualItem {
+        id: id.clone(),
+        start,
+        duration,
+        transform,
+        z_index,
+        content: content.clone(),
+    };
+    track.visual_items.push(item);
+    Ok(Applied {
+        resolved: Command::AddVisualItem {
+            track_id,
+            content,
+            start,
+            duration,
+            transform,
+            z_index,
+            id: Some(id.clone()),
+        },
+        inverse: Command::DropVisualItems { item_ids: vec![id] },
+    })
+}
+
+fn set_visual_transform(
+    project: &mut Project,
+    item_id: String,
+    transform: VisualTransform,
+) -> Result<Applied, String> {
+    let (track, item) = project
+        .locate_visual_item(&item_id)
+        .ok_or("that visual item is not on the timeline")?;
+    let previous = project.tracks[track].visual_items[item].transform;
+    project.tracks[track].visual_items[item].transform = transform;
+    Ok(Applied {
+        resolved: Command::SetVisualTransform {
+            item_id: item_id.clone(),
+            transform,
+        },
+        inverse: Command::SetVisualTransform {
+            item_id,
+            transform: previous,
+        },
+    })
+}
+
+fn set_visual_timing(
+    project: &mut Project,
+    item_id: String,
+    start: i64,
+    duration: i64,
+) -> Result<Applied, String> {
+    let (track, item) = project
+        .locate_visual_item(&item_id)
+        .ok_or("that visual item is not on the timeline")?;
+    let previous = &project.tracks[track].visual_items[item];
+    let (was_start, was_duration) = (previous.start, previous.duration);
+    let item = &mut project.tracks[track].visual_items[item];
+    item.start = start;
+    item.duration = duration;
+    Ok(Applied {
+        resolved: Command::SetVisualTiming {
+            item_id: item_id.clone(),
+            start,
+            duration,
+        },
+        inverse: Command::SetVisualTiming {
+            item_id,
+            start: was_start,
+            duration: was_duration,
+        },
+    })
+}
+
+fn set_visual_z_index(
+    project: &mut Project,
+    item_id: String,
+    z_index: i32,
+) -> Result<Applied, String> {
+    let (track, item) = project
+        .locate_visual_item(&item_id)
+        .ok_or("that visual item is not on the timeline")?;
+    let previous = project.tracks[track].visual_items[item].z_index;
+    project.tracks[track].visual_items[item].z_index = z_index;
+    Ok(Applied {
+        resolved: Command::SetVisualZIndex {
+            item_id: item_id.clone(),
+            z_index,
+        },
+        inverse: Command::SetVisualZIndex {
+            item_id,
+            z_index: previous,
+        },
+    })
+}
+
+fn set_visual_content(
+    project: &mut Project,
+    item_id: String,
+    content: VisualContent,
+) -> Result<Applied, String> {
+    validate_visual_content(project, &content)?;
+    let (track, item) = project
+        .locate_visual_item(&item_id)
+        .ok_or("that visual item is not on the timeline")?;
+    let previous = project.tracks[track].visual_items[item].content.clone();
+    project.tracks[track].visual_items[item].content = content.clone();
+    Ok(Applied {
+        resolved: Command::SetVisualContent {
+            item_id: item_id.clone(),
+            content,
+        },
+        inverse: Command::SetVisualContent {
+            item_id,
+            content: previous,
+        },
+    })
+}
+
+fn validate_visual_content(project: &Project, content: &VisualContent) -> Result<(), String> {
+    let Some(asset_id) = content.asset_id() else {
+        return Ok(());
+    };
+    let asset = project
+        .asset(asset_id)
+        .ok_or("that visual item asset is not in this project")?;
+    match (content, asset.kind) {
+        (VisualContent::Image { .. }, crate::AssetKind::Image)
+        | (VisualContent::VideoOverlay { .. }, crate::AssetKind::Video) => Ok(()),
+        (VisualContent::Image { .. }, _) => Err("an image item needs an image asset".into()),
+        (VisualContent::VideoOverlay { .. }, _) => {
+            Err("a video overlay needs a video asset".into())
+        }
+        (VisualContent::Text { .. } | VisualContent::Shape, _) => Ok(()),
+    }
+}
+
+fn remove_visual_item(project: &mut Project, item_id: String) -> Result<Applied, String> {
+    let entry = project
+        .visual_item_placement(&item_id)
+        .ok_or("that visual item is not on the timeline")?;
+    for track in &mut project.tracks {
+        track.visual_items.retain(|item| item.id != item_id);
+    }
+    Ok(Applied {
+        resolved: Command::RemoveVisualItem { item_id },
+        inverse: Command::RestoreVisualItems {
+            entries: vec![entry],
+        },
+    })
+}
+
 /// Changing the timebase carries the edit with it, so a project cut at 30 and
 /// then set to 29.97 keeps every clip where it was in time rather than where it
 /// was in frame numbers.
@@ -1051,6 +1320,7 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
     }
 
     let mut restore = Vec::new();
+    let mut restore_items = Vec::new();
     for track in &mut project.tracks {
         for clip in &mut track.clips {
             restore.push(ClipAt {
@@ -1063,6 +1333,14 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
             // frame that makes it a clip at all.
             clip.out_point = rescale(clip.out_point, from, to).max(clip.in_point + 1);
         }
+        for item in &mut track.visual_items {
+            restore_items.push(VisualItemAt {
+                track_id: track.id.clone(),
+                item: item.clone(),
+            });
+            item.start = rescale(item.start, from, to);
+            item.duration = rescale(item.duration, from, to).max(1);
+        }
         track.sort();
     }
     Applied {
@@ -1071,6 +1349,9 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
             commands: vec![
                 Command::SetSettings { settings: was },
                 Command::RestoreClips { entries: restore },
+                Command::RestoreVisualItems {
+                    entries: restore_items,
+                },
             ],
         },
     }
@@ -1204,5 +1485,47 @@ fn drop_tracks(project: &mut Project, track_ids: Vec<String>) -> Applied {
     Applied {
         resolved: Command::DropTracks { track_ids },
         inverse: Command::RestoreTracks { entries: previous },
+    }
+}
+
+fn restore_visual_items(project: &mut Project, entries: Vec<VisualItemAt>) -> Applied {
+    let mut previous = Vec::new();
+    let mut invented = Vec::new();
+    for entry in &entries {
+        match project.visual_item_placement(&entry.item.id) {
+            Some(placement) => previous.push(placement),
+            None => invented.push(entry.item.id.clone()),
+        }
+        for track in &mut project.tracks {
+            track.visual_items.retain(|item| item.id != entry.item.id);
+        }
+        if let Some(track) = project.track_mut(&entry.track_id) {
+            track.visual_items.push(entry.item.clone());
+        }
+    }
+    Applied {
+        resolved: Command::RestoreVisualItems { entries },
+        inverse: Command::Transaction {
+            commands: vec![
+                Command::DropVisualItems { item_ids: invented },
+                Command::RestoreVisualItems { entries: previous },
+            ],
+        },
+    }
+}
+
+fn drop_visual_items(project: &mut Project, item_ids: Vec<String>) -> Applied {
+    let previous: Vec<VisualItemAt> = item_ids
+        .iter()
+        .filter_map(|id| project.visual_item_placement(id))
+        .collect();
+    for track in &mut project.tracks {
+        track
+            .visual_items
+            .retain(|item| !item_ids.contains(&item.id));
+    }
+    Applied {
+        resolved: Command::DropVisualItems { item_ids },
+        inverse: Command::RestoreVisualItems { entries: previous },
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -1158,4 +1158,32 @@ mod tests {
         assert!(error.contains("no area"), "{error}");
         assert!(document.project().tracks[0].visual_items.is_empty());
     }
+
+    #[test]
+    fn duplicate_visual_item_ids_are_rejected_without_changing_the_project() {
+        let mut document = document();
+        let track_id = video_track(&document);
+        let command = Command::AddVisualItem {
+            track_id,
+            content: VisualContent::Shape,
+            start: 0,
+            duration: 30,
+            transform: VisualTransform {
+                x: 0.0,
+                y: 0.0,
+                width: 100.0,
+                height: 100.0,
+                rotation: 0.0,
+                opacity: 1.0,
+            },
+            z_index: 0,
+            id: Some("item".into()),
+        };
+        document.apply(command.clone()).unwrap();
+
+        let error = document.apply(command).unwrap_err();
+
+        assert!(error.contains("already in this project"), "{error}");
+        assert_eq!(document.project().tracks[0].visual_items.len(), 1);
+    }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -73,6 +73,9 @@ impl Document {
                     ids.observe(group);
                 }
             }
+            for item in &track.visual_items {
+                ids.observe(&item.id);
+            }
         }
         Document {
             project,
@@ -249,7 +252,10 @@ impl Document {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Asset, AssetKind, Clip, Command, Edge, ProjectSettings, Rate, TrackKind};
+    use crate::{
+        Asset, AssetKind, Clip, Command, Edge, ProjectSettings, Rate, TrackKind, VisualContent,
+        VisualTransform,
+    };
 
     fn asset(id: &str, kind: AssetKind, duration_ms: u64) -> Asset {
         Asset {
@@ -1068,5 +1074,88 @@ mod tests {
                 link_groups: Vec::new()
             }
         );
+    }
+
+    #[test]
+    fn visual_item_edits_are_commands_with_undo_and_stable_ids() {
+        let mut document = document();
+        let track_id = video_track(&document);
+        let initial = VisualTransform {
+            x: 100.0,
+            y: 80.0,
+            width: 640.0,
+            height: 360.0,
+            rotation: 0.0,
+            opacity: 1.0,
+        };
+        document
+            .apply(Command::AddVisualItem {
+                track_id: track_id.clone(),
+                content: VisualContent::Text {
+                    text: "title".into(),
+                },
+                start: 30,
+                duration: 90,
+                transform: initial,
+                z_index: 2,
+                id: None,
+            })
+            .unwrap();
+        let item_id = document.project().tracks[0].visual_items[0].id.clone();
+        assert_eq!(item_id, "i3");
+
+        let moved = VisualTransform {
+            x: 320.0,
+            y: 180.0,
+            width: 800.0,
+            height: 450.0,
+            rotation: 12.5,
+            opacity: 0.6,
+        };
+        document
+            .apply(Command::SetVisualTransform {
+                item_id: item_id.clone(),
+                transform: moved,
+            })
+            .unwrap();
+        assert_eq!(
+            document.project().visual_item(&item_id).unwrap().transform,
+            moved
+        );
+
+        document.undo().unwrap();
+        assert_eq!(
+            document.project().visual_item(&item_id).unwrap().transform,
+            initial
+        );
+        document.undo().unwrap();
+        assert!(document.project().visual_item(&item_id).is_none());
+        document.redo().unwrap();
+        assert_eq!(document.project().tracks[0].visual_items[0].id, item_id);
+    }
+
+    #[test]
+    fn invalid_visual_geometry_is_rejected_without_changing_the_project() {
+        let mut document = document();
+        let error = document
+            .apply(Command::AddVisualItem {
+                track_id: video_track(&document),
+                content: VisualContent::Shape,
+                start: 0,
+                duration: 30,
+                transform: VisualTransform {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 0.0,
+                    height: 100.0,
+                    rotation: 0.0,
+                    opacity: 1.0,
+                },
+                z_index: 0,
+                id: None,
+            })
+            .unwrap_err();
+        assert!(error.contains("no area"), "{error}");
+        assert!(document.project().tracks[0].visual_items.is_empty());
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -502,7 +502,11 @@ impl Project {
                 .iter()
                 .filter(|item| item.contains_frame(frame))
                 .collect();
-            items.sort_by_key(|item| item.z_index);
+            items.sort_by(|left, right| {
+                left.z_index
+                    .cmp(&right.z_index)
+                    .then_with(|| left.id.cmp(&right.id))
+            });
             visible.extend(items.into_iter().map(|item| VisualItemAt {
                 track_id: track.id.clone(),
                 item: item.clone(),
@@ -927,7 +931,9 @@ mod tests {
         let mut project = Project::new(ProjectSettings::default());
         project.tracks[0].visual_items = vec![
             visual_item("front", 0, 60, 20),
+            visual_item("middle-b", 0, 60, 15),
             visual_item("back", 0, 60, 10),
+            visual_item("middle-a", 0, 60, 15),
         ];
         project.tracks.push(Track {
             id: "t3".into(),
@@ -946,7 +952,7 @@ mod tests {
                 .iter()
                 .map(|entry| entry.item.id.as_str())
                 .collect::<Vec<_>>(),
-            ["back", "front", "top-track"]
+            ["back", "middle-a", "middle-b", "front", "top-track"]
         );
         assert!(
             project.visual_items_at(60).is_empty(),

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -24,7 +24,7 @@ pub mod command;
 pub mod document;
 pub mod migrate;
 
-pub use command::{ClipAt, Command, Edge};
+pub use command::{ClipAt, Command, Edge, VisualItemAt};
 pub use document::{Document, DocumentState};
 pub use makevideo_time::{Rate, RationalTime};
 
@@ -213,6 +213,10 @@ pub struct Track {
     pub name: String,
     #[serde(default)]
     pub clips: Vec<Clip>,
+    /// Elements drawn over the track's clips. They may overlap in time; their
+    /// `z_index` decides their order within this track.
+    #[serde(default)]
+    pub visual_items: Vec<VisualItem>,
     /// An audio track that contributes nothing, or the audio of a video track.
     #[serde(default)]
     pub muted: bool,
@@ -250,6 +254,10 @@ impl Track {
         self.clips.iter().find(|clip| clip.id == clip_id)
     }
 
+    pub fn visual_item(&self, item_id: &str) -> Option<&VisualItem> {
+        self.visual_items.iter().find(|item| item.id == item_id)
+    }
+
     /// Clips are kept in start order, which is what lets the ripple and the
     /// overlap check read the track once instead of sorting on every question.
     pub fn sort(&mut self) {
@@ -277,6 +285,68 @@ impl Track {
             }
         }
         start
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualTransform {
+    /// Project pixels, independent of the monitor's display scale.
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+    /// Clockwise degrees around the item's centre.
+    pub rotation: f32,
+    #[serde(default = "one")]
+    pub opacity: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum VisualContent {
+    Text { text: String },
+    Shape,
+    Image { asset_id: String },
+    VideoOverlay { asset_id: String },
+}
+
+impl VisualContent {
+    pub fn asset_id(&self) -> Option<&str> {
+        match self {
+            VisualContent::Image { asset_id } | VisualContent::VideoOverlay { asset_id } => {
+                Some(asset_id)
+            }
+            VisualContent::Text { .. } | VisualContent::Shape => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualItem {
+    pub id: String,
+    /// Frame indexes on the project rate, like clip times.
+    pub start: i64,
+    pub duration: i64,
+    pub transform: VisualTransform,
+    /// Higher values draw later within the track. Track array order remains
+    /// the primary layer order.
+    pub z_index: i32,
+    pub content: VisualContent,
+}
+
+impl VisualItem {
+    pub fn end_frame(&self) -> i64 {
+        self.start.saturating_add(self.duration.max(0))
+    }
+
+    pub fn contains_frame(&self, frame: i64) -> bool {
+        self.start <= frame && frame < self.end_frame()
     }
 }
 
@@ -341,6 +411,7 @@ impl Project {
                     kind: TrackKind::Video,
                     name: "V1".into(),
                     clips: Vec::new(),
+                    visual_items: Vec::new(),
                     muted: false,
                     hidden: false,
                 },
@@ -349,6 +420,7 @@ impl Project {
                     kind: TrackKind::Audio,
                     name: "A1".into(),
                     clips: Vec::new(),
+                    visual_items: Vec::new(),
                     muted: false,
                     hidden: false,
                 },
@@ -389,6 +461,54 @@ impl Project {
     pub fn clip(&self, clip_id: &str) -> Option<&Clip> {
         let (track, clip) = self.locate(clip_id)?;
         Some(&self.tracks[track].clips[clip])
+    }
+
+    pub fn locate_visual_item(&self, item_id: &str) -> Option<(usize, usize)> {
+        for (track, entry) in self.tracks.iter().enumerate() {
+            if let Some(item) = entry
+                .visual_items
+                .iter()
+                .position(|item| item.id == item_id)
+            {
+                return Some((track, item));
+            }
+        }
+        None
+    }
+
+    pub fn visual_item(&self, item_id: &str) -> Option<&VisualItem> {
+        let (track, item) = self.locate_visual_item(item_id)?;
+        Some(&self.tracks[track].visual_items[item])
+    }
+
+    pub fn visual_item_placement(&self, item_id: &str) -> Option<VisualItemAt> {
+        let (track, item) = self.locate_visual_item(item_id)?;
+        Some(VisualItemAt {
+            track_id: self.tracks[track].id.clone(),
+            item: self.tracks[track].visual_items[item].clone(),
+        })
+    }
+
+    /// The compositor order at one frame. Track order is primary and z-index
+    /// only orders items that belong to the same track.
+    pub fn visual_items_at(&self, frame: i64) -> Vec<VisualItemAt> {
+        let mut visible = Vec::new();
+        for track in &self.tracks {
+            if track.kind != TrackKind::Video || track.hidden {
+                continue;
+            }
+            let mut items: Vec<&VisualItem> = track
+                .visual_items
+                .iter()
+                .filter(|item| item.contains_frame(frame))
+                .collect();
+            items.sort_by_key(|item| item.z_index);
+            visible.extend(items.into_iter().map(|item| VisualItemAt {
+                track_id: track.id.clone(),
+                item: item.clone(),
+            }));
+        }
+        visible
     }
 
     pub fn linked_placements(&self, clip_id: &str) -> Vec<ClipAt> {
@@ -436,9 +556,19 @@ impl Project {
         self.tracks
             .iter()
             .filter(|track| track.contributes())
-            .flat_map(|track| track.clips.iter())
-            .filter(|clip| clip.duration_frames() > 0)
-            .map(|clip| clip.end_frame())
+            .flat_map(|track| {
+                let clips = track
+                    .clips
+                    .iter()
+                    .filter(|clip| clip.duration_frames() > 0)
+                    .map(Clip::end_frame);
+                let items = track
+                    .visual_items
+                    .iter()
+                    .filter(|item| item.duration > 0)
+                    .map(VisualItem::end_frame);
+                clips.chain(items)
+            })
             .max()
             .unwrap_or(0)
     }
@@ -491,6 +621,42 @@ impl Project {
                     links.entry(group).or_default().push((track, clip));
                 }
                 previous_end = clip.end_frame();
+            }
+            if track.kind == TrackKind::Audio && !track.visual_items.is_empty() {
+                return Err("visual items belong on video tracks".into());
+            }
+            for item in &track.visual_items {
+                let name = &item.id;
+                if item.start < 0 {
+                    return Err(format!(
+                        "visual item {name} would start before the timeline does"
+                    ));
+                }
+                if item.duration <= 0 {
+                    return Err(format!("visual item {name} would have no length"));
+                }
+                let transform = item.transform;
+                if ![
+                    transform.x,
+                    transform.y,
+                    transform.width,
+                    transform.height,
+                    transform.rotation,
+                    transform.opacity,
+                ]
+                .into_iter()
+                .all(f32::is_finite)
+                {
+                    return Err(format!("visual item {name} has a non-finite transform"));
+                }
+                if transform.width <= 0.0 || transform.height <= 0.0 {
+                    return Err(format!("visual item {name} would have no area"));
+                }
+                if !(0.0..=1.0).contains(&transform.opacity) {
+                    return Err(format!(
+                        "visual item {name} has opacity outside 0 through 1"
+                    ));
+                }
             }
         }
         for (group, entries) in links {
@@ -547,6 +713,20 @@ impl Project {
                 clip.start = clip.start.max(end);
                 end = clip.end_frame();
             }
+            if track.kind == TrackKind::Audio {
+                track.visual_items.clear();
+            } else {
+                for item in &mut track.visual_items {
+                    item.start = item.start.max(0);
+                    item.duration = item.duration.max(1);
+                    item.transform.x = finite_or(item.transform.x, 0.0);
+                    item.transform.y = finite_or(item.transform.y, 0.0);
+                    item.transform.width = finite_or(item.transform.width, 1.0).max(1.0);
+                    item.transform.height = finite_or(item.transform.height, 1.0).max(1.0);
+                    item.transform.rotation = finite_or(item.transform.rotation, 0.0);
+                    item.transform.opacity = finite_or(item.transform.opacity, 1.0).clamp(0.0, 1.0);
+                }
+            }
         }
         let mut groups: HashMap<String, Vec<(TrackKind, String, i64, i64, i64)>> = HashMap::new();
         for track in &self.tracks {
@@ -592,6 +772,10 @@ impl Project {
     }
 }
 
+fn finite_or(value: f32, fallback: f32) -> f32 {
+    value.is_finite().then_some(value).unwrap_or(fallback)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -627,6 +811,24 @@ mod tests {
         project.assets.push(video(10_000));
         project.tracks[0].clips = clips;
         project
+    }
+
+    fn visual_item(id: &str, start: i64, duration: i64, z_index: i32) -> VisualItem {
+        VisualItem {
+            id: id.into(),
+            start,
+            duration,
+            transform: VisualTransform {
+                x: 0.0,
+                y: 0.0,
+                width: 320.0,
+                height: 180.0,
+                rotation: 0.0,
+                opacity: 1.0,
+            },
+            z_index,
+            content: VisualContent::Shape,
+        }
     }
 
     #[test]
@@ -718,5 +920,44 @@ mod tests {
             .clips
             .iter()
             .all(|clip| clip.out_point <= 300));
+    }
+
+    #[test]
+    fn visual_items_overlap_and_draw_by_track_then_z_index() {
+        let mut project = Project::new(ProjectSettings::default());
+        project.tracks[0].visual_items = vec![
+            visual_item("front", 0, 60, 20),
+            visual_item("back", 0, 60, 10),
+        ];
+        project.tracks.push(Track {
+            id: "t3".into(),
+            kind: TrackKind::Video,
+            name: "V2".into(),
+            clips: Vec::new(),
+            visual_items: vec![visual_item("top-track", 0, 60, -100)],
+            muted: false,
+            hidden: false,
+        });
+
+        assert!(project.validate().is_ok());
+        assert_eq!(
+            project
+                .visual_items_at(30)
+                .iter()
+                .map(|entry| entry.item.id.as_str())
+                .collect::<Vec<_>>(),
+            ["back", "front", "top-track"]
+        );
+        assert!(
+            project.visual_items_at(60).is_empty(),
+            "the end is exclusive"
+        );
+    }
+
+    #[test]
+    fn a_visual_item_extends_the_timeline() {
+        let mut project = Project::new(ProjectSettings::default());
+        project.tracks[0].visual_items = vec![visual_item("title", 90, 60, 0)];
+        assert_eq!(project.duration_frames(), 150);
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
@@ -11,7 +11,10 @@
 //! that has `start` is a version 2 one. `version` is there for a reader, and
 //! for the next format after this one.
 
-use crate::{Asset, Clip, FORMAT_VERSION, Project, ProjectSettings, Rate, RationalTime, Track, TrackKind};
+use crate::{
+    Asset, Clip, Project, ProjectSettings, Rate, RationalTime, Track, TrackKind, VisualItem,
+    FORMAT_VERSION,
+};
 use serde::Deserialize;
 
 fn one() -> f32 {
@@ -52,6 +55,8 @@ struct WireTrack {
     name: String,
     #[serde(default)]
     clips: Vec<WireClip>,
+    #[serde(default)]
+    visual_items: Vec<VisualItem>,
     #[serde(default)]
     muted: bool,
     #[serde(default)]
@@ -121,6 +126,7 @@ impl From<WireProject> for Project {
                     name: track.name,
                     muted: track.muted,
                     hidden: track.hidden,
+                    visual_items: track.visual_items,
                     clips: track
                         .clips
                         .into_iter()
@@ -160,7 +166,10 @@ mod tests {
         assert_eq!(project.rate(), Rate::fps(30));
         let clip = &project.tracks[0].clips[0];
         assert_eq!((clip.start, clip.in_point, clip.out_point), (60, 30, 120));
-        assert_eq!(clip.volume, 1.0, "a field that never existed still defaults");
+        assert_eq!(
+            clip.volume, 1.0,
+            "a field that never existed still defaults"
+        );
     }
 
     #[test]
@@ -209,6 +218,32 @@ mod tests {
     }
 
     #[test]
+    fn a_track_from_before_visual_items_gets_an_empty_list() {
+        let project: Project = serde_json::from_str(
+            r#"{
+                "version": 2,
+                "settings": {"rate": {"num": 30, "den": 1}},
+                "tracks": [{"id": "V1", "kind": "video", "clips": []}]
+            }"#,
+        )
+        .unwrap();
+        assert!(project.tracks[0].visual_items.is_empty());
+    }
+
+    #[test]
+    fn visual_content_uses_the_page_camel_case_shape() {
+        let text = r#"{"kind":"videoOverlay","assetId":"a1"}"#;
+        let content: crate::VisualContent = serde_json::from_str(text).unwrap();
+        assert_eq!(
+            content,
+            crate::VisualContent::VideoOverlay {
+                asset_id: "a1".into()
+            }
+        );
+        assert_eq!(serde_json::to_string(&content).unwrap(), text);
+    }
+
+    #[test]
     fn what_comes_back_out_is_todays_format_only() {
         let text = r#"{
             "version": 1,
@@ -220,7 +255,10 @@ mod tests {
         let project: Project = serde_json::from_str(text).unwrap();
         let written = serde_json::to_string(&project).unwrap();
         assert!(written.contains(r#""version":2"#), "{written}");
-        assert!(written.contains(r#""rate":{"num":60,"den":1}"#), "{written}");
+        assert!(
+            written.contains(r#""rate":{"num":60,"den":1}"#),
+            "{written}"
+        );
         assert!(written.contains(r#""start":30"#), "{written}");
         assert!(!written.contains("startMs"), "{written}");
         assert!(!written.contains("\"fps\""), "{written}");

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -521,6 +521,7 @@ mod tests {
                     volume: 1.0,
                     opacity: 1.0,
                 }],
+                visual_items: Vec::new(),
                 muted: false,
                 hidden: false,
             }],

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
@@ -671,6 +671,7 @@ mod tests {
                     volume: 1.0,
                     opacity: 1.0,
                 }],
+                visual_items: Vec::new(),
                 muted: false,
                 hidden: false,
             }],

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
@@ -251,6 +251,7 @@ mod tests {
                     volume: 1.0,
                     opacity: 1.0,
                 }],
+                visual_items: Vec::new(),
                 muted: false,
                 hidden: false,
             }],

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
@@ -718,6 +718,7 @@ mod tests {
             kind,
             name: id.into(),
             clips,
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
@@ -335,6 +335,7 @@ mod tests {
             kind: TrackKind::Video,
             name: id.into(),
             clips,
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         }
@@ -510,6 +511,7 @@ mod tests {
             kind: TrackKind::Audio,
             name: id.into(),
             clips,
+            visual_items: Vec::new(),
             muted: false,
             hidden: false,
         }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
@@ -18,6 +18,7 @@ pub mod tools;
 pub mod workspace;
 
 pub use makevideo_edit::{
-    asset_id, Asset, AssetKind, Clip, Project, ProjectSettings, Track, TrackKind, FORMAT_VERSION,
+    asset_id, Asset, AssetKind, Clip, Project, ProjectSettings, Track, TrackKind, VisualContent,
+    VisualItem, VisualTransform, FORMAT_VERSION,
 };
 pub use makevideo_time::{RationalTime, Rate};


### PR DESCRIPTION
# 구현

텍스트·도형·이미지·영상 오버레이 공통 Visual Item 모델과 undo 명령 추가
- 편집 모델 48개, Node 66개, CPU compositor 33개와 렌더 통합 4개 통과, Tauri 앱 실제 기동 확인

# 어려웠던 점

Track 구조 변경에 따른 재생·오디오·렌더 테스트 fixture 동시 호환
- 전체 Rust workspace test target 빌드로 누락된 초기화 경로 확인

# 리스크

내용별 세부 속성과 실제 합성은 후속 기능에서 구현 예정
- 이번 범위는 공통 저장 형식·검증·순서·명령 경계까지 포함

Issue #680
