### PR TITLE
akbun-makevideo: Program Monitor 선택과 변형 핸들

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-program-monitor-transform.md
+++ b/product/akbun-makevideo/adr/2026-08-program-monitor-transform.md
@@ -1,0 +1,15 @@
+# Program Monitor transform pass
+
+## Decision
+
+- Convert pointer positions from the fitted stage to project pixels before selection or editing
+- Hit test a rotated item by rotating the pointer back into the item rectangle
+- Draw handles in an editor-only canvas pass and commit a drag as one transform command
+- Hide the native surface while that pass is visible and show an exact compositor frame behind it
+
+## Reason
+
+- Project-space transforms keep the saved edit independent of the window and monitor scale
+- One shared rectangle test works for every future Visual Item content type
+- Canvas handles do not enter the project model or export pipeline
+- A native view sits above the webview, so the page must own the editing picture while handles are visible

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -23,5 +23,6 @@
 | [2026-08-asset-waveform-cache.md](./2026-08-asset-waveform-cache.md) | Audio waveforms are cached per asset and clips draw only their source interval |
 | [2026-08-native-project-trash.md](./2026-08-native-project-trash.md) | Windows and macOS move validated project targets with native trash APIs |
 | [2026-08-common-visual-item-model.md](./2026-08-common-visual-item-model.md) | Text, shape, image and video overlays share one timed transform model |
+| [2026-08-program-monitor-transform.md](./2026-08-program-monitor-transform.md) | Transform Visual Items in project space through an editor-only monitor pass |
 | [2026-08-edit-point-navigation.md](./2026-08-edit-point-navigation.md) | Visible clip boundaries drive previous and next edit navigation |
 | [2026-08-persistent-playback-pipeline.md](./2026-08-persistent-playback-pipeline.md) | Play and pause keep one decoder and audio pipeline alive |

--- a/product/akbun-makevideo/wiki/architecture/viewport.md
+++ b/product/akbun-makevideo/wiki/architecture/viewport.md
@@ -166,6 +166,16 @@ invisible. So the badge is hidden and the exact frame is not asked for.
 
 On the media element fallback both are still there, unchanged.
 
+## Transform handles are a separate pass
+
+Selection and transform handles belong to the page, not to the project picture.
+
+- Pointer positions convert from the fitted stage to project pixels before the hit test
+- A rotated item rotates the pointer back before its rectangle is tested
+- A drag changes only the page's temporary transform until pointer-up sends one edit command
+- The native view hides while the page draws handles and an exact compositor frame behind them
+- Export never reads the handle canvas
+
 ## Zoom changes the native picture, not the page
 
 The monitor has two native views. The outer view stays exactly on the stage and

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -134,7 +134,10 @@
           </div>
         </header>
         <div id="stage-wrap">
-          <div id="stage"><div id="stage-inner"><canvas id="stage-exact"></canvas></div></div>
+          <div id="stage">
+            <div id="stage-inner"><canvas id="stage-exact"></canvas></div>
+            <canvas id="stage-overlay" aria-label="Program Monitor selection overlay"></canvas>
+          </div>
           <span id="stage-mode" hidden></span>
           <p id="stage-hint">Drop media on the timeline below to see it here.</p>
         </div>
@@ -401,6 +404,7 @@
   <script src="shortcuts.js"></script>
   <script src="quality.js"></script>
   <script src="preview.js"></script>
+  <script src="transform.js"></script>
   <script src="monitor.js"></script>
   <script src="renderer.js"></script>
 </body>

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -140,6 +140,7 @@ function createMonitor(options) {
 
   let native = false;
   let covered = false;
+  let editing = false;
   let lastVisible = null;
   let lastPlace = null;
   let polling = false;
@@ -182,7 +183,7 @@ function createMonitor(options) {
       native,
       timeline: timelineMode(),
       hasContent: total() > 0,
-      covered,
+      covered: covered || editing,
     });
     if (wanted === lastVisible) return;
     lastVisible = wanted;
@@ -365,6 +366,14 @@ function createMonitor(options) {
       syncVisibility();
     },
 
+    /** The page owns the selection pass. It hides the native surface while an
+     *  item is being edited, then shows it again once the editor-only overlay
+     *  is gone. The pass never reaches the project or the renderer. */
+    setEditing(active) {
+      editing = Boolean(active);
+      syncVisibility();
+    },
+
     layout() {
       preview.layout();
       place();
@@ -467,13 +476,13 @@ function createMonitor(options) {
     // surface, as the frames during playback — there is nothing left for a
     // second path to show or for a badge to tell apart.
     showExact(drawn) {
-      return drivingNatively() ? false : preview.showExact(drawn);
+      return drivingNatively() && !editing ? false : preview.showExact(drawn);
     },
     clearExact() {
-      if (!drivingNatively()) preview.clearExact();
+      if (!drivingNatively() || editing) preview.clearExact();
     },
     isExact() {
-      return drivingNatively() ? false : preview.isExact();
+      return drivingNatively() && !editing ? false : preview.isExact();
     },
 
     zoomIn(cursor) {

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -479,7 +479,7 @@ function createMonitor(options) {
       return drivingNatively() && !editing ? false : preview.showExact(drawn);
     },
     clearExact() {
-      if (!drivingNatively() || editing) preview.clearExact();
+      preview.clearExact();
     },
     isExact() {
       return drivingNatively() && !editing ? false : preview.isExact();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -799,7 +799,7 @@ async function requestExactFrame() {
 function scheduleExactFrame() {
   if (!window.api.available) return;
   window.clearTimeout(exactTimer);
-  if (preview.usesNativeMonitor()) return;
+  if (preview.usesNativeMonitor() && !state.selectedVisualItemId) return;
   if (preview.isPlaying() || preview.mode() !== 'timeline') return;
   exactTimer = window.setTimeout(requestExactFrame, 180);
 }
@@ -845,11 +845,12 @@ function selectVisualItem(itemId) {
   state.selectedVisualItemId = itemId || null;
   const editing = Boolean(state.selectedVisualItemId);
   dom.stage.classList.toggle('editing', editing);
-  preview.setEditing(editing);
   if (!editing) {
     preview.clearExact();
+    preview.setEditing(false);
     preview.redraw();
   } else {
+    preview.setEditing(true);
     scheduleExactFrame();
   }
   renderStageOverlay();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -19,6 +19,7 @@
 const L = globalThis.timelineLib;
 const T = globalThis.timeLib;
 const K = globalThis.shortcutLib;
+const X = globalThis.transformLib;
 
 // Pointer distance from a clip edge that starts a trim instead of a move.
 const HANDLE_PX = 8;
@@ -71,6 +72,7 @@ const dom = {
   stage: el('stage'),
   stageInner: el('stage-inner'),
   stageExact: el('stage-exact'),
+  stageOverlay: el('stage-overlay'),
   stageMode: el('stage-mode'),
   stageHint: el('stage-hint'),
   btnPlay: el('btn-play'),
@@ -131,6 +133,7 @@ const state = {
   path: null,
   waveforms: {},
   selectedClipId: null,
+  selectedVisualItemId: null,
   selectedAssetId: null,
   targetTrackId: null,
   pxPerSecond: 30,
@@ -145,6 +148,7 @@ const state = {
 let preview = null;
 let mediaPreview = null;
 let qualityMonitor = null;
+let visualDrag = null;
 
 // --- helpers ---------------------------------------------------------------
 
@@ -684,6 +688,7 @@ function updateMonitorZoomUi() {
 }
 
 function renderTimeline() {
+  if (state.selectedVisualItemId && !selectedVisualItem()) selectVisualItem(null);
   renderHeads();
   renderRuler();
   renderLanes();
@@ -696,6 +701,7 @@ function renderTimeline() {
   updateLinkUi();
   updateHistoryUi();
   updateMonitorZoomUi();
+  renderStageOverlay();
   scheduleExactFrame();
   if (preview) preview.redraw();
 }
@@ -715,6 +721,7 @@ function updatePlayhead(frame) {
   dom.playhead.style.left = `${L.framesToPx(frame, rate(), state.pxPerSecond)}px`;
   dom.clock.textContent = L.formatTimecode(frame, rate());
   dom.stageHint.hidden = L.projectDurationFrames(state.project) > 0 || preview.mode() === 'asset';
+  renderStageOverlay();
 }
 
 function seekPreviousEdit() {
@@ -770,7 +777,7 @@ function setStageMode(mode) {
  *  stopped, and a newer request cancels an older one by token. */
 async function requestExactFrame() {
   if (!window.api.available) return;
-  if (preview.usesNativeMonitor()) return;
+  if (preview.usesNativeMonitor() && !state.selectedVisualItemId) return;
   if (preview.isPlaying() || preview.mode() !== 'timeline') return;
   if (L.projectDurationFrames(state.project) <= 0) return;
   if (state.settings.compositor === 'ffmpeg') return;
@@ -805,6 +812,162 @@ function selectClip(clipId) {
     node.classList.toggle('selected', node.dataset.clipId === clipId);
   }
   updateLinkUi();
+}
+
+function selectedVisualItem() {
+  if (!state.selectedVisualItemId) return null;
+  for (const track of state.project.tracks) {
+    const item = (track.visualItems || []).find((entry) => entry.id === state.selectedVisualItemId);
+    if (item) return item;
+  }
+  return null;
+}
+
+function projectPointAt(event) {
+  const box = dom.stage.getBoundingClientRect();
+  if (box.width < 1 || box.height < 1) return null;
+  return X.projectPoint(
+    { x: event.clientX - box.left, y: event.clientY - box.top },
+    box,
+    state.project.settings
+  );
+}
+
+function overlayScale() {
+  const box = dom.stage.getBoundingClientRect();
+  return Math.min(
+    box.width / Math.max(1, state.project.settings.width),
+    box.height / Math.max(1, state.project.settings.height)
+  );
+}
+
+function selectVisualItem(itemId) {
+  state.selectedVisualItemId = itemId || null;
+  const editing = Boolean(state.selectedVisualItemId);
+  dom.stage.classList.toggle('editing', editing);
+  preview.setEditing(editing);
+  if (!editing) {
+    preview.clearExact();
+    preview.redraw();
+  } else {
+    scheduleExactFrame();
+  }
+  renderStageOverlay();
+}
+
+function renderStageOverlay() {
+  const canvas = dom.stageOverlay;
+  const item = selectedVisualItem();
+  if (!canvas || !item) {
+    if (canvas) canvas.width = 0;
+    return;
+  }
+  const box = dom.stage.getBoundingClientRect();
+  const ratio = window.devicePixelRatio || 1;
+  const width = Math.max(1, Math.round(box.width * ratio));
+  const height = Math.max(1, Math.round(box.height * ratio));
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+  const context = canvas.getContext('2d');
+  if (!context) return;
+  context.setTransform(ratio, 0, 0, ratio, 0, 0);
+  context.clearRect(0, 0, box.width, box.height);
+  const transform = item.transform;
+  const center = X.displayPoint(X.centre(transform), box, state.project.settings);
+  const size = {
+    x: (transform.width * box.width) / state.project.settings.width,
+    y: (transform.height * box.height) / state.project.settings.height,
+  };
+  const scale = overlayScale();
+  const handleRadius = 5;
+  context.save();
+  context.translate(center.x, center.y);
+  context.rotate((transform.rotation * Math.PI) / 180);
+  context.strokeStyle = '#4e9bff';
+  context.lineWidth = 1.5;
+  context.setLineDash([5, 3]);
+  context.strokeRect(-size.x / 2, -size.y / 2, size.x, size.y);
+  context.setLineDash([]);
+  context.beginPath();
+  context.moveTo(0, -size.y / 2);
+  context.lineTo(0, -size.y / 2 - 24);
+  context.stroke();
+  context.restore();
+  const handles = X.handlePoints(transform, 24 / scale);
+  for (const [name, point] of Object.entries(handles)) {
+    const at = X.displayPoint(point, box, state.project.settings);
+    context.beginPath();
+    context.arc(at.x, at.y, name === 'rotate' ? 6 : handleRadius, 0, Math.PI * 2);
+    context.fillStyle = name === 'rotate' ? '#4e9bff' : '#ffffff';
+    context.fill();
+    context.strokeStyle = '#4e9bff';
+    context.lineWidth = 1.5;
+    context.stroke();
+  }
+}
+
+function beginVisualDrag(event) {
+  if (event.button !== 0 || preview.isPlaying()) return false;
+  const point = projectPointAt(event);
+  if (!point) return false;
+  const scale = overlayScale();
+  const hit = X.hitItem(
+    state.project,
+    Math.round(preview.position()),
+    point,
+    state.selectedVisualItemId,
+    { handleRadius: 8 / scale, rotateOffset: 24 / scale }
+  );
+  if (!hit) {
+    selectVisualItem(null);
+    return false;
+  }
+  if (hit.item.id !== state.selectedVisualItemId) selectVisualItem(hit.item.id);
+  visualDrag = {
+    itemId: hit.item.id,
+    action: hit.action === 'resize' ? hit.handle : hit.action,
+    initial: { ...hit.item.transform },
+    start: point,
+    next: { ...hit.item.transform },
+  };
+  dom.stage.setPointerCapture(event.pointerId);
+  event.preventDefault();
+  return true;
+}
+
+function updateVisualDrag(event) {
+  if (!visualDrag) return;
+  const point = projectPointAt(event);
+  if (!point) return;
+  visualDrag.next = X.transformForDrag(
+    visualDrag.initial,
+    visualDrag.action,
+    visualDrag.start,
+    point
+  );
+  const item = selectedVisualItem();
+  if (item) item.transform = visualDrag.next;
+  renderStageOverlay();
+}
+
+async function endVisualDrag(event) {
+  if (!visualDrag) return;
+  const finished = visualDrag;
+  visualDrag = null;
+  if (dom.stage.hasPointerCapture(event.pointerId)) dom.stage.releasePointerCapture(event.pointerId);
+  if (JSON.stringify(finished.initial) === JSON.stringify(finished.next)) return;
+  await edit({ op: 'setVisualTransform', itemId: finished.itemId, transform: finished.next });
+  selectVisualItem(finished.itemId);
+}
+
+function cancelVisualDrag() {
+  if (!visualDrag) return;
+  const item = selectedVisualItem();
+  if (item) item.transform = visualDrag.initial;
+  visualDrag = null;
+  renderStageOverlay();
 }
 
 function closeTimelineContextMenu() {
@@ -1316,10 +1479,14 @@ async function confirmDiscard(what) {
  *  page keeps alongside it. The history belongs to the document, so opening a
  *  project starts with nothing to undo. */
 function loadDocument(doc, path) {
+  if (preview) preview.setEditing(false);
+  dom.stage.classList.remove('editing');
+  visualDrag = null;
   adopt(doc);
   state.path = path || null;
   state.savedRevision = doc.revision;
   state.selectedClipId = null;
+  state.selectedVisualItemId = null;
   state.selectedAssetId = null;
   state.targetTrackId = null;
   state.proxies = {};
@@ -1999,6 +2166,7 @@ function wireTransport() {
     }
   }, { passive: false });
   dom.stage.addEventListener('pointerdown', (event) => {
+    if (beginVisualDrag(event)) return;
     const zoom = preview.zoomState();
     if (event.button !== 0 || !zoom.available || zoom.zoom <= 1) return;
     monitorPan = { x: event.clientX, y: event.clientY };
@@ -2006,16 +2174,25 @@ function wireTransport() {
     event.preventDefault();
   });
   dom.stage.addEventListener('pointermove', (event) => {
+    if (visualDrag) {
+      updateVisualDrag(event);
+      return;
+    }
     if (!monitorPan) return;
     preview.panBy(event.clientX - monitorPan.x, event.clientY - monitorPan.y);
     monitorPan = { x: event.clientX, y: event.clientY };
   });
   dom.stage.addEventListener('pointerup', (event) => {
+    if (visualDrag) {
+      endVisualDrag(event).catch((error) => reportError(error, 'visual-item:transform'));
+      return;
+    }
     if (!monitorPan) return;
     monitorPan = null;
     dom.stage.releasePointerCapture(event.pointerId);
   });
   dom.stage.addEventListener('pointercancel', () => {
+    cancelVisualDrag();
     monitorPan = null;
   });
 }

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -487,6 +487,19 @@ select {
   display: block;
 }
 
+#stage-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 70;
+  pointer-events: none;
+}
+
+#stage.editing #stage-overlay {
+  pointer-events: auto;
+}
+
 #stage-mode {
   position: absolute;
   top: 8px;

--- a/product/akbun-makevideo/workspace/src/transform.js
+++ b/product/akbun-makevideo/workspace/src/transform.js
@@ -1,0 +1,183 @@
+'use strict';
+
+(function () {
+
+const MIN_SIZE = 16;
+
+function projectPoint(point, stage, project) {
+  return {
+    x: (point.x * project.width) / stage.width,
+    y: (point.y * project.height) / stage.height,
+  };
+}
+
+function displayPoint(point, stage, project) {
+  return {
+    x: (point.x * stage.width) / project.width,
+    y: (point.y * stage.height) / project.height,
+  };
+}
+
+function centre(transform) {
+  return {
+    x: transform.x + transform.width / 2,
+    y: transform.y + transform.height / 2,
+  };
+}
+
+function radians(degrees) {
+  return (degrees * Math.PI) / 180;
+}
+
+function rotate(point, around, degrees) {
+  const angle = radians(degrees);
+  const x = point.x - around.x;
+  const y = point.y - around.y;
+  return {
+    x: around.x + x * Math.cos(angle) - y * Math.sin(angle),
+    y: around.y + x * Math.sin(angle) + y * Math.cos(angle),
+  };
+}
+
+function localPoint(point, transform) {
+  return rotate(point, centre(transform), -transform.rotation);
+}
+
+function containsPoint(item, point) {
+  const transform = item.transform;
+  const local = localPoint(point, transform);
+  return local.x >= transform.x && local.x <= transform.x + transform.width
+    && local.y >= transform.y && local.y <= transform.y + transform.height;
+}
+
+function visibleItems(project, frame) {
+  const items = [];
+  for (let trackIndex = 0; trackIndex < project.tracks.length; trackIndex += 1) {
+    const track = project.tracks[trackIndex];
+    if (track.kind !== 'video' || track.hidden) continue;
+    for (let itemIndex = 0; itemIndex < (track.visualItems || []).length; itemIndex += 1) {
+      const item = track.visualItems[itemIndex];
+      if (item.start <= frame && frame < item.start + item.duration) {
+        items.push({ item, trackIndex, itemIndex });
+      }
+    }
+  }
+  return items.sort((a, b) =>
+    a.trackIndex - b.trackIndex || a.item.zIndex - b.item.zIndex || a.itemIndex - b.itemIndex
+  );
+}
+
+function handlePoints(transform, offset) {
+  const halfWidth = transform.width / 2;
+  const halfHeight = transform.height / 2;
+  const centrePoint = centre(transform);
+  const points = {
+    nw: { x: -halfWidth, y: -halfHeight },
+    n: { x: 0, y: -halfHeight },
+    ne: { x: halfWidth, y: -halfHeight },
+    e: { x: halfWidth, y: 0 },
+    se: { x: halfWidth, y: halfHeight },
+    s: { x: 0, y: halfHeight },
+    sw: { x: -halfWidth, y: halfHeight },
+    w: { x: -halfWidth, y: 0 },
+    rotate: { x: 0, y: -halfHeight - offset },
+  };
+  return Object.fromEntries(
+    Object.entries(points).map(([name, point]) => [name, rotate({
+      x: centrePoint.x + point.x,
+      y: centrePoint.y + point.y,
+    }, centrePoint, transform.rotation)])
+  );
+}
+
+function hitHandle(transform, point, radius, rotateOffset) {
+  for (const [handle, at] of Object.entries(handlePoints(transform, rotateOffset))) {
+    if (Math.hypot(point.x - at.x, point.y - at.y) <= radius) return handle;
+  }
+  return null;
+}
+
+function hitItem(project, frame, point, selectedId, options = {}) {
+  const items = visibleItems(project, frame);
+  const selected = items.find(({ item }) => item.id === selectedId);
+  if (selected) {
+    const handle = hitHandle(
+      selected.item.transform,
+      point,
+      options.handleRadius || 8,
+      options.rotateOffset || 24
+    );
+    if (handle) return { item: selected.item, action: handle === 'rotate' ? 'rotate' : 'resize', handle };
+    if (containsPoint(selected.item, point)) return { item: selected.item, action: 'move' };
+  }
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const candidate = items[index].item;
+    if (candidate.id !== selectedId && containsPoint(candidate, point)) {
+      return { item: candidate, action: 'move' };
+    }
+  }
+  return null;
+}
+
+function normalizeDegrees(value) {
+  const normalized = ((value + 180) % 360 + 360) % 360 - 180;
+  return normalized === -180 ? 180 : normalized;
+}
+
+function transformForDrag(initial, action, start, point) {
+  if (action === 'move') {
+    return {
+      ...initial,
+      x: initial.x + point.x - start.x,
+      y: initial.y + point.y - start.y,
+    };
+  }
+  const initialCentre = centre(initial);
+  if (action === 'rotate') {
+    const from = Math.atan2(start.y - initialCentre.y, start.x - initialCentre.x);
+    const to = Math.atan2(point.y - initialCentre.y, point.x - initialCentre.x);
+    return { ...initial, rotation: normalizeDegrees(initial.rotation + ((to - from) * 180) / Math.PI) };
+  }
+
+  const local = localPoint(point, initial);
+  const moveWest = action.includes('w');
+  const moveEast = action.includes('e');
+  const moveNorth = action.includes('n');
+  const moveSouth = action.includes('s');
+  const left = moveWest ? Math.min(local.x, initial.x + initial.width - MIN_SIZE) : initial.x;
+  const right = moveEast ? Math.max(local.x, initial.x + MIN_SIZE) : initial.x + initial.width;
+  const top = moveNorth ? Math.min(local.y, initial.y + initial.height - MIN_SIZE) : initial.y;
+  const bottom = moveSouth ? Math.max(local.y, initial.y + MIN_SIZE) : initial.y + initial.height;
+  const nextCentre = rotate({ x: (left + right) / 2, y: (top + bottom) / 2 }, initialCentre, initial.rotation);
+  const width = right - left;
+  const height = bottom - top;
+  return {
+    ...initial,
+    x: nextCentre.x - width / 2,
+    y: nextCentre.y - height / 2,
+    width,
+    height,
+  };
+}
+
+const exported = {
+  MIN_SIZE,
+  projectPoint,
+  displayPoint,
+  centre,
+  rotate,
+  localPoint,
+  containsPoint,
+  visibleItems,
+  handlePoints,
+  hitHandle,
+  hitItem,
+  transformForDrag,
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = exported;
+} else {
+  globalThis.transformLib = exported;
+}
+})();

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -135,6 +135,38 @@ test('the native monitor yields to the editor-only selection pass', async (t) =>
   assert.deepStrictEqual(visibility, [true, false, true]);
 });
 
+test('leaving native editing clears the page exact frame', async (t) => {
+  const previousWindow = global.window;
+  t.after(() => {
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+  });
+  global.window = { devicePixelRatio: 1 };
+  let cleared = 0;
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => { cleared += 1; },
+    },
+    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  monitor.setEditing(true);
+  monitor.setEditing(false);
+  const beforeClear = cleared;
+  monitor.clearExact();
+  assert.strictEqual(cleared, beforeClear + 1);
+});
+
 test('the same box twice is recognised, so a drag is not a command per frame', () => {
   const box = { x: 1, y: 2, width: 3, height: 4 };
   assert.ok(samePlace(box, { ...box }));

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -104,6 +104,37 @@ test('panning against an edge does not place the unchanged viewport', async (t) 
   assert.strictEqual(places.length, placeCount);
 });
 
+test('the native monitor yields to the editor-only selection pass', async (t) => {
+  const previousWindow = global.window;
+  t.after(() => {
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+  });
+  global.window = { devicePixelRatio: 1 };
+  const visibility = [];
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => {},
+    },
+    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async (visible) => visibility.push(visible),
+    },
+  });
+
+  await monitor.attach();
+  monitor.setEditing(true);
+  monitor.setEditing(false);
+  await Promise.resolve();
+  assert.deepStrictEqual(visibility, [true, false, true]);
+});
+
 test('the same box twice is recognised, so a drag is not a command per frame', () => {
   const box = { x: 1, y: 2, width: 3, height: 4 };
   assert.ok(samePlace(box, { ...box }));
@@ -160,7 +191,7 @@ test('the router answers everything the page asks a preview for', () => {
     'mode', 'prune', 'clear', 'showAsset', 'showTimeline', 'setQuality',
     'setScrubbing', 'setMuteWhileScrubbing', 'showExact', 'clearExact', 'isExact',
     'attach', 'release', 'place', 'redraw', 'setVisible', 'usesNativeMonitor',
-    'refreshMedia',
+    'refreshMedia', 'setEditing',
   ];
   const missing = asked.filter((name) => typeof monitor[name] !== 'function');
   assert.deepStrictEqual(missing, []);

--- a/product/akbun-makevideo/workspace/test/transform.test.js
+++ b/product/akbun-makevideo/workspace/test/transform.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  containsPoint,
+  hitItem,
+  projectPoint,
+  transformForDrag,
+  visibleItems,
+} = require('../src/transform.js');
+
+const transform = { x: 100, y: 50, width: 200, height: 100, rotation: 0, opacity: 1 };
+
+function item(id, zIndex, nextTransform = transform) {
+  return { id, start: 0, duration: 60, zIndex, transform: nextTransform };
+}
+
+function project(items) {
+  return {
+    tracks: [
+      { kind: 'video', hidden: false, visualItems: items },
+      { kind: 'audio', hidden: false, visualItems: [item('audio', 99)] },
+    ],
+  };
+}
+
+test('display points become project pixels without carrying the monitor scale', () => {
+  assert.deepStrictEqual(
+    projectPoint({ x: 320, y: 180 }, { width: 640, height: 360 }, { width: 1920, height: 1080 }),
+    { x: 960, y: 540 }
+  );
+});
+
+test('selection reverses the rotation before testing the item rectangle', () => {
+  const rotated = { ...transform, rotation: 90 };
+  assert.strictEqual(containsPoint({ transform: rotated }, { x: 200, y: 150 }), true);
+  assert.strictEqual(containsPoint({ transform: rotated }, { x: 350, y: 100 }), false);
+});
+
+test('topmost item wins except the current selection and its handles', () => {
+  const lower = item('lower', 1);
+  const upper = item('upper', 2);
+  const model = project([lower, upper]);
+  assert.strictEqual(hitItem(model, 0, { x: 200, y: 100 }, null).item.id, 'upper');
+  assert.strictEqual(hitItem(model, 0, { x: 200, y: 100 }, 'lower').item.id, 'lower');
+  assert.deepStrictEqual(hitItem(model, 0, { x: 100, y: 50 }, 'lower'), {
+    item: lower,
+    action: 'resize',
+    handle: 'nw',
+  });
+});
+
+test('only visible video track items participate in selection order', () => {
+  const hidden = { kind: 'video', hidden: true, visualItems: [item('hidden', 10)] };
+  const model = { tracks: [project([item('visible', 1)]).tracks[0], hidden] };
+  assert.deepStrictEqual(visibleItems(model, 0).map(({ item: entry }) => entry.id), ['visible']);
+});
+
+test('a move changes only the project-space origin', () => {
+  assert.deepStrictEqual(
+    transformForDrag(transform, 'move', { x: 100, y: 50 }, { x: 130, y: 90 }),
+    { ...transform, x: 130, y: 90 }
+  );
+});
+
+test('a rotated resize keeps the opposite edge fixed', () => {
+  const initial = { ...transform, rotation: 90 };
+  const result = transformForDrag(initial, 'e', { x: 0, y: 0 }, { x: 200, y: 200 });
+  assert.strictEqual(result.height, initial.height);
+  assert.strictEqual(result.width, 200);
+  assert.ok(Math.abs(result.x - 100) < 0.0001);
+  assert.ok(Math.abs(result.y - 50) < 0.0001);
+});
+
+test('a rotate drag stores degrees on the shared transform', () => {
+  const result = transformForDrag(transform, 'rotate', { x: 200, y: 0 }, { x: 300, y: 100 });
+  assert.strictEqual(result.rotation, 90);
+});


### PR DESCRIPTION
# 구현

Program Monitor Visual Item 선택·이동·리사이즈·회전 canvas pass 추가
- Node 91개와 Rust edit 53개 테스트 통과

# 어려웠던 점

Native surface가 WebView 위에 놓이는 레이어 충돌
- 변형 중 native surface 숨김과 exact compositor frame 표시로 편집 pass 분리

# 리스크

Visual Item 내용 렌더링 미구현 상태
- #673 또는 #682 이후 실제 요소를 둔 UI 조작 검증 필요

Issue #681
