### PR TITLE
akbun-makevideo 프록시 완료 시 재생 중단 수정

### DIFF
--- a/product/akbun-makevideo/wiki/architecture/preview.md
+++ b/product/akbun-makevideo/wiki/architecture/preview.md
@@ -46,6 +46,7 @@ The stage box stays the same size on screen. `#stage-inner` is laid out at `scal
 - 동영상 장변이 1920px보다 크면 프로젝트의 `proxies/` 폴더에 1280px 프록시 생성
 - 생성 중 asset 행에 진행률 표시
 - 준비 전 원본 재생, 준비 후 프록시 재생
+- 재생 중 준비된 프록시는 현재 재생을 유지하고 정지 후 다음 세션부터 사용
 - Playback → Proxy Media…에서 프록시 재생 사용 여부와 생성 상태 확인
 - 원본 경로·수정 시각 불일치 시 재생성
 - export와 정지 상태 exact frame은 원본 사용

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -217,7 +217,9 @@ function createMonitor(options) {
       await refreshingMedia;
     } finally {
       refreshingMedia = null;
-      if (mediaRefreshPending && !currentlyPlaying()) applyMediaRefresh();
+      if (mediaRefreshPending && !currentlyPlaying()) {
+        void applyMediaRefresh().catch(() => {});
+      }
     }
   }
 

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -100,6 +100,8 @@ function createMonitor(options) {
   let position = 0;
   let playing = false;
   let attaching = null;
+  let mediaRefreshPending = false;
+  let refreshingMedia = null;
 
   function timelineMode() {
     return preview.mode() === 'timeline';
@@ -200,6 +202,29 @@ function createMonitor(options) {
     }
   }
 
+  async function applyMediaRefresh() {
+    if (!mediaRefreshPending || refreshingMedia || currentlyPlaying()) return refreshingMedia;
+    mediaRefreshPending = false;
+    refreshingMedia = (async () => {
+      if (drivingNatively()) {
+        await release();
+        await attach();
+      } else {
+        preview.redraw();
+      }
+    })();
+    try {
+      await refreshingMedia;
+    } finally {
+      refreshingMedia = null;
+      if (mediaRefreshPending && !currentlyPlaying()) applyMediaRefresh();
+    }
+  }
+
+  function currentlyPlaying() {
+    return drivingNatively() ? playing : preview.isPlaying();
+  }
+
   /** Tell Rust where the box is now. Cheap enough to call on every layout, and
    *  it compares before sending so a drag is one command per pixel rather than
    *  one per frame. */
@@ -265,6 +290,17 @@ function createMonitor(options) {
     place,
     usesNativeMonitor: drivingNatively,
 
+    /** Use newly generated proxy paths without replacing a live decoder.
+     *
+     *  A native session captures its proxy map when it starts, while media
+     *  elements capture their paths when they are drawn. Replacing either
+     *  during playback stops the current stream, so defer the refresh until
+     *  playback is stopped. */
+    refreshMedia() {
+      mediaRefreshPending = true;
+      return applyMediaRefresh();
+    },
+
     /** The page is about to draw over the stage, or has stopped.
      *
      *  A sheet or an open menu is one of four reasons the view might have to
@@ -284,19 +320,31 @@ function createMonitor(options) {
     },
 
     play() {
-      if (!drivingNatively()) return preview.play();
-      if (total() <= 0) return;
-      if (position >= total()) position = 0;
-      playing = true;
-      if (onTick) onTick(position, true);
-      return api.playbackPlay().then(take).catch(() => {});
+      const start = () => {
+        if (!drivingNatively()) return preview.play();
+        if (total() <= 0) return;
+        if (position >= total()) position = 0;
+        playing = true;
+        if (onTick) onTick(position, true);
+        return api.playbackPlay().then(take).catch(() => {});
+      };
+      return mediaRefreshPending ? Promise.resolve(applyMediaRefresh()).then(start) : start();
     },
 
-    pause() {
-      if (!drivingNatively()) return preview.pause();
+    async pause() {
+      if (!drivingNatively()) {
+        await Promise.resolve(preview.pause());
+        await applyMediaRefresh();
+        return;
+      }
       playing = false;
       if (onTick) onTick(position, false);
-      return api.playbackPause().then(take).catch(() => {});
+      try {
+        take(await api.playbackPause());
+      } catch (_error) {
+        return;
+      }
+      await applyMediaRefresh();
     },
 
     toggle() {
@@ -304,7 +352,7 @@ function createMonitor(options) {
     },
 
     isPlaying() {
-      return drivingNatively() ? playing : preview.isPlaying();
+      return currentlyPlaying();
     },
 
     seek(frames) {

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -376,7 +376,9 @@ function onProxyStatus(statuses) {
     return status.state === 'ready' && (!before || before.state !== 'ready');
   });
   adoptProxyStatuses(statuses);
-  if (becameReady && preview) preview.refreshMedia();
+  if (becameReady && preview) {
+    void Promise.resolve(preview.refreshMedia()).catch((error) => reportError(error, 'proxy:refresh'));
+  }
 }
 
 function onWaveformStatus(statuses) {

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -376,10 +376,7 @@ function onProxyStatus(statuses) {
     return status.state === 'ready' && (!before || before.state !== 'ready');
   });
   adoptProxyStatuses(statuses);
-  if (becameReady && preview) {
-    preview.redraw();
-    if (preview.usesNativeMonitor()) attachMonitor(true);
-  }
+  if (becameReady && preview) preview.refreshMedia();
 }
 
 function onWaveformStatus(statuses) {

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -107,7 +107,12 @@ test('the router answers everything the page asks a preview for', () => {
   assert.deepStrictEqual(missing, []);
 });
 
-test('a ready proxy waits for playback to stop before replacing the native session', async () => {
+test('a ready proxy waits for playback to stop before replacing the native session', async (t) => {
+  const previousWindow = global.window;
+  t.after(() => {
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+  });
   global.window = { devicePixelRatio: 1 };
   const calls = [];
   const preview = {

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { placeOf, samePlace, readChoice } = require('../src/monitor.js');
+const { createMonitor, placeOf, samePlace, readChoice } = require('../src/monitor.js');
 
 // The page's half of the native viewport. Everything here is arithmetic over
 // plain objects on purpose: the rest of monitor.js needs a window, an IPC
@@ -101,9 +101,76 @@ test('the router answers everything the page asks a preview for', () => {
     'mode', 'prune', 'clear', 'showAsset', 'showTimeline', 'setQuality',
     'setScrubbing', 'setMuteWhileScrubbing', 'showExact', 'clearExact', 'isExact',
     'attach', 'release', 'place', 'redraw', 'setVisible', 'usesNativeMonitor',
+    'refreshMedia',
   ];
   const missing = asked.filter((name) => typeof monitor[name] !== 'function');
   assert.deepStrictEqual(missing, []);
+});
+
+test('a ready proxy waits for playback to stop before replacing the native session', async () => {
+  global.window = { devicePixelRatio: 1 };
+  const calls = [];
+  const preview = {
+    mode: () => 'timeline',
+    total: () => 100,
+    pause: () => {},
+    clear: () => {},
+    clearExact: () => {},
+    isPlaying: () => false,
+    redraw: () => calls.push('previewRedraw'),
+  };
+  const api = {
+    available: true,
+    playbackAttach: async () => {
+      calls.push('attach');
+      return { engine: 'native' };
+    },
+    playbackRelease: async () => calls.push('release'),
+    playbackVisible: async () => {},
+    playbackPlay: async () => ({ position: 0, playing: true }),
+    playbackPause: async () => {
+      calls.push('pause');
+      return { position: 10, playing: false };
+    },
+  };
+  const monitor = createMonitor({
+    preview,
+    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    api,
+    getProject: () => ({ settings: { rate: { numerator: 30, denominator: 1 } } }),
+  });
+
+  await monitor.attach();
+  await monitor.play();
+  await monitor.refreshMedia();
+  assert.deepStrictEqual(calls, ['attach']);
+
+  await monitor.pause();
+  assert.deepStrictEqual(calls, ['attach', 'pause', 'release', 'attach']);
+});
+
+test('a ready proxy does not redraw playing media elements', async () => {
+  let playing = true;
+  let redraws = 0;
+  const preview = new Proxy(
+    {},
+    {
+      get: (_target, name) => {
+        if (name === 'mode') return () => 'timeline';
+        if (name === 'isPlaying') return () => playing;
+        if (name === 'pause') return () => { playing = false; };
+        if (name === 'redraw') return () => { redraws += 1; };
+        return () => undefined;
+      },
+    }
+  );
+  const monitor = createMonitor({ preview, stage: null, api: { available: false } });
+
+  await monitor.refreshMedia();
+  assert.strictEqual(redraws, 0);
+
+  await monitor.pause();
+  assert.strictEqual(redraws, 1);
 });
 
 // With no monitor attached, every transport call has to reach the media element


### PR DESCRIPTION
# 구현

프록시 준비 완료 시 재생 세션 교체를 정지 시점까지 지연
- Node 테스트 71개 통과, macOS 앱에서 프록시 27%부터 ready 전환 후 재생 1.29초→14.04초 연속 진행 확인

# 어려웠던 점

native monitor와 media element의 서로 다른 미디어 갱신 경로 통합
- 재생 중에는 갱신 예약만 남기고 정지 또는 다음 재생 직전에 엔진별 갱신 수행

# 리스크

재생 중 완성된 프록시는 현재 재생 세션에 즉시 반영되지 않음
- 현재 재생 연속성 우선, 정지 후 재생부터 준비된 프록시 사용

Issue #789
