### PR TITLE
akbun-makevideo: native playback stutter 진단

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-playback-stutter-is-measured-by-stage.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-playback-stutter-is-measured-by-stage.md
@@ -1,0 +1,21 @@
+---
+type: Decision
+title: 재생 끊김은 경로별 계측으로 원인을 분리
+description: native playback의 공급 부족, 재동기화, 표시 지연, A/V 지연을 별도 수치로 본다.
+tags: [makevideo, playback, diagnostics]
+timestamp: 2026-08-09T00:00:00Z
+---
+
+# 재생 끊김은 경로별 계측으로 원인을 분리
+
+## 결정
+
+* native monitor 상태에 frame-source starvation, 재동기화, 표시 실패, 표시 호출 시간, A/V 지연 기록
+* Debug 패널에서 1초 간격으로 집계값 표시
+* 화면 끊김만으로 WGPU·proxy 구조 교체 판단 금지
+
+## 이유
+
+* WGPU surface 경로에서는 프레임이 WebView IPC를 통과하지 않음
+* starvation 증가는 디코드·큐 공급 문제를 가리킴
+* 표시 호출 또는 A/V 지연 증가는 surface·GPU·스케줄 문제를 가리킴

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -1,0 +1,5 @@
+# Decisions
+
+## 목록
+
+* [재생 끊김은 경로별 계측으로 원인을 분리](2026-08-playback-stutter-is-measured-by-stage.md) - native surface 전환 뒤에도 공급·표시·A/V 지연을 따로 확인하는 결정.

--- a/product/akbun-makevideo/knowledge/index.md
+++ b/product/akbun-makevideo/knowledge/index.md
@@ -1,0 +1,7 @@
+# Knowledge
+
+akbun-makevideo의 구현 판단과 반복 절차 기록.
+
+## 분류
+
+* [Decisions](./decisions/index.md)

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,0 +1,5 @@
+# Knowledge Update Log
+
+## 2026-08-09
+
+* [재생 끊김은 경로별 계측으로 원인을 분리](decisions/2026-08-playback-stutter-is-measured-by-stage.md) 결정 기록. native surface 전환 뒤에는 원인 수치를 먼저 확인하고 구조 변경 여부를 판단함.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -52,6 +52,7 @@ pub enum Tick {
     /// A frame reached the screen. `late_ms` is signed: what the clock said
     /// when the drawing was finished, less when the frame was due. Positive is
     /// the picture behind the sound, which is the direction that can happen.
+    /// `present_ms` is the elapsed time spent in the sink's `show` call.
     Presented {
         frame: i64,
         late_ms: f64,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -52,7 +52,11 @@ pub enum Tick {
     /// A frame reached the screen. `late_ms` is signed: what the clock said
     /// when the drawing was finished, less when the frame was due. Positive is
     /// the picture behind the sound, which is the direction that can happen.
-    Presented { frame: i64, late_ms: f64 },
+    Presented {
+        frame: i64,
+        late_ms: f64,
+        present_ms: f64,
+    },
     /// A late frame was thrown away.
     Skipped { frame: i64 },
     /// Not this frame's turn yet. The driver sleeps for `wait`.
@@ -390,16 +394,19 @@ impl Scheduler {
     /// reported is when the frame *reached* the screen, not when it was picked,
     /// so compositing time counts against the drift the way a viewer sees it.
     fn draw(&mut self, sink: &mut dyn Sink, frame: &Frame, due: Option<i128>) -> Tick {
+        let started = std::time::Instant::now();
         if let Err(reason) = sink.show(frame) {
             return self.fail(reason);
         }
         self.counters.presented.fetch_add(1, Ordering::Relaxed);
+        let present_ms = started.elapsed().as_secs_f64() * 1000.0;
         let late_ms = due
             .map(|due| samples_to_millis(self.clock.position_samples() as i128 - due))
             .unwrap_or(0.0);
         Tick::Presented {
             frame: frame.frame,
             late_ms,
+            present_ms,
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -36,7 +36,7 @@ use makevideo_present::transport::{Setup, Transport};
 use makevideo_render::Project;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
@@ -95,6 +95,13 @@ pub struct Status {
     /// Frames drawn and frames dropped since this session started.
     pub presented: u64,
     pub skipped: u64,
+    pub resynced: u64,
+    pub starved: u64,
+    pub failed_frames: u64,
+    pub last_present_ms: f64,
+    pub peak_present_ms: f64,
+    pub last_late_ms: f64,
+    pub peak_late_ms: f64,
     pub failure: Option<String>,
 }
 
@@ -113,8 +120,44 @@ pub struct Session {
 /// Totals that outlive a play, so pausing does not reset what the page shows.
 #[derive(Debug, Default)]
 struct Counters {
-    presented: std::sync::atomic::AtomicU64,
-    skipped: std::sync::atomic::AtomicU64,
+    presented: AtomicU64,
+    skipped: AtomicU64,
+    resynced: AtomicU64,
+    starved: AtomicU64,
+    failed_frames: AtomicU64,
+    last_present_us: AtomicU64,
+    peak_present_us: AtomicU64,
+    last_late_us: AtomicI64,
+    peak_late_us: AtomicI64,
+}
+
+impl Counters {
+    fn record_present(&self, present_ms: f64, late_ms: f64) {
+        let present_us = micros(present_ms);
+        let late_us = signed_micros(late_ms);
+        self.last_present_us.store(present_us, Ordering::Relaxed);
+        self.last_late_us.store(late_us, Ordering::Relaxed);
+        self.peak_present_us
+            .fetch_max(present_us, Ordering::Relaxed);
+        self.peak_late_us
+            .fetch_max(late_us.max(0), Ordering::Relaxed);
+    }
+}
+
+fn micros(milliseconds: f64) -> u64 {
+    (milliseconds.max(0.0) * 1000.0).round() as u64
+}
+
+fn signed_micros(milliseconds: f64) -> i64 {
+    (milliseconds * 1000.0).round() as i64
+}
+
+fn milliseconds(micros: u64) -> f64 {
+    micros as f64 / 1000.0
+}
+
+fn signed_milliseconds(micros: i64) -> f64 {
+    micros as f64 / 1000.0
 }
 
 /// Everything the loop needs that does not change while it runs.
@@ -260,6 +303,13 @@ impl Session {
             playing: self.shared.playing(),
             presented: self.counters.presented.load(Ordering::Relaxed),
             skipped: self.counters.skipped.load(Ordering::Relaxed),
+            resynced: self.counters.resynced.load(Ordering::Relaxed),
+            starved: self.counters.starved.load(Ordering::Relaxed),
+            failed_frames: self.counters.failed_frames.load(Ordering::Relaxed),
+            last_present_ms: milliseconds(self.counters.last_present_us.load(Ordering::Relaxed)),
+            peak_present_ms: milliseconds(self.counters.peak_present_us.load(Ordering::Relaxed)),
+            last_late_ms: signed_milliseconds(self.counters.last_late_us.load(Ordering::Relaxed)),
+            peak_late_ms: signed_milliseconds(self.counters.peak_late_us.load(Ordering::Relaxed)),
             failure: self.shared.failure(),
         }
     }
@@ -347,8 +397,13 @@ fn run(mut state: Loop) {
             .store(current.transport.position(), Ordering::Relaxed);
 
         match tick {
-            Tick::Presented { .. } => {
+            Tick::Presented {
+                present_ms,
+                late_ms,
+                ..
+            } => {
                 state.counters.presented.fetch_add(1, Ordering::Relaxed);
+                state.counters.record_present(present_ms, late_ms);
             }
             Tick::Skipped { .. } => {
                 state.counters.skipped.fetch_add(1, Ordering::Relaxed);
@@ -358,7 +413,10 @@ fn run(mut state: Loop) {
                     std::thread::sleep(wait);
                 }
             }
-            Tick::Starved => std::thread::sleep(Duration::from_millis(1)),
+            Tick::Starved => {
+                state.counters.starved.fetch_add(1, Ordering::Relaxed);
+                std::thread::sleep(Duration::from_millis(1));
+            }
             Tick::Idle => std::thread::sleep(REST),
             Tick::Ended => {
                 // The timeline is over. Stop where it ended and leave the last
@@ -371,6 +429,7 @@ fn run(mut state: Loop) {
                 }
             }
             Tick::Failed { reason } => {
+                state.counters.failed_frames.fetch_add(1, Ordering::Relaxed);
                 // Recorded once and then carried on with. A frame that could
                 // not be drawn is a frame missing from the screen, and stopping
                 // the sound as well would make a bad monitor into a broken app.
@@ -380,7 +439,9 @@ fn run(mut state: Loop) {
                 }
                 std::thread::sleep(REST);
             }
-            Tick::Resynced { .. } => {}
+            Tick::Resynced { .. } => {
+                state.counters.resynced.fetch_add(1, Ordering::Relaxed);
+            }
         }
     }
 }
@@ -438,5 +499,17 @@ mod tests {
     fn shared_state_crosses_threads() {
         assert_send_sync::<Shared>();
         assert_send_sync::<Counters>();
+    }
+
+    #[test]
+    fn counters_keep_the_latest_and_peak_playback_measurements() {
+        let counters = Counters::default();
+        counters.record_present(4.25, -1.5);
+        counters.record_present(2.0, 8.75);
+
+        assert_eq!(counters.last_present_us.load(Ordering::Relaxed), 2_000);
+        assert_eq!(counters.peak_present_us.load(Ordering::Relaxed), 4_250);
+        assert_eq!(counters.last_late_us.load(Ordering::Relaxed), 8_750);
+        assert_eq!(counters.peak_late_us.load(Ordering::Relaxed), 8_750);
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -220,7 +220,7 @@ pub fn detach(inner: &Inner) {
 }
 
 pub fn target(inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
-    Ok(wgpu::SurfaceTarget::Window(Box::new(ViewTarget(
+    Ok(wgpu::SurfaceTarget::DisplayAndWindow(Box::new(ViewTarget(
         inner.view.0.cast::<std::ffi::c_void>(),
     ))))
 }

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -407,12 +407,27 @@ function byteText(value) {
   return `${(value / (1024 * 1024)).toFixed(1)} MiB`;
 }
 
+function millisecondsText(value) {
+  return Number.isFinite(value) ? `${value.toFixed(1)} ms` : 'unavailable';
+}
+
+function playbackDebugLines(status) {
+  if (!status) return ['Native playback: not attached'];
+  return [
+    `Native frames: ${status.presented} presented, ${status.skipped} skipped, ${status.resynced} resynced`,
+    `Native source: ${status.starved} starved, ${status.failedFrames} display failures`,
+    `Native display call: ${millisecondsText(status.lastPresentMs)} last, ${millisecondsText(status.peakPresentMs)} peak`,
+    `Native A/V lateness: ${millisecondsText(status.lastLateMs)} last, ${millisecondsText(status.peakLateMs)} peak`,
+  ];
+}
+
 async function refreshDebug() {
   if (dom.debugPanel.hidden || debugRefreshInFlight) return;
   debugRefreshInFlight = true;
   try {
-    const [metrics, logs] = await Promise.all([
+    const [metrics, playback, logs] = await Promise.all([
       window.api.processMetrics(),
+      window.api.playbackStatus(),
       dom.debugLog.hidden ? Promise.resolve(null) : window.api.readErrorLog(),
     ]);
     const active = Object.values(state.proxies).filter((status) => status.state === 'queued' || status.state === 'generating');
@@ -422,6 +437,7 @@ async function refreshDebug() {
       `Timeline: ${state.project.tracks.length} tracks, ${state.project.assets.length} assets`,
       `Proxy jobs: ${active.length} active, ${Object.keys(state.proxies).length} known`,
       `Playback engine: ${state.settings.playbackEngine}`,
+      ...playbackDebugLines(playback),
       `IPC proxy updates: percentage-throttled`,
     ].join('\n');
     if (logs !== null) dom.debugLog.textContent = logs || 'No error log entries.';


### PR DESCRIPTION
# 구현

native monitor surface에 display handle을 전달하고 재생 경로별 진단 수치 표시

* release 앱에서 5초 1080p 재생 중 84 frame 표시, skip·resync·display failure 0 확인

# 어려웠던 점

window handle만 전달해 native surface가 생성 직후 media element로 폴백

* display handle을 함께 받는 wgpu surface target으로 변경

# 리스크

표시 호출 시간은 display scanout 완료 시각이 아님

* scanout 지연 분석이 필요하면 플랫폼별 GPU timestamp 또는 present callback 추가 필요

Issue #843
