### PR TITLE
akbun-makepresentation 시스템 클립보드와 영역 다중 선택

### DIFF
--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -11,7 +11,8 @@ Desktop slide deck editor for the slides actually used in blog posts and talks: 
 - Per-shape line color, width, style (solid/dashed/dotted) and fill
 - Zoom from 50% to 400%, from the status bar or the keyboard
 - Slide numbers, toggled from the status bar
-- Undo and redo, copy and paste, duplicate
+- Undo and redo, multi-object selection, copy and paste, duplicate
+- Paste text and images from the system clipboard
 - Open and save .pptx, export every slide as a .pdf
 - Presentation mode (fullscreen, arrow keys)
 - Self update from the Updates button
@@ -23,7 +24,7 @@ Cmd on macOS, Ctrl on Windows and Linux.
 | Key | What it does |
 |---|---|
 | Cmd+Z / Shift+Cmd+Z | Undo / redo |
-| Cmd+C, Cmd+V | Copy the selected shape, paste it down and to the right |
+| Cmd+C, Cmd+V | Copy selected objects, or paste the latest system clipboard text or image |
 | Cmd+D | Duplicate the selected shape, or the whole slide when nothing is selected |
 | Cmd+S | Save |
 | Cmd+B, Cmd+I, Cmd+U | Bold, italic, underline the selected text box, or the style new ones start with |
@@ -31,6 +32,7 @@ Cmd on macOS, Ctrl on Windows and Linux.
 | Cmd+0 | Fit the slide to the window |
 | Shift while drawing | Square or circle; lines and arrows snap to 45 degrees |
 | Shift while dragging | Move on one axis only |
+| Drag on an empty slide | Select every object fully enclosed by the dragged area |
 | Cmd+drag | Drag a copy and leave the original in place |
 | Cmd+Shift+drag | Same, with the copy kept on one axis |
 | V R O L A P T | Select, rectangle, ellipse, line, arrow, pen, text |

--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -25,7 +25,7 @@ Cmd on macOS, Ctrl on Windows and Linux.
 |---|---|
 | Cmd+Z / Shift+Cmd+Z | Undo / redo |
 | Cmd+C, Cmd+V | Copy selected objects, or paste the latest system clipboard text or image |
-| Cmd+D | Duplicate the selected shape, or the whole slide when nothing is selected |
+| Cmd+D | Duplicate the selected objects, or the whole slide when nothing is selected |
 | Cmd+S | Save |
 | Cmd+B, Cmd+I, Cmd+U | Bold, italic, underline the selected text box, or the style new ones start with |
 | Cmd++ / Cmd+- | Zoom in / out |

--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.3.2",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -143,6 +143,30 @@ function shapeBBox(shape) {
   return { x, y, w: Math.abs(shape.w), h: Math.abs(shape.h) };
 }
 
+function normalizeRect(x0, y0, x1, y1) {
+  return {
+    x: Math.min(x0, x1),
+    y: Math.min(y0, y1),
+    w: Math.abs(x1 - x0),
+    h: Math.abs(y1 - y0),
+  };
+}
+
+function shapeIndicesInRect(shapes, rect) {
+  const right = rect.x + rect.w;
+  const bottom = rect.y + rect.h;
+  return shapes.reduce((indices, shape, index) => {
+    const box = shapeBBox(shape);
+    const contained =
+      box.x >= rect.x &&
+      box.y >= rect.y &&
+      box.x + box.w <= right &&
+      box.y + box.h <= bottom;
+    if (contained) indices.push(index);
+    return indices;
+  }, []);
+}
+
 function moveShape(shape, dx, dy) {
   if (shape.kind === 'pen') {
     for (const p of shape.points) {
@@ -447,6 +471,8 @@ const exported = {
   dragShape,
   isDegenerate,
   shapeBBox,
+  normalizeRect,
+  shapeIndicesInRect,
   moveShape,
   handlesFor,
   resizeShape,

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -31,6 +31,9 @@ const DEFAULT_STYLE = {
 };
 
 const BOXY = new Set(['rect', 'ellipse', 'text', 'image']);
+const SHAPE_KINDS = new Set(['rect', 'ellipse', 'line', 'arrow', 'pen', 'text', 'image']);
+const MAX_CLIPBOARD_SHAPES = 100;
+const MAX_GEOMETRY = 1_000_000;
 
 function createDeck() {
   return { slides: [createSlide()] };
@@ -76,6 +79,81 @@ function createShape(kind, x, y, style) {
     cropBottom: 0,
     rotation: 0,
   };
+}
+
+function isFiniteInRange(value, min, max) {
+  return Number.isFinite(value) && value >= min && value <= max;
+}
+
+function safeColor(value, fallback) {
+  const color = String(value || '');
+  return /^(none|#[0-9a-f]{3}|#[0-9a-f]{4}|#[0-9a-f]{6}|#[0-9a-f]{8})$/i.test(color)
+    ? color
+    : fallback;
+}
+
+function normalizeClipboardShape(value) {
+  if (!value || typeof value !== 'object' || !SHAPE_KINDS.has(value.kind)) return null;
+  if (![value.x, value.y, value.w, value.h].every(
+    (number) => isFiniteInRange(number, -MAX_GEOMETRY, MAX_GEOMETRY)
+  )) return null;
+
+  if (value.kind === 'pen') {
+    if (!Array.isArray(value.points) || value.points.length < 2 || value.points.length > 100_000) {
+      return null;
+    }
+    const validPoints = value.points.every(
+      (point) => Array.isArray(point) && point.length === 2 && point.every(
+        (number) => isFiniteInRange(number, -MAX_GEOMETRY, MAX_GEOMETRY)
+      )
+    );
+    if (!validPoints) return null;
+  }
+
+  const shape = createShape(value.kind, value.x, value.y, {});
+  shape.w = value.w;
+  shape.h = value.h;
+  if (value.kind === 'pen') shape.points = value.points.map((point) => [...point]);
+  shape.stroke = safeColor(value.stroke, shape.stroke);
+  shape.fill = safeColor(value.fill, shape.fill);
+  shape.textColor = safeColor(value.textColor, shape.textColor);
+  if (isFiniteInRange(value.strokeWidth, 0, 1_000)) shape.strokeWidth = value.strokeWidth;
+  if (['solid', 'dash', 'dot'].includes(value.dash)) shape.dash = value.dash;
+  if (typeof value.text === 'string' && value.text.length <= 1_000_000) shape.text = value.text;
+  if (isFiniteInRange(value.fontSize, 1, 1_000)) shape.fontSize = value.fontSize;
+  if (typeof value.fontFamily === 'string' && value.fontFamily.length <= 200) {
+    shape.fontFamily = value.fontFamily;
+  }
+  if (typeof value.src === 'string' && value.src.length <= 100_000_000 &&
+      /^data:image\/[a-z0-9.+-]+;base64,/i.test(value.src)) {
+    shape.src = value.src;
+  }
+  for (const name of ['bold', 'italic', 'underline']) {
+    if (typeof value[name] === 'boolean') shape[name] = value[name];
+  }
+  if (['left', 'center', 'right'].includes(value.textAlign)) {
+    shape.textAlign = value.textAlign;
+  }
+  if (['top', 'center', 'bottom'].includes(value.verticalAlign)) {
+    shape.verticalAlign = value.verticalAlign;
+  }
+  for (const name of ['cropLeft', 'cropTop', 'cropRight', 'cropBottom']) {
+    if (isFiniteInRange(value[name], 0, 1)) shape[name] = value[name];
+  }
+  if (isFiniteInRange(value.rotation, -360_000, 360_000)) shape.rotation = value.rotation;
+  return shape;
+}
+
+function parseClipboardShapes(value) {
+  try {
+    const shapes = JSON.parse(value);
+    if (!Array.isArray(shapes) || shapes.length === 0 || shapes.length > MAX_CLIPBOARD_SHAPES) {
+      return [];
+    }
+    return shapes.map(normalizeClipboardShape).filter(Boolean);
+  } catch (_) {
+    return [];
+  }
 }
 
 // Update a shape while the pointer drags from (x0,y0) to (x,y) during
@@ -468,6 +546,7 @@ const exported = {
   createSlide,
   slideBackground,
   createShape,
+  parseClipboardShapes,
   dragShape,
   isDegenerate,
   shapeBBox,

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -646,7 +646,6 @@ function deleteSelectedShape() {
 
 const PASTE_OFFSET = 20;
 const SHAPE_CLIPBOARD_TYPE = 'application/x-akbun-makepresentation-shapes';
-const SHAPE_KINDS = new Set(['rect', 'ellipse', 'line', 'arrow', 'pen', 'text', 'image']);
 
 function insertShapes(shapes, offset) {
   const copies = shapes.map((shape) => structuredClone(shape));
@@ -665,16 +664,6 @@ function isFormField(target) {
   return target instanceof HTMLInputElement ||
     target instanceof HTMLSelectElement ||
     target instanceof HTMLTextAreaElement;
-}
-
-function parseClipboardShapes(value) {
-  try {
-    const shapes = JSON.parse(value);
-    if (!Array.isArray(shapes) || shapes.length === 0) return [];
-    return shapes.filter((shape) => shape && SHAPE_KINDS.has(shape.kind));
-  } catch (_) {
-    return [];
-  }
 }
 
 document.addEventListener('copy', (event) => {
@@ -734,7 +723,7 @@ document.addEventListener('paste', async (event) => {
   if (isFormField(event.target) || !event.clipboardData) return;
 
   const encoded = event.clipboardData.getData(SHAPE_CLIPBOARD_TYPE);
-  const copiedShapes = parseClipboardShapes(encoded);
+  const copiedShapes = L.parseClipboardShapes(encoded);
   if (copiedShapes.length) {
     event.preventDefault();
     insertShapes(copiedShapes, PASTE_OFFSET);

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -9,6 +9,7 @@ const state = {
   deck: L.createDeck(),
   current: 0,
   selected: -1,
+  selection: [],
   tool: 'select',
   filePath: null,
   dirty: false,
@@ -18,7 +19,6 @@ const state = {
   presenting: false,
   presentIndex: 0,
   showNumbers: false,
-  clipboard: null,
   zoom: L.ZOOM_FIT,
 };
 
@@ -31,6 +31,26 @@ const present = $('present');
 const slide = () => state.deck.slides[state.current];
 const selectedShape = () =>
   state.selected >= 0 ? slide().shapes[state.selected] : null;
+const selectedShapes = () =>
+  state.selection
+    .filter((index) => index >= 0 && index < slide().shapes.length)
+    .map((index) => slide().shapes[index]);
+
+function selectOnly(index) {
+  state.selected = index;
+  state.selection = index >= 0 ? [index] : [];
+}
+
+function selectMany(indices) {
+  state.selection = [...new Set(indices)].filter(
+    (index) => index >= 0 && index < slide().shapes.length
+  );
+  state.selected = state.selection.length ? state.selection[state.selection.length - 1] : -1;
+}
+
+function clearSelection() {
+  selectOnly(-1);
+}
 
 // --- rendering ---------------------------------------------------------------
 
@@ -56,20 +76,29 @@ function hitSvg(shape) {
   }
 }
 
-function selectionSvg(shape) {
+function selectionSvg(shape, handles) {
   const parts = [];
-  if (shape.kind !== 'line' && shape.kind !== 'arrow') {
+  if (!handles || (shape.kind !== 'line' && shape.kind !== 'arrow')) {
     const b = L.shapeBBox(shape);
     parts.push(
       `<rect x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" class="sel-box"/>`
     );
   }
-  for (const h of L.handlesFor(shape)) {
-    parts.push(
-      `<rect x="${h.x - HANDLE / 2}" y="${h.y - HANDLE / 2}" width="${HANDLE}" height="${HANDLE}" class="sel-handle" data-handle="${h.id}"/>`
-    );
+  if (handles) {
+    for (const h of L.handlesFor(shape)) {
+      parts.push(
+        `<rect x="${h.x - HANDLE / 2}" y="${h.y - HANDLE / 2}" width="${HANDLE}" height="${HANDLE}" class="sel-handle" data-handle="${h.id}"/>`
+      );
+    }
   }
   return parts.join('');
+}
+
+function marqueeSvg() {
+  const drag = state.drag;
+  if (!drag || drag.mode !== 'marquee') return '';
+  const rect = L.normalizeRect(drag.x0, drag.y0, drag.x1, drag.y1);
+  return `<rect x="${rect.x}" y="${rect.y}" width="${rect.w}" height="${rect.h}" class="selection-marquee"/>`;
 }
 
 // The slide number is not part of slide().shapes, so it draws after them and
@@ -91,11 +120,17 @@ function renderCanvas() {
         })}${hitSvg(shape)}</g>`
     )
     .join('');
-  const sel = selectedShape();
+  const showHandles = state.selection.length === 1 && state.editingIndex < 0;
+  const selections = state.selection
+    .map((index) => slide().shapes[index])
+    .filter(Boolean)
+    .map((shape) => selectionSvg(shape, showHandles))
+    .join('');
   canvas.innerHTML =
     shapes +
     slideNumberSvg(state.current) +
-    (sel && state.editingIndex < 0 ? selectionSvg(sel) : '');
+    (state.editingIndex < 0 ? selections : '') +
+    marqueeSvg();
 }
 
 function renderThumbs() {
@@ -122,7 +157,9 @@ function renderProps() {
   $('props-stroke').hidden = !showStroke;
   $('props-text').hidden = !showText;
   $('btn-delete-shape').hidden = !shape;
-  $('props-hint').textContent = shape
+  $('props-hint').textContent = state.selection.length > 1
+    ? `Selected: ${state.selection.length} objects`
+    : shape
     ? `Selected: ${kind}`
     : 'No selection — sets style for new shapes';
 
@@ -213,7 +250,7 @@ function markDirty() {
 function restore(deck) {
   state.deck = structuredClone(deck);
   state.current = Math.min(state.current, state.deck.slides.length - 1);
-  state.selected = -1;
+  clearSelection();
   state.dirty = true;
   renderAll();
 }
@@ -280,7 +317,7 @@ canvas.addEventListener('pointerdown', (event) => {
     shape.w = 320;
     shape.h = shape.fontSize * 1.4;
     slide().shapes.push(shape);
-    state.selected = slide().shapes.length - 1;
+    selectOnly(slide().shapes.length - 1);
     setTool('select');
     markDirty();
     renderAll();
@@ -297,7 +334,7 @@ canvas.addEventListener('pointerdown', (event) => {
   }
 
   const handleEl = event.target.closest('[data-handle]');
-  if (handleEl && selectedShape()) {
+  if (handleEl && state.selection.length === 1 && selectedShape()) {
     state.drag = {
       mode: 'resize',
       handle: handleEl.dataset.handle,
@@ -311,7 +348,7 @@ canvas.addEventListener('pointerdown', (event) => {
 
   const group = event.target.closest('g[data-i]');
   if (group) {
-    let index = Number(group.dataset.i);
+    const index = Number(group.dataset.i);
 
     // Opening a text box for editing is decided here rather than from a
     // dblclick event, because the browser never reports one: pointerup
@@ -323,34 +360,42 @@ canvas.addEventListener('pointerdown', (event) => {
     // deletes the box being typed into instead of a character.
     if (isSecondPress(index) && slide().shapes[index].kind === 'text') {
       event.preventDefault();
-      state.selected = index;
+      selectOnly(index);
       renderCanvas();
       renderProps();
       startTextEdit(index);
       return;
     }
 
-    const clicked = index;
+    if (!state.selection.includes(index)) selectOnly(index);
+
     // Cmd/Ctrl+drag drags a copy and leaves the original where it was, the
     // way PowerPoint does. Add Shift and the copy travels on one axis.
     const duplicated = event.metaKey || event.ctrlKey;
+    const originalSelection = [...state.selection];
     if (duplicated) {
-      slide().shapes.push(structuredClone(slide().shapes[index]));
-      index = slide().shapes.length - 1;
+      const copies = selectedShapes().map((shape) => structuredClone(shape));
+      const first = slide().shapes.length;
+      slide().shapes.push(...copies);
+      selectMany(copies.map((_, offset) => first + offset));
     }
-    state.selected = index;
     state.drag = {
       mode: 'move',
-      from: structuredClone(selectedShape()),
+      items: state.selection.map((selectedIndex) => ({
+        index: selectedIndex,
+        from: structuredClone(slide().shapes[selectedIndex]),
+      })),
       x0: p.x,
       y0: p.y,
       moved: false,
       duplicated,
-      clicked,
+      originalSelection,
     };
     canvas.setPointerCapture(event.pointerId);
   } else {
-    state.selected = -1;
+    clearSelection();
+    state.drag = { mode: 'marquee', x0: p.x, y0: p.y, x1: p.x, y1: p.y };
+    canvas.setPointerCapture(event.pointerId);
   }
   renderCanvas();
   renderProps();
@@ -365,20 +410,25 @@ canvas.addEventListener('pointermove', (event) => {
 
   if (drag.mode === 'draw') {
     L.dragShape(slide().shapes[drag.index], drag.x0, drag.y0, p.x, p.y, event.shiftKey);
-  } else {
+  } else if (drag.mode === 'marquee') {
+    drag.x1 = p.x;
+    drag.y1 = p.y;
+  } else if (drag.mode === 'resize') {
     const shape = selectedShape();
     if (!shape) return;
     Object.assign(shape, structuredClone(drag.from));
-    if (drag.mode === 'move') {
-      // Shift keeps the move on whichever axis has travelled further.
-      const straight = event.shiftKey;
-      const mx = straight && Math.abs(dx) <= Math.abs(dy) ? 0 : dx;
-      const my = straight && Math.abs(dx) > Math.abs(dy) ? 0 : dy;
+    L.resizeShape(shape, drag.from, drag.handle, dx, dy);
+  } else if (drag.mode === 'move') {
+    // Shift keeps the move on whichever axis has travelled further.
+    const straight = event.shiftKey;
+    const mx = straight && Math.abs(dx) <= Math.abs(dy) ? 0 : dx;
+    const my = straight && Math.abs(dx) > Math.abs(dy) ? 0 : dy;
+    for (const item of drag.items) {
+      const shape = slide().shapes[item.index];
+      Object.assign(shape, structuredClone(item.from));
       L.moveShape(shape, mx, my);
-      drag.moved = drag.moved || mx !== 0 || my !== 0;
-    } else {
-      L.resizeShape(shape, drag.from, drag.handle, dx, dy);
     }
+    drag.moved = drag.moved || mx !== 0 || my !== 0;
   }
   renderCanvas();
 });
@@ -393,18 +443,20 @@ canvas.addEventListener('pointerup', () => {
     if (L.isDegenerate(shapes[drag.index])) {
       shapes.splice(drag.index, 1);
     } else {
-      state.selected = drag.index;
+      selectOnly(drag.index);
       markDirty();
     }
     setTool('select');
+  } else if (drag.mode === 'marquee') {
+    const rect = L.normalizeRect(drag.x0, drag.y0, drag.x1, drag.y1);
+    selectMany(L.shapeIndicesInRect(slide().shapes, rect));
   } else if (drag.mode === 'resize' || drag.moved) {
     markDirty();
   } else if (drag.duplicated) {
-    // A Cmd+click that never moved selects the shape it hit, the way a plain
-    // click does. The copy pointerdown made has nowhere useful to sit: on top
-    // of the original nobody can see it.
-    slide().shapes.pop();
-    state.selected = drag.clicked;
+    // A Cmd+click that never moved keeps the original selection. The copies
+    // made on pointerdown have nowhere useful to sit on top of the originals.
+    slide().shapes.splice(slide().shapes.length - drag.items.length, drag.items.length);
+    selectMany(drag.originalSelection);
   }
   renderAll();
 });
@@ -459,7 +511,7 @@ function commitTextEdit() {
   // while the overlay was open. There is nothing to commit into, and reading
   // through it would take the whole page down.
   if (!shape) {
-    state.selected = -1;
+    clearSelection();
     renderAll();
     return;
   }
@@ -473,7 +525,7 @@ function commitTextEdit() {
 
   if (removed) {
     slide().shapes.splice(index, 1);
-    state.selected = -1;
+    clearSelection();
   } else if (changed) {
     shape.text = text;
     const lines = text.split('\n').length;
@@ -546,8 +598,7 @@ document.addEventListener('keydown', (event) => {
     else if (key === 'z' && event.shiftKey) redo();
     else if (key === 'z') undo();
     else if (key === 'y') redo();
-    else if (key === 'c') copyShape();
-    else if (key === 'v') pasteShape();
+    else if (key === 'c' || key === 'v') return;
     else if (key === 'd') duplicateSelection();
     else if (TEXT_STYLE_KEYS[key]) toggleTextStyle(TEXT_STYLE_KEYS[key]);
     else return;
@@ -561,18 +612,18 @@ document.addEventListener('keydown', (event) => {
     return;
   }
   if (event.key === 'Escape') {
-    state.selected = -1;
+    clearSelection();
     renderCanvas();
     renderProps();
     return;
   }
   if (event.key.startsWith('Arrow')) {
-    const shape = selectedShape();
-    if (!shape) return;
+    const shapes = selectedShapes();
+    if (shapes.length === 0) return;
     const step = event.shiftKey ? 10 : 1;
     const dx = event.key === 'ArrowLeft' ? -step : event.key === 'ArrowRight' ? step : 0;
     const dy = event.key === 'ArrowUp' ? -step : event.key === 'ArrowDown' ? step : 0;
-    L.moveShape(shape, dx, dy);
+    for (const shape of shapes) L.moveShape(shape, dx, dy);
     markDirty();
     renderCanvas();
     event.preventDefault();
@@ -583,9 +634,10 @@ document.addEventListener('keydown', (event) => {
 });
 
 function deleteSelectedShape() {
-  if (state.selected < 0) return;
-  slide().shapes.splice(state.selected, 1);
-  state.selected = -1;
+  if (state.selection.length === 0) return;
+  const descending = [...state.selection].sort((a, b) => b - a);
+  for (const index of descending) slide().shapes.splice(index, 1);
+  clearSelection();
   markDirty();
   renderAll();
 }
@@ -593,35 +645,133 @@ function deleteSelectedShape() {
 // --- copy, paste, duplicate ----------------------------------------------------
 
 const PASTE_OFFSET = 20;
+const SHAPE_CLIPBOARD_TYPE = 'application/x-akbun-makepresentation-shapes';
+const SHAPE_KINDS = new Set(['rect', 'ellipse', 'line', 'arrow', 'pen', 'text', 'image']);
 
-function addCopy(shape) {
-  const copy = structuredClone(shape);
-  L.moveShape(copy, PASTE_OFFSET, PASTE_OFFSET);
-  slide().shapes.push(copy);
-  state.selected = slide().shapes.length - 1;
+function insertShapes(shapes, offset) {
+  const copies = shapes.map((shape) => structuredClone(shape));
+  if (offset) {
+    for (const copy of copies) L.moveShape(copy, offset, offset);
+  }
+  const first = slide().shapes.length;
+  slide().shapes.push(...copies);
+  selectMany(copies.map((_, index) => first + index));
   markDirty();
   renderAll();
-  return copy;
+  return copies;
 }
 
-function copyShape() {
-  const shape = selectedShape();
-  if (shape) state.clipboard = structuredClone(shape);
+function isFormField(target) {
+  return target instanceof HTMLInputElement ||
+    target instanceof HTMLSelectElement ||
+    target instanceof HTMLTextAreaElement;
 }
 
-function pasteShape() {
-  if (!state.clipboard) return;
-  // The clipboard follows the last paste so a run of them walks down the
-  // slide instead of piling up on one spot.
-  state.clipboard = structuredClone(addCopy(state.clipboard));
+function parseClipboardShapes(value) {
+  try {
+    const shapes = JSON.parse(value);
+    if (!Array.isArray(shapes) || shapes.length === 0) return [];
+    return shapes.filter((shape) => shape && SHAPE_KINDS.has(shape.kind));
+  } catch (_) {
+    return [];
+  }
 }
+
+document.addEventListener('copy', (event) => {
+  if (isFormField(event.target)) return;
+  const shapes = selectedShapes();
+  if (shapes.length === 0 || !event.clipboardData) return;
+  event.clipboardData.setData(SHAPE_CLIPBOARD_TYPE, JSON.stringify(shapes));
+  const text = shapes
+    .filter((shape) => shape.kind === 'text')
+    .map((shape) => shape.text)
+    .join('\n');
+  if (text) event.clipboardData.setData('text/plain', text);
+  event.preventDefault();
+});
+
+function readFileDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error || new Error('cannot read clipboard image'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function readImageSize(src) {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve({ width: image.naturalWidth, height: image.naturalHeight });
+    image.onerror = () => reject(new Error('cannot decode clipboard image'));
+    image.src = src;
+  });
+}
+
+function pastedTextShape(text) {
+  const shape = L.createShape('text', 80, 80, state.defaults);
+  shape.w = 640;
+  shape.text = text.replace(/\r\n/g, '\n');
+  const lines = L.wrapTextLines(shape.text, shape.w, shape.fontSize).length;
+  shape.h = Math.max(shape.fontSize * 1.4, lines * shape.fontSize * 1.35);
+  return shape;
+}
+
+async function pastedImageShape(file, index) {
+  const src = await readFileDataUrl(file);
+  const size = await readImageSize(src);
+  const scale = Math.min(1, (L.SLIDE_W * 0.8) / size.width, (L.SLIDE_H * 0.8) / size.height);
+  const shape = L.createShape('image', 0, 0, state.defaults);
+  shape.w = Math.max(1, size.width * scale);
+  shape.h = Math.max(1, size.height * scale);
+  shape.x = (L.SLIDE_W - shape.w) / 2 + index * PASTE_OFFSET;
+  shape.y = (L.SLIDE_H - shape.h) / 2 + index * PASTE_OFFSET;
+  shape.src = src;
+  return shape;
+}
+
+document.addEventListener('paste', async (event) => {
+  if (isFormField(event.target) || !event.clipboardData) return;
+
+  const encoded = event.clipboardData.getData(SHAPE_CLIPBOARD_TYPE);
+  const copiedShapes = parseClipboardShapes(encoded);
+  if (copiedShapes.length) {
+    event.preventDefault();
+    insertShapes(copiedShapes, PASTE_OFFSET);
+    return;
+  }
+
+  const itemFiles = Array.from(event.clipboardData.items || [])
+    .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
+    .map((item) => item.getAsFile())
+    .filter(Boolean);
+  const directFiles = Array.from(event.clipboardData.files || [])
+    .filter((file) => file.type.startsWith('image/'));
+  const imageFiles = [...new Set([...itemFiles, ...directFiles])];
+  if (imageFiles.length) {
+    event.preventDefault();
+    try {
+      const shapes = await Promise.all(imageFiles.map(pastedImageShape));
+      insertShapes(shapes, 0);
+    } catch (error) {
+      await window.api.message(String(error), { title: 'Cannot paste image', kind: 'error' });
+    }
+    return;
+  }
+
+  const text = event.clipboardData.getData('text/plain');
+  if (text) {
+    event.preventDefault();
+    insertShapes([pastedTextShape(text)], 0);
+  }
+});
 
 // Cmd+D duplicates the selected shape, or the whole slide when nothing on it
 // is selected. Same split PowerPoint makes.
 function duplicateSelection() {
-  const shape = selectedShape();
-  if (shape) {
-    addCopy(shape);
+  const shapes = selectedShapes();
+  if (shapes.length) {
+    insertShapes(shapes, PASTE_OFFSET);
     return;
   }
   state.current = L.duplicateSlide(state.deck, state.current);
@@ -632,9 +782,9 @@ function duplicateSelection() {
 // --- property panel -------------------------------------------------------------------
 
 function applyProp(patch) {
-  const shape = selectedShape();
-  if (shape) {
-    Object.assign(shape, patch);
+  const shapes = selectedShapes();
+  if (shapes.length) {
+    for (const shape of shapes) Object.assign(shape, patch);
     markDirty();
     renderCanvas();
     renderThumbs();
@@ -755,13 +905,13 @@ $('thumbs').addEventListener('click', (event) => {
   const thumb = event.target.closest('[data-slide]');
   if (!thumb) return;
   state.current = Number(thumb.dataset.slide);
-  state.selected = -1;
+  clearSelection();
   renderAll();
 });
 
 $('btn-add-slide').addEventListener('click', () => {
   state.current = L.addSlide(state.deck, state.current);
-  state.selected = -1;
+  clearSelection();
   markDirty();
   renderAll();
 });
@@ -776,7 +926,7 @@ $('btn-del-slide').addEventListener('click', async () => {
     if (!sure) return;
   }
   state.current = L.deleteSlide(state.deck, state.current);
-  state.selected = -1;
+  clearSelection();
   markDirty();
   renderAll();
 });
@@ -795,7 +945,7 @@ async function newDeck() {
   if (!(await confirmDiscard())) return;
   state.deck = L.createDeck();
   state.current = 0;
-  state.selected = -1;
+  clearSelection();
   state.filePath = null;
   state.dirty = false;
   resetHistory();
@@ -809,7 +959,7 @@ async function openFile() {
   try {
     state.deck = await window.api.openDeck(path);
     state.current = 0;
-    state.selected = -1;
+    clearSelection();
     state.filePath = path;
     state.dirty = false;
     // The number flag has nowhere to live in a .pptx, so an opened file

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -256,6 +256,14 @@ main {
   cursor: pointer;
 }
 
+.selection-marquee {
+  fill: color-mix(in srgb, var(--accent) 12%, transparent);
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 4;
+  pointer-events: none;
+}
+
 #text-editor {
   position: absolute;
   border: 1px dashed var(--accent);

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -10,6 +10,31 @@ test('createDeck starts with one empty slide', () => {
   assert.deepStrictEqual(deck.slides[0].shapes, []);
 });
 
+test('parseClipboardShapes normalizes valid shapes with safe defaults', () => {
+  const rect = L.createShape('rect', 10, 20, { fill: '#abcdef' });
+  rect.w = 100;
+  rect.h = 80;
+  const [parsed] = L.parseClipboardShapes(JSON.stringify([rect]));
+  assert.deepStrictEqual(
+    { kind: parsed.kind, x: parsed.x, y: parsed.y, w: parsed.w, h: parsed.h, fill: parsed.fill },
+    { kind: 'rect', x: 10, y: 20, w: 100, h: 80, fill: '#abcdef' }
+  );
+});
+
+test('parseClipboardShapes rejects malformed geometry and pen points', () => {
+  const malformed = [
+    { kind: 'rect', x: '10', y: 20, w: 100, h: 80 },
+    { kind: 'pen', x: 0, y: 0, w: 10, h: 10 },
+    { kind: 'pen', x: 0, y: 0, w: 10, h: 10, points: [[0, 0], [NaN, 10]] },
+  ];
+  assert.deepStrictEqual(L.parseClipboardShapes(JSON.stringify(malformed)), []);
+});
+
+test('parseClipboardShapes rejects an excessive object count', () => {
+  const shape = L.createShape('rect', 0, 0, {});
+  assert.deepStrictEqual(L.parseClipboardShapes(JSON.stringify(Array(101).fill(shape))), []);
+});
+
 test('dragShape normalizes a rect dragged up and left', () => {
   const shape = L.createShape('rect', 100, 100, {});
   L.dragShape(shape, 100, 100, 40, 60);

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -89,6 +89,29 @@ test('shapeBBox normalizes negative line extents', () => {
   assert.deepStrictEqual(L.shapeBBox(shape), { x: 40, y: 100, w: 60, h: 60 });
 });
 
+test('normalizeRect accepts a drag in any direction', () => {
+  assert.deepStrictEqual(L.normalizeRect(100, 80, 20, 10), {
+    x: 20,
+    y: 10,
+    w: 80,
+    h: 70,
+  });
+});
+
+test('shapeIndicesInRect selects only fully enclosed shapes', () => {
+  const inside = L.createShape('rect', 20, 20, {});
+  L.dragShape(inside, 20, 20, 80, 80);
+  const crossing = L.createShape('ellipse', 90, 90, {});
+  L.dragShape(crossing, 90, 90, 130, 130);
+  const line = L.createShape('line', 30, 100, {});
+  L.dragShape(line, 30, 100, 70, 40);
+
+  assert.deepStrictEqual(
+    L.shapeIndicesInRect([inside, crossing, line], { x: 10, y: 10, w: 100, h: 100 }),
+    [0, 2]
+  );
+});
+
 test('moveShape shifts pen points', () => {
   const shape = L.createShape('pen', 0, 0, {});
   L.dragShape(shape, 0, 0, 10, 10);


### PR DESCRIPTION
# 구현

시스템 클립보드 MIME 기반 텍스트·이미지 붙여넣기와 드래그 영역 다중 선택
- JavaScript 41개, Rust 10개 테스트 통과

# 어려웠던 점

기존 단일 선택 상태에 다중 선택 동작 결합
- 기준 객체는 속성·크기 조절용으로 유지하고 선택 목록은 그룹 이동·삭제·복제에 사용

# 리스크

클립보드 이미지 판별은 WebView가 제공하는 MIME 데이터에 의존
- 원본 애플리케이션이 이미지 MIME 없이 HTML이나 URL만 제공하면 텍스트로 붙여넣거나 무시함

Issue #794
