### PR TITLE
akbun-makevideo: 프록시 설정 변경 시 미리보기 멈춤 수정

### DIFF
--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.23.1",
+      "version": "0.23.2",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
@@ -71,6 +71,14 @@ pub fn write_manifest(project_path: &str, asset: &Asset) -> Result<(), String> {
     std::fs::write(&path, text).map_err(|error| format!("cannot write {path:?}: {error}"))
 }
 
+pub fn progress_percent_changed(previous: &mut u8, current: u8) -> bool {
+    if *previous == current {
+        return false;
+    }
+    *previous = current;
+    true
+}
+
 pub fn ffmpeg_args(asset: &Asset, output: &Path) -> Vec<String> {
     vec![
         "-hide_banner".into(),
@@ -173,6 +181,16 @@ mod tests {
             .windows(2)
             .any(|pair| pair[0] == "-threads" && pair[1] == ENCODE_THREADS.to_string()));
         assert_eq!(args.last().map(String::as_str), Some("proxy.mp4"));
+    }
+
+    #[test]
+    fn proxy_progress_reports_only_changed_percentages() {
+        let mut previous = 0;
+        let reported = [0, 0, 1, 1, 2, 2, 100]
+            .into_iter()
+            .filter(|percent| progress_percent_changed(&mut previous, *percent))
+            .collect::<Vec<_>>();
+        assert_eq!(reported, vec![1, 2, 100]);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -775,6 +775,7 @@ fn make_proxy(
         .spawn()
         .map_err(|error| format!("cannot start ffmpeg: {error}"))?;
     if let Some(stdout) = child.stdout.take() {
+        let mut last_percent = 0;
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
             if let Some(ffmpeg::Progress::Position(position_ms)) =
                 ffmpeg::parse_progress_line(&line)
@@ -784,6 +785,9 @@ fn make_proxy(
                 } else {
                     0
                 };
+                if !makevideo_proxy::progress_percent_changed(&mut last_percent, percent) {
+                    continue;
+                }
                 if !set_proxy_status(
                     app,
                     proxies,

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1819,8 +1819,8 @@ function applySettings(next) {
   // nothing.
   if (was !== next.playbackEngine) attachMonitor(true);
   else if (usedProxies !== next.proxyEnabled) {
-    preview.redraw();
     if (preview.usesNativeMonitor()) attachMonitor(true);
+    else preview.redraw();
   }
 }
 


### PR DESCRIPTION
# 구현

네이티브 모니터 프록시 설정 변경의 중복 redraw 제거와 진행률 IPC 퍼센트 단위 제한
- Node 92개, proxy Rust 5개, cargo check 통과, 실제 앱 프록시 설정 켜기·끄기 적용 확인

# 어려웠던 점

프록시 진행률 중복 억제 로직을 Tauri command 밖의 순수 proxy crate로 분리
- 앱 전체 의존성을 끌지 않는 단위 테스트로 연속 중복 퍼센트 미전송 검증

# 리스크

진행률 UI 갱신이 퍼센트 단위로 제한됨
- 1% 미만 인코딩 진행 변화는 다음 퍼센트까지 표시 유예

Issue #821