### PR TITLE
akbun-makepresentation - 슬라이드 확대·축소 핸들 비례 조절

### DIFF
--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -56,7 +56,10 @@ function clearSelection() {
 
 // --- rendering ---------------------------------------------------------------
 
-const HANDLE = 12;
+// The selection overlay shares the slide SVG viewBox. Keep its geometry in
+// slide units rather than CSS pixels so the browser scales handles with the
+// slide at every zoom level.
+const HANDLE_SLIDE_UNITS = 12;
 
 function hitSvg(shape) {
   // An invisible, fatter twin so thin strokes are still clickable. Filled
@@ -89,7 +92,7 @@ function selectionSvg(shape, handles) {
   if (handles) {
     for (const h of L.handlesFor(shape)) {
       parts.push(
-        `<rect x="${h.x - HANDLE / 2}" y="${h.y - HANDLE / 2}" width="${HANDLE}" height="${HANDLE}" class="sel-handle" data-handle="${h.id}"/>`
+        `<rect x="${h.x - HANDLE_SLIDE_UNITS / 2}" y="${h.y - HANDLE_SLIDE_UNITS / 2}" width="${HANDLE_SLIDE_UNITS}" height="${HANDLE_SLIDE_UNITS}" class="sel-handle" data-handle="${h.id}"/>`
       );
     }
   }

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -250,6 +250,8 @@ main {
 }
 
 .sel-handle {
+  /* Geometry stays in the slide SVG coordinate space. A CSS-pixel transform
+     here would make the grip ignore the slide zoom. */
   fill: #ffffff;
   stroke: var(--accent);
   stroke-width: 1.5;


### PR DESCRIPTION
# 구현

선택 핸들 좌표를 슬라이드 SVG 기준으로 명시

- 50%·125% UI 비례 확대·축소 확인

# 리스크

선택 overlay를 SVG 밖으로 분리하면 비례 확대·축소 깨질 가능성

- overlay 구조 변경 시 CSS 픽셀 크기 미사용 검토 필요

Issue #836