### PR TITLE
akbun-makevideo: 타임라인 컨텍스트 메뉴와 공백 ripple delete

### DIFF
--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -1151,14 +1151,12 @@ fn ripple_delete_gap(
         }
     }
     let amount = end - start;
-    for track in &mut project.tracks {
-        for clip in &mut track.clips {
-            if moved_ids.contains(&clip.id) {
-                clip.start -= amount;
-            }
-        }
-        track.sort();
-    }
+    let mut after = project.clone();
+    shift_clips_left(&mut after, &moved_ids, amount);
+    after
+        .validate()
+        .map_err(|_| "closing that gap would overlap a linked clip".to_string())?;
+    shift_clips_left(project, &moved_ids, amount);
 
     Ok(Applied {
         resolved: Command::RippleDeleteGap {
@@ -1168,6 +1166,17 @@ fn ripple_delete_gap(
         },
         inverse: Command::RestoreClips { entries: moved },
     })
+}
+
+fn shift_clips_left(project: &mut Project, moved_ids: &HashSet<String>, amount: i64) {
+    for track in &mut project.tracks {
+        for clip in &mut track.clips {
+            if moved_ids.contains(&clip.id) {
+                clip.start -= amount;
+            }
+        }
+        track.sort();
+    }
 }
 
 fn set_clip_gain(

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -32,7 +32,7 @@ use crate::{
     VisualItem, VisualTransform,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Which end of a clip a trim is dragging.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -162,6 +162,15 @@ pub enum Command {
     /// an undo to take it back.
     #[serde(rename_all = "camelCase")]
     RippleDelete { clip_id: String },
+    /// Close the empty space between two clips on one track. The two edges are
+    /// named rather than inferred again on redo, because after closing the gap
+    /// the frame originally clicked can be inside a clip.
+    #[serde(rename_all = "camelCase")]
+    RippleDeleteGap {
+        track_id: String,
+        start: i64,
+        end: i64,
+    },
     #[serde(rename_all = "camelCase")]
     SetClipGain {
         clip_id: String,
@@ -314,6 +323,7 @@ impl Command {
             Command::LinkClips { .. } => "Link clips",
             Command::UnlinkClips { .. } => "Unlink clips",
             Command::RippleDelete { .. } => "Ripple delete",
+            Command::RippleDeleteGap { .. } => "Ripple delete gap",
             Command::SetClipGain { .. } => "Clip levels",
             Command::AddVisualItem { .. } => "Add visual item",
             Command::SetVisualTransform { .. } => "Transform visual item",
@@ -383,6 +393,11 @@ impl Command {
             } => link_clips(project, ids, clip_ids, link_group),
             Command::UnlinkClips { clip_id } => unlink_clips(project, clip_id),
             Command::RippleDelete { clip_id } => ripple_delete(project, clip_id),
+            Command::RippleDeleteGap {
+                track_id,
+                start,
+                end,
+            } => ripple_delete_gap(project, track_id, start, end),
             Command::SetClipGain {
                 clip_id,
                 volume,
@@ -1093,6 +1108,65 @@ fn ripple_delete(project: &mut Project, clip_id: String) -> Result<Applied, Stri
     Ok(Applied {
         resolved: Command::RippleDelete { clip_id },
         inverse: Command::RestoreClips { entries: restore },
+    })
+}
+
+/// Close one of a track's internal gaps. Leading and trailing space is not a
+/// gap to ripple: there must be a clip on both sides for the range to have an
+/// unambiguous owner. A linked clip brings its counterpart with it, which is
+/// the same rule a direct move follows.
+fn ripple_delete_gap(
+    project: &mut Project,
+    track_id: String,
+    start: i64,
+    end: i64,
+) -> Result<Applied, String> {
+    if start < 0 || end <= start {
+        return Err("that is not a timeline gap".into());
+    }
+    let track = project
+        .track(&track_id)
+        .ok_or("that track is not in this project")?;
+    let is_gap = track
+        .clips
+        .windows(2)
+        .any(|clips| clips[0].end_frame() == start && clips[1].start == end);
+    if !is_gap {
+        return Err("that gap is no longer on the timeline".into());
+    }
+
+    let selected_ids: Vec<String> = track
+        .clips
+        .iter()
+        .filter(|clip| clip.start >= end)
+        .map(|clip| clip.id.clone())
+        .collect();
+    let mut moved_ids = HashSet::new();
+    let mut moved = Vec::new();
+    for clip_id in selected_ids {
+        for entry in project.linked_placements(&clip_id) {
+            if moved_ids.insert(entry.clip.id.clone()) {
+                moved.push(entry);
+            }
+        }
+    }
+    let amount = end - start;
+    for track in &mut project.tracks {
+        for clip in &mut track.clips {
+            if moved_ids.contains(&clip.id) {
+                clip.start -= amount;
+            }
+        }
+        track.sort();
+    }
+
+    Ok(Applied {
+        resolved: Command::RippleDeleteGap {
+            track_id,
+            start,
+            end,
+        },
+        inverse: Command::RestoreClips { entries: moved },
     })
 }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -533,6 +533,75 @@ mod tests {
     }
 
     #[test]
+    fn ripple_delete_gap_closes_only_the_selected_track_and_redoes() {
+        let mut document = document();
+        add(&mut document, 0);
+        add(&mut document, 600);
+        add(&mut document, 1_200);
+        let track_id = video_track(&document);
+
+        document
+            .apply(Command::RippleDeleteGap {
+                track_id,
+                start: 300,
+                end: 600,
+            })
+            .unwrap();
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.start)
+                .collect::<Vec<_>>(),
+            [0, 300, 900]
+        );
+        assert_eq!(document.state().undo_label, "Ripple delete gap");
+
+        document.undo().unwrap();
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.start)
+                .collect::<Vec<_>>(),
+            [0, 600, 1_200]
+        );
+        document.redo().unwrap();
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.start)
+                .collect::<Vec<_>>(),
+            [0, 300, 900]
+        );
+    }
+
+    #[test]
+    fn ripple_delete_gap_keeps_a_linked_clip_pair_together() {
+        let mut document = document();
+        add(&mut document, 0);
+        add_linked(&mut document, 600);
+        let track_id = video_track(&document);
+
+        document
+            .apply(Command::RippleDeleteGap {
+                track_id,
+                start: 300,
+                end: 600,
+            })
+            .unwrap();
+
+        assert_eq!(
+            document.project().tracks[0].clips[1].start,
+            300,
+            "the video clip moves into the gap"
+        );
+        assert_eq!(
+            document.project().tracks[1].clips[0].start,
+            300,
+            "its audio counterpart follows"
+        );
+    }
+
+    #[test]
     fn a_transaction_that_fails_half_way_changes_nothing() {
         let mut document = document();
         let clip = add(&mut document, 0);

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -602,6 +602,35 @@ mod tests {
     }
 
     #[test]
+    fn ripple_delete_gap_refuses_to_overlap_a_linked_counterpart() {
+        let mut document = document();
+        add(&mut document, 0);
+        add_linked(&mut document, 600);
+        let audio = audio_track(&document);
+        document
+            .apply(Command::AddClip {
+                track_id: audio,
+                asset_id: "v".into(),
+                start: 300,
+                id: None,
+                link_group: None,
+            })
+            .unwrap();
+        let before = serde_json::to_string(document.project()).unwrap();
+
+        let error = document
+            .apply(Command::RippleDeleteGap {
+                track_id: video_track(&document),
+                start: 300,
+                end: 600,
+            })
+            .unwrap_err();
+
+        assert!(error.contains("overlap a linked clip"), "{error}");
+        assert_eq!(serde_json::to_string(document.project()).unwrap(), before);
+    }
+
+    #[test]
     fn a_transaction_that_fails_half_way_changes_nothing() {
         let mut document = document();
         let clip = add(&mut document, 0);

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -187,6 +187,8 @@
     </section>
   </main>
 
+  <div id="timeline-context-menu" class="timeline-context-menu" hidden></div>
+
   <div id="render-overlay" class="overlay" hidden>
     <div class="sheet">
       <h3 id="render-title">Rendering</h3>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -91,6 +91,7 @@ const dom = {
   content: el('timeline-content'),
   ruler: el('ruler'),
   lanes: el('lanes'),
+  timelineContextMenu: el('timeline-context-menu'),
   playhead: el('playhead'),
   renderOverlay: el('render-overlay'),
   renderTitle: el('render-title'),
@@ -755,6 +756,35 @@ function selectClip(clipId) {
     node.classList.toggle('selected', node.dataset.clipId === clipId);
   }
   updateLinkUi();
+}
+
+function closeTimelineContextMenu() {
+  if (!dom.timelineContextMenu) return;
+  dom.timelineContextMenu.hidden = true;
+  dom.timelineContextMenu.textContent = '';
+}
+
+/** The desktop application's menu is part of the page, like the menu bar.
+ *  This keeps the target and the action in one event flow and never exposes
+ *  the webview's Reload menu over unsaved edits. */
+function openTimelineContextMenu(event, items) {
+  const menu = dom.timelineContextMenu;
+  if (!menu || !items.length) return;
+  menu.textContent = '';
+  for (const item of items) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = item.label;
+    button.addEventListener('click', () => {
+      closeTimelineContextMenu();
+      Promise.resolve(item.run()).catch((error) => reportError(error, `timeline-menu:${item.label}`));
+    });
+    menu.appendChild(button);
+  }
+  menu.hidden = false;
+  const box = menu.getBoundingClientRect();
+  menu.style.left = `${Math.max(4, Math.min(event.clientX, window.innerWidth - box.width - 4))}px`;
+  menu.style.top = `${Math.max(4, Math.min(event.clientY, window.innerHeight - box.height - 4))}px`;
 }
 
 function updateLinkUi() {
@@ -1728,6 +1758,7 @@ function wireMenus() {
   });
   document.addEventListener('pointerdown', (event) => {
     if (!event.target.closest('#menus')) closeMenus();
+    if (!event.target.closest('#timeline-context-menu')) closeTimelineContextMenu();
   });
   // The webview brings its own right-click menu, and the first item on it is
   // Reload. The project lives in this page and nowhere else until it is saved,
@@ -1799,6 +1830,13 @@ function wireTimeline() {
   });
 
   dom.ruler.addEventListener('pointerdown', beginScrub);
+  dom.ruler.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+    const frame = Math.round(frameAtClientX(event.clientX));
+    openTimelineContextMenu(event, [
+      { label: 'Move Playhead Here', run: () => preview.seek(frame) },
+    ]);
+  });
   dom.lanes.addEventListener('pointerdown', (event) => {
     const clip = event.target.closest('.clip');
     if (clip) {
@@ -1807,6 +1845,30 @@ function wireTimeline() {
     }
     selectClip(null);
     beginScrub(event);
+  });
+  dom.lanes.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+    const clip = event.target.closest('.clip');
+    if (clip) {
+      selectClip(clip.dataset.clipId);
+      openTimelineContextMenu(event, [
+        { label: 'Delete Clip', run: () => deleteSelected(false) },
+        { label: 'Ripple Delete', run: () => deleteSelected(true) },
+      ]);
+      return;
+    }
+    const lane = event.target.closest('.lane');
+    if (!lane) return;
+    const track = L.findTrack(state.project, lane.dataset.trackId);
+    const gap = L.gapAt(track, frameAtClientX(event.clientX));
+    if (!gap) return;
+    selectClip(null);
+    openTimelineContextMenu(event, [
+      {
+        label: 'Ripple Delete Gap',
+        run: () => edit({ op: 'rippleDeleteGap', trackId: track.id, start: gap.start, end: gap.end }),
+      },
+    ]);
   });
 
   window.addEventListener('pointermove', (event) => {
@@ -1991,6 +2053,7 @@ function wireKeyboard() {
     if (typing) return;
     if (event.key === 'Escape') {
       closeMenus();
+      closeTimelineContextMenu();
       for (const sheet of document.querySelectorAll('.overlay')) {
         if (sheet.id !== 'render-overlay' || !state.rendering) sheet.hidden = true;
       }

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -777,7 +777,7 @@ function openTimelineContextMenu(event, items) {
     button.textContent = item.label;
     button.addEventListener('click', () => {
       closeTimelineContextMenu();
-      Promise.resolve(item.run()).catch((error) => reportError(error, `timeline-menu:${item.label}`));
+      Promise.resolve().then(() => item.run()).catch((error) => reportError(error, `timeline-menu:${item.label}`));
     });
     menu.appendChild(button);
   }

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -835,6 +835,38 @@ button.icon.on {
   clip-path: polygon(0 0, 100% 0, 50% 100%);
 }
 
+.timeline-context-menu {
+  position: fixed;
+  z-index: 350;
+  min-width: 180px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.timeline-context-menu[hidden] {
+  display: none;
+}
+
+.timeline-context-menu button {
+  display: block;
+  width: 100%;
+  padding: 6px 9px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg);
+  text-align: left;
+}
+
+.timeline-context-menu button:hover,
+.timeline-context-menu button:focus-visible {
+  background: var(--select);
+  color: #201800;
+}
+
 /* --- overlays ------------------------------------------------------------ */
 
 .overlay {

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -167,6 +167,22 @@ function clipsAt(project, frame) {
   return active;
 }
 
+/** The internal empty range under a pointer, or null for a clip, leading
+ *  space, trailing space, and a track with fewer than two clips. The page uses
+ *  this to decide whether a gap can have a context-menu action; Rust checks
+ *  the same two edges before it changes the document. */
+function gapAt(track, frame) {
+  if (!track) return null;
+  const at = Math.max(0, Math.floor(frame));
+  const clips = [...track.clips].sort((left, right) => left.start - right.start);
+  for (let index = 0; index + 1 < clips.length; index += 1) {
+    const start = clipEnd(clips[index]);
+    const end = clips[index + 1].start;
+    if (start < end && start <= at && at < end) return { start, end };
+  }
+  return null;
+}
+
 /** Everything worth snapping to: zero, both edges of every other clip, and
  *  whatever extra frames the caller passes in (the playhead, usually). */
 function snapTargets(project, exceptClipId, extra) {
@@ -291,6 +307,7 @@ const exported = {
   previousEditPoint,
   nextEditPoint,
   clipsAt,
+  gapAt,
   rateOf,
   snapTargets,
   snapTime,

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -135,6 +135,18 @@ test('what is under the playhead knows which frame of the asset it is', () => {
   assert.strictEqual(L.clipsAt(project, 329).length, 1);
 });
 
+test('only an internal empty track range is a ripple-delete gap', () => {
+  const lane = track('t1', 'video', 'V1', [
+    clip('c1', 'v', 0, 0, 300),
+    clip('c2', 'v', 600, 0, 300),
+  ]);
+  assert.deepStrictEqual(L.gapAt(lane, 450), { start: 300, end: 600 });
+  assert.deepStrictEqual(L.gapAt(lane, 300), { start: 300, end: 600 });
+  assert.strictEqual(L.gapAt(lane, 600), null, 'the next clip owns its start');
+  assert.strictEqual(L.gapAt(lane, 50), null, 'a clip is not a gap');
+  assert.strictEqual(L.gapAt(lane, 900), null, 'trailing space is not a gap');
+});
+
 test('the playhead snaps to the nearest edge inside the tolerance', () => {
   const project = projectOf([VIDEO], [track('t1', 'video', 'V1', [clip('c1', 'v', 120, 0, 300)])]);
   assert.strictEqual(L.snapTime(project, 122, 5), 120, 'to a clip start');


### PR DESCRIPTION
# 구현

타임라인의 클립·공백·눈금 우클릭 메뉴와 공백 ripple delete 명령 추가
- Node 테스트 78개와 makevideo-edit 테스트 51개 통과

# 어려웠던 점

공백을 다시 찾는 방식은 redo 시 클릭 지점이 이미 클립 안으로 들어가는 문제
- 공백 양 끝 프레임을 명령에 저장해 같은 범위로 undo·redo

# 리스크

같은 앱 식별자의 기존 창만 노출되어 실제 Tauri 창 조작 검증 불가
- 사유와 대체 검증을 General Discussion #813에 기록

Issue #746