### PR TITLE
akbun-makevideo: 오디오 중복과 진단 화면 수정

### DIFF
--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
@@ -119,7 +119,7 @@ fn collect_items(project: &Project) -> Vec<Item<'_>> {
                 // of it, because the playback mixer asks the same question and
                 // two answers to it would be a clip that plays and does not
                 // render, or the other way round.
-                let audio = layout::carries_sound(asset, track);
+                let audio = layout::clip_carries_sound(project, asset, track, clip);
                 if !video && !audio {
                     continue;
                 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
@@ -10,7 +10,7 @@
 //! index on the project rate. Floats would let the two callers round
 //! differently, which is exactly the divergence this removes.
 
-use crate::{Asset, AssetKind, Project, Rate, RationalTime, Track, TrackKind};
+use crate::{Asset, AssetKind, Clip, Project, Rate, RationalTime, Track, TrackKind};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Rect {
@@ -115,6 +115,27 @@ pub fn carries_sound(asset: &Asset, track: &Track) -> bool {
     }
 }
 
+/// A linked video/audio pair has one source stream but two timeline clips.
+/// The audio-track clip is the mix source; keeping the video-track clip in the
+/// mix too would make the same samples play twice.
+pub fn linked_audio_track_has_group(project: &Project, clip: &Clip) -> bool {
+    let Some(group) = clip.link_group.as_deref() else {
+        return false;
+    };
+    project.tracks.iter().any(|track| {
+        track.kind == TrackKind::Audio
+            && track
+                .clips
+                .iter()
+                .any(|candidate| candidate.link_group.as_deref() == Some(group))
+    })
+}
+
+pub fn clip_carries_sound(project: &Project, asset: &Asset, track: &Track, clip: &Clip) -> bool {
+    carries_sound(asset, track)
+        && !(track.kind == TrackKind::Video && linked_audio_track_has_group(project, clip))
+}
+
 /// Every clip that is audible, video tracks first and then audio tracks, each
 /// in track order. The order does not change a sum, but keeping it the same as
 /// the render's input order means a report from either side lists the clips the
@@ -133,7 +154,7 @@ pub fn audio_placements(project: &Project) -> Vec<AudioPlacement> {
                 let Some(asset) = project.asset(&clip.asset_id) else {
                     continue;
                 };
-                if !carries_sound(asset, track) {
+                if !clip_carries_sound(project, asset, track, clip) {
                     continue;
                 }
                 placements.push(AudioPlacement {
@@ -340,6 +361,24 @@ mod tests {
             muted: false,
             hidden: false,
         }
+    }
+
+    #[test]
+    fn linked_video_and_audio_mix_once() {
+        let mut video = clip("v", "a", 0, 0, 120);
+        video.link_group = Some("g1".into());
+        let mut audio = clip("a", "a", 0, 0, 120);
+        audio.link_group = Some("g1".into());
+        let mut source = asset("a", AssetKind::Video, 1920, 1080);
+        source.has_audio = true;
+        let project = project(
+            vec![video_track("V1", vec![video]), audio_track("A1", vec![audio])],
+            vec![source],
+        );
+
+        let placements = audio_placements(&project);
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].clip_id, "a");
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -1784,6 +1784,40 @@ pub struct ProcessMetrics {
     pub cpu_percent: f64,
 }
 
+fn process_metrics_rows(output: &str) -> Result<Vec<(u32, u32, u64, f64)>, String> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let mut fields = line.split_whitespace();
+            let pid = fields
+                .next()
+                .ok_or_else(|| format!("cannot parse process metrics row: {line:?}"))?
+                .parse()
+                .map_err(|error| format!("cannot parse process metrics row {line:?}: {error}"))?;
+            let parent = fields
+                .next()
+                .ok_or_else(|| format!("cannot parse process metrics row: {line:?}"))?
+                .parse()
+                .map_err(|error| format!("cannot parse process metrics row {line:?}: {error}"))?;
+            let rss_kib = fields
+                .next()
+                .ok_or_else(|| format!("cannot parse process metrics row: {line:?}"))?
+                .parse()
+                .map_err(|error| format!("cannot parse process metrics row {line:?}: {error}"))?;
+            let cpu_percent = fields
+                .next()
+                .ok_or_else(|| format!("cannot parse process metrics row: {line:?}"))?
+                .parse()
+                .map_err(|error| format!("cannot parse process metrics row {line:?}: {error}"))?;
+            if fields.next().is_some() {
+                return Err(format!("cannot parse process metrics row: {line:?}"));
+            }
+            Ok((pid, parent, rss_kib, cpu_percent))
+        })
+        .collect()
+}
+
 /// Process-tree metrics include WebView and ffmpeg children, which hold most
 /// preview memory and CPU outside the Rust process itself.
 #[tauri::command]
@@ -1795,25 +1829,20 @@ pub fn process_metrics() -> Result<ProcessMetrics, String> {
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
-    let rows: Vec<(u32, u32, u64, f64)> = String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| {
-            let mut fields = line.split_whitespace();
-            Some((
-                fields.next()?.parse().ok()?,
-                fields.next()?.parse().ok()?,
-                fields.next()?.parse().ok()?,
-                fields.next()?.parse().ok()?,
-            ))
-        })
-        .collect();
+    let rows = process_metrics_rows(&String::from_utf8_lossy(&output.stdout))?;
+    let root = std::process::id();
+    if !rows.iter().any(|(pid, _, _, _)| *pid == root) {
+        return Err(format!(
+            "cannot find current process {root} in process metrics"
+        ));
+    }
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
     let mut values = HashMap::new();
     for (pid, parent, rss_kib, cpu_percent) in rows {
         children.entry(parent).or_default().push(pid);
         values.insert(pid, (rss_kib, cpu_percent));
     }
-    let mut pending = vec![std::process::id()];
+    let mut pending = vec![root];
     let mut found = HashSet::new();
     while let Some(pid) = pending.pop() {
         if !found.insert(pid) {
@@ -2037,7 +2066,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{process_tree_rss_bytes, Settings};
+    use super::{process_metrics_rows, process_tree_rss_bytes, Settings};
 
     #[test]
     fn existing_settings_delete_the_project_folder_by_default() {
@@ -2058,5 +2087,10 @@ mod tests {
     fn memory_includes_descendants_but_not_neighbours() {
         let ps = "10 1 100\n11 10 20\n12 11 5\n20 1 900\n";
         assert_eq!(process_tree_rss_bytes(ps, 10), 125 * 1024);
+    }
+
+    #[test]
+    fn process_metrics_rejects_invalid_rows() {
+        assert!(process_metrics_rows("10 1 100 0.2\nbroken row\n").is_err());
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -37,8 +37,8 @@ use tauri::{AppHandle, Emitter, Manager, State};
 pub struct Settings {
     /// "system", "light" or "dark".
     pub theme: String,
-    /// "full", "half" or "quarter". Half by default: the preview stacks real
-    /// media elements, and at full size a few tracks at once will not keep up.
+    /// "full", "half" or "quarter". Quarter by default: it leaves decoding
+    /// headroom when proxy generation and a multi-track preview overlap.
     pub preview_quality: String,
     /// Drop preview audio while the playhead is being dragged. Scrubbing with
     /// audio on means a seek per frame, which is what actually stalls playback.
@@ -104,7 +104,7 @@ impl Default for Settings {
     fn default() -> Self {
         Settings {
             theme: "system".into(),
-            preview_quality: "half".into(),
+            preview_quality: "quarter".into(),
             preview_mute_while_scrubbing: true,
             snap: true,
             show_action_safe_area: false,
@@ -1775,6 +1775,70 @@ pub fn process_memory_bytes() -> Result<u64, String> {
         &String::from_utf8_lossy(&output.stdout),
         std::process::id(),
     ))
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessMetrics {
+    pub memory_bytes: u64,
+    pub cpu_percent: f64,
+}
+
+/// Process-tree metrics include WebView and ffmpeg children, which hold most
+/// preview memory and CPU outside the Rust process itself.
+#[tauri::command]
+pub fn process_metrics() -> Result<ProcessMetrics, String> {
+    let output = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,rss=,pcpu="])
+        .output()
+        .map_err(|error| format!("cannot read process metrics: {error}"))?;
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+    let rows: Vec<(u32, u32, u64, f64)> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split_whitespace();
+            Some((
+                fields.next()?.parse().ok()?,
+                fields.next()?.parse().ok()?,
+                fields.next()?.parse().ok()?,
+                fields.next()?.parse().ok()?,
+            ))
+        })
+        .collect();
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut values = HashMap::new();
+    for (pid, parent, rss_kib, cpu_percent) in rows {
+        children.entry(parent).or_default().push(pid);
+        values.insert(pid, (rss_kib, cpu_percent));
+    }
+    let mut pending = vec![std::process::id()];
+    let mut found = HashSet::new();
+    while let Some(pid) = pending.pop() {
+        if !found.insert(pid) {
+            continue;
+        }
+        if let Some(next) = children.get(&pid) {
+            pending.extend(next);
+        }
+    }
+    let (rss_kib, cpu_percent) = found.into_iter().fold((0, 0.0), |total, pid| {
+        let Some((rss, cpu)) = values.get(&pid) else {
+            return total;
+        };
+        (total.0 + rss, total.1 + cpu)
+    });
+    Ok(ProcessMetrics {
+        memory_bytes: rss_kib.saturating_mul(1024),
+        cpu_percent,
+    })
+}
+
+#[tauri::command]
+pub fn read_error_log(app: AppHandle, state: State<AppState>) -> Result<String, String> {
+    let settings = state.settings.lock().unwrap().clone();
+    crate::store::recent_error_log(&app, &settings, 200)
 }
 
 #[tauri::command]

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -89,6 +89,8 @@ pub fn run() {
             commands::playback_visible,
             commands::playback_status,
             commands::process_memory_bytes,
+            commands::process_metrics,
+            commands::read_error_log,
             commands::save_quality_report,
         ])
         .run(tauri::generate_context!())

--- a/product/akbun-makevideo/workspace/src-tauri/src/store.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/store.rs
@@ -96,6 +96,28 @@ pub fn append_error(
         .map_err(|error| format!("cannot write error log {active:?}: {error}"))
 }
 
+pub fn recent_error_log(
+    app: &AppHandle,
+    settings: &Settings,
+    lines: usize,
+) -> Result<String, String> {
+    let path = log_dir(app, settings).join(ERROR_LOG);
+    let text = match std::fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(error) => return Err(format!("cannot read error log {path:?}: {error}")),
+    };
+    Ok(text
+        .lines()
+        .rev()
+        .take(lines)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
 /// Write to a temp file and rename over the target. A crash halfway through a
 /// direct write would leave a truncated settings.json; rename is atomic, so the
 /// old file survives until the new one is complete.

--- a/product/akbun-makevideo/workspace/src-tauri/src/store.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/store.rs
@@ -5,7 +5,8 @@
 //! ~/Library/Application Support/io.akbun.makevideo on macOS.
 
 use crate::commands::Settings;
-use std::io::Write;
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager};
@@ -102,20 +103,26 @@ pub fn recent_error_log(
     lines: usize,
 ) -> Result<String, String> {
     let path = log_dir(app, settings).join(ERROR_LOG);
-    let text = match std::fs::read_to_string(&path) {
-        Ok(text) => text,
+    let file = match std::fs::File::open(&path) {
+        Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(String::new()),
         Err(error) => return Err(format!("cannot read error log {path:?}: {error}")),
     };
-    Ok(text
-        .lines()
-        .rev()
-        .take(lines)
-        .collect::<Vec<_>>()
-        .into_iter()
-        .rev()
-        .collect::<Vec<_>>()
-        .join("\n"))
+    recent_lines(BufReader::new(file), lines)
+}
+
+fn recent_lines<R: BufRead>(reader: R, lines: usize) -> Result<String, String> {
+    let mut recent = VecDeque::with_capacity(lines);
+    for line in reader.lines() {
+        let line = line.map_err(|error| format!("cannot read error log: {error}"))?;
+        if recent.len() == lines {
+            recent.pop_front();
+        }
+        if lines > 0 {
+            recent.push_back(line);
+        }
+    }
+    Ok(recent.into_iter().collect::<Vec<_>>().join("\n"))
 }
 
 /// Write to a temp file and rename over the target. A crash halfway through a

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -57,7 +57,7 @@ if (!window.__TAURI__) {
     bootstrap: async () => ({
       settings: {
         theme: 'system',
-        previewQuality: 'half',
+        previewQuality: 'quarter',
         previewMuteWhileScrubbing: true,
         snap: true,
         defaultWidth: 1920,
@@ -127,6 +127,8 @@ if (!window.__TAURI__) {
       performance.memory && performance.memory.usedJSHeapSize
         ? performance.memory.usedJSHeapSize
         : null,
+    processMetrics: async () => ({ memoryBytes: null, cpuPercent: null }),
+    readErrorLog: async () => '',
     saveQualityReport: async () => null,
     writeQualityReport: async () => null,
     // Pretends the folder was made, the way saveProject below pretends the
@@ -279,6 +281,8 @@ window.api = {
   playbackVisible: (visible) => invoke('playback_visible', { visible }),
   playbackStatus: () => invoke('playback_status'),
   processMemoryBytes: () => invoke('process_memory_bytes'),
+  processMetrics: () => invoke('process_metrics'),
+  readErrorLog: () => invoke('read_error_log'),
   saveQualityReport: async (report) => {
     const path = await saveDialog({
       title: 'Save Playback Quality Report',

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -33,8 +33,6 @@
   </svg>
 
   <header id="menubar">
-    <span class="brand">akbun-makevideo</span>
-
     <nav id="menus">
       <div class="menu">
         <button class="menu-title" data-menu="project">Project</button>
@@ -128,10 +126,7 @@
       <section id="preview-panel">
         <header class="panel-head">
           <h2>Preview</h2>
-          <div class="segmented" id="preview-source">
-            <button data-source="timeline" class="on">Timeline</button>
-            <button data-source="asset">Asset</button>
-          </div>
+          <button id="btn-debug" class="small" type="button">Debug</button>
         </header>
         <div id="stage-wrap">
           <div id="stage">
@@ -180,6 +175,7 @@
         <button id="btn-add-video" class="small">+ Video track</button>
         <button id="btn-add-audio" class="small">+ Audio track</button>
         <span class="menubar-gap"></span>
+        <span id="proxy-progress" class="dim small-text" hidden></span>
         <label class="inline">Zoom <input type="range" id="zoom" min="0" max="100" value="45" /></label>
       </div>
 
@@ -212,6 +208,19 @@
       </details>
     </section>
   </main>
+
+  <aside id="debug-panel" hidden>
+    <header class="panel-head">
+      <h2>Debug</h2>
+      <button id="btn-close-debug" class="small" type="button">Close</button>
+    </header>
+    <div id="debug-metrics" class="debug-block"></div>
+    <div class="debug-actions">
+      <button id="btn-refresh-debug" class="small" type="button">Refresh</button>
+      <button id="btn-toggle-logs" class="small" type="button">Show error log</button>
+    </div>
+    <pre id="debug-log" class="debug-log" hidden></pre>
+  </aside>
 
   <div id="timeline-context-menu" class="timeline-context-menu" hidden></div>
 
@@ -301,8 +310,8 @@
       <label class="row">Preview quality
         <select id="as-quality">
           <option value="full">Full</option>
-          <option value="half">Half — default</option>
-          <option value="quarter">Quarter</option>
+          <option value="half">Half</option>
+          <option value="quarter">Quarter — default</option>
         </select>
       </label>
       <label class="row check">
@@ -371,10 +380,10 @@
         </select>
       </label>
       <p class="dim small-text" id="as-accel-note"></p>
-      <label class="row">ffmpeg folder
-        <input type="text" id="as-ffmpeg" placeholder="empty = look in the usual places" />
+      <label class="row">ffmpeg binaries folder
+        <input type="text" id="as-ffmpeg" placeholder="folder containing ffmpeg and ffprobe" />
       </label>
-      <p class="dim small-text" id="as-tools"></p>
+      <p class="dim small-text" id="as-tools">Optional. Select the folder containing ffmpeg and ffprobe executables, not project outputs.</p>
       <label class="row">Error log folder
         <span class="row-input">
           <input type="text" id="as-log-dir" placeholder="empty = operating system default" />

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -33,7 +33,7 @@ const TAIL_SECONDS = 10;
 
 const DEFAULT_SETTINGS = {
   theme: 'system',
-  previewQuality: 'half',
+  previewQuality: 'quarter',
   previewMuteWhileScrubbing: true,
   snap: true,
   defaultWidth: 1920,
@@ -72,7 +72,13 @@ const dom = {
   assetEmpty: el('asset-empty'),
   assetsPanel: el('assets-panel'),
   btnImport: el('btn-import'),
-  previewSource: el('preview-source'),
+  btnDebug: el('btn-debug'),
+  debugPanel: el('debug-panel'),
+  debugMetrics: el('debug-metrics'),
+  debugLog: el('debug-log'),
+  btnCloseDebug: el('btn-close-debug'),
+  btnRefreshDebug: el('btn-refresh-debug'),
+  btnToggleLogs: el('btn-toggle-logs'),
   stageWrap: el('stage-wrap'),
   stage: el('stage'),
   stageInner: el('stage-inner'),
@@ -94,6 +100,7 @@ const dom = {
   btnAddVideo: el('btn-add-video'),
   btnAddAudio: el('btn-add-audio'),
   zoom: el('zoom'),
+  proxyProgress: el('proxy-progress'),
   timeline: el('timeline'),
   heads: el('timeline-heads'),
   scroll: el('timeline-scroll'),
@@ -348,6 +355,7 @@ function adoptProxyStatuses(statuses) {
   state.proxies = Object.fromEntries((statuses || []).map((status) => [status.assetId, status]));
   renderAssets();
   renderProxySummary();
+  renderProxyProgress();
 }
 
 function proxySummary() {
@@ -366,6 +374,60 @@ function proxySummary() {
 function renderProxySummary() {
   const summary = el('proxy-summary');
   if (summary) summary.textContent = proxySummary();
+}
+
+function renderProxyProgress() {
+  const statuses = Object.values(state.proxies);
+  const active = statuses.filter((status) => status.state === 'queued' || status.state === 'generating');
+  if (!active.length) {
+    dom.proxyProgress.hidden = true;
+    return;
+  }
+  const percent = Math.round(active.reduce((total, status) => total + (status.percent || 0), 0) / active.length);
+  dom.proxyProgress.textContent = `Proxy ${percent}% · ${active.length} processing`;
+  dom.proxyProgress.hidden = false;
+}
+
+let debugTimer = null;
+
+function byteText(value) {
+  if (!Number.isFinite(value)) return 'unavailable';
+  return `${(value / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+async function refreshDebug() {
+  if (dom.debugPanel.hidden) return;
+  try {
+    const [metrics, logs] = await Promise.all([
+      window.api.processMetrics(),
+      dom.debugLog.hidden ? Promise.resolve(null) : window.api.readErrorLog(),
+    ]);
+    const active = Object.values(state.proxies).filter((status) => status.state === 'queued' || status.state === 'generating');
+    dom.debugMetrics.textContent = [
+      `Process tree CPU: ${Number.isFinite(metrics.cpuPercent) ? `${metrics.cpuPercent.toFixed(1)}%` : 'unavailable'}`,
+      `Process tree memory: ${byteText(metrics.memoryBytes)}`,
+      `Timeline: ${state.project.tracks.length} tracks, ${state.project.assets.length} assets`,
+      `Proxy jobs: ${active.length} active, ${Object.keys(state.proxies).length} known`,
+      `Playback engine: ${state.settings.playbackEngine}`,
+      `IPC proxy updates: percentage-throttled`,
+    ].join('\n');
+    if (logs !== null) dom.debugLog.textContent = logs || 'No error log entries.';
+  } catch (error) {
+    reportError(error, 'debug:refresh');
+    dom.debugMetrics.textContent = `Debug data unavailable\n${errorText(error)}`;
+  }
+}
+
+function showDebug() {
+  dom.debugPanel.hidden = false;
+  void refreshDebug();
+  if (debugTimer === null) debugTimer = window.setInterval(() => void refreshDebug(), 1000);
+}
+
+function hideDebug() {
+  dom.debugPanel.hidden = true;
+  if (debugTimer !== null) window.clearInterval(debugTimer);
+  debugTimer = null;
 }
 
 async function prepareProxies() {
@@ -1619,7 +1681,6 @@ function loadDocument(doc, path) {
   state.waveforms = {};
   preview.clear();
   preview.showTimeline();
-  setPreviewSource('timeline');
   for (const asset of state.project.assets) hydrateDuration(asset);
   refresh();
   prepareDerivedMedia();
@@ -2072,29 +2133,6 @@ const actions = {
     ),
 };
 
-// --- preview source --------------------------------------------------------
-
-function setPreviewSource(source) {
-  for (const button of dom.previewSource.querySelectorAll('button')) {
-    button.classList.toggle('on', button.dataset.source === source);
-  }
-  if (source === 'asset') {
-    preview.clearExact();
-    setStageMode('');
-    const asset = state.selectedAssetId && L.findAsset(state.project, state.selectedAssetId);
-    preview.showAsset(asset || null);
-    dom.stageHint.hidden = Boolean(asset);
-    if (!asset) dom.stageHint.textContent = 'Select an asset on the left to preview it.';
-  } else {
-    preview.showTimeline();
-    dom.stageHint.textContent = 'Drop media on the timeline below to see it here.';
-  }
-  syncEditorOverlay();
-  renderStageOverlay();
-  preview.layout();
-  dom.duration.textContent = L.formatTimecode(preview.total(), rate());
-}
-
 // --- wiring ----------------------------------------------------------------
 
 function wireMenus() {
@@ -2132,6 +2170,17 @@ function wireMenus() {
 
 function wireAssets() {
   dom.btnImport.addEventListener('click', importViaDialog);
+  dom.btnDebug.addEventListener('click', () => {
+    if (dom.debugPanel.hidden) showDebug();
+    else hideDebug();
+  });
+  dom.btnCloseDebug.addEventListener('click', hideDebug);
+  dom.btnRefreshDebug.addEventListener('click', () => void refreshDebug());
+  dom.btnToggleLogs.addEventListener('click', () => {
+    dom.debugLog.hidden = !dom.debugLog.hidden;
+    dom.btnToggleLogs.textContent = dom.debugLog.hidden ? 'Show error log' : 'Hide error log';
+    void refreshDebug();
+  });
   dom.assetList.addEventListener('click', (event) => {
     const remove = event.target.closest('[data-remove]');
     if (remove) {
@@ -2142,12 +2191,6 @@ function wireAssets() {
     const item = event.target.closest('.asset');
     if (!item) return;
     selectAsset(item.dataset.id);
-    if (preview.mode() === 'asset') setPreviewSource('asset');
-  });
-  dom.assetList.addEventListener('dblclick', (event) => {
-    const item = event.target.closest('.asset');
-    if (!item) return;
-    setPreviewSource('asset');
   });
   dom.assetList.addEventListener('pointerdown', beginAssetDrag);
   window.addEventListener('pointermove', (event) => {
@@ -2293,10 +2336,6 @@ function wireTransport() {
       dom.previewQuality.value = previous;
       preview.setQuality(previous);
     });
-  });
-  dom.previewSource.addEventListener('click', (event) => {
-    const button = event.target.closest('[data-source]');
-    if (button) setPreviewSource(button.dataset.source);
   });
   dom.stage.addEventListener('wheel', (event) => {
     if (!event.metaKey) return;
@@ -2623,7 +2662,6 @@ async function boot() {
   });
 
   refresh();
-  setPreviewSource('timeline');
 
   try {
     adopt(await window.api.editState());

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -389,6 +389,7 @@ function renderProxyProgress() {
 }
 
 let debugTimer = null;
+let debugRefreshInFlight = false;
 
 function byteText(value) {
   if (!Number.isFinite(value)) return 'unavailable';
@@ -396,7 +397,8 @@ function byteText(value) {
 }
 
 async function refreshDebug() {
-  if (dom.debugPanel.hidden) return;
+  if (dom.debugPanel.hidden || debugRefreshInFlight) return;
+  debugRefreshInFlight = true;
   try {
     const [metrics, logs] = await Promise.all([
       window.api.processMetrics(),
@@ -415,6 +417,8 @@ async function refreshDebug() {
   } catch (error) {
     reportError(error, 'debug:refresh');
     dom.debugMetrics.textContent = `Debug data unavailable\n${errorText(error)}`;
+  } finally {
+    debugRefreshInFlight = false;
   }
 }
 

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -293,6 +293,43 @@ select {
   min-height: 0;
 }
 
+#debug-panel {
+  position: fixed;
+  z-index: 5;
+  top: 34px;
+  right: 12px;
+  width: min(360px, calc(100vw - 24px));
+  max-height: calc(100vh - 46px);
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  overflow: hidden;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 12px 30px rgb(0 0 0 / 24%);
+}
+
+.debug-block,
+.debug-log {
+  margin: 0;
+  padding: 10px;
+  overflow: auto;
+  font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre-wrap;
+}
+
+.debug-actions {
+  display: flex;
+  gap: 6px;
+  padding: 0 10px 10px;
+}
+
+.debug-log {
+  border-top: 1px solid var(--border);
+  background: var(--stage);
+  color: var(--fg);
+}
+
 #upper {
   display: grid;
   grid-template-columns: 264px minmax(0, 1fr);


### PR DESCRIPTION
# 구현

링크된 비디오·오디오 클립을 한 번만 믹스하고 프록시 진행률과 Debug 진단 화면 추가

- npm test 96개, cargo test -p makevideo-render 96개, cargo check -p akbun-makevideo 통과

# 어려웠던 점

동일한 앱 이름의 기존 개발 창 때문에 worktree 앱 창을 UI 자동화에서 구분할 수 없음

- 새 앱 프로세스 기동, 정적 구문 검사와 컴파일 검증으로 대체

# 리스크

Debug CPU·메모리 값은 운영체제 ps 출력에 의존

- ps 조회 실패 시 Debug 패널에 이용 불가 상태 표시

Issue #834
