### PR TITLE
akbun-makevideo: add shape layers

### DIFF
--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -6,7 +6,7 @@ use crate::Placement;
 use fontdb::{Database, Family, Query};
 use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle as LayoutTextStyle};
 use fontdue::{Font, FontSettings};
-use makevideo_render::{Project, TextAlign, TextStyle, VisualContent};
+use makevideo_render::{Project, ShapeKind, TextAlign, TextStyle, VisualContent};
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -46,10 +46,6 @@ pub fn layers_at(project: &Project, frame: i64, width: u32, height: u32) -> Vec<
             .collect();
         items.sort_by_key(|item| item.z_index);
         for item in items {
-            let VisualContent::Text { text, style } = &item.content else {
-                continue;
-            };
-            let style = track.subtitle_style.as_ref().unwrap_or(style);
             let transform = if track.kind == makevideo_render::TrackKind::Subtitle {
                 makevideo_render::VisualTransform {
                     x: 96.0,
@@ -64,10 +60,40 @@ pub fn layers_at(project: &Project, frame: i64, width: u32, height: u32) -> Vec<
             };
             let item_width = (transform.width * scale_x).round().max(1.0) as u32;
             let item_height = (transform.height * scale_y).round().max(1.0) as u32;
-            let key = format!(
-                "{text}\u{0}{style:?}\u{0}{item_width}x{item_height}\u{0}{scale:.4}"
-            );
-            let pixels = cached(&key, || rasterize(text, style, item_width, item_height, scale));
+            let pixels = match &item.content {
+                VisualContent::Text { text, style } => {
+                    let style = track.subtitle_style.as_ref().unwrap_or(style);
+                    let key = format!(
+                        "text\u{0}{text}\u{0}{style:?}\u{0}{item_width}x{item_height}\u{0}{scale:.4}"
+                    );
+                    cached(&key, || rasterize(text, style, item_width, item_height, scale))
+                }
+                VisualContent::Shape {
+                    shape,
+                    fill,
+                    stroke,
+                    stroke_width,
+                    corner_radius,
+                    start_arrow,
+                    end_arrow,
+                } => {
+                    let key = format!(
+                        "shape\u{0}{shape:?}\u{0}{fill}\u{0}{stroke}\u{0}{stroke_width}\u{0}{corner_radius}\u{0}{start_arrow}\u{0}{end_arrow}\u{0}{item_width}x{item_height}\u{0}{scale:.4}"
+                    );
+                    cached(&key, || rasterize_shape(
+                        *shape,
+                        fill,
+                        stroke,
+                        *stroke_width * scale,
+                        *corner_radius * scale,
+                        *start_arrow,
+                        *end_arrow,
+                        item_width,
+                        item_height,
+                    ))
+                }
+                VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => continue,
+            };
             layers.push(RasterLayer {
                 pixels,
                 width: item_width,
@@ -85,6 +111,70 @@ pub fn layers_at(project: &Project, frame: i64, width: u32, height: u32) -> Vec<
         }
     }
     layers
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rasterize_shape(
+    shape: ShapeKind,
+    fill: &str,
+    stroke: &str,
+    stroke_width: f32,
+    corner_radius: f32,
+    start_arrow: bool,
+    end_arrow: bool,
+    width: u32,
+    height: u32,
+) -> Vec<u8> {
+    let mut pixels = vec![0; width as usize * height as usize * 4];
+    let fill = colour(fill, [79, 140, 255, 204]);
+    let stroke = colour(stroke, [255, 255, 255, 255]);
+    let edge = stroke_width.max(0.0) / 2.0;
+    for y in 0..height {
+        for x in 0..width {
+            let point = (x as f32 + 0.5, y as f32 + 0.5);
+            let (inside, outlined) = match shape {
+                ShapeKind::Rectangle => rounded_rectangle(point, width as f32, height as f32, corner_radius, edge),
+                ShapeKind::Ellipse => ellipse(point, width as f32, height as f32, edge),
+                ShapeKind::Line => line(point, width as f32, height as f32, edge.max(1.0), start_arrow, end_arrow),
+            };
+            if inside {
+                put_pixel(&mut pixels, width, x, y, if outlined { stroke } else { fill });
+            }
+        }
+    }
+    pixels
+}
+
+fn rounded_rectangle(point: (f32, f32), width: f32, height: f32, radius: f32, edge: f32) -> (bool, bool) {
+    let radius = radius.clamp(0.0, width.min(height) / 2.0);
+    let dx = (point.0 - width / 2.0).abs() - (width / 2.0 - radius);
+    let dy = (point.1 - height / 2.0).abs() - (height / 2.0 - radius);
+    let distance = dx.max(0.0).hypot(dy.max(0.0)) + dx.max(dy).min(0.0) - radius;
+    (distance <= 0.0, distance >= -edge)
+}
+
+fn ellipse(point: (f32, f32), width: f32, height: f32, edge: f32) -> (bool, bool) {
+    let nx = (point.0 - width / 2.0) / (width / 2.0).max(1.0);
+    let ny = (point.1 - height / 2.0) / (height / 2.0).max(1.0);
+    let distance = (nx * nx + ny * ny).sqrt();
+    let outline = edge / (width.min(height) / 2.0).max(1.0);
+    (distance <= 1.0, distance >= 1.0 - outline)
+}
+
+fn line(point: (f32, f32), width: f32, height: f32, radius: f32, start_arrow: bool, end_arrow: bool) -> (bool, bool) {
+    let centre = height / 2.0;
+    let body = (point.1 - centre).abs() <= radius && point.0 >= radius && point.0 <= width - radius;
+    let arrow_size = (radius * 3.0).max(8.0);
+    let arrow = |tip_x: f32, points_left: bool| {
+        let dx = if points_left { tip_x - point.0 } else { point.0 - tip_x };
+        dx >= 0.0 && dx <= arrow_size && (point.1 - centre).abs() <= dx * 0.65 + 0.5
+    };
+    (body || (start_arrow && arrow(0.0, false)) || (end_arrow && arrow(width, true)), true)
+}
+
+fn put_pixel(pixels: &mut [u8], width: u32, x: u32, y: u32, color: [u8; 4]) {
+    let index = ((y * width + x) * 4) as usize;
+    pixels[index..index + 4].copy_from_slice(&color);
 }
 
 fn cached(key: &str, build: impl FnOnce() -> Vec<u8>) -> Arc<[u8]> {
@@ -266,5 +356,36 @@ mod tests {
     #[test]
     fn colour_accepts_css_hex_with_alpha() {
         assert_eq!(colour("#11223344", [0; 4]), [0x11, 0x22, 0x33, 0x44]);
+    }
+
+    #[test]
+    fn shapes_rasterize_fill_outline_and_line_arrows() {
+        let rectangle = rasterize_shape(
+            ShapeKind::Rectangle,
+            "#112233",
+            "#ffffff",
+            2.0,
+            4.0,
+            false,
+            false,
+            20,
+            12,
+        );
+        assert_eq!(&rectangle[(6 * 20 + 10) * 4..(6 * 20 + 10) * 4 + 4], &[0x11, 0x22, 0x33, 255]);
+        assert_eq!(&rectangle[(10) * 4..(10) * 4 + 4], &[255, 255, 255, 255]);
+
+        let line = rasterize_shape(
+            ShapeKind::Line,
+            "#00000000",
+            "#ff0000",
+            3.0,
+            0.0,
+            true,
+            true,
+            30,
+            12,
+        );
+        assert_eq!(&line[(6 * 30) * 4..(6 * 30) * 4 + 4], &[255, 0, 0, 255]);
+        assert_eq!(&line[(6 * 30 + 29) * 4..(6 * 30 + 29) * 4 + 4], &[255, 0, 0, 255]);
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -135,7 +135,7 @@ fn rasterize_shape(
             let (inside, outlined) = match shape {
                 ShapeKind::Rectangle => rounded_rectangle(point, width as f32, height as f32, corner_radius, edge),
                 ShapeKind::Ellipse => ellipse(point, width as f32, height as f32, edge),
-                ShapeKind::Line => line(point, width as f32, height as f32, edge.max(1.0), start_arrow, end_arrow),
+                ShapeKind::Line => line(point, width as f32, height as f32, edge, start_arrow, end_arrow),
             };
             if inside {
                 put_pixel(&mut pixels, width, x, y, if outlined { stroke } else { fill });
@@ -162,6 +162,9 @@ fn ellipse(point: (f32, f32), width: f32, height: f32, edge: f32) -> (bool, bool
 }
 
 fn line(point: (f32, f32), width: f32, height: f32, radius: f32, start_arrow: bool, end_arrow: bool) -> (bool, bool) {
+    if radius <= 0.0 {
+        return (false, false);
+    }
     let centre = height / 2.0;
     let body = (point.1 - centre).abs() <= radius && point.0 >= radius && point.0 <= width - radius;
     let arrow_size = (radius * 3.0).max(8.0);
@@ -387,5 +390,18 @@ mod tests {
         );
         assert_eq!(&line[(6 * 30) * 4..(6 * 30) * 4 + 4], &[255, 0, 0, 255]);
         assert_eq!(&line[(6 * 30 + 29) * 4..(6 * 30 + 29) * 4 + 4], &[255, 0, 0, 255]);
+
+        let no_stroke = rasterize_shape(
+            ShapeKind::Line,
+            "#00000000",
+            "#ff0000",
+            0.0,
+            0.0,
+            true,
+            true,
+            30,
+            12,
+        );
+        assert!(no_stroke.chunks_exact(4).all(|pixel| pixel[3] == 0));
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -1513,7 +1513,7 @@ fn validate_visual_content(project: &Project, content: &VisualContent) -> Result
         (VisualContent::VideoOverlay { .. }, _) => {
             Err("a video overlay needs a video asset".into())
         }
-        (VisualContent::Text { .. } | VisualContent::Shape, _) => Ok(()),
+        (VisualContent::Text { .. } | VisualContent::Shape { .. }, _) => Ok(()),
     }
 }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -1243,7 +1243,15 @@ mod tests {
         let error = document
             .apply(Command::AddVisualItem {
                 track_id: video_track(&document),
-                content: VisualContent::Shape,
+                content: VisualContent::Shape {
+                    shape: Default::default(),
+                    fill: "#4f8cffcc".into(),
+                    stroke: "#ffffff".into(),
+                    stroke_width: 4.0,
+                    corner_radius: 0.0,
+                    start_arrow: false,
+                    end_arrow: false,
+                },
                 start: 0,
                 duration: 30,
                 transform: VisualTransform {
@@ -1268,7 +1276,15 @@ mod tests {
         let track_id = video_track(&document);
         let command = Command::AddVisualItem {
             track_id,
-            content: VisualContent::Shape,
+            content: VisualContent::Shape {
+                shape: Default::default(),
+                fill: "#4f8cffcc".into(),
+                stroke: "#ffffff".into(),
+                stroke_width: 4.0,
+                corner_radius: 0.0,
+                start_arrow: false,
+                end_arrow: false,
+            },
             start: 0,
             duration: 30,
             transform: VisualTransform {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -388,7 +388,22 @@ pub enum VisualContent {
         #[serde(default)]
         style: TextStyle,
     },
-    Shape,
+    Shape {
+        #[serde(default)]
+        shape: ShapeKind,
+        #[serde(default = "default_shape_fill")]
+        fill: String,
+        #[serde(default = "default_shape_stroke")]
+        stroke: String,
+        #[serde(default = "default_shape_stroke_width")]
+        stroke_width: f32,
+        #[serde(default)]
+        corner_radius: f32,
+        #[serde(default)]
+        start_arrow: bool,
+        #[serde(default)]
+        end_arrow: bool,
+    },
     Image { asset_id: String },
     VideoOverlay { asset_id: String },
 }
@@ -399,9 +414,36 @@ impl VisualContent {
             VisualContent::Image { asset_id } | VisualContent::VideoOverlay { asset_id } => {
                 Some(asset_id)
             }
-            VisualContent::Text { .. } | VisualContent::Shape => None,
+            VisualContent::Text { .. } | VisualContent::Shape { .. } => None,
         }
     }
+}
+
+/// The primitive drawn inside a shape item's shared transform rectangle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ShapeKind {
+    Rectangle,
+    Ellipse,
+    Line,
+}
+
+impl Default for ShapeKind {
+    fn default() -> Self {
+        ShapeKind::Rectangle
+    }
+}
+
+fn default_shape_fill() -> String {
+    "#4f8cffcc".into()
+}
+
+fn default_shape_stroke() -> String {
+    "#ffffff".into()
+}
+
+fn default_shape_stroke_width() -> f32 {
+    4.0
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -978,7 +1020,15 @@ mod tests {
                 opacity: 1.0,
             },
             z_index,
-            content: VisualContent::Shape,
+            content: VisualContent::Shape {
+                shape: ShapeKind::Rectangle,
+                fill: default_shape_fill(),
+                stroke: default_shape_stroke(),
+                stroke_width: default_shape_stroke_width(),
+                corner_radius: 0.0,
+                start_arrow: false,
+                end_arrow: false,
+            },
         }
     }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
@@ -251,6 +251,16 @@ mod tests {
     }
 
     #[test]
+    fn an_early_shape_without_style_opens_with_editable_defaults() {
+        let content: crate::VisualContent = serde_json::from_str(r#"{"kind":"shape"}"#).unwrap();
+        assert!(matches!(content, crate::VisualContent::Shape {
+            shape: crate::ShapeKind::Rectangle,
+            stroke_width: 4.0,
+            ..
+        }));
+    }
+
+    #[test]
     fn what_comes_back_out_is_todays_format_only() {
         let text = r#"{
             "version": 1,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
@@ -19,6 +19,6 @@ pub mod workspace;
 
 pub use makevideo_edit::{
     asset_id, Asset, AssetKind, Clip, Project, ProjectSettings, TextAlign, TextStyle, Track,
-    TrackKind, VisualContent, VisualItem, VisualTransform, FORMAT_VERSION,
+    ShapeKind, TrackKind, VisualContent, VisualItem, VisualTransform, FORMAT_VERSION,
 };
 pub use makevideo_time::{RationalTime, Rate};

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -170,6 +170,7 @@
         </button>
         <button id="btn-link" class="small" title="Link or unlink synchronized audio and video clips">Link Clips</button>
         <button id="btn-add-text" class="small" title="Add a title at the playhead">+ Text</button>
+        <button id="btn-add-shape" class="small" title="Add a rectangle at the playhead">+ Shape</button>
         <button id="btn-add-marker" class="small" title="Add a marker at the playhead">+ Marker</button>
         <span class="sep-v"></span>
         <button id="btn-add-video" class="small">+ Video track</button>
@@ -207,6 +208,18 @@
           <label class="row">Outline <input id="text-stroke-color" type="color" /></label>
           <label class="row">Outline width <input id="text-stroke-width" type="number" min="0" max="32" step="1" /></label>
           <label class="row">Shadow <input id="text-shadow-color" type="color" /></label>
+        </div>
+      </details>
+      <details id="shape-panel" hidden>
+        <summary>Shape</summary>
+        <div id="shape-inspector">
+          <label class="row">Type <select id="shape-kind"><option value="rectangle">Rectangle</option><option value="ellipse">Ellipse</option><option value="line">Line</option></select></label>
+          <label class="row">Fill <input id="shape-fill" type="color" /></label>
+          <label class="row">Outline <input id="shape-stroke" type="color" /></label>
+          <label class="row">Outline width <input id="shape-stroke-width" type="number" min="0" max="128" step="1" /></label>
+          <label class="row">Corner radius <input id="shape-corner-radius" type="number" min="0" max="2048" step="1" /></label>
+          <label class="row check"><input id="shape-start-arrow" type="checkbox" /> Start arrow</label>
+          <label class="row check"><input id="shape-end-arrow" type="checkbox" /> End arrow</label>
         </div>
       </details>
       <details id="subtitle-panel" hidden>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -96,6 +96,7 @@ const dom = {
   btnRipple: el('btn-ripple'),
   btnLink: el('btn-link'),
   btnAddText: el('btn-add-text'),
+  btnAddShape: el('btn-add-shape'),
   btnAddMarker: el('btn-add-marker'),
   btnAddVideo: el('btn-add-video'),
   btnAddAudio: el('btn-add-audio'),
@@ -119,6 +120,14 @@ const dom = {
   textStrokeColor: el('text-stroke-color'),
   textStrokeWidth: el('text-stroke-width'),
   textShadowColor: el('text-shadow-color'),
+  shapePanel: el('shape-panel'),
+  shapeKind: el('shape-kind'),
+  shapeFill: el('shape-fill'),
+  shapeStroke: el('shape-stroke'),
+  shapeStrokeWidth: el('shape-stroke-width'),
+  shapeCornerRadius: el('shape-corner-radius'),
+  shapeStartArrow: el('shape-start-arrow'),
+  shapeEndArrow: el('shape-end-arrow'),
   subtitlePanel: el('subtitle-panel'),
   subtitleValue: el('subtitle-value'),
   subtitleStart: el('subtitle-start'),
@@ -1005,6 +1014,7 @@ function overlayScale() {
 
 function selectVisualItem(itemId) {
   state.selectedVisualItemId = itemId || null;
+  renderTextInspector();
   syncEditorOverlay();
   renderStageOverlay();
 }
@@ -1245,6 +1255,35 @@ async function addText() {
   if (item) selectVisualItem(item.id);
 }
 
+async function addShape() {
+  const target = state.targetTrackId && L.findTrack(state.project, state.targetTrackId);
+  const track = target && target.kind === 'video' ? target : L.tracksOf(state.project, 'video')[0];
+  if (!track) return;
+  const known = new Set((track.visualItems || []).map((item) => item.id));
+  await edit({
+    op: 'addVisualItem',
+    trackId: track.id,
+    content: {
+      kind: 'shape', shape: 'rectangle', fill: '#4f8cffcc', stroke: '#ffffff',
+      strokeWidth: 4, cornerRadius: 20, startArrow: false, endArrow: false,
+    },
+    start: Math.round(preview.position()),
+    duration: Math.max(Math.round(T.rateToNumber(rate()) * 5), 1),
+    transform: {
+      x: state.project.settings.width * 0.3,
+      y: state.project.settings.height * 0.3,
+      width: state.project.settings.width * 0.4,
+      height: state.project.settings.height * 0.25,
+      rotation: 0,
+      opacity: 1,
+    },
+    zIndex: 0,
+  });
+  const liveTrack = L.findTrack(state.project, track.id);
+  const item = (liveTrack && liveTrack.visualItems || []).find((entry) => !known.has(entry.id));
+  if (item) selectVisualItem(item.id);
+}
+
 async function addSubtitle() {
   const track = L.tracksOf(state.project, 'subtitle')[0];
   if (!track) return;
@@ -1294,10 +1333,21 @@ function preserveAlpha(color, previous) {
 function renderTextInspector() {
   const item = selectedVisualItem();
   const text = item && item.content && item.content.kind === 'text' ? item.content : null;
+  const shape = item && item.content && item.content.kind === 'shape' ? item.content : null;
   const track = item && state.project.tracks.find((candidate) => (candidate.visualItems || []).some((entry) => entry.id === item.id));
   const subtitle = track && track.kind === 'subtitle';
   dom.textPanel.hidden = !text || subtitle;
   dom.subtitlePanel.hidden = !text || !subtitle;
+  dom.shapePanel.hidden = !shape;
+  if (shape) {
+    dom.shapeKind.value = shape.shape || 'rectangle';
+    dom.shapeFill.value = hexColor(shape.fill, '#4f8cff');
+    dom.shapeStroke.value = hexColor(shape.stroke, '#ffffff');
+    dom.shapeStrokeWidth.value = shape.strokeWidth ?? 4;
+    dom.shapeCornerRadius.value = shape.cornerRadius ?? 0;
+    dom.shapeStartArrow.checked = Boolean(shape.startArrow);
+    dom.shapeEndArrow.checked = Boolean(shape.endArrow);
+  }
   if (!text) return;
   if (subtitle) {
     dom.subtitleValue.value = text.text || '';
@@ -1318,6 +1368,24 @@ function renderTextInspector() {
   dom.textStrokeColor.value = hexColor(style.strokeColor, '#000000');
   dom.textStrokeWidth.value = style.strokeWidth || 0;
   dom.textShadowColor.value = hexColor(style.shadowColor, '#000000');
+}
+
+function updateSelectedShape() {
+  const item = selectedVisualItem();
+  if (!item || item.content.kind !== 'shape') return;
+  const content = {
+    kind: 'shape',
+    shape: dom.shapeKind.value,
+    fill: preserveAlpha(dom.shapeFill.value, item.content.fill),
+    stroke: preserveAlpha(dom.shapeStroke.value, item.content.stroke),
+    strokeWidth: Math.max(0, Number(dom.shapeStrokeWidth.value) || 0),
+    cornerRadius: Math.max(0, Number(dom.shapeCornerRadius.value) || 0),
+    startArrow: dom.shapeStartArrow.checked,
+    endArrow: dom.shapeEndArrow.checked,
+  };
+  edit({ op: 'setVisualContent', itemId: item.id, content })
+    .then(() => selectVisualItem(item.id))
+    .catch((error) => reportError(error, 'shape:edit'));
 }
 
 function updateSelectedSubtitle() {
@@ -2375,6 +2443,7 @@ function wireTimeline() {
   dom.btnRipple.addEventListener('click', () => deleteSelected(true));
   dom.btnLink.addEventListener('click', toggleClipLink);
   dom.btnAddText.addEventListener('click', addText);
+  dom.btnAddShape.addEventListener('click', addShape);
   dom.btnAddMarker.addEventListener('click', () => addMarker());
   dom.btnAddVideo.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'video' }));
   dom.btnAddAudio.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'audio' }));
@@ -2443,6 +2512,12 @@ function wireTimeline() {
     dom.textStrokeColor, dom.textStrokeWidth, dom.textShadowColor,
   ]) {
     input.addEventListener('change', updateSelectedText);
+  }
+  for (const input of [
+    dom.shapeKind, dom.shapeFill, dom.shapeStroke, dom.shapeStrokeWidth,
+    dom.shapeCornerRadius, dom.shapeStartArrow, dom.shapeEndArrow,
+  ]) {
+    input.addEventListener('change', updateSelectedShape);
   }
   for (const input of [dom.subtitleValue, dom.subtitleStart, dom.subtitleEnd]) {
     input.addEventListener('change', updateSelectedSubtitle);


### PR DESCRIPTION
# 구현

도형 레이어 모델과 편집·합성 경로 추가
- 사각형·원·선·화살표, 채움·테두리·모서리 둥글기 편집

# 어려웠던 점

화면과 export의 도형 결과 일치
- 텍스트 래스터 캐시와 동일한 합성 레이어 경로 재사용

# 리스크

선 도형의 화살표 크기 고정
- 작은 도형에서 선 두께 대비 화살표 비율 차이 가능

Issue #682