### PR TITLE
akbun-makepresentation 전체화면·가이드라인·PNG 내보내기

### DIFF
--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src-tauri/capabilities/default.json
+++ b/product/akbun-makepresentation/workspace/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "core:window:allow-set-title",
+    "core:window:allow-set-fullscreen",
+    "core:window:allow-is-fullscreen",
     "dialog:allow-open",
     "dialog:allow-save",
     "dialog:allow-message",

--- a/product/akbun-makepresentation/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/src/commands.rs
@@ -2,10 +2,10 @@
 //! command receives a path plus data, so nothing here blocks on UI.
 
 use base64::Engine;
-use serde::Deserialize;
 use makepresentation_deck::{pdf, pptx, Deck};
+use serde::Deserialize;
 use std::fs::File;
-use std::io::BufWriter;
+use std::io::{BufWriter, Write};
 
 #[tauri::command]
 pub fn open_deck(path: String) -> Result<Deck, String> {
@@ -48,4 +48,17 @@ pub fn export_pdf(path: String, pages: Vec<PageImage>) -> Result<(), String> {
     }
     let file = File::create(&path).map_err(|e| format!("cannot write {path}: {e}"))?;
     pdf::write(&jpegs, BufWriter::new(file))
+}
+
+#[tauri::command]
+pub fn save_png(path: String, data_url: String) -> Result<(), String> {
+    let b64 = data_url
+        .strip_prefix("data:image/png;base64,")
+        .ok_or("image is not a PNG data URL")?;
+    let data = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| format!("bad PNG image: {e}"))?;
+    let mut file = File::create(&path).map_err(|e| format!("cannot write {path}: {e}"))?;
+    file.write_all(&data)
+        .map_err(|e| format!("cannot write {path}: {e}"))
 }

--- a/product/akbun-makepresentation/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/src/lib.rs
@@ -1,5 +1,55 @@
 mod commands;
 
+#[cfg(desktop)]
+const GUIDELINES_MENU_ID: &str = "view-guidelines";
+#[cfg(desktop)]
+const GUIDELINES_EVENT: &str = "guidelines-changed";
+
+#[cfg(desktop)]
+fn install_menu(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{
+        CheckMenuItemBuilder, Menu, MenuItemKind, SubmenuBuilder, WINDOW_SUBMENU_ID,
+    };
+    use tauri::Emitter;
+
+    let menu = Menu::default(app.handle())?;
+    let guidelines = CheckMenuItemBuilder::with_id(GUIDELINES_MENU_ID, "Guidelines")
+        .checked(false)
+        .build(app)?;
+    let items = menu.items()?;
+    let view = items.iter().find_map(|item| match item {
+        MenuItemKind::Submenu(submenu)
+            if submenu.text().map(|text| text == "View").unwrap_or(false) =>
+        {
+            Some(submenu.clone())
+        }
+        _ => None,
+    });
+
+    if let Some(view) = view {
+        view.append(&guidelines)?;
+    } else {
+        let view = SubmenuBuilder::new(app, "View").item(&guidelines).build()?;
+        let position = items
+            .iter()
+            .position(|item| item.id() == WINDOW_SUBMENU_ID)
+            .unwrap_or(items.len());
+        menu.insert(&view, position)?;
+    }
+    app.set_menu(menu)?;
+
+    let guidelines_item = guidelines.clone();
+    app.on_menu_event(move |app, event| {
+        if event.id() != GUIDELINES_MENU_ID {
+            return;
+        }
+        if let Ok(checked) = guidelines_item.is_checked() {
+            let _ = app.emit_to("main", GUIDELINES_EVENT, checked);
+        }
+    });
+    Ok(())
+}
+
 pub fn run() {
     let mut builder = tauri::Builder::default().plugin(tauri_plugin_dialog::init());
 
@@ -12,6 +62,9 @@ pub fn run() {
 
     builder
         .setup(|app| {
+            #[cfg(desktop)]
+            install_menu(app)?;
+
             // The window is the whole app, so the webview console is where
             // almost every bug shows up first. Debug builds only.
             #[cfg(debug_assertions)]
@@ -28,6 +81,7 @@ pub fn run() {
             commands::open_deck,
             commands::save_deck,
             commands::export_pdf,
+            commands::save_png,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/product/akbun-makepresentation/workspace/src/api.js
+++ b/product/akbun-makepresentation/workspace/src/api.js
@@ -22,19 +22,32 @@ if (!window.__TAURI__) {
     openDeck: async () => null,
     saveDeck: async () => {},
     exportPdf: async () => {},
+    savePng: async () => {},
     message: async (text) => alert(text),
     ask: async (text) => confirm(text),
     setTitle: (title) => {
       document.title = title;
     },
+    setFullscreen: async (enabled) => {
+      if (enabled) await document.documentElement.requestFullscreen();
+      else if (document.fullscreenElement) await document.exitFullscreen();
+    },
+    onFullscreenChanged: (handler) => {
+      const listener = () => handler(!!document.fullscreenElement);
+      document.addEventListener('fullscreenchange', listener);
+      return () => document.removeEventListener('fullscreenchange', listener);
+    },
+    onGuidelinesChanged: () => Promise.resolve(() => {}),
     checkUpdate: async () => {},
   };
   throw new Error('not running under Tauri; using the browser fallback api');
 }
 
 const { invoke } = window.__TAURI__.core;
+const { listen } = window.__TAURI__.event;
 const { open: openDialog, save: saveDialog, message, ask } = window.__TAURI__.dialog;
 const { getCurrentWindow } = window.__TAURI__.window;
+const currentWindow = getCurrentWindow();
 
 async function checkUpdate() {
   const { check } = window.__TAURI__.updater;
@@ -77,9 +90,15 @@ window.api = {
   openDeck: (path) => invoke('open_deck', { path }),
   saveDeck: (path, deck) => invoke('save_deck', { path, deck }),
   exportPdf: (path, pages) => invoke('export_pdf', { path, pages }),
+  savePng: (path, dataUrl) => invoke('save_png', { path, dataUrl }),
 
   message: (text, opts) => message(text, opts),
   ask: (text, opts) => ask(text, opts),
-  setTitle: (title) => getCurrentWindow().setTitle(title),
+  setTitle: (title) => currentWindow.setTitle(title),
+  setFullscreen: (enabled) => currentWindow.setFullscreen(enabled),
+  onFullscreenChanged: (handler) =>
+    currentWindow.onResized(async () => handler(await currentWindow.isFullscreen())),
+  onGuidelinesChanged: (handler) =>
+    listen('guidelines-changed', (event) => handler(!!event.payload)),
   checkUpdate,
 };

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -515,6 +515,51 @@ function renderSlideSvg(slide, options) {
   );
 }
 
+function rotatedBBox(box, degrees) {
+  if (!degrees) return box;
+  const radians = degrees * Math.PI / 180;
+  const width = Math.abs(box.w * Math.cos(radians)) + Math.abs(box.h * Math.sin(radians));
+  const height = Math.abs(box.w * Math.sin(radians)) + Math.abs(box.h * Math.cos(radians));
+  const cx = box.x + box.w / 2;
+  const cy = box.y + box.h / 2;
+  return { x: cx - width / 2, y: cy - height / 2, w: width, h: height };
+}
+
+function shapeImageBBox(shape) {
+  const stroke = shape.stroke === 'none' || shape.kind === 'text' || shape.kind === 'image'
+    ? 0
+    : Math.max(0, shape.strokeWidth || 0) / 2;
+  const arrow = shape.kind === 'arrow'
+    ? Math.max(10, Math.max(0, shape.strokeWidth || 0) * 4) * 0.5
+    : 0;
+  const padding = Math.max(2, stroke, arrow);
+  const box = shapeBBox(shape);
+  const padded = {
+    x: box.x - padding,
+    y: box.y - padding,
+    w: Math.max(1, box.w + padding * 2),
+    h: Math.max(1, box.h + padding * 2),
+  };
+  return rotatedBBox(padded, shape.rotation || 0);
+}
+
+function renderShapesSvg(shapes) {
+  if (!Array.isArray(shapes) || shapes.length === 0) return null;
+  const boxes = shapes.map(shapeImageBBox);
+  const left = Math.min(...boxes.map((box) => box.x));
+  const top = Math.min(...boxes.map((box) => box.y));
+  const right = Math.max(...boxes.map((box) => box.x + box.w));
+  const bottom = Math.max(...boxes.map((box) => box.y + box.h));
+  const width = Math.max(1, right - left);
+  const height = Math.max(1, bottom - top);
+  const markup = shapes.map((shape) => renderShapeSvg(shape)).join('');
+  return {
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${left} ${top} ${width} ${height}">${markup}</svg>`,
+    width,
+    height,
+  };
+}
+
 // --- zoom ---------------------------------------------------------------------
 //
 // Fixed steps rather than a free factor: every stop is a round number the
@@ -563,6 +608,7 @@ const exported = {
   wrapTextLines,
   renderShapeSvg,
   renderSlideSvg,
+  renderShapesSvg,
 };
 
 // A script tag makes top level names globals, so everything stays behind one

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -178,8 +178,8 @@
 
   <div id="present" hidden></div>
 
-  <div id="context-menu" role="menu" hidden>
-    <button id="context-save-image" role="menuitem">Save as Image</button>
+  <div id="context-menu" hidden>
+    <button id="context-save-image">Save as Image</button>
   </div>
 
   <script src="editor.js"></script>

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -178,6 +178,10 @@
 
   <div id="present" hidden></div>
 
+  <div id="context-menu" role="menu" hidden>
+    <button id="context-save-image" role="menuitem">Save as Image</button>
+  </div>
+
   <script src="editor.js"></script>
   <script src="api.js"></script>
   <script src="renderer.js"></script>

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -19,6 +19,7 @@ const state = {
   presenting: false,
   presentIndex: 0,
   showNumbers: false,
+  showGuidelines: false,
   zoom: L.ZOOM_FIT,
 };
 
@@ -27,6 +28,7 @@ const canvas = $('canvas');
 const stageInner = $('stage-inner');
 const textEditor = $('text-editor');
 const present = $('present');
+const contextMenu = $('context-menu');
 
 const slide = () => state.deck.slides[state.current];
 const selectedShape = () =>
@@ -108,6 +110,18 @@ function slideNumberSvg(index) {
   return L.renderShapeSvg(L.slideNumberShape(index + 1));
 }
 
+function guidelinesSvg() {
+  if (!state.showGuidelines) return '';
+  return (
+    '<g class="guidelines" aria-hidden="true">' +
+    '<rect x="64" y="48" width="1152" height="112"/>' +
+    '<text x="76" y="72">TITLE</text>' +
+    '<rect x="64" y="192" width="1152" height="464"/>' +
+    '<text x="76" y="216">CONTENT</text>' +
+    '</g>'
+  );
+}
+
 function renderCanvas() {
   // The slide's own color, not the app theme: what the editor shows here is
   // what the pdf and the projector show.
@@ -129,6 +143,7 @@ function renderCanvas() {
   canvas.innerHTML =
     shapes +
     slideNumberSvg(state.current) +
+    guidelinesSvg() +
     (state.editingIndex < 0 ? selections : '') +
     marqueeSvg();
 }
@@ -560,6 +575,11 @@ textEditor.addEventListener('keydown', (event) => {
 const TOOL_KEYS = { v: 'select', r: 'rect', o: 'ellipse', l: 'line', a: 'arrow', p: 'pen', t: 'text' };
 
 document.addEventListener('keydown', (event) => {
+  if (!contextMenu.hidden && event.key === 'Escape') {
+    hideContextMenu();
+    event.preventDefault();
+    return;
+  }
   if (state.presenting) {
     if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'PageDown') presentStep(1);
     else if (event.key === 'ArrowLeft' || event.key === 'PageUp') presentStep(-1);
@@ -767,6 +787,97 @@ function duplicateSelection() {
   markDirty();
   renderAll();
 }
+
+// --- context menu and image export ------------------------------------------
+
+function hideContextMenu() {
+  contextMenu.hidden = true;
+}
+
+function showContextMenu(x, y) {
+  contextMenu.hidden = false;
+  contextMenu.style.left = `${x}px`;
+  contextMenu.style.top = `${y}px`;
+  const bounds = contextMenu.getBoundingClientRect();
+  contextMenu.style.left = `${Math.max(4, Math.min(x, window.innerWidth - bounds.width - 4))}px`;
+  contextMenu.style.top = `${Math.max(4, Math.min(y, window.innerHeight - bounds.height - 4))}px`;
+  $('context-save-image').focus();
+}
+
+document.addEventListener('contextmenu', (event) => {
+  event.preventDefault();
+  hideContextMenu();
+  if (state.presenting || !(event.target instanceof Element)) return;
+  const group = event.target.closest('#canvas [data-i]');
+  if (!group) return;
+  const index = Number(group.dataset.i);
+  if (!state.selection.includes(index)) {
+    selectOnly(index);
+    renderCanvas();
+    renderProps();
+  }
+  showContextMenu(event.clientX, event.clientY);
+});
+
+document.addEventListener('pointerdown', (event) => {
+  if (!contextMenu.contains(event.target)) hideContextMenu();
+});
+window.addEventListener('blur', hideContextMenu);
+window.addEventListener('resize', hideContextMenu);
+$('stage-scroll').addEventListener('scroll', hideContextMenu);
+
+function rasterizeShapes(shapes) {
+  return new Promise((resolve, reject) => {
+    const imageSvg = L.renderShapesSvg(shapes);
+    if (!imageSvg) {
+      reject(new Error('no shape selected'));
+      return;
+    }
+    const url = URL.createObjectURL(new Blob([imageSvg.svg], { type: 'image/svg+xml' }));
+    const image = new Image();
+    image.onload = () => {
+      const scale = Math.max(
+        0.01,
+        Math.min(2, 4096 / imageSvg.width, 4096 / imageSvg.height)
+      );
+      const raster = document.createElement('canvas');
+      raster.width = Math.max(1, Math.ceil(imageSvg.width * scale));
+      raster.height = Math.max(1, Math.ceil(imageSvg.height * scale));
+      raster.getContext('2d').drawImage(image, 0, 0, raster.width, raster.height);
+      URL.revokeObjectURL(url);
+      resolve(raster.toDataURL('image/png'));
+    };
+    image.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('cannot render selected shape'));
+    };
+    image.src = url;
+  });
+}
+
+function suggestShapeImageName() {
+  if (!state.filePath) return `slide-${state.current + 1}-shape.png`;
+  const file = state.filePath.split('/').pop().split('\\').pop();
+  const deckName = file.replace(/\.pptx$/i, '');
+  return `${deckName}-slide-${state.current + 1}-shape.png`;
+}
+
+async function saveSelectionAsImage() {
+  hideContextMenu();
+  const shapes = selectedShapes().map((shape) => structuredClone(shape));
+  if (shapes.length === 0) return;
+  const path = await window.api.pickSave(suggestShapeImageName(), 'png');
+  if (!path) return;
+  try {
+    const dataUrl = await rasterizeShapes(shapes);
+    await window.api.savePng(path, dataUrl);
+    await window.api.message('Image saved.', { title: 'akbun-makepresentation' });
+  } catch (error) {
+    await window.api.message(String(error), { title: 'Image export failed', kind: 'error' });
+  }
+}
+
+$('context-save-image').addEventListener('click', saveSelectionAsImage);
 
 // --- property panel -------------------------------------------------------------------
 
@@ -1040,18 +1151,38 @@ function renderPresent() {
   });
 }
 
-function enterPresent() {
+let presentationOwnsFullscreen = false;
+
+async function enterPresent() {
+  if (state.presenting) return;
   state.presenting = true;
   state.presentIndex = state.current;
   present.hidden = false;
   renderPresent();
-  if (present.requestFullscreen) present.requestFullscreen().catch(() => {});
+  try {
+    await window.api.setFullscreen(true);
+    presentationOwnsFullscreen = true;
+  } catch (error) {
+    state.presenting = false;
+    present.hidden = true;
+    await window.api.message(String(error), {
+      title: 'Cannot start presentation',
+      kind: 'error',
+    });
+  }
 }
 
-function exitPresent() {
+async function exitPresent(restoreWindow = true) {
+  if (!state.presenting) return;
   state.presenting = false;
   present.hidden = true;
-  if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
+  const leaveFullscreen = presentationOwnsFullscreen;
+  presentationOwnsFullscreen = false;
+  if (restoreWindow && leaveFullscreen) {
+    try {
+      await window.api.setFullscreen(false);
+    } catch (_) {}
+  }
 }
 
 function presentStep(direction) {
@@ -1062,8 +1193,17 @@ function presentStep(direction) {
 }
 
 present.addEventListener('click', () => presentStep(1));
-document.addEventListener('fullscreenchange', () => {
-  if (!document.fullscreenElement && state.presenting) exitPresent();
+window.api.onFullscreenChanged((fullscreen) => {
+  if (fullscreen && state.presenting) {
+    presentationOwnsFullscreen = true;
+  } else if (!fullscreen && state.presenting && presentationOwnsFullscreen) {
+    exitPresent(false);
+  }
+});
+
+window.api.onGuidelinesChanged((enabled) => {
+  state.showGuidelines = enabled;
+  renderCanvas();
 });
 
 // --- toolbar ---------------------------------------------------------------------------------------

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -804,19 +804,31 @@ function showContextMenu(x, y) {
   $('context-save-image').focus();
 }
 
+function contextMenuPoint(event, group) {
+  if (event.clientX || event.clientY) {
+    return { x: event.clientX, y: event.clientY };
+  }
+  const bounds = group.getBoundingClientRect();
+  return {
+    x: bounds.left + Math.min(16, bounds.width / 2),
+    y: bounds.top + Math.min(16, bounds.height / 2),
+  };
+}
+
 document.addEventListener('contextmenu', (event) => {
   event.preventDefault();
   hideContextMenu();
   if (state.presenting || !(event.target instanceof Element)) return;
   const group = event.target.closest('#canvas [data-i]');
   if (!group) return;
+  const point = contextMenuPoint(event, group);
   const index = Number(group.dataset.i);
   if (!state.selection.includes(index)) {
     selectOnly(index);
     renderCanvas();
     renderProps();
   }
-  showContextMenu(event.clientX, event.clientY);
+  showContextMenu(point.x, point.y);
 });
 
 document.addEventListener('pointerdown', (event) => {
@@ -836,16 +848,23 @@ function rasterizeShapes(shapes) {
     const url = URL.createObjectURL(new Blob([imageSvg.svg], { type: 'image/svg+xml' }));
     const image = new Image();
     image.onload = () => {
-      const scale = Math.max(
-        0.01,
-        Math.min(2, 4096 / imageSvg.width, 4096 / imageSvg.height)
-      );
-      const raster = document.createElement('canvas');
-      raster.width = Math.max(1, Math.ceil(imageSvg.width * scale));
-      raster.height = Math.max(1, Math.ceil(imageSvg.height * scale));
-      raster.getContext('2d').drawImage(image, 0, 0, raster.width, raster.height);
-      URL.revokeObjectURL(url);
-      resolve(raster.toDataURL('image/png'));
+      try {
+        const scale = Math.max(
+          0.01,
+          Math.min(2, 4096 / imageSvg.width, 4096 / imageSvg.height)
+        );
+        const raster = document.createElement('canvas');
+        raster.width = Math.max(1, Math.ceil(imageSvg.width * scale));
+        raster.height = Math.max(1, Math.ceil(imageSvg.height * scale));
+        const context = raster.getContext('2d');
+        if (!context) throw new Error('cannot create image canvas');
+        context.drawImage(image, 0, 0, raster.width, raster.height);
+        resolve(raster.toDataURL('image/png'));
+      } catch (error) {
+        reject(error);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     };
     image.onerror = () => {
       URL.revokeObjectURL(url);

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -264,6 +264,23 @@ main {
   pointer-events: none;
 }
 
+.guidelines {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  stroke-dasharray: 8 6;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.guidelines text {
+  fill: var(--accent);
+  stroke: none;
+  font-size: 15px;
+  font-family: Helvetica, Arial, sans-serif;
+  letter-spacing: 0.08em;
+}
+
 #text-editor {
   position: absolute;
   border: 1px dashed var(--accent);
@@ -423,6 +440,32 @@ input[type='color'] {
   border: 1px solid var(--border);
   border-radius: 4px;
   background: var(--panel);
+}
+
+/* --- context menu --- */
+
+#context-menu {
+  position: fixed;
+  z-index: 20;
+  min-width: 170px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+}
+
+#context-menu button {
+  width: 100%;
+  border: 0;
+  padding: 6px 10px;
+  text-align: left;
+}
+
+#context-menu button:hover,
+#context-menu button:focus-visible {
+  background: var(--accent-soft);
+  outline: none;
 }
 
 /* --- presentation mode --- */

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -224,6 +224,28 @@ test('renderSlideSvg draws the number only when asked', () => {
   assert.ok(L.renderSlideSvg(slide, { number: 3 }).includes('>3<'));
 });
 
+test('renderShapesSvg crops selected shapes without a slide background', () => {
+  const shape = L.createShape('rect', 100, 200, { fill: '#abcdef', strokeWidth: 4 });
+  shape.w = 300;
+  shape.h = 100;
+  const image = L.renderShapesSvg([shape]);
+  assert.ok(image.svg.includes('viewBox="98 198 304 104"'));
+  assert.ok(image.svg.includes('fill="#abcdef"'));
+  assert.ok(!image.svg.includes(`width="${L.SLIDE_W}"`));
+  assert.strictEqual(image.width, 304);
+  assert.strictEqual(image.height, 104);
+});
+
+test('renderShapesSvg expands the crop for a rotated shape', () => {
+  const shape = L.createShape('text', 100, 100, {});
+  shape.w = 200;
+  shape.h = 50;
+  shape.text = 'title';
+  shape.rotation = 90;
+  const image = L.renderShapesSvg([shape]);
+  assert.ok(image.width < image.height);
+});
+
 test('renderShapeSvg uses the shape font family with a fallback', () => {
   const shape = L.createShape('text', 0, 0, { fontFamily: 'Georgia' });
   shape.text = 'hi';


### PR DESCRIPTION
# 구현

모니터 전체화면 프레젠테이션, View 가이드라인, 선택 도형 PNG 저장 추가 및 기본 우클릭 메뉴 제거
- JavaScript 43개, Rust 10개 테스트와 Tauri debug 빌드 통과

# 어려웠던 점

DOM 전체화면과 네이티브 창 전체화면 상태를 분리해 종료 경로 동기화
- 창 크기 변경 시 fullscreen 상태를 확인해 OS 종료 동작에서도 편집 화면으로 복귀

# 리스크

도형 PNG를 4096px 이내로 래스터화하므로 초대형 출력 시 해상도 제한
- 투명 배경과 메모리 사용량을 유지하기 위한 최대 크기 설정

Issue #807