### PR TITLE
akbun-makepresentation: 객체 복수 선택

### DIFF
--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -245,6 +245,19 @@ function shapeIndicesInRect(shapes, rect) {
   }, []);
 }
 
+// Add an unselected item to a selection, or remove it when it is already
+// present. Keeping this independent of the page makes modifier-click
+// selection use the same valid-index rules as every other selection path.
+function toggleSelection(selection, index, length) {
+  const current = [...new Set(selection)].filter(
+    (selected) => Number.isInteger(selected) && selected >= 0 && selected < length
+  );
+  if (!Number.isInteger(index) || index < 0 || index >= length) return current;
+  return current.includes(index)
+    ? current.filter((selected) => selected !== index)
+    : [...current, index];
+}
+
 function moveShape(shape, dx, dy) {
   if (shape.kind === 'pen') {
     for (const p of shape.points) {
@@ -597,6 +610,7 @@ const exported = {
   shapeBBox,
   normalizeRect,
   shapeIndicesInRect,
+  toggleSelection,
   moveShape,
   handlesFor,
   resizeShape,

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -365,6 +365,16 @@ canvas.addEventListener('pointerdown', (event) => {
   if (group) {
     const index = Number(group.dataset.i);
 
+    // Shift-click changes only this object's membership. It does not begin a
+    // drag, so repeated Shift-clicks can build or shrink a selection without
+    // moving an object by a pixel.
+    if (event.shiftKey && !(event.metaKey || event.ctrlKey)) {
+      selectMany(L.toggleSelection(state.selection, index, slide().shapes.length));
+      renderCanvas();
+      renderProps();
+      return;
+    }
+
     // Opening a text box for editing is decided here rather than from a
     // dblclick event, because the browser never reports one: pointerup
     // redraws the canvas, so mouseup lands on a freshly built element and

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -141,6 +141,8 @@ test('toggleSelection adds and removes one valid object without disturbing other
   assert.deepStrictEqual(L.toggleSelection([0], 2, 3), [0, 2]);
   assert.deepStrictEqual(L.toggleSelection([0, 2], 0, 3), [2]);
   assert.deepStrictEqual(L.toggleSelection([0, 2], 3, 3), [0, 2]);
+  assert.deepStrictEqual(L.toggleSelection([0, 0, 2, -1, 3, 1.5], 1, 3), [0, 2, 1]);
+  assert.deepStrictEqual(L.toggleSelection([0, 0, 2, -1, 3, 1.5], 3, 3), [0, 2]);
 });
 
 test('moveShape shifts pen points', () => {

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -137,6 +137,12 @@ test('shapeIndicesInRect selects only fully enclosed shapes', () => {
   );
 });
 
+test('toggleSelection adds and removes one valid object without disturbing others', () => {
+  assert.deepStrictEqual(L.toggleSelection([0], 2, 3), [0, 2]);
+  assert.deepStrictEqual(L.toggleSelection([0, 2], 0, 3), [2]);
+  assert.deepStrictEqual(L.toggleSelection([0, 2], 3, 3), [0, 2]);
+});
+
 test('moveShape shifts pen points', () => {
   const shape = L.createShape('pen', 0, 0, {});
   L.dragShape(shape, 0, 0, 10, 10);


### PR DESCRIPTION
# 구현

Shift-click으로 객체 복수 선택·해제

- 선택 상태 단위 테스트 추가와 앱 버전 0.7.0 반영

Issue #798