### PR TITLE
akbun-makevideo: Program Monitor 확대축소

### DIFF
--- a/product/akbun-makevideo/wiki/architecture/viewport.md
+++ b/product/akbun-makevideo/wiki/architecture/viewport.md
@@ -166,6 +166,21 @@ invisible. So the badge is hidden and the exact frame is not asked for.
 
 On the media element fallback both are still there, unchanged.
 
+## Zoom changes the native picture, not the page
+
+The monitor has two native views. The outer view stays exactly on the stage and
+clips its child. The child is the Metal surface, and zoom changes only its size
+and origin inside that clip.
+
+- Cmd-wheel keeps the project point below the cursor fixed
+- Drag moves the enlarged child but cannot reveal outside its edges
+- Fit restores the child to the outer view's bounds
+- The outer view passes pointer input through to the WebView, which owns the
+  gesture arithmetic
+
+Changing CSS scale would enlarge an already rendered frame. Resizing the
+Metal surface instead gives the compositor the new pixel budget.
+
 ## Falling back is a supported answer
 
 `fallback::choose` takes the setting and whether the native engine actually

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -11,7 +11,7 @@
 //! copy of the timeline along with the request.
 
 use crate::playback::{Config as PlaybackConfig, Session, Status as PlaybackStatus};
-use crate::viewport::Place;
+use crate::viewport::MonitorPlace;
 use makevideo_compositor::{Backend, Compositor};
 // Aliased because this file also spawns processes, and two things called
 // Command in one file is one too many.
@@ -1751,7 +1751,7 @@ impl PlaybackChoice {
 pub fn playback_attach(
     window: tauri::WebviewWindow,
     state: State<AppState>,
-    place: Place,
+    place: MonitorPlace,
     frame: i64,
 ) -> PlaybackChoice {
     let settings = state.settings.lock().unwrap().clone();
@@ -1788,7 +1788,7 @@ fn start_session(
     window: &tauri::WebviewWindow,
     state: &State<AppState>,
     settings: &Settings,
-    place: Place,
+    place: MonitorPlace,
     frame: i64,
 ) -> Result<Session, String> {
     if !place.is_visible() {
@@ -1860,7 +1860,7 @@ pub fn playback_redraw(state: State<AppState>) -> Option<PlaybackStatus> {
 }
 
 #[tauri::command]
-pub fn playback_place(state: State<AppState>, place: Place) -> Option<PlaybackStatus> {
+pub fn playback_place(state: State<AppState>, place: MonitorPlace) -> Option<PlaybackStatus> {
     with_session(&state, |session| session.place(place))
 }
 

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -20,7 +20,7 @@
 //! compositor. That is what let the live/exact split go: there is nothing left
 //! for a badge to tell apart.
 
-use crate::viewport::{Place, Viewport};
+use crate::viewport::{MonitorPlace, Viewport};
 use makevideo_audio::device::DeviceSink;
 use makevideo_audio::engine::Options as AudioOptions;
 use makevideo_audio::source::{
@@ -53,7 +53,7 @@ enum Command {
     /// The panel moved or the window resized. Carried to the loop rather than
     /// done where it was noticed, because only the thread drawing on a surface
     /// may reconfigure it.
-    Place(Place),
+    Place(MonitorPlace),
     /// The timeline changed under a paused playhead: redraw the still.
     Redraw,
     Stop,
@@ -167,7 +167,7 @@ impl Session {
         window: &tauri::WebviewWindow,
         document: Arc<Mutex<makevideo_edit::Document>>,
         config: Config,
-        place: Place,
+        place: MonitorPlace,
         frame: i64,
     ) -> Result<Session, String> {
         if config.compositor.gpu().is_none() {
@@ -239,7 +239,7 @@ impl Session {
     /// the main thread; the swapchain is resized by the loop at the top of its
     /// next frame, because only the thread drawing on a surface may reconfigure
     /// it. Doing the second one here would be a data race wgpu cannot see.
-    pub fn place(&self, place: Place) {
+    pub fn place(&self, place: MonitorPlace) {
         self.viewport.lock().unwrap().place(place);
         let _ = self.control.send(Command::Place(place));
     }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -22,9 +22,9 @@
 //! the flip happens here, once, at the boundary — the same place the
 //! physical-pixel conversion happens.
 
-use super::Place;
+use super::{MonitorPlace, Place};
 use objc2::rc::Retained;
-use objc2::{MainThreadMarker, MainThreadOnly};
+use objc2::{define_class, msg_send, MainThreadMarker, MainThreadOnly};
 use objc2_app_kit::{NSView, NSWindow, NSWindowOrderingMode};
 use objc2_foundation::{NSPoint, NSRect, NSSize};
 use raw_window_handle::{
@@ -35,9 +35,34 @@ use std::ptr::NonNull;
 use std::sync::mpsc::channel;
 
 pub struct Inner {
+    /// Clips the enlarged Metal view to the monitor rectangle and lets pointer
+    /// events continue through to the WebView, which owns zoom gestures.
+    container: Handle,
     /// A retained `NSView`. Released in `detach`, on the main thread.
     view: Handle,
     window: tauri::WebviewWindow,
+}
+
+struct PassThroughIvars;
+
+define_class!(
+    #[unsafe(super(NSView))]
+    #[ivars = PassThroughIvars]
+    struct PassThroughView;
+
+    impl PassThroughView {
+        #[unsafe(method(hitTest:))]
+        fn hit_test(&self, _point: NSPoint) -> Option<&NSView> {
+            None
+        }
+    }
+);
+
+impl PassThroughView {
+    fn new(main: MainThreadMarker, frame: NSRect) -> Retained<Self> {
+        let view = Self::alloc(main).set_ivars(PassThroughIvars);
+        unsafe { msg_send![super(view), initWithFrame: frame] }
+    }
 }
 
 /// A retained view pointer that can be carried between threads.
@@ -120,11 +145,14 @@ where
         .map_err(|error| format!("the main thread never answered: {error}"))?
 }
 
-pub fn attach(window: &tauri::WebviewWindow, place: Place) -> Result<Inner, String> {
+pub fn attach(window: &tauri::WebviewWindow, place: MonitorPlace) -> Result<Inner, String> {
     let handle = window.clone();
-    let view = on_main(window, move |main| {
+    let handles = on_main(window, move |main| {
         let content = content_view(&handle)?;
-        let view = NSView::initWithFrame(NSView::alloc(main), rect(&content, place));
+        let container = PassThroughView::new(main, rect(&content, place.stage));
+        container.setWantsLayer(true);
+        container.setClipsToBounds(true);
+        let view = NSView::initWithFrame(NSView::alloc(main), child_rect(&container, place));
         // Metal draws into this view's layer, so it has to have one. wgpu
         // replaces it with a CAMetalLayer when it makes the surface; without
         // this the view is not layer backed and there is nothing to replace.
@@ -132,52 +160,61 @@ pub fn attach(window: &tauri::WebviewWindow, place: Place) -> Result<Inner, Stri
         // Over the webview. A `None` sibling with `Above` means "over all of
         // them", which is the front. The page hides it before drawing anything
         // on top; see the note in mod.rs for why it is not the other way round.
-        content.addSubview_positioned_relativeTo(&view, NSWindowOrderingMode::Above, None);
+        container.addSubview(&view);
+        content.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Above, None);
         // Retained past the end of this block on purpose: the `Viewport` owns
         // it now and `detach` is what releases it.
         let pointer =
             NonNull::new(Retained::into_raw(view)).ok_or("the monitor view has no address")?;
-        Ok(Handle(pointer))
+        let container = NonNull::new(Retained::into_raw(container))
+            .ok_or("the monitor container has no address")?;
+        Ok((Handle(container.cast()), Handle(pointer)))
     })?;
     Ok(Inner {
-        view,
+        container: handles.0,
+        view: handles.1,
         window: window.clone(),
     })
 }
 
-pub fn place(inner: &Inner, at: Place) {
+pub fn place(inner: &Inner, at: MonitorPlace) {
     let handle = inner.window.clone();
     let view = inner.view;
+    let container = inner.container;
     // Placement is best effort: a window that has gone during a resize is a
     // window nobody is looking at.
     let _ = on_main(&inner.window, move |_| {
         let content = content_view(&handle)?;
-        // SAFETY: messaged on the main thread, and the view is alive until
-        // `detach` releases it.
+        // SAFETY: both views are alive until `detach` releases the container.
+        let container = unsafe { container.ptr().as_ref() };
+        container.setFrame(rect(&content, at.stage));
         let view = unsafe { view.ptr().as_ref() };
-        view.setFrame(rect(&content, at));
+        view.setFrame(child_rect(container, at));
         Ok(())
     });
 }
 
 pub fn set_visible(inner: &Inner, visible: bool) {
-    let view = inner.view;
+    let container = inner.container;
     let _ = on_main(&inner.window, move |_| {
         // SAFETY: messaged on the main thread, and the view is alive until
         // `detach` releases it.
-        unsafe { view.ptr().as_ref().setHidden(!visible) };
+        unsafe { container.ptr().as_ref().setHidden(!visible) };
         Ok(())
     });
 }
 
 pub fn detach(inner: &Inner) {
     let view = inner.view;
+    let container = inner.container;
     let _ = on_main(&inner.window, move |_| {
         // SAFETY: the pointer came from `Retained::into_raw` in `attach` and is
         // released exactly once, here.
-        let view: Retained<NSView> = unsafe { Retained::from_raw(view.ptr().as_ptr()) }
+        let _view: Retained<NSView> = unsafe { Retained::from_raw(view.ptr().as_ptr()) }
             .ok_or("the monitor view was already gone")?;
-        view.removeFromSuperview();
+        let container: Retained<NSView> = unsafe { Retained::from_raw(container.ptr().as_ptr()) }
+            .ok_or("the monitor container was already gone")?;
+        container.removeFromSuperview();
         Ok(())
     });
 }
@@ -223,6 +260,19 @@ fn rect(content: &NSView, at: Place) -> NSRect {
     );
     NSRect::new(
         NSPoint::new(x, bounds.size.height - y - height),
+        NSSize::new(width, height),
+    )
+}
+
+fn child_rect(container: &NSView, at: MonitorPlace) -> NSRect {
+    let scale = backing_scale(container);
+    let bounds = container.bounds();
+    let x = (at.content.x - at.stage.x) / scale;
+    let top = (at.content.y - at.stage.y) / scale;
+    let width = at.content.width.max(1.0) / scale;
+    let height = at.content.height.max(1.0) / scale;
+    NSRect::new(
+        NSPoint::new(x, bounds.size.height - top - height),
         NSSize::new(width, height),
     )
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/mod.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/mod.rs
@@ -60,6 +60,28 @@ pub struct Place {
     pub height: f64,
 }
 
+/// The clipped monitor box and the larger picture inside it.
+///
+/// Both rectangles use physical window pixels. The page keeps the transform in
+/// CSS pixels so cursor math stays in one coordinate system, then converts the
+/// two rectangles together at the IPC boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MonitorPlace {
+    pub stage: Place,
+    pub content: Place,
+}
+
+impl MonitorPlace {
+    pub fn surface_size(&self) -> (u32, u32) {
+        self.content.surface_size()
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.stage.is_visible() && self.content.is_visible()
+    }
+}
+
 impl Place {
     /// The size to configure a swapchain at, never zero. A surface configured
     /// at zero is a validation error on every backend, and a stage box can
@@ -80,13 +102,13 @@ impl Place {
 /// A native view, owned for as long as playback is.
 pub struct Viewport {
     inner: platform::Inner,
-    place: Place,
+    place: MonitorPlace,
     visible: bool,
 }
 
 impl Viewport {
     /// Attach a view to `window` and put it at `place`.
-    pub fn attach(window: &tauri::WebviewWindow, place: Place) -> Result<Viewport, String> {
+    pub fn attach(window: &tauri::WebviewWindow, place: MonitorPlace) -> Result<Viewport, String> {
         let inner = platform::attach(window, place)?;
         Ok(Viewport {
             inner,
@@ -96,7 +118,7 @@ impl Viewport {
     }
 
     /// Move or resize it. Cheap, and safe to call with what it already is.
-    pub fn place(&mut self, place: Place) {
+    pub fn place(&mut self, place: MonitorPlace) {
         if place == self.place {
             return;
         }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/unsupported.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/unsupported.rs
@@ -11,15 +11,15 @@
 //! independent, and wgpu and ffmpeg both run there, so what is missing is a
 //! child HWND, its placement, and its resize.
 
-use super::Place;
+use super::MonitorPlace;
 
 pub struct Inner;
 
-pub fn attach(_window: &tauri::WebviewWindow, _place: Place) -> Result<Inner, String> {
+pub fn attach(_window: &tauri::WebviewWindow, _place: MonitorPlace) -> Result<Inner, String> {
     Err("the native monitor is macOS only so far; playback uses media elements here".into())
 }
 
-pub fn place(_inner: &Inner, _at: Place) {}
+pub fn place(_inner: &Inner, _at: MonitorPlace) {}
 
 pub fn set_visible(_inner: &Inner, _visible: bool) {}
 

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -84,6 +84,10 @@
           <li><button data-action="timeline-start">Timeline Start<kbd data-shortcut="timeline-start"></kbd></button></li>
           <li><button data-action="timeline-end">Timeline End<kbd data-shortcut="timeline-end"></kbd></button></li>
           <li class="sep"></li>
+          <li><button id="menu-monitor-zoom-in" data-action="monitor-zoom-in">Zoom In</button></li>
+          <li><button id="menu-monitor-zoom-out" data-action="monitor-zoom-out">Zoom Out</button></li>
+          <li><button id="menu-monitor-fit" data-action="monitor-fit">Fit Monitor</button></li>
+          <li class="sep"></li>
           <li><button data-action="proxy-media">Proxy Media…</button></li>
         </ul>
       </div>

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -502,7 +502,12 @@ function createMonitor(options) {
 
     panBy(dx, dy) {
       if (!drivingNatively() || !stage || viewport.zoom <= FIT_ZOOM) return false;
-      viewport = clampViewport({ ...viewport, x: viewport.x + dx, y: viewport.y + dy }, stage.getBoundingClientRect());
+      const next = clampViewport(
+        { ...viewport, x: viewport.x + dx, y: viewport.y + dy },
+        stage.getBoundingClientRect()
+      );
+      if (next.x === viewport.x && next.y === viewport.y) return false;
+      viewport = next;
       place();
       return true;
     },

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -46,10 +46,56 @@ function placeOf(box, ratio) {
   };
 }
 
+const FIT_ZOOM = 1;
+const MAX_ZOOM = 4;
+const ZOOM_STEP = 1.25;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(value, max));
+}
+
+function fittedViewport() {
+  return { zoom: FIT_ZOOM, x: 0, y: 0 };
+}
+
+function clampViewport(viewport, box) {
+  const zoom = clamp(viewport.zoom, FIT_ZOOM, MAX_ZOOM);
+  return {
+    zoom,
+    x: clamp(viewport.x, box.width - box.width * zoom, 0),
+    y: clamp(viewport.y, box.height - box.height * zoom, 0),
+  };
+}
+
+function zoomViewport(viewport, box, cursor, zoom) {
+  const nextZoom = clamp(zoom, FIT_ZOOM, MAX_ZOOM);
+  const sourceX = (cursor.x - viewport.x) / viewport.zoom;
+  const sourceY = (cursor.y - viewport.y) / viewport.zoom;
+  return clampViewport({
+    zoom: nextZoom,
+    x: cursor.x - sourceX * nextZoom,
+    y: cursor.y - sourceY * nextZoom,
+  }, box);
+}
+
+function monitorPlaceOf(box, viewport, ratio) {
+  const stage = placeOf(box, ratio);
+  const content = placeOf({
+    left: box.left + viewport.x,
+    top: box.top + viewport.y,
+    width: box.width * viewport.zoom,
+    height: box.height * viewport.zoom,
+  }, ratio);
+  return { stage, content };
+}
+
 /** Whether two placements are the same box, so a resize observer firing on
  *  every frame of a drag does not send a command for every one of them. */
 function samePlace(a, b) {
   if (!a || !b) return false;
+  if (a.stage || b.stage) {
+    return samePlace(a.stage, b.stage) && samePlace(a.content, b.content);
+  }
   return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
 }
 
@@ -102,6 +148,7 @@ function createMonitor(options) {
   let attaching = null;
   let mediaRefreshPending = false;
   let refreshingMedia = null;
+  let viewport = fittedViewport();
 
   function timelineMode() {
     return preview.mode() === 'timeline';
@@ -144,7 +191,9 @@ function createMonitor(options) {
 
   function currentPlace() {
     if (!stage) return null;
-    return placeOf(stage.getBoundingClientRect(), window.devicePixelRatio);
+    const box = stage.getBoundingClientRect();
+    viewport = clampViewport(viewport, box);
+    return monitorPlaceOf(box, viewport, window.devicePixelRatio);
   }
 
   /** Ask Rust for a monitor, and take whatever it gives back.
@@ -155,7 +204,7 @@ function createMonitor(options) {
   async function attach() {
     if (!api || !api.available) return false;
     const place = currentPlace();
-    if (!place || place.width < 1 || place.height < 1) return native;
+    if (!place || place.stage.width < 1 || place.stage.height < 1) return native;
     // One at a time. The layout settles over several frames when a project
     // opens, and a second attach mid-flight would start a session the first one
     // is about to replace.
@@ -426,12 +475,47 @@ function createMonitor(options) {
     isExact() {
       return drivingNatively() ? false : preview.isExact();
     },
+
+    zoomIn(cursor) {
+      return this.zoomTo(viewport.zoom * ZOOM_STEP, cursor);
+    },
+
+    zoomOut(cursor) {
+      return this.zoomTo(viewport.zoom / ZOOM_STEP, cursor);
+    },
+
+    zoomTo(zoom, cursor) {
+      if (!drivingNatively() || !stage) return false;
+      const box = stage.getBoundingClientRect();
+      const at = cursor || { x: box.width / 2, y: box.height / 2 };
+      viewport = zoomViewport(viewport, box, at, zoom);
+      place();
+      return true;
+    },
+
+    fit() {
+      if (!drivingNatively()) return false;
+      viewport = fittedViewport();
+      place();
+      return true;
+    },
+
+    panBy(dx, dy) {
+      if (!drivingNatively() || !stage || viewport.zoom <= FIT_ZOOM) return false;
+      viewport = clampViewport({ ...viewport, x: viewport.x + dx, y: viewport.y + dy }, stage.getBoundingClientRect());
+      place();
+      return true;
+    },
+
+    zoomState() {
+      return { ...viewport, available: drivingNatively() };
+    },
   };
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { createMonitor, placeOf, samePlace, readChoice, shouldShowMonitor };
+  module.exports = { createMonitor, placeOf, monitorPlaceOf, samePlace, readChoice, shouldShowMonitor, fittedViewport, clampViewport, zoomViewport };
 } else {
-  globalThis.monitorLib = { createMonitor, placeOf, samePlace, readChoice, shouldShowMonitor };
+  globalThis.monitorLib = { createMonitor, placeOf, monitorPlaceOf, samePlace, readChoice, shouldShowMonitor, fittedViewport, clampViewport, zoomViewport };
 }
 })();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1999,7 +1999,8 @@ function wireTransport() {
     }
   }, { passive: false });
   dom.stage.addEventListener('pointerdown', (event) => {
-    if (event.button !== 0 || !preview.zoomState().available) return;
+    const zoom = preview.zoomState();
+    if (event.button !== 0 || !zoom.available || zoom.zoom <= 1) return;
     monitorPan = { x: event.clientX, y: event.clientY };
     dom.stage.setPointerCapture(event.pointerId);
     event.preventDefault();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -676,6 +676,13 @@ function updateHistoryUi() {
   redo.firstChild.textContent = doc.canRedo ? `Redo ${doc.redoLabel}` : 'Redo';
 }
 
+function updateMonitorZoomUi() {
+  const zoom = preview && preview.zoomState ? preview.zoomState() : { zoom: 1, available: false };
+  el('menu-monitor-zoom-in').disabled = !zoom.available || zoom.zoom >= 4;
+  el('menu-monitor-zoom-out').disabled = !zoom.available || zoom.zoom <= 1;
+  el('menu-monitor-fit').disabled = !zoom.available || zoom.zoom === 1;
+}
+
 function renderTimeline() {
   renderHeads();
   renderRuler();
@@ -688,6 +695,7 @@ function renderTimeline() {
   dom.btnAddAudio.disabled = L.tracksOf(state.project, 'audio').length >= L.MAX_TRACKS_PER_KIND;
   updateLinkUi();
   updateHistoryUi();
+  updateMonitorZoomUi();
   scheduleExactFrame();
   if (preview) preview.redraw();
 }
@@ -1661,6 +1669,7 @@ async function attachMonitor(restart) {
   }
   await preview.attach();
   updateToolWarning();
+  updateMonitorZoomUi();
   el('as-playback-note').textContent = playbackNote();
 }
 
@@ -1705,6 +1714,9 @@ const actions = {
   'next-edit': seekNextEdit,
   'timeline-start': seekTimelineStart,
   'timeline-end': seekTimelineEnd,
+  'monitor-zoom-in': () => { preview.zoomIn(); updateMonitorZoomUi(); },
+  'monitor-zoom-out': () => { preview.zoomOut(); updateMonitorZoomUi(); },
+  'monitor-fit': () => { preview.fit(); updateMonitorZoomUi(); },
   'render-fhd': () => startRender('fhd'),
   'render-4k': () => startRender('4k'),
   'cancel-render': () => window.api.cancelRender(),
@@ -1960,6 +1972,7 @@ function wireTimeline() {
 }
 
 function wireTransport() {
+  let monitorPan = null;
   dom.btnPlay.addEventListener('click', () => preview.toggle());
   dom.previewQuality.addEventListener('change', () => {
     const previous = state.settings.previewQuality;
@@ -1974,6 +1987,35 @@ function wireTransport() {
   dom.previewSource.addEventListener('click', (event) => {
     const button = event.target.closest('[data-source]');
     if (button) setPreviewSource(button.dataset.source);
+  });
+  dom.stage.addEventListener('wheel', (event) => {
+    if (!event.metaKey) return;
+    const box = dom.stage.getBoundingClientRect();
+    const cursor = { x: event.clientX - box.left, y: event.clientY - box.top };
+    const changed = event.deltaY < 0 ? preview.zoomIn(cursor) : preview.zoomOut(cursor);
+    if (changed) {
+      event.preventDefault();
+      updateMonitorZoomUi();
+    }
+  }, { passive: false });
+  dom.stage.addEventListener('pointerdown', (event) => {
+    if (event.button !== 0 || !preview.zoomState().available) return;
+    monitorPan = { x: event.clientX, y: event.clientY };
+    dom.stage.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  });
+  dom.stage.addEventListener('pointermove', (event) => {
+    if (!monitorPan) return;
+    preview.panBy(event.clientX - monitorPan.x, event.clientY - monitorPan.y);
+    monitorPan = { x: event.clientX, y: event.clientY };
+  });
+  dom.stage.addEventListener('pointerup', (event) => {
+    if (!monitorPan) return;
+    monitorPan = null;
+    dom.stage.releasePointerCapture(event.pointerId);
+  });
+  dom.stage.addEventListener('pointercancel', () => {
+    monitorPan = null;
   });
 }
 

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -447,6 +447,10 @@ select {
   background: #000;
 }
 
+#stage:active {
+  cursor: grabbing;
+}
+
 #stage-inner {
   position: absolute;
   top: 0;

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -3,7 +3,10 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const { createMonitor, placeOf, samePlace, readChoice } = require('../src/monitor.js');
+const {
+  createMonitor, placeOf, monitorPlaceOf, samePlace, readChoice,
+  fittedViewport, clampViewport, zoomViewport,
+} = require('../src/monitor.js');
 
 // The page's half of the native viewport. Everything here is arithmetic over
 // plain objects on purpose: the rest of monitor.js needs a window, an IPC
@@ -43,6 +46,28 @@ test('a collapsed box never becomes a negative size', () => {
   const place = placeOf({ left: 0, top: 0, width: -10, height: -10 }, 2);
   assert.strictEqual(place.width, 0);
   assert.strictEqual(place.height, 0);
+});
+
+test('the native monitor keeps a clipped stage and a scaled picture separate', () => {
+  const box = { left: 100, top: 50, width: 640, height: 360 };
+  const place = monitorPlaceOf(box, { zoom: 2, x: -100, y: -40 }, 2);
+  assert.deepStrictEqual(place.stage, { x: 200, y: 100, width: 1280, height: 720 });
+  assert.deepStrictEqual(place.content, { x: 0, y: 20, width: 2560, height: 1440 });
+});
+
+test('zooming at the cursor keeps the source point under it', () => {
+  const box = { width: 640, height: 360 };
+  const cursor = { x: 480, y: 270 };
+  const viewport = zoomViewport(fittedViewport(), box, cursor, 2);
+  assert.deepStrictEqual(viewport, { zoom: 2, x: -480, y: -270 });
+});
+
+test('panning cannot expose space past an enlarged monitor edge', () => {
+  const box = { width: 640, height: 360 };
+  assert.deepStrictEqual(
+    clampViewport({ zoom: 2, x: 20, y: -999 }, box),
+    { zoom: 2, x: 0, y: -360 }
+  );
 });
 
 test('the same box twice is recognised, so a drag is not a command per frame', () => {

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -70,6 +70,40 @@ test('panning cannot expose space past an enlarged monitor edge', () => {
   );
 });
 
+test('panning against an edge does not place the unchanged viewport', async (t) => {
+  const previousWindow = global.window;
+  t.after(() => {
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+  });
+  global.window = { devicePixelRatio: 1 };
+  const places = [];
+  const preview = {
+    mode: () => 'timeline',
+    total: () => 1,
+    pause: () => {},
+    clear: () => {},
+    clearExact: () => {},
+  };
+  const api = {
+    available: true,
+    playbackAttach: async () => ({ engine: 'native' }),
+    playbackVisible: async () => {},
+    playbackPlace: async (place) => places.push(place),
+  };
+  const stage = {
+    getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }),
+  };
+  const monitor = createMonitor({ preview, stage, api });
+
+  await monitor.attach();
+  monitor.zoomTo(2);
+  assert.strictEqual(monitor.panBy(10_000, 10_000), true);
+  const placeCount = places.length;
+  assert.strictEqual(monitor.panBy(1, 1), false);
+  assert.strictEqual(places.length, placeCount);
+});
+
 test('the same box twice is recognised, so a drag is not a command per frame', () => {
   const box = { x: 1, y: 2, width: 3, height: 4 };
   assert.ok(samePlace(box, { ...box }));


### PR DESCRIPTION
# 구현

네이티브 Program Monitor 확대·축소·이동과 화면 맞춤 메뉴 추가
- Cmd-휠 커서 기준 확대, 드래그 이동, JS 좌표 테스트 82개 통과

# 어려웠던 점

WebView 위의 네이티브 Metal 뷰가 입력과 화면 밖 영역을 가리는 문제
- 클리핑 컨테이너와 입력 통과 처리로 확대된 렌더링만 stage 안에 표시

# 리스크

실제 앱 창에서 확대 제스처 조작 미검증
- 동일 앱 식별자의 기존 창만 Computer Use에 노출되어 General Discussion #817에 사유와 대체 검증 기록

Issue #769