### PR TITLE
akbun-makevideo: 재생 pipeline 상시 유지

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-persistent-playback-pipeline.md
+++ b/product/akbun-makevideo/adr/2026-08-persistent-playback-pipeline.md
@@ -1,0 +1,17 @@
+# Keep the playback pipeline through pause
+
+## Decision
+
+- Native monitor는 session 하나당 decoder, audio mixer, output device를 한 번만 생성
+- Pause는 audio callback을 무음으로 바꾸고 scheduler clock만 멈춤
+- 정지 상태 편집 반영만 pipeline 재구성
+
+## Reason
+
+- Play와 pause마다 ffmpeg process와 audio stream을 생성·종료하면 teardown 대기가 main thread까지 전파될 수 있음
+- 무음 callback은 audio device를 열린 상태로 두면서 ring과 playhead를 모두 정지 가능
+
+## Consequence
+
+- Pause 뒤 다음 play는 새 decoder와 audio device 준비를 기다리지 않음
+- 정지 상태 편집 반영은 새 project snapshot이 필요해 pipeline을 한 번 재구성

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -24,3 +24,4 @@
 | [2026-08-native-project-trash.md](./2026-08-native-project-trash.md) | Windows and macOS move validated project targets with native trash APIs |
 | [2026-08-common-visual-item-model.md](./2026-08-common-visual-item-model.md) | Text, shape, image and video overlays share one timed transform model |
 | [2026-08-edit-point-navigation.md](./2026-08-edit-point-navigation.md) | Visible clip boundaries drive previous and next edit navigation |
+| [2026-08-persistent-playback-pipeline.md](./2026-08-persistent-playback-pipeline.md) | Play and pause keep one decoder and audio pipeline alive |

--- a/product/akbun-makevideo/wiki/architecture/preview.md
+++ b/product/akbun-makevideo/wiki/architecture/preview.md
@@ -47,6 +47,16 @@ The stage box stays the same size on screen. `#stage-inner` is laid out at `scal
 - 생성 중 asset 행에 진행률 표시
 - 준비 전 원본 재생, 준비 후 프록시 재생
 - 재생 중 준비된 프록시는 현재 재생을 유지하고 정지 후 다음 세션부터 사용
+- 프록시 작업은 재생 중 새 인코딩을 시작하지 않고 정지 뒤 다음 작업부터 재개
+- 프록시 인코더는 2개 스레드로 제한
 - Playback → Proxy Media…에서 프록시 재생 사용 여부와 생성 상태 확인
 - 원본 경로·수정 시각 불일치 시 재생성
 - export와 정지 상태 exact frame은 원본 사용
+
+## Native monitor pause
+
+- Native monitor session은 attach 시 한 번만 decoder, audio mixer, output device를 생성
+- Pause는 output callback을 무음으로 전환하고 scheduler clock만 정지
+- Play는 같은 pipeline을 다시 열어 decoder process와 audio device 재생성 방지
+- 재생용 video decoder는 검증된 hardware acceleration hint를 사용
+- 정지 상태에서 편집한 timeline을 반영할 때만 pipeline 재구성

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/device.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/device.rs
@@ -106,7 +106,7 @@ impl DeviceSink {
     /// is coming out, because a device that takes two seconds to open should
     /// not hold up the rest of playback starting. [`Status::silent`] says
     /// whether it got there.
-    pub fn open(consumer: Consumer, clock: Arc<Clock>) -> DeviceSink {
+    pub fn open(consumer: Consumer, clock: Arc<Clock>, active: Arc<AtomicBool>) -> DeviceSink {
         let stop = Arc::new(AtomicBool::new(false));
         let status = Arc::new(Status::default());
         // One Arc, and only the current callback ever holds a clone of it. The
@@ -135,6 +135,7 @@ impl DeviceSink {
                     match build(
                         Arc::clone(&consumer),
                         Arc::clone(&clock),
+                        Arc::clone(&active),
                         Arc::clone(&thread_status),
                     ) {
                         Ok(open) => {
@@ -217,6 +218,7 @@ fn choose(device: &cpal::Device) -> Result<SupportedStreamConfig, String> {
 fn build(
     consumer: Arc<Consumer>,
     clock: Arc<Clock>,
+    active: Arc<AtomicBool>,
     status: Arc<Status>,
 ) -> Result<Playing, String> {
     let device = cpal::default_host()
@@ -244,7 +246,7 @@ fn build(
     let lost = Arc::new(AtomicBool::new(false));
     let error_lost = Arc::clone(&lost);
     let error_status = Arc::clone(&status);
-    let mut playback = Playback::new(consumer, clock, &config);
+    let mut playback = Playback::new(consumer, clock, active, &config);
     let stream = device
         .build_output_stream::<f32, _, _>(
             config,
@@ -288,6 +290,7 @@ fn build(
 struct Playback {
     consumer: Arc<Consumer>,
     clock: Arc<Clock>,
+    active: Arc<AtomicBool>,
     /// Device channels, which is not always two.
     channels: usize,
     /// Engine frames per device frame. Exactly 1 when the device took 48 kHz,
@@ -310,11 +313,17 @@ struct Playback {
 }
 
 impl Playback {
-    fn new(consumer: Arc<Consumer>, clock: Arc<Clock>, config: &StreamConfig) -> Playback {
+    fn new(
+        consumer: Arc<Consumer>,
+        clock: Arc<Clock>,
+        active: Arc<AtomicBool>,
+        config: &StreamConfig,
+    ) -> Playback {
         let ratio = f64::from(ENGINE_HZ) / f64::from(config.sample_rate.max(1));
         Playback {
             consumer,
             clock,
+            active,
             channels: (config.channels as usize).max(1),
             ratio,
             // Two extra frames for priming the interpolation on the first
@@ -340,6 +349,10 @@ impl Playback {
         // A seek that arrives while the ring is empty still has to take effect,
         // and this callback may never reach a `pop`.
         self.consumer.take_flush();
+
+        if !self.active.load(Ordering::Relaxed) {
+            return;
+        }
 
         let frames = out.len() / self.channels;
         if frames == 0 {
@@ -482,7 +495,12 @@ mod tests {
     fn rig(rate: u32, channels: u16) -> (Playback, crate::realtime::Producer, Arc<Clock>) {
         let (producer, consumer) = Ring::new(1 << 15);
         let clock = Arc::new(Clock::new());
-        let playback = Playback::new(Arc::new(consumer), Arc::clone(&clock), &config(rate, channels));
+        let playback = Playback::new(
+            Arc::new(consumer),
+            Arc::clone(&clock),
+            Arc::new(AtomicBool::new(true)),
+            &config(rate, channels),
+        );
         (playback, producer, clock)
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -215,7 +215,11 @@ impl FrameReader for FfmpegReader {
             self.began = true;
             return true;
         }
-        !self.began && self.retry_with_software() && self.stdout.read_exact(buffer).is_ok()
+        if self.began || !self.retry_with_software() || self.stdout.read_exact(buffer).is_err() {
+            return false;
+        }
+        self.began = true;
+        true
     }
 
     fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -111,7 +111,7 @@ impl FfmpegReaders {
 
 impl Readers for FfmpegReaders {
     fn open(&self, request: &Open) -> Option<Box<dyn FrameReader>> {
-        let args = ffmpeg::decoder_args(&ffmpeg::Decode {
+        let decode = ffmpeg::Decode {
             path: &request.path,
             kind: request.kind,
             in_time: RationalTime::new(request.in_frame, request.rate),
@@ -125,9 +125,51 @@ impl Readers for FfmpegReaders {
             } else {
                 None
             },
+        };
+        let fallback = decode.hwaccel.map(|_| {
+            let software = ffmpeg::decoder_args(&ffmpeg::Decode {
+                path: &request.path,
+                kind: request.kind,
+                in_time: RationalTime::new(request.in_frame, request.rate),
+                duration: RationalTime::new(request.frames, request.rate),
+                width: request.width,
+                height: request.height,
+                rate: request.rate,
+                hwaccel: None,
+            });
+            (self.ffmpeg.clone(), software)
         });
-        let mut child = Command::new(&self.ffmpeg)
-            .args(&args)
+        let args = ffmpeg::decoder_args(&decode);
+        FfmpegReader::start(&self.ffmpeg, &args, fallback)
+            .map(|reader| Box::new(reader) as Box<dyn FrameReader>)
+    }
+}
+
+struct FfmpegReader {
+    child: Arc<Mutex<Child>>,
+    stdout: ChildStdout,
+    fallback: Option<(String, Vec<String>)>,
+    began: bool,
+}
+
+impl FfmpegReader {
+    fn start(
+        ffmpeg: &str,
+        args: &[String],
+        fallback: Option<(String, Vec<String>)>,
+    ) -> Option<FfmpegReader> {
+        let (child, stdout) = Self::spawn(ffmpeg, args)?;
+        Some(FfmpegReader {
+            child,
+            stdout,
+            fallback,
+            began: false,
+        })
+    }
+
+    fn spawn(ffmpeg: &str, args: &[String]) -> Option<(Arc<Mutex<Child>>, ChildStdout)> {
+        let mut child = Command::new(ffmpeg)
+            .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             // A decoder that cannot open its file stops drawing rather than
@@ -136,16 +178,25 @@ impl Readers for FfmpegReaders {
             .spawn()
             .ok()?;
         let stdout = child.stdout.take()?;
-        Some(Box::new(FfmpegReader {
-            child: Arc::new(Mutex::new(child)),
-            stdout,
-        }))
+        Some((Arc::new(Mutex::new(child)), stdout))
     }
-}
 
-struct FfmpegReader {
-    child: Arc<Mutex<Child>>,
-    stdout: ChildStdout,
+    fn retry_with_software(&mut self) -> bool {
+        let Some((ffmpeg, args)) = self.fallback.take() else {
+            return false;
+        };
+        {
+            let mut child = self.child.lock().unwrap();
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let Some((child, stdout)) = Self::spawn(&ffmpeg, &args) else {
+            return false;
+        };
+        self.child = child;
+        self.stdout = stdout;
+        true
+    }
 }
 
 struct FfmpegCancel {
@@ -160,7 +211,11 @@ impl CancelRead for FfmpegCancel {
 
 impl FrameReader for FfmpegReader {
     fn read(&mut self, buffer: &mut [u8]) -> bool {
-        self.stdout.read_exact(buffer).is_ok()
+        if self.stdout.read_exact(buffer).is_ok() {
+            self.began = true;
+            return true;
+        }
+        !self.began && self.retry_with_software() && self.stdout.read_exact(buffer).is_ok()
     }
 
     fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
@@ -7,6 +7,7 @@ use std::time::UNIX_EPOCH;
 pub const FOLDER: &str = "proxies";
 pub const LONG_EDGE: u32 = 1280;
 pub const SOURCE_LONG_EDGE: u32 = 1920;
+pub const ENCODE_THREADS: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -76,6 +77,8 @@ pub fn ffmpeg_args(asset: &Asset, output: &Path) -> Vec<String> {
         "-y".into(),
         "-i".into(),
         asset.path.clone(),
+        "-threads".into(),
+        ENCODE_THREADS.to_string(),
         "-map".into(),
         "0:v:0".into(),
         "-map".into(),
@@ -165,6 +168,9 @@ mod tests {
         let args = ffmpeg_args(&asset(AssetKind::Video, 3840, 2160), Path::new("proxy.mp4"));
         assert!(args.iter().any(|arg| arg.contains("1280")));
         assert!(args.windows(2).any(|pair| pair == ["-map", "0:a?"]));
+        assert!(args
+            .windows(2)
+            .any(|pair| pair[0] == "-threads" && pair[1] == ENCODE_THREADS.to_string()));
         assert_eq!(args.last().map(String::as_str), Some("proxy.mp4"));
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -27,6 +27,7 @@ use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 
 /// Application settings, as opposed to the project settings that live in the
@@ -620,9 +621,9 @@ pub fn bootstrap(app: AppHandle, state: State<AppState>) -> Bootstrap {
 /// decode for a given frame and one that can only work from whatever snapshot
 /// happened to come with the call.
 #[tauri::command]
-pub fn preview_frame(
+pub async fn preview_frame(
     app: AppHandle,
-    state: State<AppState>,
+    state: State<'_, AppState>,
     frame: i64,
     max_width: u32,
 ) -> Result<tauri::ipc::Response, String> {
@@ -762,6 +763,7 @@ fn make_proxy(
     ffmpeg_path: &str,
     asset: &Asset,
 ) -> Result<String, String> {
+    wait_for_playback_pause(app);
     let output = makevideo_proxy::media_path(project_path, &asset.id)?;
     let temporary = output.with_extension("part.mp4");
     let args = makevideo_proxy::ffmpeg_args(asset, &temporary);
@@ -816,15 +818,34 @@ fn make_proxy(
     Ok(output.to_string_lossy().to_string())
 }
 
+/// Jobs queued for proxying wait until playback stops. A job already encoding
+/// finishes its current file: killing ffmpeg midway would leave partial media
+/// and does not make the current playback smoother.
+fn wait_for_playback_pause(app: &AppHandle) {
+    loop {
+        let playing = app
+            .state::<AppState>()
+            .playback
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|session| session.status().playing);
+        if !playing {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
 #[tauri::command]
 pub fn proxy_status(state: State<AppState>) -> Vec<ProxyStatus> {
     proxy_statuses(&state.proxies.lock().unwrap())
 }
 
 #[tauri::command]
-pub fn start_proxies(
+pub async fn start_proxies(
     app: AppHandle,
-    state: State<AppState>,
+    state: State<'_, AppState>,
     project_path: String,
 ) -> Result<Vec<ProxyStatus>, String> {
     let configured = state.settings.lock().unwrap().ffmpeg_dir.clone();
@@ -1785,13 +1806,17 @@ fn start_session(
     } else {
         HashMap::new()
     };
+    let hwaccel = acceleration(state, Some(&ffmpeg))
+        .available
+        .and_then(|candidate| candidate.hwaccel);
     let config = PlaybackConfig::new(
         compositor,
         ffmpeg,
         project.settings.width.max(2),
         project.settings.height.max(2),
     )
-    .with_proxies(proxy_paths);
+    .with_proxies(proxy_paths)
+    .with_hwaccel(hwaccel);
     Session::start(
         window,
         Arc::clone(&state.document),

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -5,28 +5,13 @@
 //! the wiring: a thread, a command channel, the output device, and the surface
 //! the frames land on.
 //!
-//! # Paused costs nothing
+//! # Pause keeps the pipeline alive
 //!
-//! There are two stages and they hold different things.
-//!
-//! | Stage | Holds | Runs |
-//! |---|---|---|
-//! | Still | a frame source and a dead clock | nothing, once the frame is drawn |
-//! | Playing | the transport, the decoders, the output device | the tick loop |
-//!
-//! Pressing play builds the second and pausing throws it away. That costs a few
-//! hundred milliseconds to the first frame — the soak measures it as the
-//! startup delay — and it buys something the media element preview never had:
-//! a paused editor with no decoder running and no audio device open. The old
-//! preview keeps a decoder per clip alive for as long as the project is, which
-//! is the caveat the wiki has carried since it was written.
-//!
-//! It also settles a question that has no good answer otherwise. The audio
-//! engine has no pause: the ring is drained by whatever holds the consumer, and
-//! the consumer is moved into the device. Stopping the sound therefore means
-//! dropping the device, and the device cannot be reopened without the consumer
-//! back. Building both together and dropping both together is the shape that
-//! has no half state in it.
+//! One monitor session owns one transport, its decoder processes and its audio
+//! output for its entire lifetime. Pause closes an atomic gate in the device
+//! callback and stops the scheduler clock; it does not drop either half. The
+//! callback writes silence while the gate is closed, so no samples leave the
+//! ring and the playhead cannot move.
 //!
 //! # The still is the same picture as the playback
 //!
@@ -38,16 +23,13 @@
 use crate::viewport::{Place, Viewport};
 use makevideo_audio::device::DeviceSink;
 use makevideo_audio::engine::Options as AudioOptions;
-use makevideo_audio::realtime::Clock;
 use makevideo_audio::source::{
     Buffering as AudioBuffering, FfmpegReaders as AudioReaders, DEFAULT_DEPTH as AUDIO_DEPTH,
     DEFAULT_LEAD as AUDIO_LEAD,
 };
-use makevideo_compositor::source::{
-    Buffering as FrameBuffering, FfmpegReaders as FrameReaders, FrameSource,
-};
+use makevideo_compositor::source::{Buffering as FrameBuffering, FfmpegReaders as FrameReaders};
 use makevideo_compositor::Compositor;
-use makevideo_present::player::{Scheduler, Tick, IDLE};
+use makevideo_present::player::{Tick, IDLE};
 use makevideo_present::schedule::DEFAULT_RESYNC;
 use makevideo_present::surface::SurfaceSink;
 use makevideo_present::transport::{Setup, Transport};
@@ -145,6 +127,7 @@ pub struct Config {
     pub audio_buffering: AudioBuffering,
     pub resync_after: i64,
     pub proxy_paths: HashMap<String, String>,
+    pub hwaccel: Option<String>,
 }
 
 impl Config {
@@ -158,11 +141,17 @@ impl Config {
             audio_buffering: AudioBuffering::new(AUDIO_DEPTH, AUDIO_LEAD),
             resync_after: DEFAULT_RESYNC,
             proxy_paths: HashMap::new(),
+            hwaccel: None,
         }
     }
 
     pub fn with_proxies(mut self, proxy_paths: HashMap<String, String>) -> Config {
         self.proxy_paths = proxy_paths;
+        self
+    }
+
+    pub fn with_hwaccel(mut self, hwaccel: Option<String>) -> Config {
+        self.hwaccel = hwaccel;
         self
     }
 }
@@ -299,49 +288,35 @@ struct Loop {
     frame: i64,
 }
 
-/// Paused holds a frame source and a clock nobody winds; playing holds the
-/// whole transport and the output device.
-enum Stage {
-    Still(Scheduler),
-    Playing {
-        transport: Transport,
-        /// Never read. Held because dropping it closes the output stream, and
-        /// the stream is what turns the ring into sound and the clock into
-        /// time. The whole of pausing is this field going out of scope.
-        _device: DeviceSink,
-    },
+/// Decoder, audio mixer and output device that survive play/pause toggles.
+struct Pipeline {
+    transport: Transport,
+    /// Held for the whole monitor lifetime. Its callback emits silence when
+    /// `active` is false instead of consuming the ring.
+    _device: DeviceSink,
+    active: Arc<AtomicBool>,
 }
 
 fn run(mut state: Loop) {
-    let mut stage = Stage::Still(still(&state, state.frame));
+    let frame = state.frame;
+    let mut current = pipeline(&mut state, frame);
     loop {
         match state.commands.try_recv() {
             Ok(Command::Stop) | Err(TryRecvError::Disconnected) => break,
             Ok(Command::Play) => {
-                let at = position(&stage);
-                stage = play(&mut state, at);
+                current.active.store(true, Ordering::Relaxed);
+                current.transport.play();
                 state.shared.playing.store(true, Ordering::Relaxed);
                 continue;
             }
             Ok(Command::Pause) => {
-                let at = position(&stage);
-                // The transport and the device are dropped here, which stops
-                // the decoders and closes the output. The still is built from
-                // the timeline as it is now, so an edit made while playing is
-                // on screen the moment it stops.
-                state.project = makevideo_proxy::playback_project(
-                    state.document.lock().unwrap().project(),
-                    &state.config.proxy_paths,
-                );
-                stage = Stage::Still(still(&state, at));
+                current.active.store(false, Ordering::Relaxed);
+                current.transport.pause();
                 state.shared.playing.store(false, Ordering::Relaxed);
                 continue;
             }
             Ok(Command::Seek(frame)) => {
-                match &mut stage {
-                    Stage::Still(scheduler) => scheduler.seek(frame),
-                    Stage::Playing { transport, .. } => transport.seek(frame),
-                }
+                current.transport.seek(frame);
                 state.shared.position.store(frame, Ordering::Relaxed);
                 continue;
             }
@@ -351,27 +326,25 @@ fn run(mut state: Loop) {
                 continue;
             }
             Ok(Command::Redraw) => {
-                if let Stage::Still(_) = stage {
-                    let at = position(&stage);
+                if !current.transport.is_playing() {
+                    let at = current.transport.position();
+                    current.active.store(false, Ordering::Relaxed);
                     state.project = makevideo_proxy::playback_project(
                         state.document.lock().unwrap().project(),
                         &state.config.proxy_paths,
                     );
-                    stage = Stage::Still(still(&state, at));
+                    current = pipeline(&mut state, at);
                 }
                 continue;
             }
             Err(TryRecvError::Empty) => {}
         }
 
-        let tick = match &mut stage {
-            Stage::Still(scheduler) => scheduler.tick(&mut state.sink),
-            Stage::Playing { transport, .. } => transport.tick(&mut state.sink),
-        };
+        let tick = current.transport.tick(&mut state.sink);
         state
             .shared
             .position
-            .store(position(&stage), Ordering::Relaxed);
+            .store(current.transport.position(), Ordering::Relaxed);
 
         match tick {
             Tick::Presented { .. } => {
@@ -391,13 +364,9 @@ fn run(mut state: Loop) {
                 // The timeline is over. Stop where it ended and leave the last
                 // frame up, which is what the transport does anyway; going back
                 // to the top would lose the place somebody was working at.
-                if let Stage::Playing { .. } = stage {
-                    let at = position(&stage);
-                    state.project = makevideo_proxy::playback_project(
-                        state.document.lock().unwrap().project(),
-                        &state.config.proxy_paths,
-                    );
-                    stage = Stage::Still(still(&state, at));
+                if current.transport.is_playing() {
+                    current.active.store(false, Ordering::Relaxed);
+                    current.transport.pause();
                     state.shared.playing.store(false, Ordering::Relaxed);
                 }
             }
@@ -416,43 +385,16 @@ fn run(mut state: Loop) {
     }
 }
 
-fn position(stage: &Stage) -> i64 {
-    match stage {
-        Stage::Still(scheduler) => scheduler.position(),
-        Stage::Playing { transport, .. } => transport.position(),
-    }
-}
-
-/// A paused monitor: the frames, and a clock that will never be wound.
-///
-/// The clock is real and it is never advanced, which is exactly right —
-/// `Scheduler` in its paused mode does not read it. Handing it one keeps the
-/// type honest without inventing a second kind of scheduler for the case where
-/// there is no sound.
-fn still(state: &Loop, frame: i64) -> Scheduler {
-    let source = FrameSource::new(
-        &state.project,
-        state.config.width,
-        state.config.height,
-        state.config.frame_buffering,
-        Arc::new(FrameReaders::new(&state.config.ffmpeg, None)),
-    );
-    let mut scheduler = Scheduler::new(source, Arc::new(Clock::new()), state.config.resync_after);
-    scheduler.pause(frame);
-    scheduler
-}
-
-fn play(state: &mut Loop, frame: i64) -> Stage {
-    state.project = makevideo_proxy::playback_project(
-        state.document.lock().unwrap().project(),
-        &state.config.proxy_paths,
-    );
+fn pipeline(state: &mut Loop, frame: i64) -> Pipeline {
     let (mut transport, consumer) = Transport::start(Setup {
         project: &state.project,
         width: state.config.width,
         height: state.config.height,
         frame_buffering: state.config.frame_buffering,
-        frame_readers: Arc::new(FrameReaders::new(&state.config.ffmpeg, None)),
+        frame_readers: Arc::new(FrameReaders::new(
+            &state.config.ffmpeg,
+            state.config.hwaccel.as_deref(),
+        )),
         audio_buffering: state.config.audio_buffering,
         audio_readers: Arc::new(AudioReaders::new(&state.config.ffmpeg)),
         audio: AudioOptions::default(),
@@ -464,11 +406,12 @@ fn play(state: &mut Loop, frame: i64) -> Stage {
     if frame > 0 {
         transport.seek(frame);
     }
-    let device = DeviceSink::open(consumer, clock);
-    transport.play();
-    Stage::Playing {
+    let active = Arc::new(AtomicBool::new(false));
+    let device = DeviceSink::open(consumer, clock, Arc::clone(&active));
+    Pipeline {
         transport,
         _device: device,
+        active,
     }
 }
 


### PR DESCRIPTION
# 구현

Native monitor의 play와 pause가 decoder·audio pipeline을 유지하도록 전환

- 재생용 hardware decoder hint와 첫 frame software fallback, proxy 2-thread 제한 포함

# 어려웠던 점

Hardware decoder 실패를 process spawn 성공만으로 판정할 수 없는 구조

- 첫 frame 미출력 시 software decoder를 한 번 재시도

# 리스크

정지 상태 편집 반영은 새 project snapshot 적용을 위해 pipeline 재구성

- play와 pause 반복은 재구성 없이 동일한 session 유지

Issue #803
