### PR TITLE
akbun-makevideo: 재생 중 프록시 인코딩 일시정지

### DIFF
--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/Cargo.lock
+++ b/product/akbun-makevideo/workspace/src-tauri/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
 name = "akbun-makevideo"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "makevideo-audio",
  "makevideo-compositor",
  "makevideo-edit",

--- a/product/akbun-makevideo/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-makevideo/workspace/src-tauri/Cargo.toml
@@ -81,3 +81,6 @@ objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSView", "NSWindow", "NSGraphics", "NSResponder"] }
 objc2-foundation = "0.3"
 raw-window-handle = "0.6"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
@@ -7,7 +7,7 @@ use std::time::UNIX_EPOCH;
 pub const FOLDER: &str = "proxies";
 pub const LONG_EDGE: u32 = 1280;
 pub const SOURCE_LONG_EDGE: u32 = 1920;
-pub const ENCODE_THREADS: u32 = 2;
+pub const DECODE_THREADS: u32 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -79,14 +79,14 @@ pub fn progress_percent_changed(previous: &mut u8, current: u8) -> bool {
     true
 }
 
-pub fn ffmpeg_args(asset: &Asset, output: &Path) -> Vec<String> {
-    vec![
+pub fn ffmpeg_args(asset: &Asset, output: &Path, encoder: Option<&str>) -> Vec<String> {
+    let mut args = vec![
         "-hide_banner".into(),
         "-y".into(),
+        "-threads".into(),
+        DECODE_THREADS.to_string(),
         "-i".into(),
         asset.path.clone(),
-        "-threads".into(),
-        ENCODE_THREADS.to_string(),
         "-map".into(),
         "0:v:0".into(),
         "-map".into(),
@@ -96,12 +96,25 @@ pub fn ffmpeg_args(asset: &Asset, output: &Path) -> Vec<String> {
             "scale='if(gte(iw,ih),{},-2)':'if(gte(iw,ih),-2,{})'",
             LONG_EDGE, LONG_EDGE
         ),
-        "-c:v".into(),
-        "libx264".into(),
-        "-preset".into(),
-        "veryfast".into(),
-        "-crf".into(),
-        "23".into(),
+    ];
+    if let Some(encoder) = encoder {
+        args.extend([
+            "-c:v".into(),
+            encoder.into(),
+            "-b:v".into(),
+            "4M".into(),
+        ]);
+    } else {
+        args.extend([
+            "-c:v".into(),
+            "libx264".into(),
+            "-preset".into(),
+            "veryfast".into(),
+            "-crf".into(),
+            "23".into(),
+        ]);
+    }
+    args.extend([
         "-pix_fmt".into(),
         "yuv420p".into(),
         "-c:a".into(),
@@ -114,7 +127,8 @@ pub fn ffmpeg_args(asset: &Asset, output: &Path) -> Vec<String> {
         "pipe:1".into(),
         "-nostats".into(),
         output.to_string_lossy().to_string(),
-    ]
+    ]);
+    args
 }
 
 pub fn playback_project(project: &Project, ready: &HashMap<String, String>) -> Project {
@@ -174,13 +188,33 @@ mod tests {
 
     #[test]
     fn ffmpeg_scales_the_long_edge_and_keeps_optional_audio() {
-        let args = ffmpeg_args(&asset(AssetKind::Video, 3840, 2160), Path::new("proxy.mp4"));
+        let args = ffmpeg_args(
+            &asset(AssetKind::Video, 3840, 2160),
+            Path::new("proxy.mp4"),
+            None,
+        );
         assert!(args.iter().any(|arg| arg.contains("1280")));
         assert!(args.windows(2).any(|pair| pair == ["-map", "0:a?"]));
         assert!(args
             .windows(2)
-            .any(|pair| pair[0] == "-threads" && pair[1] == ENCODE_THREADS.to_string()));
+            .any(|pair| pair[0] == "-threads" && pair[1] == DECODE_THREADS.to_string()));
+        assert!(args.windows(2).any(|pair| pair == ["-threads", "2"]));
+        assert!(args.windows(2).any(|pair| pair == ["-i", "/media/original.mov"]));
         assert_eq!(args.last().map(String::as_str), Some("proxy.mp4"));
+    }
+
+    #[test]
+    fn ffmpeg_uses_a_confirmed_hardware_encoder() {
+        let args = ffmpeg_args(
+            &asset(AssetKind::Video, 3840, 2160),
+            Path::new("proxy.mp4"),
+            Some("h264_videotoolbox"),
+        );
+        assert!(args
+            .windows(2)
+            .any(|pair| pair == ["-c:v", "h264_videotoolbox"]));
+        assert!(args.windows(2).any(|pair| pair == ["-b:v", "4M"]));
+        assert!(!args.iter().any(|arg| arg == "libx264"));
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -771,11 +771,12 @@ fn make_proxy(
     project_path: &str,
     ffmpeg_path: &str,
     asset: &Asset,
+    encoder: Option<&str>,
 ) -> Result<String, String> {
     wait_for_playback_pause(app);
     let output = makevideo_proxy::media_path(project_path, &asset.id)?;
     let temporary = output.with_extension("part.mp4");
-    let args = makevideo_proxy::ffmpeg_args(asset, &temporary);
+    let args = makevideo_proxy::ffmpeg_args(asset, &temporary, encoder);
     let mut child = Command::new(ffmpeg_path)
         .args(args)
         .stdin(Stdio::null())
@@ -783,6 +784,8 @@ fn make_proxy(
         .stderr(Stdio::null())
         .spawn()
         .map_err(|error| format!("cannot start ffmpeg: {error}"))?;
+    let done = Arc::new(AtomicBool::new(false));
+    let monitor = monitor_proxy_playback(app.clone(), child.id(), Arc::clone(&done));
     if let Some(stdout) = child.stdout.take() {
         let mut last_percent = 0;
         for line in BufReader::new(stdout).lines().map_while(Result::ok) {
@@ -811,12 +814,17 @@ fn make_proxy(
                 ) {
                     let _ = child.kill();
                     let _ = child.wait();
+                    done.store(true, Ordering::Relaxed);
+                    let _ = monitor.join();
                     return Err("the project changed".into());
                 }
             }
         }
     }
-    let status = child.wait().map_err(|error| error.to_string())?;
+    let status = child.wait();
+    done.store(true, Ordering::Relaxed);
+    let _ = monitor.join();
+    let status = status.map_err(|error| error.to_string())?;
     if !status.success() {
         let _ = std::fs::remove_file(&temporary);
         return Err("ffmpeg could not create the proxy".into());
@@ -850,6 +858,43 @@ fn wait_for_playback_pause(app: &AppHandle) {
     }
 }
 
+fn monitor_proxy_playback(app: AppHandle, pid: u32, done: Arc<AtomicBool>) -> JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut paused = false;
+        while !done.load(Ordering::Relaxed) {
+            let playing = app
+                .state::<AppState>()
+                .playback
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|session| session.status().playing);
+            if playing != paused {
+                let _ = set_proxy_process_paused(pid, playing);
+                paused = playing;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        if paused {
+            let _ = set_proxy_process_paused(pid, false);
+        }
+    })
+}
+
+#[cfg(unix)]
+fn set_proxy_process_paused(pid: u32, paused: bool) -> Result<(), String> {
+    let signal = if paused { libc::SIGSTOP } else { libc::SIGCONT };
+    let result = unsafe { libc::kill(pid as libc::pid_t, signal) };
+    (result == 0)
+        .then_some(())
+        .ok_or_else(|| std::io::Error::last_os_error().to_string())
+}
+
+#[cfg(not(unix))]
+fn set_proxy_process_paused(_: u32, _: bool) -> Result<(), String> {
+    Ok(())
+}
+
 #[tauri::command]
 pub fn proxy_status(state: State<AppState>) -> Vec<ProxyStatus> {
     proxy_statuses(&state.proxies.lock().unwrap())
@@ -864,6 +909,7 @@ pub async fn start_proxies(
     let configured = state.settings.lock().unwrap().ffmpeg_dir.clone();
     let ffmpeg_path = find_tool(&app, "ffmpeg", &configured)
         .ok_or("ffmpeg was not found, so proxies cannot be created")?;
+    let acceleration = acceleration(&state, Some(&ffmpeg_path)).available;
     let project = state.document.lock().unwrap().project().clone();
     let mut jobs = Vec::new();
     {
@@ -956,7 +1002,14 @@ pub async fn start_proxies(
                 ) {
                     return;
                 }
-                match make_proxy(&app, &proxies, &project_path, &ffmpeg_path, &asset) {
+                match make_proxy(
+                    &app,
+                    &proxies,
+                    &project_path,
+                    &ffmpeg_path,
+                    &asset,
+                    acceleration.as_ref().map(|item| item.encoder.as_str()),
+                ) {
                     Ok(path) => {
                         allow_asset_file(&app, &path);
                         set_proxy_status(

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -840,8 +840,7 @@ fn make_proxy(
 }
 
 /// Jobs queued for proxying wait until playback stops. A job already encoding
-/// finishes its current file: killing ffmpeg midway would leave partial media
-/// and does not make the current playback smoother.
+/// pauses while playback runs, then resumes without leaving partial media.
 fn wait_for_playback_pause(app: &AppHandle) {
     loop {
         let playing = app
@@ -860,22 +859,22 @@ fn wait_for_playback_pause(app: &AppHandle) {
 
 fn monitor_proxy_playback(app: AppHandle, pid: u32, done: Arc<AtomicBool>) -> JoinHandle<()> {
     std::thread::spawn(move || {
-        let mut paused = false;
+        let mut proxy_paused = false;
         while !done.load(Ordering::Relaxed) {
-            let playing = app
+            let should_pause_proxy = app
                 .state::<AppState>()
                 .playback
                 .lock()
                 .unwrap()
                 .as_ref()
                 .is_some_and(|session| session.status().playing);
-            if playing != paused {
-                let _ = set_proxy_process_paused(pid, playing);
-                paused = playing;
+            if should_pause_proxy != proxy_paused {
+                let _ = set_proxy_process_paused(pid, should_pause_proxy);
+                proxy_paused = should_pause_proxy;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-        if paused {
+        if proxy_paused {
             let _ = set_proxy_process_paused(pid, false);
         }
     })


### PR DESCRIPTION
# 구현

재생 중 프록시 ffmpeg 정지와 재생 종료 뒤 재개

- 입력 디코드 스레드 2개 제한, 확인된 하드웨어 인코더 재사용, 앱 버전 0.24.2

# 어려웠던 점

하드웨어 인코더별 CRF 지원 차이

- 하드웨어 경로는 공통 비트레이트, 미감지 경로는 기존 libx264 CRF 유지

# 리스크

Unix 외 환경의 프로세스 정지 미지원

- macOS 우선 경로이며 실제 장시간 네이티브 재생 검증 제한은 Discussion #830 기록

Issue #829
