### PR TITLE
akbun-makevideo: 타임라인 마커와 목록 추가

### DIFF
--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.19.1",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.19.1",
+      "version": "0.21.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
@@ -141,6 +141,7 @@ mod tests {
             },
             assets,
             tracks,
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
@@ -896,6 +896,7 @@ pub(crate) mod tests {
             },
             assets,
             tracks,
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
@@ -128,6 +128,7 @@ fn project(rate: Rate, a: &str, b: &str) -> Project {
             audio_track("A1", vec![clip("c1", "a1", 0, 15, 75, 0.333_5)]),
             audio_track("A2", vec![clip("c2", "a2", 23, 0, 60, 0.707_9)]),
         ],
+        markers: Vec::new(),
     }
 }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -892,6 +892,7 @@ mod tests {
             },
             assets,
             tracks,
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
@@ -449,6 +449,7 @@ mod tests {
                 muted: false,
                 hidden: false,
             }],
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
@@ -237,6 +237,7 @@ fn two_tracks_composite_the_way_the_timeline_says() {
                 vec![clip("c2", "narrow", 30, 60)],
             ),
         ],
+        markers: Vec::new(),
     };
     let output = temp_dir()
         .join("composited.mp4")
@@ -288,6 +289,7 @@ fn the_output_is_the_length_the_timeline_says_with_the_sound_on_it() {
             TrackKind::Video,
             vec![clip("c1", "wide", 0, 90)],
         )],
+        markers: Vec::new(),
     };
     let output = temp_dir().join("length.mp4").to_string_lossy().to_string();
     render(&project, &output).expect("the render should succeed");
@@ -343,6 +345,7 @@ fn a_missing_source_leaves_a_hole_rather_than_an_error() {
             track("V1", TrackKind::Video, vec![clip("c1", "wide", 0, 60)]),
             track("V2", TrackKind::Video, vec![clip("c2", "gone", 0, 60)]),
         ],
+        markers: Vec::new(),
     };
     let output = temp_dir().join("missing.mp4").to_string_lossy().to_string();
     render(&project, &output).expect("a missing file must not fail the render");
@@ -380,6 +383,7 @@ fn the_preview_frame_matches_the_rendered_frame() {
                 vec![clip("c2", "narrow", 30, 60)],
             ),
         ],
+        markers: Vec::new(),
     };
     let output = temp_dir().join("match.mp4").to_string_lossy().to_string();
     render(&project, &output).expect("the render should succeed");

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -28,8 +28,8 @@
 //! many times to press undo, and neither can the app.
 
 use crate::{
-    min_clip_frames, Asset, Clip, Project, ProjectSettings, Rate, Track, TrackKind, VisualContent,
-    VisualItem, VisualTransform,
+    min_clip_frames, Asset, Clip, Marker, Project, ProjectSettings, Rate, Track, TrackKind,
+    VisualContent, VisualItem, VisualTransform,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -58,6 +58,13 @@ pub struct VisualItemAt {
     pub item: VisualItem,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkerAt {
+    pub index: usize,
+    pub marker: Marker,
+}
+
 /// An asset and where it sat in the library, so undoing an import does not
 /// quietly reorder the list.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -84,11 +91,15 @@ pub enum Command {
     /// Import. An asset already in the library is updated rather than added
     /// twice, because an asset's identity is its path.
     #[serde(rename_all = "camelCase")]
-    AddAssets { assets: Vec<Asset> },
+    AddAssets {
+        assets: Vec<Asset>,
+    },
     /// Removing an asset takes its clips with it, or the render fails on a clip
     /// pointing at nothing.
     #[serde(rename_all = "camelCase")]
-    RemoveAsset { asset_id: String },
+    RemoveAsset {
+        asset_id: String,
+    },
     #[serde(rename_all = "camelCase")]
     AddTrack {
         track_kind: TrackKind,
@@ -98,7 +109,9 @@ pub enum Command {
         id: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
-    RemoveTrack { track_id: String },
+    RemoveTrack {
+        track_id: String,
+    },
     #[serde(rename_all = "camelCase")]
     SetTrackFlags {
         track_id: String,
@@ -148,7 +161,9 @@ pub enum Command {
         link_groups: Vec<Option<String>>,
     },
     #[serde(rename_all = "camelCase")]
-    RemoveClip { clip_id: String },
+    RemoveClip {
+        clip_id: String,
+    },
     #[serde(rename_all = "camelCase")]
     LinkClips {
         clip_ids: Vec<String>,
@@ -156,12 +171,16 @@ pub enum Command {
         link_group: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
-    UnlinkClips { clip_id: String },
+    UnlinkClips {
+        clip_id: String,
+    },
     /// Delete and close the gap: everything after it on the same track moves
     /// left by its length. Destructive, and only reasonable now that there is
     /// an undo to take it back.
     #[serde(rename_all = "camelCase")]
-    RippleDelete { clip_id: String },
+    RippleDelete {
+        clip_id: String,
+    },
     /// Close the empty space between two clips on one track. The two edges are
     /// named rather than inferred again on redo, because after closing the gap
     /// the frame originally clicked can be inside a clip.
@@ -202,43 +221,97 @@ pub enum Command {
         duration: i64,
     },
     #[serde(rename_all = "camelCase")]
-    SetVisualZIndex { item_id: String, z_index: i32 },
+    SetVisualZIndex {
+        item_id: String,
+        z_index: i32,
+    },
     #[serde(rename_all = "camelCase")]
     SetVisualContent {
         item_id: String,
         content: VisualContent,
     },
     #[serde(rename_all = "camelCase")]
-    RemoveVisualItem { item_id: String },
+    RemoveVisualItem {
+        item_id: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    AddMarker {
+        frame: i64,
+        #[serde(default)]
+        name: String,
+        #[serde(default)]
+        color: String,
+        #[serde(default)]
+        id: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetMarker {
+        marker_id: String,
+        #[serde(default)]
+        frame: Option<i64>,
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        color: Option<String>,
+    },
+    RemoveMarker {
+        marker_id: String,
+    },
     /// Resolution and timebase. Changing the rate carries the edit with it, so
     /// a cut stays where it was in time rather than where it was in frames.
     #[serde(rename_all = "camelCase")]
-    SetSettings { settings: ProjectSettings },
+    SetSettings {
+        settings: ProjectSettings,
+    },
 
     // --- primitives, which exist to be inverses ----------------------------
     /// Put these clips back exactly, on the tracks named. A clip with the same
     /// id anywhere else is taken out first, so this also undoes a move between
     /// tracks.
     #[serde(rename_all = "camelCase")]
-    RestoreClips { entries: Vec<ClipAt> },
+    RestoreClips {
+        entries: Vec<ClipAt>,
+    },
     #[serde(rename_all = "camelCase")]
-    DropClips { clip_ids: Vec<String> },
+    DropClips {
+        clip_ids: Vec<String>,
+    },
     #[serde(rename_all = "camelCase")]
-    RestoreAssets { entries: Vec<AssetAt> },
+    RestoreAssets {
+        entries: Vec<AssetAt>,
+    },
     #[serde(rename_all = "camelCase")]
-    DropAssets { asset_ids: Vec<String> },
+    DropAssets {
+        asset_ids: Vec<String>,
+    },
     #[serde(rename_all = "camelCase")]
-    RestoreTracks { entries: Vec<TrackAt> },
+    RestoreTracks {
+        entries: Vec<TrackAt>,
+    },
     #[serde(rename_all = "camelCase")]
-    DropTracks { track_ids: Vec<String> },
+    DropTracks {
+        track_ids: Vec<String>,
+    },
     #[serde(rename_all = "camelCase")]
-    RestoreVisualItems { entries: Vec<VisualItemAt> },
+    RestoreVisualItems {
+        entries: Vec<VisualItemAt>,
+    },
     #[serde(rename_all = "camelCase")]
-    DropVisualItems { item_ids: Vec<String> },
+    DropVisualItems {
+        item_ids: Vec<String>,
+    },
+    RestoreMarkers {
+        entries: Vec<MarkerAt>,
+    },
+    DropMarkers {
+        marker_ids: Vec<String>,
+    },
 
     /// One undo step made of several commands, all or nothing.
     #[serde(rename_all = "camelCase")]
-    Transaction { commands: Vec<Command> },
+    Transaction {
+        commands: Vec<Command>,
+    },
 }
 
 /// What applying a command produced: the command as it actually happened, and
@@ -333,11 +406,15 @@ impl Command {
             Command::RemoveVisualItem { .. } | Command::DropVisualItems { .. } => {
                 "Delete visual item"
             }
+            Command::AddMarker { .. } => "Add marker",
+            Command::SetMarker { .. } => "Edit marker",
+            Command::RemoveMarker { .. } | Command::DropMarkers { .. } => "Delete marker",
             Command::SetSettings { .. } => "Project settings",
             Command::RestoreClips { .. } => "Restore clips",
             Command::RestoreAssets { .. } | Command::DropAssets { .. } => "Assets",
             Command::RestoreTracks { .. } => "Restore track",
             Command::RestoreVisualItems { .. } => "Restore visual items",
+            Command::RestoreMarkers { .. } => "Restore markers",
             Command::Transaction { commands } => commands
                 .iter()
                 .find(|command| !command.is_nothing())
@@ -429,6 +506,19 @@ impl Command {
                 set_visual_content(project, item_id, content)
             }
             Command::RemoveVisualItem { item_id } => remove_visual_item(project, item_id),
+            Command::AddMarker {
+                frame,
+                name,
+                color,
+                id,
+            } => add_marker(project, ids, frame, name, color, id),
+            Command::SetMarker {
+                marker_id,
+                frame,
+                name,
+                color,
+            } => set_marker(project, marker_id, frame, name, color),
+            Command::RemoveMarker { marker_id } => remove_marker(project, marker_id),
             Command::SetSettings { settings } => Ok(set_settings(project, settings)),
             Command::RestoreClips { entries } => Ok(restore_clips(project, entries)),
             Command::DropClips { clip_ids } => Ok(drop_clips(project, clip_ids)),
@@ -438,6 +528,8 @@ impl Command {
             Command::DropTracks { track_ids } => Ok(drop_tracks(project, track_ids)),
             Command::RestoreVisualItems { entries } => Ok(restore_visual_items(project, entries)),
             Command::DropVisualItems { item_ids } => Ok(drop_visual_items(project, item_ids)),
+            Command::RestoreMarkers { entries } => Ok(restore_markers(project, entries)),
+            Command::DropMarkers { marker_ids } => Ok(drop_markers(project, marker_ids)),
             Command::Transaction { commands } => transaction(project, ids, commands),
         }
     }
@@ -1407,6 +1499,14 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
 
     let mut restore = Vec::new();
     let mut restore_items = Vec::new();
+    let mut restore_markers = Vec::new();
+    for (index, marker) in project.markers.iter_mut().enumerate() {
+        restore_markers.push(MarkerAt {
+            index,
+            marker: marker.clone(),
+        });
+        marker.frame = rescale(marker.frame, from, to);
+    }
     for track in &mut project.tracks {
         for clip in &mut track.clips {
             restore.push(ClipAt {
@@ -1438,6 +1538,9 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
                 Command::RestoreVisualItems {
                     entries: restore_items,
                 },
+                Command::RestoreMarkers {
+                    entries: restore_markers,
+                },
             ],
         },
     }
@@ -1445,6 +1548,112 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
 
 fn rescale(value: i64, from: Rate, to: Rate) -> i64 {
     crate::RationalTime::new(value, from).rescaled(to).value()
+}
+
+fn add_marker(
+    project: &mut Project,
+    ids: &mut Ids,
+    frame: i64,
+    name: String,
+    color: String,
+    id: Option<String>,
+) -> Result<Applied, String> {
+    if frame < 0 {
+        return Err("a marker cannot be before the timeline starts".into());
+    }
+    let id = id.unwrap_or_else(|| ids.make('m'));
+    if project.marker(&id).is_some() {
+        return Err("that marker already exists".into());
+    }
+    let marker = Marker {
+        id: id.clone(),
+        frame,
+        name,
+        color: if color.trim().is_empty() {
+            "#e6a700".into()
+        } else {
+            color
+        },
+    };
+    let index = project.markers.partition_point(|item| item.frame <= frame);
+    project.markers.insert(index, marker.clone());
+    Ok(Applied {
+        resolved: Command::AddMarker {
+            frame,
+            name: marker.name,
+            color: marker.color,
+            id: Some(id.clone()),
+        },
+        inverse: Command::DropMarkers {
+            marker_ids: vec![id],
+        },
+    })
+}
+
+fn set_marker(
+    project: &mut Project,
+    marker_id: String,
+    frame: Option<i64>,
+    name: Option<String>,
+    color: Option<String>,
+) -> Result<Applied, String> {
+    let index = project
+        .markers
+        .iter()
+        .position(|marker| marker.id == marker_id)
+        .ok_or("that marker is not in this project")?;
+    let previous = MarkerAt {
+        index,
+        marker: project.markers[index].clone(),
+    };
+    let marker = &mut project.markers[index];
+    if let Some(frame) = frame {
+        if frame < 0 {
+            return Err("a marker cannot be before the timeline starts".into());
+        }
+        marker.frame = frame;
+    }
+    if let Some(name) = name {
+        marker.name = name;
+    }
+    if let Some(color) = color {
+        if color.trim().is_empty() {
+            return Err("a marker needs a color".into());
+        }
+        marker.color = color;
+    }
+    project.markers.sort_by(|left, right| {
+        left.frame
+            .cmp(&right.frame)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let marker = project.marker(&marker_id).expect("marker was just updated");
+    Ok(Applied {
+        resolved: Command::SetMarker {
+            marker_id,
+            frame: Some(marker.frame),
+            name: Some(marker.name.clone()),
+            color: Some(marker.color.clone()),
+        },
+        inverse: Command::RestoreMarkers {
+            entries: vec![previous],
+        },
+    })
+}
+
+fn remove_marker(project: &mut Project, marker_id: String) -> Result<Applied, String> {
+    let index = project
+        .markers
+        .iter()
+        .position(|marker| marker.id == marker_id)
+        .ok_or("that marker is not in this project")?;
+    let marker = project.markers.remove(index);
+    Ok(Applied {
+        resolved: Command::RemoveMarker { marker_id },
+        inverse: Command::RestoreMarkers {
+            entries: vec![MarkerAt { index, marker }],
+        },
+    })
 }
 
 fn restore_clips(project: &mut Project, entries: Vec<ClipAt>) -> Applied {
@@ -1613,5 +1822,62 @@ fn drop_visual_items(project: &mut Project, item_ids: Vec<String>) -> Applied {
     Applied {
         resolved: Command::DropVisualItems { item_ids },
         inverse: Command::RestoreVisualItems { entries: previous },
+    }
+}
+
+fn restore_markers(project: &mut Project, entries: Vec<MarkerAt>) -> Applied {
+    let mut previous = Vec::new();
+    let mut invented = Vec::new();
+    for entry in &entries {
+        if let Some(index) = project
+            .markers
+            .iter()
+            .position(|marker| marker.id == entry.marker.id)
+        {
+            previous.push(MarkerAt {
+                index,
+                marker: project.markers[index].clone(),
+            });
+            project.markers.remove(index);
+        } else {
+            invented.push(entry.marker.id.clone());
+        }
+        project
+            .markers
+            .insert(entry.index.min(project.markers.len()), entry.marker.clone());
+    }
+    Applied {
+        resolved: Command::RestoreMarkers { entries },
+        inverse: Command::Transaction {
+            commands: vec![
+                Command::DropMarkers {
+                    marker_ids: invented,
+                },
+                Command::RestoreMarkers { entries: previous },
+            ],
+        },
+    }
+}
+
+fn drop_markers(project: &mut Project, marker_ids: Vec<String>) -> Applied {
+    let previous = marker_ids
+        .iter()
+        .filter_map(|id| {
+            project
+                .markers
+                .iter()
+                .position(|marker| marker.id == *id)
+                .map(|index| MarkerAt {
+                    index,
+                    marker: project.markers[index].clone(),
+                })
+        })
+        .collect();
+    project
+        .markers
+        .retain(|marker| !marker_ids.contains(&marker.id));
+    Applied {
+        resolved: Command::DropMarkers { marker_ids },
+        inverse: Command::RestoreMarkers { entries: previous },
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -65,6 +65,9 @@ impl Document {
     pub fn opened(mut project: Project) -> Document {
         project.repair();
         let mut ids = Ids::default();
+        for marker in &project.markers {
+            ids.observe(&marker.id);
+        }
         for track in &project.tracks {
             ids.observe(&track.id);
             for clip in &track.clips {
@@ -1283,5 +1286,38 @@ mod tests {
 
         assert!(error.contains("already in this project"), "{error}");
         assert_eq!(document.project().tracks[0].visual_items.len(), 1);
+    }
+
+    #[test]
+    fn markers_are_saved_edited_and_undone() {
+        let mut document = document();
+        document
+            .apply(Command::AddMarker {
+                frame: 90,
+                name: "cut here".into(),
+                color: "#ff0000".into(),
+                id: None,
+            })
+            .unwrap();
+        let marker = document.project().markers[0].clone();
+        assert_eq!((marker.frame, marker.name.as_str()), (90, "cut here"));
+
+        document
+            .apply(Command::SetMarker {
+                marker_id: marker.id.clone(),
+                frame: Some(120),
+                name: Some("review".into()),
+                color: None,
+            })
+            .unwrap();
+        assert_eq!(document.project().markers[0].frame, 120);
+        assert_eq!(document.project().markers[0].name, "review");
+
+        document.undo().unwrap();
+        assert_eq!(document.project().markers[0], marker);
+        document.undo().unwrap();
+        assert!(document.project().markers.is_empty());
+        document.redo().unwrap();
+        assert_eq!(document.project().markers[0].frame, 90);
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -24,7 +24,7 @@ pub mod command;
 pub mod document;
 pub mod migrate;
 
-pub use command::{ClipAt, Command, Edge, VisualItemAt};
+pub use command::{ClipAt, Command, Edge, MarkerAt, VisualItemAt};
 pub use document::{Document, DocumentState};
 pub use makevideo_time::{Rate, RationalTime};
 
@@ -84,6 +84,8 @@ pub struct Project {
     pub settings: ProjectSettings,
     pub assets: Vec<Asset>,
     pub tracks: Vec<Track>,
+    #[serde(default)]
+    pub markers: Vec<Marker>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -370,6 +372,21 @@ pub struct Clip {
     pub opacity: f32,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Marker {
+    pub id: String,
+    pub frame: i64,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default = "default_marker_color")]
+    pub color: String,
+}
+
+fn default_marker_color() -> String {
+    "#e6a700".into()
+}
+
 impl Clip {
     pub fn duration_frames(&self) -> i64 {
         (self.out_point - self.in_point).max(0)
@@ -425,6 +442,7 @@ impl Project {
                     hidden: false,
                 },
             ],
+            markers: Vec::new(),
         }
     }
 
@@ -577,6 +595,10 @@ impl Project {
             .unwrap_or(0)
     }
 
+    pub fn marker(&self, marker_id: &str) -> Option<&Marker> {
+        self.markers.iter().find(|marker| marker.id == marker_id)
+    }
+
     pub fn duration(&self) -> RationalTime {
         RationalTime::new(self.duration_frames(), self.rate())
     }
@@ -597,6 +619,21 @@ impl Project {
     /// out at the edit costs a rejected drag; finding out at the render costs
     /// the render.
     pub fn validate(&self) -> Result<(), String> {
+        let mut marker_ids = HashSet::new();
+        for marker in &self.markers {
+            if marker.frame < 0 {
+                return Err(format!(
+                    "marker {} would start before the timeline does",
+                    marker.id
+                ));
+            }
+            if marker.color.trim().is_empty() {
+                return Err(format!("marker {} has no color", marker.id));
+            }
+            if !marker_ids.insert(marker.id.as_str()) {
+                return Err(format!("marker {} is duplicated", marker.id));
+            }
+        }
         let mut links: HashMap<&str, Vec<(&Track, &Clip)>> = HashMap::new();
         for track in &self.tracks {
             let mut previous_end = i64::MIN;
@@ -691,6 +728,21 @@ impl Project {
     /// all. So a clip that breaks a rule is pulled back to the nearest state
     /// that keeps it, and one that has nothing left is dropped.
     pub fn repair(&mut self) {
+        self.markers.retain(|marker| !marker.id.is_empty());
+        for marker in &mut self.markers {
+            marker.frame = marker.frame.max(0);
+            if marker.color.trim().is_empty() {
+                marker.color = default_marker_color();
+            }
+        }
+        self.markers.sort_by(|left, right| {
+            left.frame
+                .cmp(&right.frame)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        let mut marker_ids = HashSet::new();
+        self.markers
+            .retain(|marker| marker_ids.insert(marker.id.clone()));
         let limits: Vec<Option<i64>> = self
             .tracks
             .iter()

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
@@ -12,8 +12,8 @@
 //! for the next format after this one.
 
 use crate::{
-    Asset, Clip, Project, ProjectSettings, Rate, RationalTime, Track, TrackKind, VisualItem,
-    FORMAT_VERSION,
+    Asset, Clip, Marker, Project, ProjectSettings, Rate, RationalTime, Track, TrackKind,
+    VisualItem, FORMAT_VERSION,
 };
 use serde::Deserialize;
 
@@ -32,6 +32,8 @@ pub struct WireProject {
     assets: Vec<Asset>,
     #[serde(default)]
     tracks: Vec<WireTrack>,
+    #[serde(default)]
+    markers: Vec<Marker>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -117,6 +119,7 @@ impl From<WireProject> for Project {
                 rate,
             },
             assets: wire.assets,
+            markers: wire.markers,
             tracks: wire
                 .tracks
                 .into_iter()

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -525,6 +525,7 @@ mod tests {
                 muted: false,
                 hidden: false,
             }],
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
@@ -675,6 +675,7 @@ mod tests {
                 muted: false,
                 hidden: false,
             }],
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
@@ -255,6 +255,7 @@ mod tests {
                 muted: false,
                 hidden: false,
             }],
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
@@ -156,6 +156,7 @@ mod tests {
             },
             assets: vec![original.clone()],
             tracks: Vec::new(),
+            markers: Vec::new(),
         };
         let ready = HashMap::from([(original.id.clone(), "/project/proxies/as1.mp4".into())]);
         let playback = playback_project(&project, &ready);

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
@@ -736,6 +736,7 @@ mod tests {
                 TrackKind::Video,
                 vec![clip("c1", "a1", 60, 30, 120)],
             )],
+            markers: Vec::new(),
         }
     }
 
@@ -758,6 +759,7 @@ mod tests {
             settings: settings(1920, 1080),
             assets: vec![],
             tracks: vec![track("V1", TrackKind::Video, vec![])],
+            markers: Vec::new(),
         };
         assert!(build_args(&project, "/out.mp4", Preset::Fhd, None).is_err());
     }
@@ -868,6 +870,7 @@ mod tests {
                 track("V1", TrackKind::Video, vec![clip("c1", "a1", 0, 0, 120)]),
                 track("V2", TrackKind::Video, vec![clip("c2", "a2", 0, 0, 120)]),
             ],
+            markers: Vec::new(),
         };
         let filter = filter_of(&build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap());
         assert!(filter.contains("[base][v0]overlay"), "{filter}");
@@ -902,6 +905,7 @@ mod tests {
                 TrackKind::Audio,
                 vec![clip("c1", "a1", 15, 0, 90)],
             )],
+            markers: Vec::new(),
         };
         let args = build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap();
         let filter = filter_of(&args);
@@ -1182,6 +1186,7 @@ mod tests {
             settings: settings(1920, 1080),
             assets: vec![],
             tracks: vec![],
+            markers: Vec::new(),
         };
         assert!(encoder_args(&project, "/o.mp4", Preset::Fhd, None).is_err());
     }
@@ -1243,6 +1248,7 @@ mod tests {
                 track("V1", TrackKind::Video, vec![clip("c1", "a1", 0, 0, 60)]),
                 track("A1", TrackKind::Audio, vec![clip("c2", "a2", 30, 0, 60)]),
             ],
+            markers: Vec::new(),
         };
         let filter = filter_of(&mix_reference_args(&project, "/tmp/mix.f32").unwrap());
         assert!(filter.contains("[0:a]"), "{filter}");

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
@@ -326,6 +326,7 @@ mod tests {
             },
             assets,
             tracks,
+            markers: Vec::new(),
         }
     }
 

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -40,6 +40,7 @@ if (!window.__TAURI__) {
       version: 2,
       settings: { width: 1920, height: 1080, rate: { num: 30, den: 1 } },
       assets: [],
+      markers: [],
       tracks: [
         { id: 't1', kind: 'video', name: 'V1', clips: [], muted: false, hidden: false },
         { id: 't2', kind: 'audio', name: 'A1', clips: [], muted: false, hidden: false },

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -167,6 +167,7 @@
           <svg viewBox="0 0 20 20"><use href="#icon-ripple" /></svg>
         </button>
         <button id="btn-link" class="small" title="Link or unlink synchronized audio and video clips">Link Clips</button>
+        <button id="btn-add-marker" class="small" title="Add a marker at the playhead">+ Marker</button>
         <span class="sep-v"></span>
         <button id="btn-add-video" class="small">+ Video track</button>
         <button id="btn-add-audio" class="small">+ Audio track</button>
@@ -184,6 +185,10 @@
           </div>
         </div>
       </div>
+      <details id="marker-panel">
+        <summary>Markers</summary>
+        <div id="marker-list"></div>
+      </details>
     </section>
   </main>
 

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -82,6 +82,7 @@ const dom = {
   btnDelete: el('btn-delete'),
   btnRipple: el('btn-ripple'),
   btnLink: el('btn-link'),
+  btnAddMarker: el('btn-add-marker'),
   btnAddVideo: el('btn-add-video'),
   btnAddAudio: el('btn-add-audio'),
   zoom: el('zoom'),
@@ -90,6 +91,7 @@ const dom = {
   scroll: el('timeline-scroll'),
   content: el('timeline-content'),
   ruler: el('ruler'),
+  markerList: el('marker-list'),
   lanes: el('lanes'),
   timelineContextMenu: el('timeline-context-menu'),
   playhead: el('playhead'),
@@ -289,7 +291,8 @@ function displayTracks() {
 function contentFrames() {
   const visible = L.pxToFrames(Math.max(dom.scroll.clientWidth, 320), rate(), state.pxPerSecond);
   const tail = Math.round(TAIL_SECONDS * T.rateToNumber(rate()));
-  return Math.max(L.projectDurationFrames(state.project) + tail, visible);
+  const markerEnd = (state.project.markers || []).reduce((end, marker) => Math.max(end, marker.frame), 0);
+  return Math.max(L.projectDurationFrames(state.project) + tail, markerEnd + tail, visible);
 }
 
 function frameAtClientX(clientX) {
@@ -621,6 +624,43 @@ function renderRuler() {
     fragment.appendChild(tick);
   }
   dom.ruler.appendChild(fragment);
+  for (const marker of state.project.markers || []) {
+    const node = document.createElement('button');
+    node.type = 'button';
+    node.className = 'marker';
+    node.dataset.markerId = marker.id;
+    node.style.left = `${L.framesToPx(marker.frame, rate(), state.pxPerSecond)}px`;
+    node.style.color = marker.color;
+    node.title = marker.name || L.formatTimecode(marker.frame, rate());
+    dom.ruler.appendChild(node);
+  }
+}
+
+function renderMarkerList() {
+  dom.markerList.textContent = '';
+  for (const marker of state.project.markers || []) {
+    const row = document.createElement('div');
+    row.className = 'marker-row';
+    const seek = document.createElement('button');
+    seek.type = 'button';
+    seek.dataset.markerSeek = marker.id;
+    seek.textContent = L.formatTimecode(marker.frame, rate());
+    const color = document.createElement('input');
+    color.type = 'color';
+    color.value = marker.color;
+    color.dataset.markerColor = marker.id;
+    const name = document.createElement('input');
+    name.type = 'text';
+    name.value = marker.name;
+    name.placeholder = 'Marker name';
+    name.dataset.markerName = marker.id;
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.dataset.markerRemove = marker.id;
+    remove.textContent = 'Delete';
+    row.append(seek, color, name, remove);
+    dom.markerList.appendChild(row);
+  }
 }
 
 /** The two menu items that are only sometimes there to press, and what they
@@ -640,6 +680,7 @@ function renderTimeline() {
   renderHeads();
   renderRuler();
   renderLanes();
+  renderMarkerList();
   updatePlayhead(preview ? preview.position() : 0);
   dom.duration.textContent = L.formatTimecode(L.projectDurationFrames(state.project), rate());
   dom.btnMagnet.classList.toggle('on', Boolean(state.settings && state.settings.snap));
@@ -816,6 +857,10 @@ function splitAtPlayhead() {
     frame: Math.round(preview.position()),
     clipId: liveSelection(),
   });
+}
+
+function addMarker(frame = Math.round(preview.position())) {
+  return edit({ op: 'addMarker', frame, name: '', color: '#e6a700' });
 }
 
 /** Delete, or delete and close the gap behind it. Ripple is destructive in a
@@ -1809,6 +1854,7 @@ function wireTimeline() {
   dom.btnDelete.addEventListener('click', () => deleteSelected(false));
   dom.btnRipple.addEventListener('click', () => deleteSelected(true));
   dom.btnLink.addEventListener('click', toggleClipLink);
+  dom.btnAddMarker.addEventListener('click', () => addMarker());
   dom.btnAddVideo.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'video' }));
   dom.btnAddAudio.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'audio' }));
 
@@ -1830,12 +1876,40 @@ function wireTimeline() {
   });
 
   dom.ruler.addEventListener('pointerdown', beginScrub);
+  dom.ruler.addEventListener('click', (event) => {
+    const marker = event.target.closest('[data-marker-id]');
+    const found = marker && L.findMarker(state.project, marker.dataset.markerId);
+    if (found) preview.seek(found.frame);
+  });
   dom.ruler.addEventListener('contextmenu', (event) => {
     event.preventDefault();
     const frame = Math.round(frameAtClientX(event.clientX));
     openTimelineContextMenu(event, [
       { label: 'Move Playhead Here', run: () => preview.seek(frame) },
+      { label: 'Add Marker Here', run: () => addMarker(frame) },
     ]);
+  });
+  dom.markerList.addEventListener('click', (event) => {
+    const seek = event.target.closest('[data-marker-seek]');
+    if (seek) {
+      const marker = L.findMarker(state.project, seek.dataset.markerSeek);
+      if (marker) preview.seek(marker.frame);
+      return;
+    }
+    const remove = event.target.closest('[data-marker-remove]');
+    if (remove) edit({ op: 'removeMarker', markerId: remove.dataset.markerRemove });
+  });
+  dom.markerList.addEventListener('change', (event) => {
+    const color = event.target.closest('[data-marker-color]');
+    if (color) edit({ op: 'setMarker', markerId: color.dataset.markerColor, color: color.value });
+  });
+  dom.markerList.addEventListener('focusout', (event) => {
+    const name = event.target.closest('[data-marker-name]');
+    if (!name) return;
+    const marker = L.findMarker(state.project, name.dataset.markerName);
+    if (marker && marker.name !== name.value) {
+      edit({ op: 'setMarker', markerId: marker.id, name: name.value });
+    }
   });
   dom.lanes.addEventListener('pointerdown', (event) => {
     const clip = event.target.closest('.clip');

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1040,6 +1040,7 @@ function scrubTo(clientX) {
 }
 
 function beginScrub(event) {
+  if (event.target.closest('[data-marker-id]')) return;
   scrubbing = true;
   preview.setScrubbing(true);
   scrubTo(event.clientX);

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -684,6 +684,9 @@ button.icon.on {
   top: 0;
   width: 2px;
   height: 100%;
+  padding: 0;
+  border: 0;
+  background: currentColor;
   cursor: pointer;
   z-index: 10;
 }

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -540,7 +540,7 @@ audio.stage-media {
 
 #lower {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto;
   min-height: 0;
   background: var(--bg);
 }
@@ -677,6 +677,58 @@ button.icon.on {
   color: var(--dim);
   white-space: nowrap;
   pointer-events: none;
+}
+
+.marker {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  height: 100%;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.marker::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: -5px;
+  width: 10px;
+  height: 10px;
+  background: currentColor;
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+}
+
+#marker-panel {
+  max-height: 160px;
+  overflow: auto;
+  padding: 6px 10px;
+  border-top: 1px solid var(--border);
+  background: var(--panel);
+}
+
+#marker-panel summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+#marker-list {
+  display: grid;
+  gap: 5px;
+  padding-top: 6px;
+}
+
+.marker-row {
+  display: grid;
+  grid-template-columns: 86px 28px minmax(80px, 1fr) auto;
+  gap: 6px;
+  align-items: center;
+}
+
+.marker-row button {
+  padding: 2px 6px;
+  font-size: 11px;
 }
 
 #lanes {

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -69,6 +69,10 @@ function findAsset(project, assetId) {
   return project.assets.find((asset) => asset.id === assetId) || null;
 }
 
+function findMarker(project, markerId) {
+  return (project.markers || []).find((marker) => marker.id === markerId) || null;
+}
+
 function linkedClips(project, clipId) {
   const found = findClip(project, clipId);
   if (!found || !found.clip.linkGroup) return found ? [found] : [];
@@ -285,6 +289,7 @@ function blankProject() {
     settings: { width: 1920, height: 1080, rate: T.fps(30) },
     assets: [],
     tracks: [],
+    markers: [],
   };
 }
 
@@ -297,6 +302,7 @@ const exported = {
   findTrack,
   findClip,
   findAsset,
+  findMarker,
   linkedClips,
   relinkCandidate,
   canAccept,

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -203,6 +203,13 @@ test('finding by id reaches into every track', () => {
   assert.deepStrictEqual(L.tracksOf(project, 'video').map((each) => each.id), ['t1']);
 });
 
+test('finding a marker reads the project marker list', () => {
+  const project = projectOf([], []);
+  project.markers = [{ id: 'm1', frame: 90, name: 'cut', color: '#e6a700' }];
+  assert.strictEqual(L.findMarker(project, 'm1').frame, 90);
+  assert.strictEqual(L.findMarker(project, 'gone'), null);
+});
+
 test('linked clips and a relink candidate are found across track kinds', () => {
   const video = clip('c1', 'v', 0, 0, 300, 'g1');
   const audio = clip('c2', 'v', 0, 0, 300, 'g1');


### PR DESCRIPTION
# 구현

프로젝트 저장 마커와 되돌리기 명령, 타임라인 표시·목록 편집 추가

- 재생헤드와 눈금 메뉴에서 추가, 목록에서 이동·이름·색·삭제

# 어려웠던 점

기존 프로젝트와 테스트 fixture의 저장 모델 호환 유지

- 누락된 markers 기본값과 각 fixture의 빈 목록 추가

# 리스크

새 개발 창의 직접 UI 조작 미검증

- 같은 bundle id의 기존 실행 창이 우선 인식되어 [검증 제한 기록](https://github.com/choisungwook/portfolio/discussions/815) 남김

Issue #745