### PR TITLE
akbun-folderview: 폴더 탐색 피드백 개선

### DIFF
--- a/product/akbun-folderview/workspace/package-lock.json
+++ b/product/akbun-folderview/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-folderview",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-folderview",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-folderview/workspace/package.json
+++ b/product/akbun-folderview/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-folderview",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "description": "Windows desktop browser for a hand-picked photo and video library with tags, ratings and instant search",
   "author": "akbun",

--- a/product/akbun-folderview/workspace/src/library.js
+++ b/product/akbun-folderview/workspace/src/library.js
@@ -158,6 +158,15 @@ function buildTree(roots, entries) {
   });
 }
 
+function findTreeNode(nodes, path) {
+  for (const node of nodes) {
+    if (node.path === path) return node;
+    const found = findTreeNode(node.folders, path);
+    if (found) return found;
+  }
+  return null;
+}
+
 // The thumbnail file name for an entry. Path, mtime and size together, so an
 // edited or replaced file gets a fresh thumbnail and the stale one is simply
 // never asked for again. FNV-1a, 64 bits so a large library will not collide.
@@ -185,6 +194,7 @@ function formatSize(bytes) {
 const exported = {
   baseName,
   buildTree,
+  findTreeNode,
   formatSize,
   isUnder,
   matchesEntry,

--- a/product/akbun-folderview/workspace/src/renderer.js
+++ b/product/akbun-folderview/workspace/src/renderer.js
@@ -498,13 +498,14 @@ function openFolder(node) {
 
 function folderCard(node) {
   const element = document.createElement('div');
+  const fileCount = countIn(node);
   element.className = 'folder-card';
   element.title = `${node.path}\nDouble click to open`;
   element.innerHTML = `
     <span class="folder-card-icon">📁</span>
     <span class="folder-card-body">
       <span class="folder-card-name">${escapeHtml(node.name)}</span>
-      <span class="folder-card-count">${countIn(node)} file${countIn(node) === 1 ? '' : 's'}</span>
+      <span class="folder-card-count">${fileCount} file${fileCount === 1 ? '' : 's'}</span>
     </span>`;
   element.addEventListener('dblclick', () => openFolder(node));
   return element;

--- a/product/akbun-folderview/workspace/src/renderer.js
+++ b/product/akbun-folderview/workspace/src/renderer.js
@@ -16,8 +16,10 @@ let state = {
   settings: {},
   version: '',
   dataDir: '',
-  // Set by clicking a folder in the tree. Narrows the grid before the query.
+  // Set by clicking a folder in the tree. Shows its direct children, while a
+  // search still scans every descendant under it.
   folder: null,
+  lastOpenedPath: null,
   query: '',
   shown: 200,
 };
@@ -96,6 +98,22 @@ function fileIcon(entry) {
   return entry.kind === 'video' ? '🎬' : '🖼️';
 }
 
+function markLastOpened(element, path) {
+  element.classList.toggle('last-opened', state.lastOpenedPath === path);
+}
+
+function syncLastOpened() {
+  for (const element of document.querySelectorAll('.file-entry')) {
+    markLastOpened(element, element.dataset.path);
+  }
+}
+
+async function openEntry(entry) {
+  await window.api.openEntry(entry.path);
+  state.lastOpenedPath = entry.path;
+  syncLastOpened();
+}
+
 function derive() {
   if (!derived) {
     derived = {
@@ -136,7 +154,9 @@ function countIn(node) {
 // A file in the tree behaves like a file in the grid: it opens.
 function fileRow(entry) {
   const row = document.createElement('div');
-  row.className = 'row-item';
+  row.className = 'row-item file-entry';
+  row.dataset.path = entry.path;
+  markLastOpened(row, entry.path);
 
   const twisty = document.createElement('span');
   twisty.className = 'twisty';
@@ -148,7 +168,12 @@ function fileRow(entry) {
   label.title = entry.path;
   row.append(label);
 
-  row.addEventListener('click', () => window.api.openEntry(entry.path));
+  row.addEventListener('click', () => {
+    if (state.settings.openOnSingleClick) void openEntry(entry);
+  });
+  row.addEventListener('dblclick', () => {
+    if (!state.settings.openOnSingleClick) void openEntry(entry);
+  });
   row.addEventListener('contextmenu', async (event) => {
     event.preventDefault();
     await window.api.entryMenu((action) => void runAction(action, entry), tagMenu(entry));
@@ -425,13 +450,14 @@ function thumb(entry) {
 
 function card(entry) {
   const element = document.createElement('div');
-  element.className = 'card';
+  element.className = 'card file-entry';
   element.dataset.path = entry.path;
+  markLastOpened(element, entry.path);
   const videoOff = entry.kind === 'video' && !state.settings.showVideoThumbs;
   element.innerHTML = `
     <div class="thumb${videoOff ? ' off' : ''}">${thumb(entry)}</div>
     <div class="card-body">
-      <div class="card-name" title="${escapeHtml(entry.path)}">${escapeHtml(entry.name)}</div>
+      <div class="card-name" title="${escapeHtml(entry.path)}"><span class="entry-icon">${fileIcon(entry)}</span>${escapeHtml(entry.name)}</div>
       <div class="card-meta">
         <span class="stars">${starsHtml(entry.rating)}</span>
         <span class="fav ${entry.favorite ? 'on' : ''}" data-fav="1">${entry.favorite ? '♥' : '♡'}</span>
@@ -449,15 +475,38 @@ function card(entry) {
 // the fast view for a disk with no thumbnails yet.
 function listRow(entry) {
   const element = document.createElement('div');
-  element.className = 'list-item';
+  element.className = 'list-item file-entry';
   element.dataset.path = entry.path;
+  markLastOpened(element, entry.path);
   element.innerHTML = `
+    <span class="entry-icon">${fileIcon(entry)}</span>
     <span class="list-name" title="${escapeHtml(entry.path)}">${escapeHtml(entry.name)}</span>
     ${entry.kind === 'video' ? '<span class="badge">VIDEO</span>' : ''}
     <span class="stars">${starsHtml(entry.rating)}</span>
     <span class="fav ${entry.favorite ? 'on' : ''}" data-fav="1">${entry.favorite ? '♥' : '♡'}</span>
     <span class="list-size">${lib.formatSize(entry.size)}</span>
     <span class="list-date">${entry.mtime ? new Date(entry.mtime).toLocaleDateString() : ''}</span>`;
+  return element;
+}
+
+function openFolder(node) {
+  state.folder = node.path;
+  state.shown = PAGE;
+  expandedFolders.set(node.path, true);
+  render();
+}
+
+function folderCard(node) {
+  const element = document.createElement('div');
+  element.className = 'folder-card';
+  element.title = `${node.path}\nDouble click to open`;
+  element.innerHTML = `
+    <span class="folder-card-icon">📁</span>
+    <span class="folder-card-body">
+      <span class="folder-card-name">${escapeHtml(node.name)}</span>
+      <span class="folder-card-count">${countIn(node)} file${countIn(node) === 1 ? '' : 's'}</span>
+    </span>`;
+  element.addEventListener('dblclick', () => openFolder(node));
   return element;
 }
 
@@ -481,6 +530,14 @@ function syncViews() {
 }
 
 function renderGrid() {
+  const selectedFolder = state.folder
+    ? lib.findTreeNode(derive().tree, state.folder)
+    : null;
+  if (selectedFolder && state.query.trim() === '') {
+    renderFolderContents(selectedFolder);
+    return;
+  }
+
   let matches = visibleEntries();
   // Filter results come from anywhere in the library, so a flat list loses
   // where each file lives. Sorting by folder and putting a folder header over
@@ -518,6 +575,42 @@ function renderGrid() {
   syncTokens();
 }
 
+function renderFolderContents(node) {
+  const listMode = state.settings.view === 'list';
+  const folders = node.folders;
+  const files = node.files;
+  const visibleFolders = folders.slice(0, state.shown);
+  const fileSlots = Math.max(0, state.shown - visibleFolders.length);
+  const visibleFiles = files.slice(0, fileSlots);
+
+  const grid = $('grid');
+  grid.textContent = '';
+  grid.classList.toggle('list', listMode);
+
+  if (folders.length > 0) {
+    grid.append(groupTitle(`📁 Folders (${folders.length})`));
+    for (const folder of visibleFolders) grid.append(folderCard(folder));
+  }
+  if (files.length > 0 && fileSlots > 0) {
+    grid.append(groupTitle(`📄 Files (${files.length})`));
+    for (const entry of visibleFiles) grid.append(listMode ? listRow(entry) : card(entry));
+  }
+  if (folders.length === 0 && files.length === 0) {
+    const empty = document.createElement('p');
+    empty.className = 'empty';
+    empty.textContent = 'This folder has no indexed files.';
+    grid.append(empty);
+  }
+
+  syncViews();
+  syncTokens();
+  syncLastOpened();
+  $('status').textContent =
+    `${folders.length} folder${folders.length === 1 ? '' : 's'}, ` +
+    `${files.length} file${files.length === 1 ? '' : 's'} in ${node.path}`;
+  $('show-more').hidden = visibleFolders.length + visibleFiles.length >= folders.length + files.length;
+}
+
 function render() {
   renderTree();
   renderCatalog();
@@ -540,7 +633,7 @@ async function patch(entry, changes) {
 }
 
 async function runAction(action, entry) {
-  if (action === 'open') return window.api.openEntry(entry.path);
+  if (action === 'open') return openEntry(entry);
   if (action === 'reveal') return window.api.revealEntry(entry.path);
   if (action === 'copyPath') return window.api.copyPath(entry.path);
   if (action === 'delete') return window.api.deleteEntry(entry.path);
@@ -718,12 +811,12 @@ $('grid').addEventListener('click', async (event) => {
   }
   if (event.target.dataset.fav) return patch(entry, { favorite: !entry.favorite });
 
-  if (state.settings.openOnSingleClick) await window.api.openEntry(entry.path);
+  if (state.settings.openOnSingleClick) await openEntry(entry);
 });
 
 $('grid').addEventListener('dblclick', async (event) => {
   const entry = entryAt(event.target);
-  if (entry && !state.settings.openOnSingleClick) await window.api.openEntry(entry.path);
+  if (entry && !state.settings.openOnSingleClick) await openEntry(entry);
 });
 
 $('grid').addEventListener('contextmenu', async (event) => {

--- a/product/akbun-folderview/workspace/src/style.css
+++ b/product/akbun-folderview/workspace/src/style.css
@@ -12,6 +12,8 @@
   --hover: #e2e4ea;
   --accent: #3b6ef5;
   --accent-fg: #ffffff;
+  --last-opened: #dcecff;
+  --last-opened-border: #83b8f2;
   --star: #e2a03f;
   --card-size: 180px;
 }
@@ -27,6 +29,8 @@
     --hover: #323238;
     --accent: #5b86f7;
     --accent-fg: #ffffff;
+    --last-opened: #294564;
+    --last-opened-border: #4f83b8;
     --star: #f0b95c;
   }
 }
@@ -40,6 +44,8 @@
   --border: #dedee1;
   --hover: #e2e4ea;
   --accent: #3b6ef5;
+  --last-opened: #dcecff;
+  --last-opened-border: #83b8f2;
   --star: #e2a03f;
 }
 
@@ -52,6 +58,8 @@
   --border: #343438;
   --hover: #323238;
   --accent: #5b86f7;
+  --last-opened: #294564;
+  --last-opened-border: #4f83b8;
   --star: #f0b95c;
 }
 
@@ -217,6 +225,10 @@ button.primary {
   color: var(--accent-fg);
 }
 
+.file-entry.last-opened {
+  background: var(--last-opened);
+}
+
 .twisty {
   /* Wide enough for the folder and file emoji icons. */
   width: 18px;
@@ -297,6 +309,11 @@ button.primary {
   border-color: var(--accent);
 }
 
+.card.file-entry.last-opened {
+  border-color: var(--last-opened-border);
+  box-shadow: inset 0 0 0 1px var(--last-opened-border);
+}
+
 .thumb {
   position: relative;
   aspect-ratio: 4 / 3;
@@ -343,9 +360,54 @@ button.primary {
 }
 
 .card-name {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.entry-icon {
+  flex-shrink: 0;
+}
+
+.folder-card {
+  min-height: 74px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.folder-card:hover {
+  border-color: var(--accent);
+  background: var(--hover);
+}
+
+.folder-card-icon {
+  font-size: 34px;
+}
+
+.folder-card-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.folder-card-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.folder-card-count {
+  color: var(--muted);
+  font-size: 11px;
 }
 
 .card-meta {
@@ -410,6 +472,24 @@ button.primary {
    thumbnails at all, which also makes it the fast view for a slow disk. */
 .grid.list {
   display: block;
+}
+
+.grid.list .folder-card {
+  min-height: 0;
+  padding: 5px 8px;
+  border-width: 0 0 1px;
+  border-radius: 0;
+}
+
+.grid.list .folder-card-icon {
+  width: 22px;
+  font-size: 16px;
+}
+
+.grid.list .folder-card-body {
+  flex: 1;
+  flex-direction: row;
+  justify-content: space-between;
 }
 
 .list-item {

--- a/product/akbun-folderview/workspace/test/library.test.js
+++ b/product/akbun-folderview/workspace/test/library.test.js
@@ -11,6 +11,7 @@ const assert = require('node:assert');
 const { test } = require('node:test');
 const {
   buildTree,
+  findTreeNode,
   formatSize,
   isUnder,
   normalizeTag,
@@ -129,6 +130,13 @@ test('a sibling folder with a shared prefix does not leak into the tree', () => 
   ]);
   assert.ok(!root.folders.some((folder) => folder.name.includes('backup')));
   assert.strictEqual(root.files.length, 1);
+});
+
+test('findTreeNode returns a nested folder without flattening the tree', () => {
+  const tree = buildTree([{ path: 'C:\\photos' }], LIBRARY);
+
+  assert.strictEqual(findTreeNode(tree, 'C:\\photos\\trip').name, 'trip');
+  assert.strictEqual(findTreeNode(tree, 'C:\\photos\\missing'), null);
 });
 
 test('tag counts are ordered by use', () => {


### PR DESCRIPTION
# 구현

최근 연 파일 강조, 트리 클릭 설정 적용, 선택 폴더의 폴더·파일 구분 레이아웃
- JavaScript 13개, Rust 4개 테스트 통과

# 어려웠던 점

검색과 폴더 탐색의 범위 구분
- 폴더 선택 시 직접 하위 항목 표시, 검색 시 기존 재귀 검색 유지

# 리스크

최근 연 파일 상태를 실행 세션에서만 유지
- 앱 재시작 후 강조 초기화

Issue #791