### PR TITLE
akbun-makevideo 단축키 설정과 사용자 지정 키맵

### DIFF
--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -89,6 +89,9 @@ pub struct Settings {
     pub log_rotation_size: u64,
     /// "kb" or "mb".
     pub log_rotation_unit: String,
+    /// User changes to the page's built-in keyboard shortcuts. Missing actions
+    /// keep their code-defined defaults, so new actions reach existing users.
+    pub shortcut_overrides: HashMap<String, Vec<String>>,
 }
 
 impl Default for Settings {
@@ -111,6 +114,7 @@ impl Default for Settings {
             log_dir: String::new(),
             log_rotation_size: 5,
             log_rotation_unit: "mb".into(),
+            shortcut_overrides: HashMap::new(),
         }
     }
 }

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -71,6 +71,7 @@ if (!window.__TAURI__) {
         logDir: '',
         logRotationSize: 5,
         logRotationUnit: 'mb',
+        shortcutOverrides: {},
       },
       workspace: '',
       version: '0.0.0-browser',

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -39,16 +39,16 @@
       <div class="menu">
         <button class="menu-title" data-menu="project">Project</button>
         <ul class="menu-list" data-list="project">
-          <li><button data-action="new-project">New Project<kbd>⌘N</kbd></button></li>
-          <li><button data-action="open-project">Open Project…<kbd>⌘O</kbd></button></li>
+          <li><button data-action="new-project">New Project<kbd data-shortcut="new-project"></kbd></button></li>
+          <li><button data-action="open-project">Open Project…<kbd data-shortcut="open-project"></kbd></button></li>
           <li class="sep"></li>
-          <li><button data-action="save-project">Save<kbd>⌘S</kbd></button></li>
-          <li><button data-action="save-project-as">Save As…<kbd>⇧⌘S</kbd></button></li>
+          <li><button data-action="save-project">Save<kbd data-shortcut="save-project"></kbd></button></li>
+          <li><button data-action="save-project-as">Save As…<kbd data-shortcut="save-project-as"></kbd></button></li>
           <li class="sep"></li>
-          <li><button data-action="import-assets">Import Media…<kbd>⌘I</kbd></button></li>
+          <li><button data-action="import-assets">Import Media…<kbd data-shortcut="import-assets"></kbd></button></li>
           <li class="sep"></li>
           <li><button id="menu-delete-project" data-action="delete-project">Delete Project…</button></li>
-          <li><button data-action="close-project">Close Project<kbd>⌘W</kbd></button></li>
+          <li><button data-action="close-project">Close Project<kbd data-shortcut="close-project"></kbd></button></li>
         </ul>
       </div>
 
@@ -57,12 +57,12 @@
         <ul class="menu-list" data-list="edit">
           <!-- The label says what will be taken back, so the two are filled in
                from the document state rather than written here. -->
-          <li><button id="menu-undo" data-action="undo">Undo<kbd>⌘Z</kbd></button></li>
-          <li><button id="menu-redo" data-action="redo">Redo<kbd>⇧⌘Z</kbd></button></li>
+          <li><button id="menu-undo" data-action="undo">Undo<kbd data-shortcut="undo"></kbd></button></li>
+          <li><button id="menu-redo" data-action="redo">Redo<kbd data-shortcut="redo"></kbd></button></li>
           <li class="sep"></li>
-          <li><button data-action="split">Split at Playhead<kbd>⌘B</kbd></button></li>
-          <li><button data-action="delete-clip">Delete Clip<kbd>⌫</kbd></button></li>
-          <li><button data-action="ripple-delete">Ripple Delete<kbd>⇧⌫</kbd></button></li>
+          <li><button data-action="split">Split at Playhead<kbd data-shortcut="split"></kbd></button></li>
+          <li><button data-action="delete-clip">Delete Clip<kbd data-shortcut="delete-clip"></kbd></button></li>
+          <li><button data-action="ripple-delete">Ripple Delete<kbd data-shortcut="ripple-delete"></kbd></button></li>
         </ul>
       </div>
 
@@ -79,10 +79,10 @@
       <div class="menu">
         <button class="menu-title" data-menu="playback">Playback</button>
         <ul class="menu-list" data-list="playback">
-          <li><button data-action="previous-edit">Previous Edit<kbd>↑ / Page Up</kbd></button></li>
-          <li><button data-action="next-edit">Next Edit<kbd>↓ / Page Down</kbd></button></li>
-          <li><button data-action="timeline-start">Timeline Start<kbd>Home</kbd></button></li>
-          <li><button data-action="timeline-end">Timeline End<kbd>End</kbd></button></li>
+          <li><button data-action="previous-edit">Previous Edit<kbd data-shortcut="previous-edit"></kbd></button></li>
+          <li><button data-action="next-edit">Next Edit<kbd data-shortcut="next-edit"></kbd></button></li>
+          <li><button data-action="timeline-start">Timeline Start<kbd data-shortcut="timeline-start"></kbd></button></li>
+          <li><button data-action="timeline-end">Timeline End<kbd data-shortcut="timeline-end"></kbd></button></li>
           <li class="sep"></li>
           <li><button data-action="proxy-media">Proxy Media…</button></li>
         </ul>
@@ -93,6 +93,7 @@
         <ul class="menu-list" data-list="settings">
           <li><button data-action="project-settings">Project Resolution…</button></li>
           <li><button data-action="app-settings">Preview &amp; Tools…</button></li>
+          <li><button data-action="shortcut-settings">Keyboard Shortcuts…</button></li>
           <li class="sep"></li>
           <li><button data-action="quality-soak">Playback Quality Soak…</button></li>
           <li><button data-action="quality-smoke">Playback Quality Smoke…</button></li>
@@ -370,9 +371,23 @@
     </div>
   </div>
 
+  <div id="shortcut-settings" class="overlay" hidden>
+    <div class="sheet shortcut-sheet">
+      <h3>Keyboard Shortcuts</h3>
+      <p class="dim small-text">Use Cmd, Shift, Option, Ctrl and a key. Separate multiple keys with commas.</p>
+      <p id="shortcut-error" class="small-text danger-text" hidden></p>
+      <div id="shortcut-list" class="shortcut-list"></div>
+      <div class="sheet-actions">
+        <button data-close="shortcut-settings">Cancel</button>
+        <button id="shortcut-save" class="primary">Apply</button>
+      </div>
+    </div>
+  </div>
+
   <script src="api.js"></script>
   <script src="time.js"></script>
   <script src="timeline.js"></script>
+  <script src="shortcuts.js"></script>
   <script src="quality.js"></script>
   <script src="preview.js"></script>
   <script src="monitor.js"></script>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -18,6 +18,7 @@
 
 const L = globalThis.timelineLib;
 const T = globalThis.timeLib;
+const K = globalThis.shortcutLib;
 
 // Pointer distance from a clip edge that starts a trim instead of a move.
 const HANDLE_PX = 8;
@@ -51,6 +52,7 @@ const DEFAULT_SETTINGS = {
   logDir: '',
   logRotationSize: 5,
   logRotationUnit: 'mb',
+  shortcutOverrides: {},
 };
 
 const el = (id) => document.getElementById(id);
@@ -681,6 +683,10 @@ function seekTimelineStart() {
 
 function seekTimelineEnd() {
   preview.seek(L.projectDurationFrames(state.project));
+}
+
+function seekTimelineOffset(offset) {
+  preview.seek(Math.round(preview.position()) + offset);
 }
 
 /** Keep the playhead on screen while it runs, without fighting a user who is
@@ -1493,10 +1499,59 @@ function fillProxySheet() {
   el('proxy-generate').disabled = !state.path || !window.api.available;
 }
 
+function shortcutMap() {
+  return K.resolved(state.settings.shortcutOverrides);
+}
+
+function renderShortcutLabels() {
+  const byAction = new Map(shortcutMap().map((shortcut) => [shortcut.action, shortcut]));
+  for (const node of document.querySelectorAll('[data-shortcut]')) {
+    const shortcut = byAction.get(node.dataset.shortcut);
+    node.textContent = shortcut ? K.formatKeys(shortcut.keys) : '';
+  }
+}
+
+function fillShortcutSheet() {
+  const list = el('shortcut-list');
+  list.textContent = '';
+  for (const shortcut of shortcutMap()) {
+    const row = document.createElement('label');
+    row.className = 'shortcut-row';
+    row.textContent = shortcut.label;
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.dataset.shortcutAction = shortcut.action;
+    input.value = K.inputKeys(shortcut.keys);
+    input.setAttribute('aria-label', `${shortcut.label} shortcut`);
+    row.appendChild(input);
+    list.appendChild(row);
+  }
+  const error = el('shortcut-error');
+  error.hidden = true;
+  error.textContent = '';
+}
+
+function collectShortcutOverrides() {
+  const keysByAction = {};
+  for (const input of el('shortcut-list').querySelectorAll('[data-shortcut-action]')) {
+    const keys = K.parseKeys(input.value);
+    if (!keys) throw new Error(`Use a key such as Cmd+S for ${input.previousSibling.textContent}.`);
+    keysByAction[input.dataset.shortcutAction] = keys;
+  }
+  const updated = K.resolved(K.overridesFor(keysByAction));
+  const conflicts = K.conflicts(updated);
+  if (conflicts.length) {
+    const conflict = conflicts[0];
+    throw new Error(`${K.formatKeys([conflict.key])} is used by ${conflict.first.label} and ${conflict.second.label}.`);
+  }
+  return K.overridesFor(keysByAction);
+}
+
 function applySettings(next) {
   const was = state.settings.playbackEngine;
   const usedProxies = state.settings.proxyEnabled;
   state.settings = next;
+  renderShortcutLabels();
   preview.setQuality(next.previewQuality);
   preview.setMuteWhileScrubbing(next.previewMuteWhileScrubbing);
   dom.previewQuality.value = next.previewQuality;
@@ -1565,6 +1620,11 @@ const actions = {
   split: splitAtPlayhead,
   'delete-clip': () => deleteSelected(false),
   'ripple-delete': () => deleteSelected(true),
+  'toggle-playback': () => preview.toggle(),
+  'previous-frame': () => seekTimelineOffset(-1),
+  'next-frame': () => seekTimelineOffset(1),
+  'previous-second': () => seekTimelineOffset(-Math.round(T.rateToNumber(rate()))),
+  'next-second': () => seekTimelineOffset(Math.round(T.rateToNumber(rate()))),
   'previous-edit': seekPreviousEdit,
   'next-edit': seekNextEdit,
   'timeline-start': seekTimelineStart,
@@ -1583,6 +1643,10 @@ const actions = {
   'app-settings': () => {
     fillAppSheet();
     openSheet('app-settings');
+  },
+  'shortcut-settings': () => {
+    fillShortcutSheet();
+    openSheet('shortcut-settings');
   },
   'quality-soak': async () => {
     try {
@@ -1839,6 +1903,27 @@ function wireSheets() {
     applySettings(state.boot.settings);
     updateToolWarning();
   });
+  el('shortcut-save').addEventListener('click', async () => {
+    const error = el('shortcut-error');
+    let shortcutOverrides;
+    try {
+      shortcutOverrides = collectShortcutOverrides();
+    } catch (cause) {
+      error.textContent = cause.message;
+      error.hidden = false;
+      return;
+    }
+    try {
+      state.boot = await window.api.saveSettings(Object.assign({}, state.settings, { shortcutOverrides }));
+    } catch (cause) {
+      reportError(cause, 'settings:shortcuts');
+      error.textContent = `Those shortcuts could not be saved. ${cause}`;
+      error.hidden = false;
+      return;
+    }
+    closeSheet('shortcut-settings');
+    applySettings(state.boot.settings);
+  });
   el('proxy-generate').addEventListener('click', async () => {
     if (!state.path) return;
     try {
@@ -1904,8 +1989,6 @@ function wireKeyboard() {
     const typing =
       target && (target.tagName === 'INPUT' || target.tagName === 'SELECT' || target.tagName === 'TEXTAREA');
     if (typing) return;
-    const meta = event.metaKey || event.ctrlKey;
-
     if (event.key === 'Escape') {
       closeMenus();
       for (const sheet of document.querySelectorAll('.overlay')) {
@@ -1913,78 +1996,11 @@ function wireKeyboard() {
       }
       return;
     }
-    if (meta && event.key.toLowerCase() === 'b') {
-      event.preventDefault();
-      splitAtPlayhead();
-      return;
-    }
-    if (meta && event.key.toLowerCase() === 's') {
-      event.preventDefault();
-      saveProject(event.shiftKey);
-      return;
-    }
-    if (meta && event.key.toLowerCase() === 'o') {
-      event.preventDefault();
-      openProject();
-      return;
-    }
-    if (meta && event.key.toLowerCase() === 'n') {
-      event.preventDefault();
-      newProject();
-      return;
-    }
-    if (meta && event.key.toLowerCase() === 'i') {
-      event.preventDefault();
-      importViaDialog();
-      return;
-    }
-    if (event.code === 'Space') {
-      event.preventDefault();
-      preview.toggle();
-      return;
-    }
-    if (meta && event.key.toLowerCase() === 'z') {
-      event.preventDefault();
-      if (event.shiftKey) redoEdit();
-      else undoEdit();
-      return;
-    }
-    if (event.key === 'Delete' || event.key === 'Backspace') {
-      event.preventDefault();
-      // Shift closes the gap behind it, which is the destructive one and the
-      // reason it is not the plain key.
-      deleteSelected(event.shiftKey);
-      return;
-    }
-    if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
-      event.preventDefault();
-      // One frame, or a second with shift. A frame is 1 now, which is the
-      // point of counting in them.
-      const step = event.shiftKey ? Math.round(T.rateToNumber(rate())) : 1;
-      const at = Math.round(preview.position());
-      preview.seek(at + (event.key === 'ArrowRight' ? step : -step));
-      return;
-    }
-    if (event.key === 'ArrowUp' || event.key === 'PageUp') {
-      event.preventDefault();
-      seekPreviousEdit();
-      return;
-    }
-    if (event.key === 'ArrowDown' || event.key === 'PageDown') {
-      event.preventDefault();
-      seekNextEdit();
-      return;
-    }
-    if (event.key === 'Home') {
-      event.preventDefault();
-      seekTimelineStart();
-      return;
-    }
-    if (event.key === 'End') {
-      event.preventDefault();
-      seekTimelineEnd();
-      return;
-    }
+    const action = K.actionFor(event, shortcutMap());
+    if (!action) return;
+    event.preventDefault();
+    const run = actions[action];
+    if (run) Promise.resolve().then(run).catch((error) => reportError(error, `shortcut:${action}`));
   });
 }
 

--- a/product/akbun-makevideo/workspace/src/shortcuts.js
+++ b/product/akbun-makevideo/workspace/src/shortcuts.js
@@ -1,0 +1,208 @@
+'use strict';
+
+(function () {
+
+const MODIFIERS = {
+  cmd: 'meta',
+  command: 'meta',
+  meta: 'meta',
+  '⌘': 'meta',
+  ctrl: 'ctrl',
+  control: 'ctrl',
+  shift: 'shift',
+  '⇧': 'shift',
+  alt: 'alt',
+  option: 'alt',
+  '⌥': 'alt',
+};
+
+const KEY_NAMES = {
+  backspace: 'Backspace',
+  delete: 'Delete',
+  space: 'Space',
+  spacebar: 'Space',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  'page up': 'PageUp',
+  pagedown: 'PageDown',
+  'page down': 'PageDown',
+  arrowup: 'ArrowUp',
+  up: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  down: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  left: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+  right: 'ArrowRight',
+};
+
+const SHORTCUTS = [
+  { action: 'new-project', label: 'New Project', keys: ['Meta+KeyN'] },
+  { action: 'open-project', label: 'Open Project', keys: ['Meta+KeyO'] },
+  { action: 'save-project', label: 'Save Project', keys: ['Meta+KeyS'] },
+  { action: 'save-project-as', label: 'Save Project As', keys: ['Meta+Shift+KeyS'] },
+  { action: 'close-project', label: 'Close Project', keys: ['Meta+KeyW'] },
+  { action: 'import-assets', label: 'Import Media', keys: ['Meta+KeyI'] },
+  { action: 'undo', label: 'Undo', keys: ['Meta+KeyZ'] },
+  { action: 'redo', label: 'Redo', keys: ['Meta+Shift+KeyZ'] },
+  { action: 'split', label: 'Split at Playhead', keys: ['Meta+KeyB', 'Meta+KeyD'] },
+  { action: 'delete-clip', label: 'Delete Clip', keys: ['Backspace', 'Delete'] },
+  { action: 'ripple-delete', label: 'Ripple Delete', keys: ['Shift+Backspace', 'Shift+Delete'] },
+  { action: 'toggle-playback', label: 'Play or Pause', keys: ['Space'] },
+  { action: 'previous-frame', label: 'Previous Frame', keys: ['ArrowLeft'] },
+  { action: 'next-frame', label: 'Next Frame', keys: ['ArrowRight'] },
+  { action: 'previous-second', label: 'Previous Second', keys: ['Shift+ArrowLeft'] },
+  { action: 'next-second', label: 'Next Second', keys: ['Shift+ArrowRight'] },
+  { action: 'previous-edit', label: 'Previous Edit', keys: ['ArrowUp', 'PageUp'] },
+  { action: 'next-edit', label: 'Next Edit', keys: ['ArrowDown', 'PageDown'] },
+  { action: 'timeline-start', label: 'Timeline Start', keys: ['Home'] },
+  { action: 'timeline-end', label: 'Timeline End', keys: ['End'] },
+];
+
+function normalizeKey(value) {
+  const word = value.trim().toLowerCase();
+  if (KEY_NAMES[word]) return KEY_NAMES[word];
+  if (/^[a-z]$/.test(word)) return `Key${word.toUpperCase()}`;
+  if (/^[0-9]$/.test(word)) return `Digit${word}`;
+  if (/^key[a-z]$/i.test(value)) return `Key${value.at(-1).toUpperCase()}`;
+  if (/^digit[0-9]$/i.test(value)) return `Digit${value.at(-1)}`;
+  return null;
+}
+
+function normalizeChord(value) {
+  const parts = String(value).split('+').map((part) => part.trim()).filter(Boolean);
+  if (!parts.length) return null;
+  const modifiers = new Set();
+  let key = null;
+  for (const part of parts) {
+    const modifier = MODIFIERS[part.toLowerCase()];
+    if (modifier) {
+      modifiers.add(modifier);
+      continue;
+    }
+    const parsed = normalizeKey(part);
+    if (!parsed || key) return null;
+    key = parsed;
+  }
+  if (!key) return null;
+  return [
+    modifiers.has('ctrl') ? 'Ctrl' : '',
+    modifiers.has('alt') ? 'Alt' : '',
+    modifiers.has('shift') ? 'Shift' : '',
+    modifiers.has('meta') ? 'Meta' : '',
+    key,
+  ].filter(Boolean).join('+');
+}
+
+function parseKeys(value) {
+  const keys = String(value).split(',').map(normalizeChord);
+  if (!keys.length || keys.some((key) => !key)) return null;
+  return [...new Set(keys)];
+}
+
+function resolved(overrides) {
+  const custom = overrides || {};
+  return SHORTCUTS.map((shortcut) => ({
+    ...shortcut,
+    keys: Array.isArray(custom[shortcut.action]) && custom[shortcut.action].length
+      ? custom[shortcut.action]
+      : shortcut.keys,
+  }));
+}
+
+function overridesFor(keysByAction) {
+  const next = {};
+  for (const shortcut of SHORTCUTS) {
+    const keys = keysByAction[shortcut.action] || shortcut.keys;
+    if (keys.join(',') !== shortcut.keys.join(',')) next[shortcut.action] = keys;
+  }
+  return next;
+}
+
+function conflicts(shortcuts) {
+  const owner = new Map();
+  const found = [];
+  for (const shortcut of shortcuts) {
+    for (const key of shortcut.keys) {
+      const other = owner.get(key);
+      if (other && other.action !== shortcut.action) {
+        found.push({ key, first: other, second: shortcut });
+      } else {
+        owner.set(key, shortcut);
+      }
+    }
+  }
+  return found;
+}
+
+function matches(event, chord) {
+  const parts = chord.split('+');
+  const key = parts.at(-1);
+  const has = (name) => parts.includes(name);
+  return event.code === key
+    && event.metaKey === has('Meta')
+    && event.ctrlKey === has('Ctrl')
+    && event.altKey === has('Alt')
+    && event.shiftKey === has('Shift');
+}
+
+function actionFor(event, shortcuts) {
+  for (const shortcut of shortcuts) {
+    if (shortcut.keys.some((key) => matches(event, key))) return shortcut.action;
+  }
+  return null;
+}
+
+function formatChord(chord) {
+  const names = {
+    Meta: '⌘',
+    Ctrl: '⌃',
+    Alt: '⌥',
+    Shift: '⇧',
+    Backspace: '⌫',
+    Delete: 'Delete',
+    Space: 'Space',
+    PageUp: 'Page Up',
+    PageDown: 'Page Down',
+    ArrowUp: '↑',
+    ArrowDown: '↓',
+    ArrowLeft: '←',
+    ArrowRight: '→',
+  };
+  return chord.split('+').map((part) => {
+    if (names[part]) return names[part];
+    if (part.startsWith('Key')) return part.slice(3);
+    if (part.startsWith('Digit')) return part.slice(5);
+    return part;
+  }).join('');
+}
+
+function formatKeys(keys) {
+  return keys.map(formatChord).join(' / ');
+}
+
+function inputKeys(keys) {
+  return keys.map((key) => key.split('+').map((part) => {
+    if (part === 'Meta') return 'Cmd';
+    if (part.startsWith('Key')) return part.slice(3);
+    if (part.startsWith('Digit')) return part.slice(5);
+    return part;
+  }).join('+')).join(', ');
+}
+
+const exported = {
+  shortcuts: SHORTCUTS,
+  parseKeys,
+  resolved,
+  overridesFor,
+  conflicts,
+  actionFor,
+  formatKeys,
+  inputKeys,
+};
+
+if (typeof module !== 'undefined' && module.exports) module.exports = exported;
+else globalThis.shortcutLib = exported;
+
+}());

--- a/product/akbun-makevideo/workspace/src/shortcuts.js
+++ b/product/akbun-makevideo/workspace/src/shortcuts.js
@@ -147,11 +147,17 @@ function matches(event, chord) {
     && event.shiftKey === has('Shift');
 }
 
-function actionFor(event, shortcuts) {
+function exactActionFor(event, shortcuts) {
   for (const shortcut of shortcuts) {
     if (shortcut.keys.some((key) => matches(event, key))) return shortcut.action;
   }
   return null;
+}
+
+function actionFor(event, shortcuts) {
+  const action = exactActionFor(event, shortcuts);
+  if (action || !event.ctrlKey || event.metaKey) return action;
+  return exactActionFor({ ...event, ctrlKey: false, metaKey: true }, shortcuts);
 }
 
 function formatChord(chord) {
@@ -185,6 +191,7 @@ function formatKeys(keys) {
 function inputKeys(keys) {
   return keys.map((key) => key.split('+').map((part) => {
     if (part === 'Meta') return 'Cmd';
+    if (part === 'Alt') return 'Option';
     if (part.startsWith('Key')) return part.slice(3);
     if (part.startsWith('Digit')) return part.slice(5);
     return part;

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -231,6 +231,29 @@ select {
   color: var(--dim);
 }
 
+.shortcut-sheet {
+  width: min(620px, calc(100vw - 32px));
+}
+
+.shortcut-list {
+  display: grid;
+  gap: 8px;
+  max-height: min(56vh, 520px);
+  overflow: auto;
+  padding: 2px;
+}
+
+.shortcut-row {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(210px, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.shortcut-row input {
+  min-width: 0;
+}
+
 .menu-list button:hover kbd {
   color: inherit;
 }

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -8,13 +8,14 @@ const vm = require('node:vm');
 
 test('classic page scripts do not leak conflicting declarations', () => {
   const context = vm.createContext({});
-  for (const name of ['time.js', 'timeline.js', 'quality.js', 'preview.js']) {
+  for (const name of ['time.js', 'timeline.js', 'shortcuts.js', 'quality.js', 'preview.js']) {
     const file = path.join(__dirname, '..', 'src', name);
     vm.runInContext(fs.readFileSync(file, 'utf8'), context, { filename: file });
   }
 
   assert.ok(context.timeLib);
   assert.ok(context.timelineLib);
+  assert.ok(context.shortcutLib);
   assert.ok(context.qualityLib);
   assert.ok(context.previewLib);
 });

--- a/product/akbun-makevideo/workspace/test/shortcuts.test.js
+++ b/product/akbun-makevideo/workspace/test/shortcuts.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const shortcuts = require('../src/shortcuts.js');
+
+test('split keeps both built-in shortcuts', () => {
+  const split = shortcuts.resolved({}).find((shortcut) => shortcut.action === 'split');
+
+  assert.deepEqual(split.keys, ['Meta+KeyB', 'Meta+KeyD']);
+});
+
+test('only changed shortcuts are saved as overrides', () => {
+  const overrides = shortcuts.overridesFor({
+    split: ['Meta+KeyB', 'Meta+KeyD'],
+    undo: ['Meta+KeyU'],
+  });
+
+  assert.deepEqual(overrides, { undo: ['Meta+KeyU'] });
+});
+
+test('conflicts name both actions', () => {
+  const map = shortcuts.resolved({ undo: ['Meta+KeyS'] });
+  const [conflict] = shortcuts.conflicts(map);
+
+  assert.equal(conflict.key, 'Meta+KeyS');
+  assert.equal(conflict.first.action, 'save-project');
+  assert.equal(conflict.second.action, 'undo');
+});
+
+test('typed shortcut input and keyboard events use the same chord', () => {
+  assert.deepEqual(shortcuts.parseKeys('Cmd+B, Cmd+D'), ['Meta+KeyB', 'Meta+KeyD']);
+  const split = shortcuts.resolved({}).find((shortcut) => shortcut.action === 'split');
+  const action = shortcuts.actionFor({
+    code: 'KeyD',
+    metaKey: true,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+  }, [split]);
+
+  assert.equal(action, 'split');
+});

--- a/product/akbun-makevideo/workspace/test/shortcuts.test.js
+++ b/product/akbun-makevideo/workspace/test/shortcuts.test.js
@@ -41,3 +41,19 @@ test('typed shortcut input and keyboard events use the same chord', () => {
 
   assert.equal(action, 'split');
 });
+
+test('Ctrl falls back to Meta shortcuts after exact Ctrl bindings', () => {
+  const action = shortcuts.actionFor({
+    code: 'KeyB',
+    metaKey: false,
+    ctrlKey: true,
+    altKey: false,
+    shiftKey: false,
+  }, shortcuts.resolved({}));
+
+  assert.equal(action, 'split');
+});
+
+test('editable shortcut input labels Alt as Option', () => {
+  assert.equal(shortcuts.inputKeys(['Alt+KeyA']), 'Option+A');
+});


### PR DESCRIPTION
# 구현

단축키 정의 하나로 메뉴 표시, 키 입력, 설정 저장 연결

- Cmd+B와 Cmd+D 동시 제공, 사용자 변경분만 저장, npm test 75개와 cargo check 통과

# 어려웠던 점

기존 키 입력 분기를 키맵 조회로 치환하면서 프레임과 초 단위 이동 동작 보존

- 기본 키와 사용자 키 모두 같은 정규화 형식으로 비교

# 리스크

실제 Tauri 창의 설정 저장과 재시작 검증 제한

- 기존 개발 창과 동일한 앱 식별자로 새 worktree 창 식별 불가, 상세는 Discussion #809

Issue #768