### PR TITLE
akbun-makevideo Program Monitor 위치와 text·shape 레이어 복구

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-graph-render-overlays-rasterized-stills.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-graph-render-overlays-rasterized-stills.md
@@ -1,0 +1,23 @@
+---
+type: Decision
+title: filter graph 렌더는 rasterize한 still을 overlay로 굽는다
+description: CPU 렌더와 폴백에서 text/shape가 조용히 빠지던 것을 drawtext도 소프트웨어 합성도 아닌 자체 raster + overlay로 해결한 결정.
+tags: [makevideo, render, ffmpeg, text]
+timestamp: 2026-08-10T00:00:00Z
+---
+
+# filter graph 렌더는 rasterize한 still을 overlay로 굽는다
+
+## 결정
+
+* compositor의 text/shape rasterizer가 item당 still 하나(PAM)를 출력 해상도로 만들고, filter graph가 overlay와 enable 구간으로 굽는다
+* drawtext 필터 생성과 전체 소프트웨어 합성은 둘 다 선택하지 않음
+
+## 이유
+
+* filter graph 경로(compositor cpu 설정, composited 렌더 실패 폴백)는 drawtext가 없어 preview에 보이던 레이어가 결과 파일에서 조용히 사라졌음
+* drawtext는 폰트 지정과 도형 표현이 rasterizer와 달라 preview와 렌더가 다른 그림이 되고, 전체 소프트웨어 합성은 filter graph가 분 단위로 끝내는 일을 시간 단위로 만들어 기존 결정([그래픽 장치 축](2026-08-one-axis-for-the-graphics-device.md))의 이유를 무너뜨림. still overlay는 픽셀은 compositor 것, 합성 속도는 ffmpeg 것
+
+## Citations
+
+1. <https://github.com/choisungwook/portfolio/pull/851>

--- a/product/akbun-makevideo/knowledge/decisions/2026-08-native-view-asks-its-superview-for-the-origin.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-native-view-asks-its-superview-for-the-origin.md
@@ -1,0 +1,23 @@
+---
+type: Decision
+title: native view 좌표는 superview에게 원점을 물어본다
+description: WKWebView는 flipped view라 bottom-left 가정이 monitor를 세로로 뒤집힌 위치에 놓았고, isFlipped 분기로 고친 결정.
+tags: [makevideo, viewport, macos, appkit]
+timestamp: 2026-08-10T00:00:00Z
+---
+
+# native view 좌표는 superview에게 원점을 물어본다
+
+## 결정
+
+* viewport 좌표 변환은 AppKit의 bottom-left를 가정하지 않고 superview의 isFlipped를 물어 원점을 정함
+* child view의 frame 계산은 container를 window에 넣은 뒤에 수행. window 밖 view의 convertRectToBacking은 그 window의 display scale을 모름
+
+## 이유
+
+* PR #853이 native container를 window contentView(bottom-left)에서 WKWebView 안으로 옮겼는데, WKWebView는 isFlipped가 YES인 top-left 원점 view라 기존 y flip이 이중 적용되어 monitor가 stage의 세로 거울상 위치에 붙음
+* NSView 계열은 서브클래스마다 원점이 다르므로, 부모를 바꾸는 변경은 좌표 가정을 함께 검증해야 함. isFlipped 분기는 어느 부모 아래서도 같은 코드가 맞음
+
+## Citations
+
+1. <https://github.com/choisungwook/portfolio/pull/853>

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,8 @@
 
 ## 목록
 
+* [native view 좌표는 superview에게 원점을 물어본다](2026-08-native-view-asks-its-superview-for-the-origin.md) - WKWebView가 flipped view라 bottom-left 가정이 monitor를 뒤집힌 위치에 놓은 뒤 정한 규칙.
+* [filter graph 렌더는 rasterize한 still을 overlay로 굽는다](2026-08-graph-render-overlays-rasterized-stills.md) - CPU 렌더와 폴백에서 text/shape가 빠지던 것을 자체 raster + overlay로 해결한 결정.
 * [그래픽 장치를 쓰는지 하나로 preview와 playback과 render를 함께 정한다](2026-08-one-axis-for-the-graphics-device.md) - compositor 설정을 GPU와 CPU 둘로 줄이고 playback 설정을 없앤 결정.
 * [재생 끊김은 경로별 계측으로 원인을 분리](2026-08-playback-stutter-is-measured-by-stage.md) - 공급과 표시와 A/V 지연을 따로 보고 구조 교체를 미룬 결정.
 * [경계 stub은 실제 API 이름만 가진다](2026-08-seam-stubs-carry-only-real-api-names.md) - 무엇에나 답하는 Proxy stub이 없는 메서드 호출을 숨긴 뒤 정한 규칙.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,10 @@
 # Knowledge Update Log
 
+## 2026-08-10
+
+* [native view 좌표는 superview에게 원점을 물어본다](decisions/2026-08-native-view-asks-its-superview-for-the-origin.md) 결정 기록. WKWebView의 isFlipped가 YES인 것을 실측으로 확인하고 viewport 변환을 superview 질의로 바꿈.
+* [filter graph 렌더는 rasterize한 still을 overlay로 굽는다](decisions/2026-08-graph-render-overlays-rasterized-stills.md) 결정 기록. CPU 렌더와 폴백이 text/shape를 조용히 떨어뜨리던 문제의 해법 선택을 남김.
+
 ## 2026-08-09
 
 * [그래픽 장치를 쓰는지 하나로 preview와 playback과 render를 함께 정한다](decisions/2026-08-one-axis-for-the-graphics-device.md) 결정 기록. 불가능한 설정 조합을 없애고 판정을 한 쌍의 함수로 모음.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/pipeline.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/pipeline.rs
@@ -200,19 +200,9 @@ where
             }
         };
 
-        let visual = crate::text::layers_at(project, frame.frame, width, height);
-        let mut layers: Vec<(Source<'_>, Draw)> = frame.sources();
-        layers.extend(visual.iter().map(|layer| {
-            (
-                Source {
-                    rgba: &layer.pixels,
-                    width: layer.width,
-                    height: layer.height,
-                    lut: None,
-                },
-                layer.placement,
-            )
-        }));
+        // Text and shape items are already in the frame — FrameSource puts
+        // them there, so playback and this export composite the same picture.
+        let layers: Vec<(Source<'_>, Draw)> = frame.sources();
         let picture = match compositor.compose(width, height, &layers) {
             Ok(picture) => picture,
             Err(error) => {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -277,6 +277,10 @@ pub struct Layer {
 pub struct Frame {
     pub frame: i64,
     pub layers: Vec<Layer>,
+    /// Text and shape items over the clips, rasterized by `text::layers_at`.
+    /// Part of the frame rather than a second pass in each sink, so playback,
+    /// the paused still and the soak all composite the same picture.
+    pub visuals: Vec<crate::text::RasterLayer>,
 }
 
 /// Deliberately hand written: a derived one would print a megabyte of pixels
@@ -293,7 +297,8 @@ impl std::fmt::Debug for Frame {
 }
 
 impl Frame {
-    /// The layers as the compositor takes them.
+    /// The layers as the compositor takes them: clips bottom first, then the
+    /// text and shape items over all of them.
     pub fn sources(&self) -> Vec<(Source<'_>, Draw)> {
         self.layers
             .iter()
@@ -311,6 +316,17 @@ impl Frame {
                     },
                 )
             })
+            .chain(self.visuals.iter().map(|layer| {
+                (
+                    Source {
+                        rgba: &layer.pixels,
+                        width: layer.width,
+                        height: layer.height,
+                        lut: None,
+                    },
+                    layer.placement,
+                )
+            }))
             .collect()
     }
 }
@@ -398,6 +414,12 @@ pub struct FrameSource {
     rate: Rate,
     frames: i64,
     position: i64,
+    /// The edit this source was built from, kept for the text and shape items.
+    /// They are rasterized per frame (and cached by content) rather than
+    /// decoded, so they have no stream of their own.
+    project: Project,
+    width: u32,
+    height: u32,
 }
 
 impl FrameSource {
@@ -436,6 +458,9 @@ impl FrameSource {
             rate: project.rate(),
             frames: layout::frame_count(project),
             position: 0,
+            project: project.clone(),
+            width,
+            height,
         }
     }
 
@@ -596,7 +621,8 @@ impl FrameSource {
             })
             .collect();
         self.position += 1;
-        Supply::Ready(Frame { frame, layers })
+        let visuals = crate::text::layers_at(&self.project, frame, self.width, self.height);
+        Supply::Ready(Frame { frame, layers, visuals })
     }
 
     /// Poll until the frame is there or `deadline` passes. `Starved` coming
@@ -958,6 +984,43 @@ mod tests {
             .find(|layer| layer.clip_id == clip_id)
             .unwrap_or_else(|| panic!("{clip_id} is not on frame {}", frame.frame))
             .pixels[0]
+    }
+
+    /// A shape or a title is part of the frame the source hands over, so the
+    /// playback sinks show it without a pass of their own. This is what makes
+    /// text visible *during* playback rather than only on the paused still.
+    #[test]
+    fn a_visual_item_rides_on_the_frames_it_covers() {
+        use makevideo_render::{ShapeKind, VisualContent, VisualItem, VisualTransform};
+        let mut with_shape = one_clip();
+        with_shape.tracks[0].visual_items.push(VisualItem {
+            id: "s1".into(),
+            start: 0,
+            duration: 1,
+            z_index: 0,
+            transform: VisualTransform {
+                x: 2.0,
+                y: 2.0,
+                width: 8.0,
+                height: 8.0,
+                rotation: 0.0,
+                opacity: 1.0,
+            },
+            content: VisualContent::Shape {
+                shape: ShapeKind::Rectangle,
+                fill: "#ff0000".into(),
+                stroke: "#ffffff".into(),
+                stroke_width: 1.0,
+                corner_radius: 0.0,
+                start_arrow: false,
+                end_arrow: false,
+            },
+        });
+        let mut source = source(&with_shape, Buffering::default(), Arc::new(Fakes::default()));
+        let covered = next(&mut source);
+        assert_eq!(covered.sources().len(), 2, "the clip and the shape");
+        let after = next(&mut source);
+        assert_eq!(after.sources().len(), 1, "the shape has ended");
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -29,7 +29,55 @@ static CACHE: OnceLock<Mutex<RasterCache>> = OnceLock::new();
 static FONT_DATABASE: OnceLock<Database> = OnceLock::new();
 static FONTS: OnceLock<Mutex<HashMap<String, Font>>> = OnceLock::new();
 
+/// One item's raster at the output size, with where it sits and the frames it
+/// covers. The pixels are the same ones `layers_at` composites — an item is
+/// static, so callers that composite over time (the filter-graph render) take
+/// one of these per item instead of one per frame.
+pub struct ItemRaster {
+    pub pixels: Arc<[u8]>,
+    pub width: u32,
+    pub height: u32,
+    pub x: i32,
+    pub y: i32,
+    pub opacity: f32,
+    pub start_frame: i64,
+    pub end_frame: i64,
+}
+
 pub fn layers_at(project: &Project, frame: i64, width: u32, height: u32) -> Vec<RasterLayer> {
+    each_visual_item(project, width, height, Some(frame))
+        .into_iter()
+        .map(|raster| RasterLayer {
+            pixels: raster.pixels,
+            width: raster.width,
+            height: raster.height,
+            placement: Placement {
+                dst: makevideo_render::layout::Rect {
+                    x: raster.x,
+                    y: raster.y,
+                    w: raster.width,
+                    h: raster.height,
+                },
+                opacity: raster.opacity,
+            },
+        })
+        .collect()
+}
+
+/// Every text and shape item in the project, rasterized once each.
+pub fn item_rasters(project: &Project, width: u32, height: u32) -> Vec<ItemRaster> {
+    each_visual_item(project, width, height, None)
+}
+
+/// The one walk both entry points share: tracks in project order, items in
+/// z order within a track, which is also the paint order. `at` narrows it to
+/// the items covering one frame.
+fn each_visual_item(
+    project: &Project,
+    width: u32,
+    height: u32,
+    at: Option<i64>,
+) -> Vec<ItemRaster> {
     let mut layers = Vec::new();
     let scale_x = width as f32 / project.settings.width.max(1) as f32;
     let scale_y = height as f32 / project.settings.height.max(1) as f32;
@@ -42,7 +90,7 @@ pub fn layers_at(project: &Project, frame: i64, width: u32, height: u32) -> Vec<
         let mut items: Vec<_> = track
             .visual_items
             .iter()
-            .filter(|item| item.contains_frame(frame))
+            .filter(|item| at.is_none_or(|frame| item.contains_frame(frame)))
             .collect();
         items.sort_by_key(|item| item.z_index);
         for item in items {
@@ -94,23 +142,38 @@ pub fn layers_at(project: &Project, frame: i64, width: u32, height: u32) -> Vec<
                 }
                 VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => continue,
             };
-            layers.push(RasterLayer {
+            layers.push(ItemRaster {
                 pixels,
                 width: item_width,
                 height: item_height,
-                placement: Placement {
-                    dst: makevideo_render::layout::Rect {
-                        x: (transform.x * scale_x).round() as i32,
-                        y: (transform.y * scale_y).round() as i32,
-                        w: item_width,
-                        h: item_height,
-                    },
-                    opacity: transform.opacity.clamp(0.0, 1.0),
-                },
+                x: (transform.x * scale_x).round() as i32,
+                y: (transform.y * scale_y).round() as i32,
+                opacity: transform.opacity.clamp(0.0, 1.0),
+                start_frame: item.start,
+                end_frame: item.end_frame(),
             });
         }
     }
     layers
+}
+
+/// Write an RGBA raster as a PAM still, for handing to ffmpeg as an overlay
+/// input. PAM because it is the alpha-capable still format that is a text
+/// header in front of the raw bytes — no encoder, no dependency.
+pub fn write_pam(
+    path: &std::path::Path,
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = std::io::BufWriter::new(std::fs::File::create(path)?);
+    write!(
+        file,
+        "P7\nWIDTH {width}\nHEIGHT {height}\nDEPTH 4\nMAXVAL 255\nTUPLTYPE RGB_ALPHA\nENDHDR\n"
+    )?;
+    file.write_all(pixels)?;
+    file.flush()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -196,6 +259,12 @@ fn cached(key: &str, build: impl FnOnce() -> Vec<u8>) -> Arc<[u8]> {
         return pixels;
     }
     let mut cache = cache.lock().unwrap();
+    // Checked again under the lock it inserts with. Playback and an export
+    // can miss the same key together, and inserting both would put the key in
+    // the eviction queue twice and count its bytes twice forever.
+    if let Some(existing) = cache.entries.get(key).cloned() {
+        return existing;
+    }
     while cache.bytes + pixels.len() > CACHE_LIMIT_BYTES {
         let Some(oldest) = cache.oldest.pop_front() else {
             break;
@@ -263,6 +332,20 @@ fn rasterize(text: &str, style: &TextStyle, width: u32, height: u32, scale: f32)
 pub fn font_available(family: &str) -> bool {
     let database = FONT_DATABASE.get_or_init(load_font_database);
     requested_font_id(database, family).is_some()
+}
+
+/// Every family the system offers, sorted and deduplicated, for the text
+/// inspector's font picker. Faces carry one entry per name variant; the first
+/// is the family name a CSS font stack and `requested_font_id` both accept.
+pub fn font_families() -> Vec<String> {
+    let database = FONT_DATABASE.get_or_init(load_font_database);
+    let mut families: Vec<String> = database
+        .faces()
+        .filter_map(|face| face.families.first().map(|(name, _)| name.clone()))
+        .collect();
+    families.sort();
+    families.dedup();
+    families
 }
 
 fn load_font(family: &str) -> Option<Font> {
@@ -355,6 +438,108 @@ fn draw_bitmap(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use makevideo_render::{
+        Project, ProjectSettings, Rate, ShapeKind as Shape, Track, TrackKind, VisualContent as Content,
+        VisualItem, VisualTransform, FORMAT_VERSION,
+    };
+
+    fn project_with_shape() -> Project {
+        Project {
+            version: FORMAT_VERSION,
+            settings: ProjectSettings {
+                width: 100,
+                height: 50,
+                rate: Rate::fps(30),
+            },
+            assets: Vec::new(),
+            markers: Vec::new(),
+            tracks: vec![Track {
+                id: "V1".into(),
+                kind: TrackKind::Video,
+                name: "V1".into(),
+                clips: Vec::new(),
+                visual_items: vec![VisualItem {
+                    id: "s1".into(),
+                    start: 30,
+                    duration: 60,
+                    z_index: 0,
+                    transform: VisualTransform {
+                        x: 10.0,
+                        y: 5.0,
+                        width: 40.0,
+                        height: 20.0,
+                        rotation: 0.0,
+                        opacity: 0.8,
+                    },
+                    content: Content::Shape {
+                        shape: Shape::Rectangle,
+                        fill: "#ff0000".into(),
+                        stroke: "#ffffff".into(),
+                        stroke_width: 1.0,
+                        corner_radius: 0.0,
+                        start_arrow: false,
+                        end_arrow: false,
+                    },
+                }],
+                subtitle_style: None,
+                muted: false,
+                hidden: false,
+            }],
+        }
+    }
+
+    /// One raster per item, scaled to the output, carrying its frame range —
+    /// what the filter-graph render overlays. The same walk answers
+    /// `layers_at`, so the per-frame and per-item views cannot disagree.
+    #[test]
+    fn an_item_rasterizes_once_with_its_place_and_frames() {
+        let project = project_with_shape();
+        let rasters = item_rasters(&project, 200, 100);
+        assert_eq!(rasters.len(), 1);
+        let raster = &rasters[0];
+        assert_eq!((raster.x, raster.y), (20, 10));
+        assert_eq!((raster.width, raster.height), (80, 40));
+        assert_eq!((raster.start_frame, raster.end_frame), (30, 90));
+        assert!((raster.opacity - 0.8).abs() < 1e-6);
+        assert_eq!(layers_at(&project, 30, 200, 100).len(), 1);
+        assert_eq!(layers_at(&project, 90, 200, 100).len(), 0);
+    }
+
+    #[test]
+    fn a_pam_still_is_the_header_and_the_raw_bytes() {
+        let dir = std::env::temp_dir().join(format!("makevideo-pam-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("still.pam");
+        write_pam(&path, &[1, 2, 3, 4, 5, 6, 7, 8], 2, 1).unwrap();
+        let bytes = std::fs::read(&path).unwrap();
+        let header = b"P7\nWIDTH 2\nHEIGHT 1\nDEPTH 4\nMAXVAL 255\nTUPLTYPE RGB_ALPHA\nENDHDR\n";
+        assert_eq!(&bytes[..header.len()], header);
+        assert_eq!(&bytes[header.len()..], &[1, 2, 3, 4, 5, 6, 7, 8]);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The outline is a band **inside** the edge, half the stroke width wide.
+    /// The page's playback overlay draws the same rim by clipping a stroke of
+    /// the full width to the shape, and the two only match while this holds.
+    #[test]
+    fn a_shape_outline_is_a_band_half_the_stroke_width_inside_the_edge() {
+        let width = 40;
+        let pixels = rasterize_shape(
+            ShapeKind::Rectangle,
+            "#00000000",
+            "#ff0000",
+            8.0,
+            0.0,
+            false,
+            false,
+            width,
+            20,
+        );
+        let opaque_at = |x: u32| pixels[((10 * width + x) * 4 + 3) as usize] > 0;
+        assert!(opaque_at(0), "the edge itself is outlined");
+        assert!(opaque_at(3), "3px in is still inside a 4px rim");
+        assert!(!opaque_at(5), "5px in is past it, and the fill is transparent");
+    }
 
     #[test]
     fn colour_accepts_css_hex_with_alpha() {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
@@ -148,6 +148,22 @@ pub fn target_bitrate_kbps(width: u32, height: u32, rate: Rate) -> u32 {
     (raw.round() as u32).clamp(2_000, 80_000)
 }
 
+/// A rasterized text or shape layer as an extra graph input: a still image
+/// file, where it sits on the output frame, and the frames it covers.
+///
+/// The compositor rasterizes these — the same pixels the composited route
+/// composites — so the graph render burns the same picture in rather than
+/// approximating it with drawtext. The graph only overlays.
+#[derive(Debug, Clone)]
+pub struct VisualInput {
+    pub path: String,
+    pub x: i32,
+    pub y: i32,
+    pub opacity: f32,
+    pub start_frame: i64,
+    pub end_frame: i64,
+}
+
 /// The full argv after the program name.
 ///
 /// `accel` is the hardware path confirmed by `accel::candidates` plus a trial
@@ -159,6 +175,7 @@ pub fn build_args(
     output: &str,
     preset: Preset,
     accel: Option<&Acceleration>,
+    visuals: &[VisualInput],
 ) -> Result<Vec<String>, String> {
     let rate = project.rate();
     let duration = project.duration();
@@ -209,6 +226,17 @@ pub fn build_args(
         args.extend(["-i".into(), item.path.to_string()]);
     }
 
+    // The visual stills come after every clip input, so a clip's input index
+    // is unchanged whether or not the project has any text on it.
+    for visual in visuals {
+        args.extend(["-loop".into(), "1".into()]);
+        args.extend(["-framerate".into(), fps.clone()]);
+        // Frames until the item's own end: overlay stops drawing a secondary
+        // input that has ended, and enable= only hides, it does not feed.
+        args.extend(["-t".into(), secs(layout::frame_time(visual.end_frame, rate))]);
+        args.extend(["-i".into(), visual.path.clone()]);
+    }
+
     let mut chains: Vec<String> = Vec::new();
 
     // The base is what fixes the output length and the frame rate; every clip
@@ -249,6 +277,28 @@ pub fn build_args(
         ));
         last_video = format!("ov{layer}");
         layer += 1;
+    }
+
+    // Text and shape layers go over every clip, which is where the composited
+    // route puts them too. Each still is already at output resolution and at
+    // its own size, so the chain is placement and timing, no scaling.
+    for (offset, visual) in visuals.iter().enumerate() {
+        let input = items.len() + offset;
+        let start = secs(layout::frame_time(visual.start_frame, rate));
+        let end = secs(layout::frame_time(visual.end_frame, rate));
+        let opacity = if visual.opacity < 1.0 {
+            format!(",colorchannelmixer=aa={:.3}", visual.opacity.max(0.0))
+        } else {
+            String::new()
+        };
+        chains.push(format!(
+            "[{input}:v]format=yuva420p,fps={fps},setpts=PTS-STARTPTS{opacity}[g{offset}]"
+        ));
+        chains.push(format!(
+            "[{last_video}][g{offset}]overlay=x={}:y={}:eof_action=pass:enable='between(t,{start},{end})'[ovg{offset}]",
+            visual.x, visual.y
+        ));
+        last_video = format!("ovg{offset}");
     }
     chains.push(format!("[{last_video}]format=yuv420p[vout]"));
 
@@ -763,12 +813,12 @@ mod tests {
             tracks: vec![track("V1", TrackKind::Video, vec![])],
             markers: Vec::new(),
         };
-        assert!(build_args(&project, "/out.mp4", Preset::Fhd, None).is_err());
+        assert!(build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).is_err());
     }
 
     #[test]
     fn a_clip_seeks_its_in_point_and_takes_its_own_length() {
-        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         let text = joined(&args);
         assert!(
             text.contains("-ss 1.000000 -t 3.000000 -i /media/a1.mp4"),
@@ -779,7 +829,7 @@ mod tests {
 
     #[test]
     fn the_clip_lands_at_its_timeline_position() {
-        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         let filter = filter_of(&args);
         assert!(filter.contains("tpad=start_duration=2.000000"), "{filter}");
         assert!(
@@ -788,9 +838,63 @@ mod tests {
         );
     }
 
+    /// The graph route burns text and shapes in from rasterized stills. The
+    /// still is an extra input above every clip; without this the CPU render
+    /// and the fallback silently dropped every layer the preview showed.
+    #[test]
+    fn a_visual_still_is_overlaid_above_every_clip_for_its_frames() {
+        let visuals = [VisualInput {
+            path: "/tmp/title-0.pam".into(),
+            x: 96,
+            y: 54,
+            opacity: 1.0,
+            start_frame: 90,
+            end_frame: 120,
+        }];
+        let args =
+            build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None, &visuals).unwrap();
+        let text = joined(&args);
+        // A looped still that lives until its own end, like an image clip.
+        assert!(
+            text.contains("-loop 1 -framerate 30 -t 4.000000 -i /tmp/title-0.pam"),
+            "{text}"
+        );
+        let filter = filter_of(&args);
+        assert!(
+            filter.contains("overlay=x=96:y=54:eof_action=pass:enable='between(t,3.000000,4.000000)'"),
+            "{filter}"
+        );
+        // Above the clip layer, and the last thing before the output format.
+        assert!(filter.contains("[ov0][g0]"), "{filter}");
+        assert!(filter.contains("[ovg0]format=yuv420p[vout]"), "{filter}");
+        // Full opacity adds no mixer stage.
+        assert!(!filter.contains("colorchannelmixer"), "{filter}");
+    }
+
+    /// A translucent layer keeps its opacity through the same mixer stage a
+    /// translucent clip uses.
+    #[test]
+    fn a_translucent_visual_still_gets_an_alpha_mixer() {
+        let visuals = [VisualInput {
+            path: "/tmp/shape-0.pam".into(),
+            x: 0,
+            y: 0,
+            opacity: 0.5,
+            start_frame: 0,
+            end_frame: 30,
+        }];
+        let args =
+            build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None, &visuals).unwrap();
+        assert!(
+            filter_of(&args).contains("colorchannelmixer=aa=0.500"),
+            "{}",
+            filter_of(&args)
+        );
+    }
+
     #[test]
     fn the_base_runs_for_the_whole_timeline() {
-        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         assert!(filter_of(&args).contains("color=c=black:s=1920x1080:r=30:d=5.000000"));
         // The output is bounded too, so stray audio cannot run past the video.
         assert!(joined(&args).contains("-t 5.000000 -movflags"));
@@ -803,7 +907,7 @@ mod tests {
         // land on a slightly different frame than the timeline says.
         let mut project = one_video_project();
         project.settings.rate = Rate::ntsc(30);
-        let args = build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         let filter = filter_of(&args);
         assert!(
             filter.contains("color=c=black:s=1920x1080:r=30000/1001"),
@@ -819,14 +923,14 @@ mod tests {
     fn a_silent_asset_produces_no_audio_output() {
         let mut project = one_video_project();
         project.assets[0].has_audio = false;
-        let args = build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         assert!(!joined(&args).contains("[aout]"));
         assert!(!joined(&args).contains("-c:a"));
     }
 
     #[test]
     fn audio_is_delayed_by_a_sample_count_rather_than_a_millisecond_count() {
-        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&one_video_project(), "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         let filter = filter_of(&args);
         // Two seconds at 48 kHz.
         assert!(filter.contains("adelay=96000S:all=1"), "{filter}");
@@ -838,7 +942,7 @@ mod tests {
     fn a_broadcast_rate_delays_audio_to_the_sample_the_picture_starts_on() {
         let mut project = one_video_project();
         project.settings.rate = Rate::ntsc(30);
-        let filter = filter_of(&build_args(&project, "/o.mp4", Preset::Fhd, None).unwrap());
+        let filter = filter_of(&build_args(&project, "/o.mp4", Preset::Fhd, None, &[]).unwrap());
         // Frame 60 of 29.97 is 2.002 seconds, which is 96096 samples. In
         // milliseconds this was 2002 either way; the difference shows on the
         // frames whose time is not a whole number of them.
@@ -850,7 +954,7 @@ mod tests {
         let mut project = one_video_project();
         project.assets[0].kind = AssetKind::Image;
         project.assets[0].has_audio = false;
-        let args = build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         let text = joined(&args);
         assert!(
             text.contains("-loop 1 -framerate 30 -t 3.000000 -i"),
@@ -874,7 +978,7 @@ mod tests {
             ],
             markers: Vec::new(),
         };
-        let filter = filter_of(&build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap());
+        let filter = filter_of(&build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap());
         assert!(filter.contains("[base][v0]overlay"), "{filter}");
         assert!(filter.contains("[ov0][v1]overlay"), "{filter}");
         assert!(filter.contains("[ov1]format=yuv420p[vout]"), "{filter}");
@@ -884,14 +988,14 @@ mod tests {
     fn a_hidden_track_drops_out_of_the_render_entirely() {
         let mut project = one_video_project();
         project.tracks[0].hidden = true;
-        assert!(build_args(&project, "/out.mp4", Preset::Fhd, None).is_err());
+        assert!(build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).is_err());
     }
 
     #[test]
     fn muting_a_video_track_keeps_its_picture() {
         let mut project = one_video_project();
         project.tracks[0].muted = true;
-        let args = build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         assert!(joined(&args).contains("-map [vout]"));
         assert!(!joined(&args).contains("[aout]"));
     }
@@ -909,7 +1013,7 @@ mod tests {
             )],
             markers: Vec::new(),
         };
-        let args = build_args(&project, "/out.mp4", Preset::Fhd, None).unwrap();
+        let args = build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap();
         let filter = filter_of(&args);
         assert!(!filter.contains("overlay"), "{filter}");
         assert!(filter.contains("[base]format=yuv420p[vout]"), "{filter}");
@@ -921,12 +1025,12 @@ mod tests {
     fn opacity_only_shows_up_when_it_is_not_full() {
         let mut project = one_video_project();
         assert!(
-            !filter_of(&build_args(&project, "/o.mp4", Preset::Fhd, None).unwrap())
+            !filter_of(&build_args(&project, "/o.mp4", Preset::Fhd, None, &[]).unwrap())
                 .contains("colorchannelmixer")
         );
         project.tracks[0].clips[0].opacity = 0.5;
         assert!(
-            filter_of(&build_args(&project, "/o.mp4", Preset::Fhd, None).unwrap())
+            filter_of(&build_args(&project, "/o.mp4", Preset::Fhd, None, &[]).unwrap())
                 .contains("colorchannelmixer=aa=0.500")
         );
     }
@@ -976,7 +1080,7 @@ mod tests {
     fn hardware_swaps_the_encoder_for_a_bitrate_target() {
         let hardware = videotoolbox();
         let args =
-            build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware)).unwrap();
+            build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware), &[]).unwrap();
         let text = joined(&args);
         assert!(text.contains("-c:v h264_videotoolbox"), "{text}");
         // -crf and -preset are libx264 options and would be silently ignored.
@@ -990,7 +1094,7 @@ mod tests {
     fn hardware_decode_is_asked_for_per_video_input() {
         let hardware = videotoolbox();
         let args =
-            build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware)).unwrap();
+            build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware), &[]).unwrap();
         assert!(joined(&args).contains("-hwaccel videotoolbox -ss 1.000000"));
     }
 
@@ -1000,7 +1104,7 @@ mod tests {
         project.assets[0].kind = AssetKind::Image;
         project.assets[0].has_audio = false;
         let hardware = videotoolbox();
-        let args = build_args(&project, "/o.mp4", Preset::Fhd, Some(&hardware)).unwrap();
+        let args = build_args(&project, "/o.mp4", Preset::Fhd, Some(&hardware), &[]).unwrap();
         assert!(!joined(&args).contains("-hwaccel"), "{}", joined(&args));
     }
 
@@ -1012,7 +1116,7 @@ mod tests {
             label: "NVIDIA NVENC".into(),
         };
         let args =
-            build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware)).unwrap();
+            build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware), &[]).unwrap();
         let text = joined(&args);
         assert!(text.contains("-c:v h264_nvenc"), "{text}");
         assert!(!text.contains("-hwaccel"), "{text}");
@@ -1025,8 +1129,8 @@ mod tests {
         // This is what lets a failed hardware render be retried on the CPU by
         // re-running rather than by rebuilding the project.
         let hardware = videotoolbox();
-        let cpu = build_args(&one_video_project(), "/o.mp4", Preset::Fhd, None).unwrap();
-        let gpu = build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware)).unwrap();
+        let cpu = build_args(&one_video_project(), "/o.mp4", Preset::Fhd, None, &[]).unwrap();
+        let gpu = build_args(&one_video_project(), "/o.mp4", Preset::Fhd, Some(&hardware), &[]).unwrap();
         assert_eq!(filter_of(&cpu), filter_of(&gpu));
     }
 
@@ -1158,7 +1262,7 @@ mod tests {
     fn both_paths_encode_with_the_same_settings() {
         // The route the picture takes must not change what it is encoded as.
         let project = one_video_project();
-        let graph = joined(&build_args(&project, "/o.mp4", Preset::Fhd, None).unwrap());
+        let graph = joined(&build_args(&project, "/o.mp4", Preset::Fhd, None, &[]).unwrap());
         let piped = joined(&encoder_args(&project, "/o.mp4", Preset::Fhd, None).unwrap());
         for setting in [
             "-c:v libx264 -preset medium -crf 20 -pix_fmt yuv420p -r 30",
@@ -1226,7 +1330,7 @@ mod tests {
         let filter = filter_of(&args);
         // Character for character what build_args puts in the file, which is
         // what makes a difference in the samples a difference in the mixing.
-        let exported = filter_of(&build_args(&one_video_project(), "/o.mp4", Preset::Fhd, None).unwrap());
+        let exported = filter_of(&build_args(&one_video_project(), "/o.mp4", Preset::Fhd, None, &[]).unwrap());
         assert!(exported.contains("adelay=96000S:all=1"), "{exported}");
         assert!(filter.contains("adelay=96000S:all=1"), "{filter}");
         assert!(filter.contains("amix=inputs=1:normalize=0"), "{filter}");

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -27,7 +27,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -683,6 +683,12 @@ pub fn bootstrap(app: AppHandle, state: State<AppState>) -> Bootstrap {
 #[tauri::command]
 pub fn font_available(family: String) -> bool {
     makevideo_compositor::text::font_available(&family)
+}
+
+/// Every installed font family, for the text inspector's picker.
+#[tauri::command]
+pub fn list_fonts() -> Vec<String> {
+    makevideo_compositor::text::font_families()
 }
 
 #[tauri::command]
@@ -1786,6 +1792,63 @@ impl Route {
 /// Starts a render and returns as soon as it is under way. Progress arrives as
 /// `render:progress` events and the outcome as one `render:done`.
 ///
+/// The rasterized text and shape stills for one render. The directory lives
+/// exactly as long as this value: dropping it — after the last route, or on
+/// the error path before any — removes the files.
+struct VisualStills {
+    dir: PathBuf,
+    inputs: Vec<ffmpeg::VisualInput>,
+}
+
+impl Drop for VisualStills {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Rasterize every text and shape item at the output size and write each as a
+/// PAM still for the filter graph to overlay. None when the project has no
+/// visual items, which is also no temp directory.
+fn write_visual_stills(
+    project: &Project,
+    preset: ffmpeg::Preset,
+) -> Result<Option<VisualStills>, String> {
+    let (width, height) = ffmpeg::output_size(&project.settings, preset);
+    let rasters = makevideo_compositor::text::item_rasters(project, width, height);
+    if rasters.is_empty() {
+        return Ok(None);
+    }
+    // A counter beside the pid, because two renders from one app run must not
+    // share a directory the first one deletes.
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "akbun-makevideo-visuals-{}-{}",
+        std::process::id(),
+        SEQUENCE.fetch_add(1, Ordering::SeqCst)
+    ));
+    std::fs::create_dir_all(&dir)
+        .map_err(|error| format!("cannot prepare the text and shape overlays: {error}"))?;
+    // Built before the writes, so a failed write still removes the directory.
+    let mut stills = VisualStills {
+        dir,
+        inputs: Vec::new(),
+    };
+    for (index, raster) in rasters.iter().enumerate() {
+        let path = stills.dir.join(format!("visual-{index}.pam"));
+        makevideo_compositor::text::write_pam(&path, &raster.pixels, raster.width, raster.height)
+            .map_err(|error| format!("cannot write a text and shape overlay: {error}"))?;
+        stills.inputs.push(ffmpeg::VisualInput {
+            path: path.to_string_lossy().into_owned(),
+            x: raster.x,
+            y: raster.y,
+            opacity: raster.opacity,
+            start_frame: raster.start_frame,
+            end_frame: raster.end_frame,
+        });
+    }
+    Ok(Some(stills))
+}
+
 /// Everything that can fail on a bad project is built here, synchronously, so
 /// the dialog never opens on a render that was never going to start. Each route
 /// is then tried in turn: anything that fails without being cancelled falls
@@ -1834,25 +1897,43 @@ pub fn start_render(
         Some(settings_compositor(&state, &settings))
     };
 
+    // The graph routes cannot draw text, so each visual item is rasterized
+    // once — the same pixels the compositor composites — and handed to the
+    // graph as an overlay input. Written even when the composited route goes
+    // first: the fallback runs after a failure, which is the wrong moment to
+    // start writing files.
+    let visual_dir = write_visual_stills(&project, preset)?;
+    let visuals = visual_dir
+        .as_ref()
+        .map(|prepared| prepared.inputs.clone())
+        .unwrap_or_default();
+
     let mut routes: Vec<Route> = Vec::new();
-    if let Some(gpu) = gpu.as_ref() {
-        // Validated now so a broken project fails before the sheet opens.
-        ffmpeg::encoder_args(&project, &path, preset, chosen.as_ref())?;
-        routes.push(Route::Composited {
-            label: format!("{} compositor, {accel_label} encoder", gpu.adapter()),
-            accel: chosen.clone(),
-        });
-    } else if let Some(hardware) = chosen.as_ref() {
+    let built = (|| -> Result<(), String> {
+        if let Some(gpu) = gpu.as_ref() {
+            // Validated now so a broken project fails before the sheet opens.
+            ffmpeg::encoder_args(&project, &path, preset, chosen.as_ref())?;
+            routes.push(Route::Composited {
+                label: format!("{} compositor, {accel_label} encoder", gpu.adapter()),
+                accel: chosen.clone(),
+            });
+        } else if let Some(hardware) = chosen.as_ref() {
+            routes.push(Route::Graph {
+                label: format!("ffmpeg filter graph, {accel_label} encoder"),
+                args: ffmpeg::build_args(&project, &path, preset, Some(hardware), &visuals)?,
+            });
+        }
+        let plain = ffmpeg::build_args(&project, &path, preset, None, &visuals)?;
         routes.push(Route::Graph {
-            label: format!("ffmpeg filter graph, {accel_label} encoder"),
-            args: ffmpeg::build_args(&project, &path, preset, Some(hardware))?,
+            label: "ffmpeg filter graph, CPU encoder".into(),
+            args: plain,
         });
+        Ok(())
+    })();
+    if let Err(error) = built {
+        drop(visual_dir);
+        return Err(error);
     }
-    let plain = ffmpeg::build_args(&project, &path, preset, None)?;
-    routes.push(Route::Graph {
-        label: "ffmpeg filter graph, CPU encoder".into(),
-        args: plain,
-    });
 
     state.cancelled.store(false, Ordering::SeqCst);
     let shared = Arc::clone(&state.render);
@@ -1860,6 +1941,9 @@ pub fn start_render(
     let document = Arc::clone(&state.document);
 
     std::thread::spawn(move || {
+        // Holds the overlay stills on disk until the last route has run; the
+        // fallback route reads them minutes after the render started.
+        let _visual_dir = visual_dir;
         let mut fell_back = false;
         let mut used = String::new();
         let mut outcome = Attempt::Failed("no route was tried".into());

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
             commands::bootstrap,
             commands::graphics_devices,
             commands::font_available,
+            commands::list_fonts,
             commands::validate_lut,
             commands::save_settings,
             commands::report_error,

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -15,12 +15,16 @@
 //! not an AppKit message: wgpu attaches a `CAMetalLayer` and then talks to
 //! Metal, which is safe from any thread.
 //!
-//! # Why the coordinates are flipped
+//! # Why the coordinates are (sometimes) flipped
 //!
-//! AppKit's origin is the **bottom** left of the content view and the page's is
-//! the top left. Everything else in the app speaks the page's coordinates, so
-//! the flip happens here, once, at the boundary — the same place the
-//! physical-pixel conversion happens.
+//! AppKit's default origin is the **bottom** left of a view and the page's is
+//! the top left — but `WKWebView` overrides `isFlipped` to `YES`, so frames of
+//! its subviews are already measured from the top. Everything else in the app
+//! speaks the page's coordinates, so the conversion happens here, once, at the
+//! boundary — the same place the physical-pixel conversion happens — and it
+//! asks the superview which origin it uses rather than assuming one. Assuming
+//! bottom-left is exactly what put the monitor at the vertically mirrored
+//! position when the container moved from the content view into the WebView.
 
 use super::{MonitorPlace, Place};
 use objc2::rc::Retained;
@@ -163,17 +167,22 @@ pub fn attach(window: &tauri::WebviewWindow, place: MonitorPlace) -> Result<Inne
         let container = PassThroughView::new(main, rect(host, place.stage));
         container.setWantsLayer(true);
         container.setClipsToBounds(true);
+        // Over the page, but *inside* its WebView. A `None` sibling with
+        // `Above` means "over all of them", which is the front. The page hides
+        // it before drawing anything on top; see the note in mod.rs for why it
+        // is not the other way round.
+        //
+        // Into the window *before* the child is measured: a view with no
+        // window answers `convertRectToBacking` with whatever the main screen
+        // happens to be, which is the wrong scale whenever this window is on
+        // another display.
+        host.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Above, None);
         let view = NSView::initWithFrame(NSView::alloc(main), child_rect(&container, place));
         // Metal draws into this view's layer, so it has to have one. wgpu
         // replaces it with a CAMetalLayer when it makes the surface; without
         // this the view is not layer backed and there is nothing to replace.
         view.setWantsLayer(true);
-        // Over the page, but *inside* its WebView. A `None` sibling with
-        // `Above` means "over all of them", which is the front. The page hides
-        // it before drawing anything on top; see the note in mod.rs for why it
-        // is not the other way round.
         container.addSubview(&view);
-        host.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Above, None);
         // Retained past the end of this block on purpose: the `Viewport` owns
         // it now and `detach` is what releases it.
         let pointer =
@@ -237,14 +246,14 @@ pub fn target(inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
 
 /// The page's rectangle as AppKit's inside the WebView.
 ///
-/// Two conversions in one place. The y axis is flipped against the content
-/// view's height, and the numbers arriving are physical pixels while AppKit
-/// wants points — the WebView's own bounds against its backing size is where
-/// that ratio comes from, rather than asking the screen, which can be the wrong
-/// one when the window straddles two displays.
+/// Two conversions in one place. The y origin is converted against the
+/// superview's own coordinate origin — `WKWebView` is flipped, so a top-left
+/// `y` passes through unchanged there — and the numbers arriving are physical
+/// pixels while AppKit wants points. The WebView's own bounds against its
+/// backing size is where that ratio comes from, rather than asking the screen,
+/// which can be the wrong one when the window straddles two displays.
 fn rect(host: &NSView, at: Place) -> NSRect {
     let scale = backing_scale(host);
-    let bounds = host.bounds();
     let (x, y, width, height) = (
         at.x / scale,
         at.y / scale,
@@ -252,22 +261,49 @@ fn rect(host: &NSView, at: Place) -> NSRect {
         at.height.max(1.0) / scale,
     );
     NSRect::new(
-        NSPoint::new(x, bounds.size.height - y - height),
+        NSPoint::new(x, origin_y(host.isFlipped(), host.bounds().size.height, y, height)),
         NSSize::new(width, height),
     )
 }
 
 fn child_rect(container: &NSView, at: MonitorPlace) -> NSRect {
     let scale = backing_scale(container);
-    let bounds = container.bounds();
     let x = (at.content.x - at.stage.x) / scale;
     let top = (at.content.y - at.stage.y) / scale;
     let width = at.content.width.max(1.0) / scale;
     let height = at.content.height.max(1.0) / scale;
     NSRect::new(
-        NSPoint::new(x, bounds.size.height - top - height),
+        NSPoint::new(
+            x,
+            origin_y(container.isFlipped(), container.bounds().size.height, top, height),
+        ),
         NSSize::new(width, height),
     )
+}
+
+/// A frame origin for a box whose top edge is `top` points below the
+/// superview's top, in whichever coordinate origin that superview uses.
+fn origin_y(flipped: bool, superview_height: f64, top: f64, height: f64) -> f64 {
+    if flipped {
+        top
+    } else {
+        superview_height - top - height
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::origin_y;
+
+    /// WKWebView is flipped, so a top-left `y` passes through unchanged; the
+    /// plain container is not, so its children flip against its height. The
+    /// first case is the one the monitor actually lives in — getting it wrong
+    /// mirrors the picture to the far side of the window.
+    #[test]
+    fn origin_matches_the_superview_coordinate_origin() {
+        assert_eq!(origin_y(true, 800.0, 50.0, 200.0), 50.0);
+        assert_eq!(origin_y(false, 800.0, 50.0, 200.0), 550.0);
+    }
 }
 
 fn backing_scale(content: &NSView) -> f64 {

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -155,6 +155,7 @@ if (!window.__TAURI__) {
     editState: async () => emptyDocument(),
     editApply: async () => emptyDocument(),
     fontAvailable: async () => true,
+    listFonts: async () => [],
     validateLut: unavailable,
     editUndo: async () => emptyDocument(),
     editRedo: async () => emptyDocument(),
@@ -327,6 +328,7 @@ window.api = {
   // user did, so it takes one press to take back.
   editApply: (commands) => invoke('edit_apply', { commands }),
   fontAvailable: (family) => invoke('font_available', { family }),
+  listFonts: () => invoke('list_fonts'),
   validateLut: (path) => invoke('validate_lut', { path }),
   editUndo: () => invoke('edit_undo'),
   editRedo: () => invoke('edit_redo'),

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -131,6 +131,7 @@
         <div id="stage-wrap">
           <div id="stage">
             <div id="stage-inner"><canvas id="stage-exact"></canvas></div>
+            <canvas id="stage-visuals" aria-label="Text and shape layers"></canvas>
             <canvas id="stage-overlay" aria-label="Program Monitor selection overlay"></canvas>
           </div>
           <span id="stage-mode" hidden></span>
@@ -152,6 +153,60 @@
           </label>
         </div>
       </section>
+
+      <aside id="inspector-panel">
+        <header class="panel-head">
+          <h2>Inspector</h2>
+        </header>
+        <div id="inspector-body">
+          <p id="inspector-empty" class="dim small-text">Select a clip or a layer to edit its properties.</p>
+          <div id="clip-panel" hidden>
+            <h3>Clip</h3>
+            <p id="clip-summary" class="dim small-text"></p>
+            <label class="row" id="clip-opacity-row">Opacity <input id="clip-opacity" type="range" min="0" max="1" step="0.01" /></label>
+            <!-- 0..1 because that is what the edit model stores; a wider
+                 slider would snap back on release. -->
+            <label class="row" id="clip-volume-row">Volume <input id="clip-volume" type="range" min="0" max="1" step="0.01" /></label>
+          </div>
+          <div id="text-panel" hidden>
+            <h3>Text</h3>
+            <div id="text-inspector">
+              <label class="row">Text <input id="text-value" type="text" /></label>
+              <label class="row">Font <input id="text-font" type="text" list="font-options" placeholder="sans-serif" /></label>
+              <label class="row">Size <input id="text-size" type="number" min="8" max="512" /></label>
+              <label class="row">Color <input id="text-color" type="color" /></label>
+              <label class="row">Align <select id="text-align"><option value="left">Left</option><option value="center">Center</option><option value="right">Right</option></select></label>
+              <label class="row">Outline <input id="text-stroke-color" type="color" /></label>
+              <label class="row">Outline width <input id="text-stroke-width" type="number" min="0" max="32" step="1" /></label>
+              <label class="row">Shadow <input id="text-shadow-color" type="color" /></label>
+            </div>
+          </div>
+          <div id="shape-panel" hidden>
+            <h3>Shape</h3>
+            <div id="shape-inspector">
+              <label class="row">Type <select id="shape-kind"><option value="rectangle">Rectangle</option><option value="ellipse">Ellipse</option><option value="line">Line / Arrow</option></select></label>
+              <label class="row">Fill <input id="shape-fill" type="color" /></label>
+              <label class="row">Outline <input id="shape-stroke" type="color" /></label>
+              <label class="row">Outline width <input id="shape-stroke-width" type="number" min="0" max="128" step="1" /></label>
+              <label class="row">Corner radius <input id="shape-corner-radius" type="number" min="0" max="2048" step="1" /></label>
+              <label class="row check"><input id="shape-start-arrow" type="checkbox" /> Start arrow</label>
+              <label class="row check"><input id="shape-end-arrow" type="checkbox" /> End arrow</label>
+            </div>
+          </div>
+          <div id="subtitle-panel" hidden>
+            <h3>Subtitle</h3>
+            <div id="subtitle-inspector">
+              <label class="row">Text <textarea id="subtitle-value" rows="3"></textarea></label>
+              <label class="row">Start <input id="subtitle-start" type="number" min="0" /></label>
+              <label class="row">End <input id="subtitle-end" type="number" min="1" /></label>
+              <label class="row">Font <input id="subtitle-font" type="text" list="font-options" /></label>
+              <label class="row">Size <input id="subtitle-size" type="number" min="8" max="512" /></label>
+              <label class="row">Color <input id="subtitle-color" type="color" /></label>
+            </div>
+          </div>
+          <datalist id="font-options"></datalist>
+        </div>
+      </aside>
     </section>
 
     <section id="lower">
@@ -169,8 +224,8 @@
           <svg viewBox="0 0 20 20"><use href="#icon-ripple" /></svg>
         </button>
         <button id="btn-link" class="small" title="Link or unlink synchronized audio and video clips">Link Clips</button>
-        <button id="btn-add-text" class="small" title="Add a title at the playhead">+ Text</button>
-        <button id="btn-add-shape" class="small" title="Add a rectangle at the playhead">+ Shape</button>
+        <button id="btn-add-text" class="small" title="Add a 4 second title at the playhead — or drag onto a video track">+ Text</button>
+        <button id="btn-add-shape" class="small" title="Add a 4 second shape at the playhead — or drag onto a video track">+ Shape</button>
         <button id="btn-add-marker" class="small" title="Add a marker at the playhead">+ Marker</button>
         <span class="sep-v"></span>
         <button id="btn-add-video" class="small">+ Video track</button>
@@ -196,42 +251,6 @@
       <details id="marker-panel">
         <summary>Markers</summary>
         <div id="marker-list"></div>
-      </details>
-      <details id="text-panel" hidden>
-        <summary>Text</summary>
-        <div id="text-inspector">
-          <label class="row">Text <input id="text-value" type="text" /></label>
-          <label class="row">Font <input id="text-font" type="text" placeholder="sans-serif" /></label>
-          <label class="row">Size <input id="text-size" type="number" min="8" max="512" /></label>
-          <label class="row">Color <input id="text-color" type="color" /></label>
-          <label class="row">Align <select id="text-align"><option value="left">Left</option><option value="center">Center</option><option value="right">Right</option></select></label>
-          <label class="row">Outline <input id="text-stroke-color" type="color" /></label>
-          <label class="row">Outline width <input id="text-stroke-width" type="number" min="0" max="32" step="1" /></label>
-          <label class="row">Shadow <input id="text-shadow-color" type="color" /></label>
-        </div>
-      </details>
-      <details id="shape-panel" hidden>
-        <summary>Shape</summary>
-        <div id="shape-inspector">
-          <label class="row">Type <select id="shape-kind"><option value="rectangle">Rectangle</option><option value="ellipse">Ellipse</option><option value="line">Line</option></select></label>
-          <label class="row">Fill <input id="shape-fill" type="color" /></label>
-          <label class="row">Outline <input id="shape-stroke" type="color" /></label>
-          <label class="row">Outline width <input id="shape-stroke-width" type="number" min="0" max="128" step="1" /></label>
-          <label class="row">Corner radius <input id="shape-corner-radius" type="number" min="0" max="2048" step="1" /></label>
-          <label class="row check"><input id="shape-start-arrow" type="checkbox" /> Start arrow</label>
-          <label class="row check"><input id="shape-end-arrow" type="checkbox" /> End arrow</label>
-        </div>
-      </details>
-      <details id="subtitle-panel" hidden>
-        <summary>Subtitle</summary>
-        <div id="subtitle-inspector">
-          <label class="row">Text <textarea id="subtitle-value" rows="3"></textarea></label>
-          <label class="row">Start <input id="subtitle-start" type="number" min="0" /></label>
-          <label class="row">End <input id="subtitle-end" type="number" min="1" /></label>
-          <label class="row">Font <input id="subtitle-font" type="text" /></label>
-          <label class="row">Size <input id="subtitle-size" type="number" min="8" max="512" /></label>
-          <label class="row">Color <input id="subtitle-color" type="color" /></label>
-        </div>
       </details>
     </section>
   </main>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -83,6 +83,7 @@ const dom = {
   stage: el('stage'),
   stageInner: el('stage-inner'),
   stageExact: el('stage-exact'),
+  stageVisuals: el('stage-visuals'),
   stageOverlay: el('stage-overlay'),
   stageMode: el('stage-mode'),
   stageHint: el('stage-hint'),
@@ -111,6 +112,14 @@ const dom = {
   content: el('timeline-content'),
   ruler: el('ruler'),
   markerList: el('marker-list'),
+  inspectorEmpty: el('inspector-empty'),
+  clipPanel: el('clip-panel'),
+  clipSummary: el('clip-summary'),
+  clipOpacityRow: el('clip-opacity-row'),
+  clipVolumeRow: el('clip-volume-row'),
+  clipOpacity: el('clip-opacity'),
+  clipVolume: el('clip-volume'),
+  fontOptions: el('font-options'),
   textPanel: el('text-panel'),
   textValue: el('text-value'),
   textFont: el('text-font'),
@@ -692,17 +701,27 @@ function clipElement(track, clip) {
   return node;
 }
 
-function subtitleElement(item) {
+/** A text, shape or subtitle layer as a timeline element. The same element
+ *  shape as a clip — left edge, name, trim handles — so a layer moves and
+ *  trims the way a clip does. */
+function visualElement(track, item) {
   const node = document.createElement('div');
-  node.className = 'clip subtitle';
-  node.dataset.subtitleItemId = item.id;
+  const kind = item.content && item.content.kind === 'shape' ? 'shape' : 'text';
+  node.className = track.kind === 'subtitle' ? 'clip subtitle' : `clip visual ${kind}`;
+  node.dataset.visualItemId = item.id;
   node.style.left = `${L.framesToPx(item.start, rate(), state.pxPerSecond)}px`;
   node.style.width = `${Math.max(2, L.framesToPx(item.duration, rate(), state.pxPerSecond))}px`;
   if (item.id === state.selectedVisualItemId) node.classList.add('selected');
   const label = document.createElement('span');
   label.className = 'clip-name';
-  label.textContent = item.content.text || 'Subtitle';
-  node.appendChild(label);
+  label.textContent = kind === 'shape'
+    ? `Shape — ${item.content.shape || 'rectangle'}`
+    : item.content.text || (track.kind === 'subtitle' ? 'Subtitle' : 'Text');
+  const left = document.createElement('span');
+  left.className = 'handle left';
+  const right = document.createElement('span');
+  right.className = 'handle right';
+  node.append(left, label, right);
   return node;
 }
 
@@ -753,9 +772,13 @@ function renderLanes() {
     if (track.hidden) lane.classList.add('off');
     if (track.muted) lane.classList.add('muted');
     if (track.kind === 'subtitle') {
-      for (const item of track.visualItems || []) lane.appendChild(subtitleElement(item));
+      for (const item of track.visualItems || []) lane.appendChild(visualElement(track, item));
     } else {
       for (const clip of track.clips) lane.appendChild(clipElement(track, clip));
+      // Text and shape layers ride on video tracks beside the clips. Without
+      // an element here they exist only on the stage, which is how a layer
+      // ends up impossible to move, trim or delete.
+      for (const item of track.visualItems || []) lane.appendChild(visualElement(track, item));
     }
     dom.lanes.appendChild(lane);
   }
@@ -839,7 +862,7 @@ function renderTimeline() {
   renderRuler();
   renderLanes();
   renderMarkerList();
-  renderTextInspector();
+  renderInspector();
   updatePlayhead(preview ? preview.position() : 0);
   dom.duration.textContent = L.formatTimecode(L.projectDurationFrames(state.project), rate());
   dom.btnMagnet.classList.toggle('on', Boolean(state.settings && state.settings.snap));
@@ -892,6 +915,7 @@ function updatePlayhead(frame) {
   dom.stageHint.hidden = L.projectDurationFrames(state.project) > 0 || preview.mode() === 'asset';
   syncEditorOverlay();
   renderStageOverlay();
+  drawStageVisuals();
 }
 
 function seekPreviousEdit() {
@@ -959,6 +983,9 @@ async function requestExactFrame() {
     const drawn = await window.api.previewFrame(Math.round(preview.position()), maxWidth);
     if (token !== exactToken || preview.isPlaying()) return;
     setStageMode(preview.showExact(drawn) ? 'exact' : 'live');
+    // The exact frame already contains the text and shape layers, drawn by
+    // the same Rust code the render uses; the page's copy comes off.
+    drawStageVisuals();
   } catch (error) {
     // No graphics device, no ffmpeg, or a source that will not decode. The
     // stacked elements are still showing something, so this is not worth a
@@ -979,10 +1006,14 @@ function scheduleExactFrame() {
 
 function selectClip(clipId) {
   state.selectedClipId = clipId;
+  // One selection at a time, so the inspector always shows the thing that was
+  // picked last rather than whichever kind happens to win a tie.
+  if (clipId && state.selectedVisualItemId) selectVisualItem(null);
   for (const node of dom.lanes.querySelectorAll('.clip')) {
     node.classList.toggle('selected', node.dataset.clipId === clipId);
   }
   updateLinkUi();
+  renderInspector();
 }
 
 function selectedVisualItem() {
@@ -1014,7 +1045,11 @@ function overlayScale() {
 
 function selectVisualItem(itemId) {
   state.selectedVisualItemId = itemId || null;
-  renderTextInspector();
+  if (itemId && state.selectedClipId) selectClip(null);
+  for (const node of dom.lanes.querySelectorAll('[data-visual-item-id]')) {
+    node.classList.toggle('selected', node.dataset.visualItemId === state.selectedVisualItemId);
+  }
+  renderInspector();
   syncEditorOverlay();
   renderStageOverlay();
 }
@@ -1096,6 +1131,190 @@ function renderStageOverlay() {
   }
 }
 
+// --- text and shape layers on the stage -------------------------------------
+
+/** Draw the text and shape layers over the stacked media elements.
+ *
+ *  This is the page's approximation of the Rust compositor, and it exists for
+ *  the one display the Rust picture cannot reach: the media element engine
+ *  while it is playing. The paused stage shows the exact frame — the Rust
+ *  picture, which already contains these layers — and the native monitor
+ *  composites them in Rust, so both of those clear this canvas instead.
+ *
+ *  Like the preview itself, this is an approximation of the render: line
+ *  breaks and glyph metrics come from the browser rather than from fontdue.
+ *  Rotation is deliberately not drawn, because the Rust compositor does not
+ *  draw it either, and the preview's job is to look like the render. */
+function drawStageVisuals() {
+  const canvas = dom.stageVisuals;
+  if (!canvas) return;
+  const clear = () => {
+    if (canvas.width > 0) canvas.width = 0;
+  };
+  if (!preview || preview.mode() !== 'timeline') return clear();
+  if (preview.usesNativeMonitor() && !editorOverlayActive) return clear();
+  if (preview.isExact()) return clear();
+  const box = dom.stage.getBoundingClientRect();
+  if (box.width < 1 || box.height < 1) return clear();
+  const ratio = window.devicePixelRatio || 1;
+  const width = Math.max(1, Math.round(box.width * ratio));
+  const height = Math.max(1, Math.round(box.height * ratio));
+  if (canvas.width !== width) canvas.width = width;
+  if (canvas.height !== height) canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) return;
+  const settings = state.project.settings;
+  const scales = {
+    x: box.width / Math.max(1, settings.width),
+    y: box.height / Math.max(1, settings.height),
+  };
+  scales.font = Math.min(scales.x, scales.y);
+  context.setTransform(ratio, 0, 0, ratio, 0, 0);
+  context.clearRect(0, 0, box.width, box.height);
+  const frame = Math.floor(preview.position());
+  // Tracks in project order: V1 first, which is the bottom layer, the same
+  // order the Rust compositor takes them in.
+  for (const track of state.project.tracks) {
+    if (track.hidden) continue;
+    if (track.kind !== 'video' && track.kind !== 'subtitle') continue;
+    const items = (track.visualItems || [])
+      .filter((item) => item.start <= frame && frame < item.start + item.duration)
+      .sort((a, b) => a.zIndex - b.zIndex);
+    for (const item of items) drawVisualItem(context, track, item, scales);
+  }
+}
+
+function drawVisualItem(context, track, item, scales) {
+  const settings = state.project.settings;
+  // A subtitle ignores its own transform and sits in the lower third, exactly
+  // as compositor/text.rs places it.
+  const transform = track.kind === 'subtitle'
+    ? { x: 96, y: settings.height * 0.78, width: settings.width - 192, height: settings.height * 0.16, opacity: 1 }
+    : item.transform;
+  const x = transform.x * scales.x;
+  const y = transform.y * scales.y;
+  const width = Math.max(1, transform.width * scales.x);
+  const height = Math.max(1, transform.height * scales.y);
+  context.save();
+  context.globalAlpha = Math.max(0, Math.min(1, transform.opacity ?? 1));
+  context.translate(x, y);
+  context.beginPath();
+  context.rect(0, 0, width, height);
+  context.clip();
+  const content = item.content || {};
+  if (content.kind === 'shape') {
+    drawShapeContent(context, content, width, height, scales.font);
+  } else if (content.kind === 'text') {
+    const style = (track.kind === 'subtitle' && track.subtitleStyle) || content.style || {};
+    drawTextContent(context, content.text || '', style, width, height, scales.font);
+  }
+  context.restore();
+}
+
+function cssFontFamily(family) {
+  const generic = ['serif', 'sans-serif', 'monospace', 'cursive', 'fantasy'];
+  return generic.includes(family) ? family : `"${String(family).replace(/"/g, '')}"`;
+}
+
+function wrapVisualText(context, text, maxWidth) {
+  const lines = [];
+  for (const paragraph of String(text).split('\n')) {
+    let line = '';
+    for (const word of paragraph.split(/\s+/).filter(Boolean)) {
+      const candidate = line ? `${line} ${word}` : word;
+      if (line && context.measureText(candidate).width > maxWidth) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = candidate;
+      }
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+function drawTextContent(context, text, style, width, height, scale) {
+  const size = Math.max(1, (style.fontSize || 64) * scale);
+  context.font = `${size}px ${cssFontFamily(style.fontFamily || 'sans-serif')}`;
+  const align = style.align || 'center';
+  context.textAlign = align === 'left' ? 'left' : align === 'right' ? 'right' : 'center';
+  context.textBaseline = 'alphabetic';
+  const anchorX = align === 'left' ? 0 : align === 'right' ? width : width / 2;
+  const strokeWidth = Math.max(0, (style.strokeWidth || 0) * scale);
+  const shadowColor = style.shadowColor || '';
+  const lines = wrapVisualText(context, text, width);
+  for (let index = 0; index < lines.length; index += 1) {
+    const baseline = index * size * 1.2 + size;
+    if (baseline - size > height) break;
+    if (shadowColor) {
+      context.shadowColor = shadowColor;
+      context.shadowOffsetX = (style.shadowX ?? 2) * scale;
+      context.shadowOffsetY = (style.shadowY ?? 2) * scale;
+    }
+    if (strokeWidth > 0 && style.strokeColor) {
+      // The Rust pass dilates by the radius, so the visible rim is the radius
+      // wide; a canvas stroke straddles the edge, so it is doubled to match.
+      context.lineWidth = strokeWidth * 2;
+      context.lineJoin = 'round';
+      context.strokeStyle = style.strokeColor;
+      context.strokeText(lines[index], anchorX, baseline);
+    }
+    context.fillStyle = style.color || '#ffffff';
+    context.fillText(lines[index], anchorX, baseline);
+    context.shadowColor = 'transparent';
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+  }
+}
+
+function drawShapeContent(context, content, width, height, scale) {
+  const stroke = content.stroke || '#ffffff';
+  const strokeWidth = Math.max(0, (content.strokeWidth ?? 4) * scale);
+  const kind = content.shape || 'rectangle';
+  if (kind === 'line') {
+    // A line is all stroke: a bar through the middle, plus the arrow heads.
+    // Nothing is drawn at width zero, the same rule the Rust rasterizer has.
+    if (strokeWidth <= 0) return;
+    const middle = height / 2;
+    const half = strokeWidth / 2;
+    const arrow = Math.max(strokeWidth * 1.5, 8);
+    context.fillStyle = stroke;
+    context.fillRect(half, middle - half, Math.max(0, width - strokeWidth), strokeWidth);
+    const head = (tipX, direction) => {
+      context.beginPath();
+      context.moveTo(tipX, middle);
+      context.lineTo(tipX + direction * arrow, middle - arrow * 0.65);
+      context.lineTo(tipX + direction * arrow, middle + arrow * 0.65);
+      context.closePath();
+      context.fill();
+    };
+    if (content.startArrow) head(0, 1);
+    if (content.endArrow) head(width, -1);
+    return;
+  }
+  context.beginPath();
+  if (kind === 'ellipse') {
+    context.ellipse(width / 2, height / 2, width / 2, height / 2, 0, 0, Math.PI * 2);
+  } else {
+    const radius = Math.min(Math.max(0, (content.cornerRadius ?? 0) * scale), Math.min(width, height) / 2);
+    context.roundRect(0, 0, width, height, radius);
+  }
+  context.fillStyle = content.fill || '#4f8cffcc';
+  context.fill();
+  if (strokeWidth > 0) {
+    // The Rust outline is a band half the width lying inside the edge, so the
+    // stroke is clipped to the shape — which throws away its outer half and
+    // leaves the same half-width rim.
+    context.save();
+    context.clip();
+    context.lineWidth = strokeWidth;
+    context.strokeStyle = stroke;
+    context.stroke();
+    context.restore();
+  }
+}
+
 function beginVisualDrag(event) {
   if (event.button !== 0 || preview.isPlaying()) return false;
   const point = projectPointAt(event);
@@ -1138,6 +1357,10 @@ function updateVisualDrag(event) {
   const item = selectedVisualItem();
   if (item) item.transform = visualDrag.next;
   renderStageOverlay();
+  // The page's own copy of the layer moves with the handles. Without this the
+  // dashed box slides away from the shape it is supposed to be around, until
+  // the drag ends and the redraw catches up.
+  drawStageVisuals();
 }
 
 async function endVisualDrag(event) {
@@ -1156,6 +1379,7 @@ function cancelVisualDrag() {
   if (item) item.transform = visualDrag.initial;
   visualDrag = null;
   renderStageOverlay();
+  drawStageVisuals();
 }
 
 function closeTimelineContextMenu() {
@@ -1222,32 +1446,31 @@ function addMarker(frame = Math.round(preview.position())) {
   return edit({ op: 'addMarker', frame, name: '', color: '#e6a700' });
 }
 
-async function addText() {
+/** The video track a new text or shape lands on: the one it was dropped on,
+ *  else the targeted track, else the first video track. */
+function visualTargetTrack(placement) {
+  if (placement) {
+    const track = L.findTrack(state.project, placement.trackId);
+    return track && track.kind === 'video' ? track : null;
+  }
   const target = state.targetTrackId && L.findTrack(state.project, state.targetTrackId);
-  const track = target && target.kind === 'video' ? target : L.tracksOf(state.project, 'video')[0];
+  return target && target.kind === 'video' ? target : L.tracksOf(state.project, 'video')[0];
+}
+
+/** Add a visual item and select what Rust made of it. `placement` is
+ *  `{ trackId, frame }` from a drop; without one the item lands on the
+ *  targeted track at the playhead. */
+async function addVisualItem(placement, content, transform) {
+  const track = visualTargetTrack(placement);
   if (!track) return;
   const known = new Set((track.visualItems || []).map((item) => item.id));
   await edit({
     op: 'addVisualItem',
     trackId: track.id,
-    content: {
-      kind: 'text',
-      text: 'Title',
-      style: {
-        fontFamily: 'sans-serif', fontSize: 64, color: '#ffffff', align: 'center',
-        strokeColor: '', strokeWidth: 0, shadowColor: '#00000080', shadowX: 2, shadowY: 2,
-      },
-    },
-    start: Math.round(preview.position()),
-    duration: Math.max(Math.round(T.rateToNumber(rate()) * 5), 1),
-    transform: {
-      x: state.project.settings.width * 0.1,
-      y: state.project.settings.height * 0.12,
-      width: state.project.settings.width * 0.8,
-      height: state.project.settings.height * 0.2,
-      rotation: 0,
-      opacity: 1,
-    },
+    content,
+    start: placement ? Math.round(placement.frame) : Math.round(preview.position()),
+    duration: L.defaultVisualItemFrames(rate()),
+    transform: { ...transform, rotation: 0, opacity: 1 },
     zIndex: 0,
   });
   const liveTrack = L.findTrack(state.project, track.id);
@@ -1255,33 +1478,32 @@ async function addText() {
   if (item) selectVisualItem(item.id);
 }
 
-async function addShape() {
-  const target = state.targetTrackId && L.findTrack(state.project, state.targetTrackId);
-  const track = target && target.kind === 'video' ? target : L.tracksOf(state.project, 'video')[0];
-  if (!track) return;
-  const known = new Set((track.visualItems || []).map((item) => item.id));
-  await edit({
-    op: 'addVisualItem',
-    trackId: track.id,
-    content: {
-      kind: 'shape', shape: 'rectangle', fill: '#4f8cffcc', stroke: '#ffffff',
-      strokeWidth: 4, cornerRadius: 20, startArrow: false, endArrow: false,
+function addText(placement) {
+  return addVisualItem(placement, {
+    kind: 'text',
+    text: 'Title',
+    style: {
+      fontFamily: 'sans-serif', fontSize: 64, color: '#ffffff', align: 'center',
+      strokeColor: '', strokeWidth: 0, shadowColor: '#00000080', shadowX: 2, shadowY: 2,
     },
-    start: Math.round(preview.position()),
-    duration: Math.max(Math.round(T.rateToNumber(rate()) * 5), 1),
-    transform: {
-      x: state.project.settings.width * 0.3,
-      y: state.project.settings.height * 0.3,
-      width: state.project.settings.width * 0.4,
-      height: state.project.settings.height * 0.25,
-      rotation: 0,
-      opacity: 1,
-    },
-    zIndex: 0,
+  }, {
+    x: state.project.settings.width * 0.1,
+    y: state.project.settings.height * 0.12,
+    width: state.project.settings.width * 0.8,
+    height: state.project.settings.height * 0.2,
   });
-  const liveTrack = L.findTrack(state.project, track.id);
-  const item = (liveTrack && liveTrack.visualItems || []).find((entry) => !known.has(entry.id));
-  if (item) selectVisualItem(item.id);
+}
+
+function addShape(placement) {
+  return addVisualItem(placement, {
+    kind: 'shape', shape: 'rectangle', fill: '#4f8cffcc', stroke: '#ffffff',
+    strokeWidth: 4, cornerRadius: 20, startArrow: false, endArrow: false,
+  }, {
+    x: state.project.settings.width * 0.3,
+    y: state.project.settings.height * 0.3,
+    width: state.project.settings.width * 0.4,
+    height: state.project.settings.height * 0.25,
+  });
 }
 
 async function addSubtitle() {
@@ -1330,15 +1552,28 @@ function preserveAlpha(color, previous) {
   return `${color}${alpha}`;
 }
 
-function renderTextInspector() {
+/** The inspector beside the preview. One switch over what is selected: a text,
+ *  shape or subtitle layer, else the selected clip, else the empty hint. */
+function renderInspector() {
   const item = selectedVisualItem();
   const text = item && item.content && item.content.kind === 'text' ? item.content : null;
   const shape = item && item.content && item.content.kind === 'shape' ? item.content : null;
   const track = item && state.project.tracks.find((candidate) => (candidate.visualItems || []).some((entry) => entry.id === item.id));
   const subtitle = track && track.kind === 'subtitle';
+  const clip = !item && liveSelection() ? L.findClip(state.project, liveSelection()) : null;
   dom.textPanel.hidden = !text || subtitle;
   dom.subtitlePanel.hidden = !text || !subtitle;
   dom.shapePanel.hidden = !shape;
+  dom.clipPanel.hidden = !clip;
+  dom.inspectorEmpty.hidden = Boolean(item || clip);
+  if (clip) {
+    const asset = L.findAsset(state.project, clip.clip.assetId);
+    dom.clipSummary.textContent = `${asset ? asset.name || baseName(asset.path) : 'missing file'} · ${clip.track.name}`;
+    dom.clipOpacityRow.hidden = clip.track.kind !== 'video';
+    dom.clipVolumeRow.hidden = Boolean(asset) && asset.kind === 'image';
+    dom.clipOpacity.value = String(clip.clip.opacity ?? 1);
+    dom.clipVolume.value = String(clip.clip.volume ?? 1);
+  }
   if (shape) {
     dom.shapeKind.value = shape.shape || 'rectangle';
     dom.shapeFill.value = hexColor(shape.fill, '#4f8cff');
@@ -1443,10 +1678,33 @@ function updateSelectedText() {
     .catch((error) => reportError(error, 'text:edit'));
 }
 
+async function removeSelectedVisualItem() {
+  const item = selectedVisualItem();
+  if (!item) return;
+  const done = await edit({ op: 'removeVisualItem', itemId: item.id });
+  if (done) selectVisualItem(null);
+}
+
+/** The clip inspector's two sliders. One command with both values: Rust takes
+ *  either as optional, and sending both keeps this one function. */
+function updateSelectedClipGain() {
+  const clipId = liveSelection();
+  if (!clipId) return;
+  edit({
+    op: 'setClipGain',
+    clipId,
+    opacity: Math.max(0, Math.min(1, Number(dom.clipOpacity.value) || 0)),
+    volume: Math.max(0, Math.min(1, Number(dom.clipVolume.value) || 0)),
+  }).catch((error) => reportError(error, 'clip:gain'));
+}
+
 /** Delete, or delete and close the gap behind it. Ripple is destructive in a
  *  way the timeline used to avoid on purpose, because until now there was no
  *  way back from it. */
 async function deleteSelected(ripple) {
+  // Selections are exclusive, so a selected layer is the thing the user is
+  // looking at; a gap cannot ripple behind one, so both buttons remove it.
+  if (selectedVisualItem()) return removeSelectedVisualItem();
   const clipId = liveSelection();
   if (!clipId) return;
   // edit() answers null when the edit was refused. The empty array a delete
@@ -1615,6 +1873,149 @@ function endClipDrag() {
           frame: current.nextEdge,
         }
   );
+}
+
+// --- dragging text and shape layers on the timeline -------------------------
+
+let visualTimingDrag = null;
+
+function beginVisualItemDrag(event, node) {
+  if (event.button !== 0) return;
+  const found = L.findVisualItem(state.project, node.dataset.visualItemId);
+  if (!found) return;
+  selectVisualItem(found.item.id);
+  const box = node.getBoundingClientRect();
+  const offsetX = event.clientX - box.left;
+  const mode =
+    offsetX <= HANDLE_PX ? 'trim-start' : offsetX >= box.width - HANDLE_PX ? 'trim-end' : 'move';
+  visualTimingDrag = {
+    mode,
+    itemId: found.item.id,
+    node,
+    grabFrames: L.pxToFrames(offsetX, rate(), state.pxPerSecond),
+    nextStart: found.item.start,
+    nextEnd: found.item.start + found.item.duration,
+    moved: false,
+  };
+  document.body.classList.add(mode === 'move' ? 'dragging' : 'trimming');
+  event.preventDefault();
+}
+
+function updateVisualItemDrag(event) {
+  const current = visualTimingDrag;
+  const pointer = frameAtClientX(event.clientX);
+  const tolerance = snapTolerance();
+  const duration = current.nextEnd - current.nextStart;
+  if (current.mode === 'move') {
+    const wanted = Math.max(0, pointer - current.grabFrames);
+    current.nextStart = L.snapClipStart(state.project, wanted, duration, tolerance, {
+      extra: [preview.position()],
+    });
+    current.nextEnd = current.nextStart + duration;
+    current.node.style.left = `${L.framesToPx(current.nextStart, rate(), state.pxPerSecond)}px`;
+  } else {
+    const snapped = L.snapTime(state.project, pointer, tolerance, { extra: [preview.position()] });
+    if (current.mode === 'trim-start') {
+      current.nextStart = Math.max(0, Math.min(snapped, current.nextEnd - 1));
+      current.node.style.left = `${L.framesToPx(current.nextStart, rate(), state.pxPerSecond)}px`;
+    } else {
+      current.nextEnd = Math.max(current.nextStart + 1, snapped);
+    }
+    const width = L.framesToPx(current.nextEnd - current.nextStart, rate(), state.pxPerSecond);
+    current.node.style.width = `${Math.max(2, width)}px`;
+  }
+  current.moved = true;
+}
+
+function endVisualItemDrag() {
+  const current = visualTimingDrag;
+  visualTimingDrag = null;
+  document.body.classList.remove('dragging', 'trimming');
+  if (!current) return;
+  if (!current.moved) {
+    renderTimeline();
+    return;
+  }
+  return edit({
+    op: 'setVisualTiming',
+    itemId: current.itemId,
+    start: current.nextStart,
+    duration: current.nextEnd - current.nextStart,
+  });
+}
+
+// --- dragging the toolbar's Text and Shape buttons onto a track --------------
+
+let toolDrag = null;
+/** Set for the moment between a dragged release and the click the browser
+ *  sends after it. Read and reset by the buttons' own click handlers. */
+let toolDragJustEnded = false;
+
+function tookToolDragClick() {
+  const dragged = toolDragJustEnded;
+  toolDragJustEnded = false;
+  return dragged;
+}
+
+/** The + Text and + Shape buttons drag like assets do: pointer events, a
+ *  ghost, and a lane that lights up. A plain click never grows a ghost, ends
+ *  here doing nothing, and the button's own click handler adds the layer at
+ *  the playhead as before. */
+function beginToolDrag(event, kind) {
+  if (event.button !== 0) return;
+  toolDrag = { kind, startX: event.clientX, startY: event.clientY, ghost: null, dragged: false };
+}
+
+/** Put the page back and report the drag, if it had got as far as a ghost.
+ *
+ *  Every way a drag can end comes through here — the pointer coming up, the
+ *  sequence being cancelled, the window losing focus mid-drag — so a ghost is
+ *  never left stuck to a cursor with no button held. Without it the next
+ *  release over a lane would add a layer nobody asked for. */
+function clearToolDrag() {
+  const current = toolDrag;
+  toolDrag = null;
+  if (!current || !current.ghost) return null;
+  current.ghost.remove();
+  document.body.classList.remove('dragging');
+  for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
+  return current;
+}
+
+function updateToolDrag(event) {
+  if (!toolDrag.ghost) {
+    const travelled =
+      Math.abs(event.clientX - toolDrag.startX) + Math.abs(event.clientY - toolDrag.startY);
+    if (travelled < 4) return;
+    toolDrag.ghost = document.createElement('div');
+    toolDrag.ghost.className = 'drag-ghost';
+    toolDrag.ghost.textContent = toolDrag.kind === 'text' ? 'Text' : 'Shape';
+    document.body.appendChild(toolDrag.ghost);
+    document.body.classList.add('dragging');
+  }
+  toolDrag.ghost.style.left = `${event.clientX + 12}px`;
+  toolDrag.ghost.style.top = `${event.clientY + 12}px`;
+  const lane = laneAtPoint(event.clientX, event.clientY);
+  const track = lane && L.findTrack(state.project, lane.dataset.trackId);
+  const accepts = Boolean(track && track.kind === 'video');
+  for (const node of dom.lanes.querySelectorAll('.lane')) {
+    node.classList.toggle('drop-target', node === lane && accepts);
+  }
+}
+
+async function endToolDrag(event) {
+  const current = clearToolDrag();
+  if (!current) return;
+  // A drag that grew a ghost is never also a click, even when it ends back on
+  // the button — the browser fires one anyway, and without this the cancelled
+  // drag would add a layer at the playhead.
+  toolDragJustEnded = true;
+  const lane = laneAtPoint(event.clientX, event.clientY);
+  const track = lane && L.findTrack(state.project, lane.dataset.trackId);
+  if (!track || track.kind !== 'video') return;
+  const frame = L.snapTime(state.project, frameAtClientX(event.clientX), snapTolerance());
+  const add = current.kind === 'text' ? addText : addShape;
+  await add({ trackId: track.id, frame });
 }
 
 // --- scrubbing -------------------------------------------------------------
@@ -2313,6 +2714,11 @@ async function attachMonitor(restart) {
   await preview.attach();
   updateToolWarning();
   updateMonitorZoomUi();
+  // Which engine is running decides who draws the text and shape layers, and
+  // the answer only arrives here. Switching to the media elements has to put
+  // the page's own copy back on the stage; switching away has to take it off.
+  drawStageVisuals();
+  scheduleExactFrame();
   // The note carries the fallback reason when a monitor refused to start, and
   // that is only known once the attach has answered.
   el('as-compositor-note').textContent = compositorNote(state.settings.compositor);
@@ -2480,8 +2886,14 @@ function wireAssets() {
     if (assetDrag) updateAssetDrag(event);
   });
   window.addEventListener('pointerup', endAssetDrag);
-  window.addEventListener('pointercancel', clearAssetDrag);
-  window.addEventListener('blur', clearAssetDrag);
+  window.addEventListener('pointercancel', () => {
+    clearAssetDrag();
+    clearToolDrag();
+  });
+  window.addEventListener('blur', () => {
+    clearAssetDrag();
+    clearToolDrag();
+  });
 }
 
 function wireTimeline() {
@@ -2496,8 +2908,16 @@ function wireTimeline() {
   dom.btnDelete.addEventListener('click', () => deleteSelected(false));
   dom.btnRipple.addEventListener('click', () => deleteSelected(true));
   dom.btnLink.addEventListener('click', toggleClipLink);
-  dom.btnAddText.addEventListener('click', addText);
-  dom.btnAddShape.addEventListener('click', addShape);
+  // Wrapped so the click event never arrives as a placement, and skipped
+  // entirely when it is the click that follows a drag.
+  dom.btnAddText.addEventListener('click', () => {
+    if (!tookToolDragClick()) addText();
+  });
+  dom.btnAddShape.addEventListener('click', () => {
+    if (!tookToolDragClick()) addShape();
+  });
+  dom.btnAddText.addEventListener('pointerdown', (event) => beginToolDrag(event, 'text'));
+  dom.btnAddShape.addEventListener('pointerdown', (event) => beginToolDrag(event, 'shape'));
   dom.btnAddMarker.addEventListener('click', () => addMarker());
   dom.btnAddVideo.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'video' }));
   dom.btnAddAudio.addEventListener('click', () => edit({ op: 'addTrack', trackKind: 'audio' }));
@@ -2579,11 +2999,13 @@ function wireTimeline() {
   for (const input of [dom.subtitleFont, dom.subtitleSize, dom.subtitleColor]) {
     input.addEventListener('change', updateSubtitleStyle);
   }
+  for (const input of [dom.clipOpacity, dom.clipVolume]) {
+    input.addEventListener('change', updateSelectedClipGain);
+  }
   dom.lanes.addEventListener('pointerdown', (event) => {
-    const subtitle = event.target.closest('[data-subtitle-item-id]');
-    if (subtitle) {
-      selectVisualItem(subtitle.dataset.subtitleItemId);
-      event.preventDefault();
+    const visual = event.target.closest('[data-visual-item-id]');
+    if (visual) {
+      beginVisualItemDrag(event, visual);
       return;
     }
     const clip = event.target.closest('.clip');
@@ -2592,10 +3014,19 @@ function wireTimeline() {
       return;
     }
     selectClip(null);
+    selectVisualItem(null);
     beginScrub(event);
   });
   dom.lanes.addEventListener('contextmenu', (event) => {
     event.preventDefault();
+    const visual = event.target.closest('[data-visual-item-id]');
+    if (visual) {
+      selectVisualItem(visual.dataset.visualItemId);
+      openTimelineContextMenu(event, [
+        { label: 'Delete Layer', run: () => removeSelectedVisualItem() },
+      ]);
+      return;
+    }
     const clip = event.target.closest('.clip');
     if (clip) {
       selectClip(clip.dataset.clipId);
@@ -2625,10 +3056,16 @@ function wireTimeline() {
 
   window.addEventListener('pointermove', (event) => {
     if (drag) updateClipDrag(event);
+    else if (visualTimingDrag) updateVisualItemDrag(event);
+    else if (toolDrag) updateToolDrag(event);
     else if (scrubbing) scrubTo(event.clientX);
   });
-  window.addEventListener('pointerup', () => {
+  window.addEventListener('pointerup', (event) => {
     if (drag) endClipDrag();
+    if (visualTimingDrag) endVisualItemDrag();
+    if (toolDrag) {
+      endToolDrag(event).catch((error) => reportError(error, 'tool-drop'));
+    }
     if (scrubbing) {
       scrubbing = false;
       preview.setScrubbing(false);
@@ -3001,6 +3438,21 @@ async function boot() {
     dom.toolWarning.textContent = 'Initialization failed';
     dom.toolWarning.title = 'Open Settings to inspect the error log location';
   }
+
+  // The system's font families, for the text inspectors' pickers. Off the
+  // boot path on purpose: reading every font file's name takes long enough to
+  // notice, and nothing before the first font edit needs the list.
+  Promise.resolve(window.api.listFonts())
+    .then((families) => {
+      if (!dom.fontOptions || !Array.isArray(families)) return;
+      dom.fontOptions.textContent = '';
+      for (const family of families) {
+        const option = document.createElement('option');
+        option.value = family;
+        dom.fontOptions.appendChild(option);
+      }
+    })
+    .catch(() => {});
 
   if (state.boot.qualityProject && state.boot.qualityReport) {
     window.setTimeout(async () => {

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -18,6 +18,8 @@
   --clip-video-edge: #5b8def;
   --clip-audio: #d3efdd;
   --clip-audio-edge: #41a86a;
+  --clip-visual: #e4d8f8;
+  --clip-visual-edge: #9a79dd;
   --select: #f0a52f;
   --danger: #d0453b;
   --stage: #0b0b0d;
@@ -44,6 +46,8 @@
     --clip-video-edge: #5b8def;
     --clip-audio: #24412e;
     --clip-audio-edge: #4cb377;
+    --clip-visual: #3d3158;
+    --clip-visual-edge: #9a79dd;
     --select: #f0a52f;
     --danger: #e2695f;
     --stage: #000000;
@@ -293,6 +297,12 @@ select {
   min-height: 0;
 }
 
+/* `display: grid` below beats the `hidden` attribute's UA `display: none`,
+   so hidden has to win again explicitly or the panel is always on screen. */
+#debug-panel[hidden] {
+  display: none;
+}
+
 #debug-panel {
   position: fixed;
   z-index: 5;
@@ -332,7 +342,7 @@ select {
 
 #upper {
   display: grid;
-  grid-template-columns: 264px minmax(0, 1fr);
+  grid-template-columns: 264px minmax(0, 1fr) 280px;
   min-height: 0;
   border-bottom: 1px solid var(--border);
 }
@@ -522,6 +532,18 @@ select {
 
 #stage-exact.on {
   display: block;
+}
+
+/* Text and shape layers during playback, drawn by the page. Under the exact
+   frame on purpose: the exact frame already contains them, composited by the
+   same Rust code the render uses. */
+#stage-visuals {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 55;
+  pointer-events: none;
 }
 
 #stage-overlay {
@@ -760,6 +782,55 @@ button.icon.on {
   clip-path: polygon(0 0, 100% 0, 50% 100%);
 }
 
+/* --- inspector ----------------------------------------------------------- */
+
+#inspector-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+  border-left: 1px solid var(--border);
+  background: var(--panel);
+}
+
+#inspector-body {
+  overflow-y: auto;
+  padding: 10px 12px;
+}
+
+#inspector-body h3 {
+  margin: 2px 0 10px;
+  font-size: 13px;
+}
+
+#inspector-body .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+
+/* The flex rule above beats the `hidden` attribute's UA display, the same trap
+   the debug panel fell into, so hidden has to win again explicitly. */
+#inspector-body .row[hidden] {
+  display: none;
+}
+
+#inspector-body .row.check {
+  justify-content: flex-start;
+}
+
+#inspector-body .row input[type='text'],
+#inspector-body .row input[type='number'],
+#inspector-body .row textarea,
+#inspector-body .row select,
+#inspector-body .row input[type='range'] {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 168px;
+}
+
 #marker-panel {
   max-height: 160px;
   overflow: auto;
@@ -866,6 +937,23 @@ button.icon.on {
   color: #0f2a1a;
 }
 
+/* A text or shape layer on a video track: a band across the lower half of the
+   lane, so it never covers the clip underneath. Sharing the whole lane height
+   would put every layer over its clip's body and trim handles, and the clip
+   could then not be selected or trimmed at all where a layer sits. */
+.clip.visual {
+  top: 50%;
+  bottom: 3px;
+  background: var(--clip-visual);
+  border: 1px solid var(--clip-visual-edge);
+  color: #2a1c4e;
+  font-size: 10px;
+}
+
+.clip.visual .clip-name {
+  font-size: 10px;
+}
+
 .clip-waveform {
   position: absolute;
   inset: 50% 8px auto;
@@ -878,7 +966,8 @@ button.icon.on {
 
 @media (prefers-color-scheme: dark) {
   .clip.video,
-  .clip.audio {
+  .clip.audio,
+  .clip.visual {
     color: var(--fg);
   }
 }

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -29,6 +29,22 @@ const MAX_TRACKS_PER_KIND = 4;
 // the edit crate, which is the one that enforces it; this copy is what stops a
 // trim from *looking* as though it went further than it will be allowed to.
 const MIN_CLIP_SECONDS = 0.1;
+// How long a new text or shape layer runs before it is trimmed to taste.
+const DEFAULT_VISUAL_ITEM_SECONDS = 4;
+
+/** The default length of a new text or shape layer, in frames of `rate`. */
+function defaultVisualItemFrames(rate) {
+  return Math.max(1, Math.round(DEFAULT_VISUAL_ITEM_SECONDS * T.rateToNumber(rate)));
+}
+
+/** The visual item with this id, with its track, or null. */
+function findVisualItem(project, itemId) {
+  for (const track of project.tracks) {
+    const item = (track.visualItems || []).find((entry) => entry.id === itemId);
+    if (item) return { track, item };
+  }
+  return null;
+}
 
 /** Rounded up, so the constant above is a floor rather than an average: at
  *  23.976 a tenth of a second is 2.4 frames, and rounding to 2 would make the
@@ -300,6 +316,9 @@ function blankProject() {
 const exported = {
   MAX_TRACKS_PER_KIND,
   MIN_CLIP_SECONDS,
+  DEFAULT_VISUAL_ITEM_SECONDS,
+  defaultVisualItemFrames,
+  findVisualItem,
   minClipFrames,
   blankProject,
   tracksOf,

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -284,3 +284,21 @@ test('a clip with nothing left of it has no negative length', () => {
   assert.strictEqual(L.clipDuration(clip('c1', 'v', 0, 30, 10)), 0);
   assert.strictEqual(L.clipEnd(clip('c1', 'v', 100, 30, 10)), 100);
 });
+
+test('a new text or shape layer runs four seconds of the project rate', () => {
+  assert.strictEqual(L.DEFAULT_VISUAL_ITEM_SECONDS, 4);
+  assert.strictEqual(L.defaultVisualItemFrames(T.fps(30)), 120);
+  // Rounded on a fractional rate, and never zero even on an absurd one.
+  assert.strictEqual(L.defaultVisualItemFrames({ num: 24000, den: 1001 }), 96);
+  assert.strictEqual(L.defaultVisualItemFrames({ num: 1, den: 100 }), 1);
+});
+
+test('a visual item is found with the track it rides on', () => {
+  const lane = track('t1', 'video', 'V1');
+  lane.visualItems = [{ id: 'title-1', start: 0, duration: 120, zIndex: 0, content: { kind: 'text', text: 'Hi' } }];
+  const project = projectOf([], [lane]);
+  const found = L.findVisualItem(project, 'title-1');
+  assert.strictEqual(found.track.id, 't1');
+  assert.strictEqual(found.item.id, 'title-1');
+  assert.strictEqual(L.findVisualItem(project, 'missing'), null);
+});


### PR DESCRIPTION
# 구현

native monitor를 stage 안으로 되돌리고, text와 shape를 timeline 레이어로 만들어 재생과 렌더 세 경로 모두에 그림
- JS 98, Rust 273개 테스트 통과. 실제 ffmpeg로 PAM overlay 그래프를 돌려 enable 구간 안팎 픽셀 확인

# 어려웠던 점

WKWebView가 flipped view라는 것이 문서가 아니라 실측으로만 드러남
- AppKit 코드를 직접 컴파일해 isFlipped=YES 확인. window에 붙기 전 view의 convertRectToBacking이 scale 1을 답하는 것도 같은 방법으로 확인

레이어를 lane 전체 높이로 그리니 클립 본체와 trim handle이 전부 가려짐
- elementFromPoint로 확인 후 아래 절반 띠로 축소. 클립 상단과 handle은 클립이, 하단은 레이어가 받음

# 리스크

페이지가 재생 중 그리는 레이어는 Rust rasterizer의 근사라 줄바꿈과 글자 간격이 렌더와 다를 수 있음
- 회전은 Rust가 그리지 않아 페이지도 그리지 않음. 정지 화면과 렌더는 항상 Rust 그림이므로 최종 결과는 일치

filter graph 렌더는 item 수만큼 임시 PAM 파일을 만듦
- 렌더 시작 시 한 번 쓰고 마지막 route가 끝나면 지움. 4K에서 큰 레이어가 여럿이면 임시 공간을 잠시 차지

Issue #855