### PR TITLE
akbun-makevideo: 첫 영상 비율로 preview canvas 자동 설정

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-first-video-defines-default-canvas-shape.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-first-video-defines-default-canvas-shape.md
@@ -1,0 +1,20 @@
+---
+type: Decision
+title: 첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다
+description: 첫 영상 clip이 기본 해상도 프로젝트의 비율을 정하되 긴 변 해상도는 유지하는 결정.
+tags: [makevideo, preview, aspect-ratio, timeline]
+timestamp: 2026-08-10T00:00:00Z
+---
+
+# 첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다
+
+## 결정
+
+* 빈 기본 프로젝트의 video track에 첫 영상을 놓으면 영상 비율에 맞춰 project width와 height를 변경
+* 기본 프로젝트의 긴 변 해상도와 frame rate는 유지
+* clip이나 visual item이 있거나 해상도를 직접 바꾼 프로젝트는 유지
+
+## 이유
+
+* 9:16 영상을 기본 16:9 canvas에 넣으면 contain 결과가 preview 중앙의 좁은 영역으로 축소되어 영상이 없는 것처럼 보임
+* 원본 2160×3840을 그대로 채택하면 FHD 기본 프로젝트가 의도하지 않게 4K로 커지므로 비율만 채택

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,7 @@
 
 ## 목록
 
+* [첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다](2026-08-first-video-defines-default-canvas-shape.md) - 첫 영상 비율을 채택하되 기본 긴 변 해상도를 유지하는 결정.
 * [native view 좌표는 superview에게 원점을 물어본다](2026-08-native-view-asks-its-superview-for-the-origin.md) - WKWebView가 flipped view라 bottom-left 가정이 monitor를 뒤집힌 위치에 놓은 뒤 정한 규칙.
 * [filter graph 렌더는 rasterize한 still을 overlay로 굽는다](2026-08-graph-render-overlays-rasterized-stills.md) - CPU 렌더와 폴백에서 text/shape가 빠지던 것을 자체 raster + overlay로 해결한 결정.
 * [그래픽 장치를 쓰는지 하나로 preview와 playback과 render를 함께 정한다](2026-08-one-axis-for-the-graphics-device.md) - compositor 설정을 GPU와 CPU 둘로 줄이고 playback 설정을 없앤 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-10
 
+* [첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다](decisions/2026-08-first-video-defines-default-canvas-shape.md) 결정 기록. 9:16 영상이 기본 16:9 preview에서 과도하게 축소된 사례를 바탕으로 비율 자동 채택 범위를 정함.
 * [native view 좌표는 superview에게 원점을 물어본다](decisions/2026-08-native-view-asks-its-superview-for-the-origin.md) 결정 기록. WKWebView의 isFlipped가 YES인 것을 실측으로 확인하고 viewport 변환을 superview 질의로 바꿈.
 * [filter graph 렌더는 rasterize한 still을 overlay로 굽는다](decisions/2026-08-graph-render-overlays-rasterized-stills.md) 결정 기록. CPU 렌더와 폴백이 text/shape를 조용히 떨어뜨리던 문제의 해법 선택을 남김.
 

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -2047,7 +2047,16 @@ function dropCommands(trackId, assets, atFrame) {
   const track = L.findTrack(state.project, trackId);
   if (!track) return [];
   const commands = [];
-  for (const asset of assets.filter((asset) => L.canAccept(track, asset))) {
+  const accepted = assets.filter((asset) => L.canAccept(track, asset));
+  if (track.kind === 'video') {
+    const firstVideo = accepted.find((asset) => asset.kind === 'video');
+    const settings = L.settingsForFirstVideo(state.project, firstVideo, {
+      width: state.settings.defaultWidth,
+      height: state.settings.defaultHeight,
+    });
+    if (settings) commands.push({ op: 'setSettings', settings });
+  }
+  for (const asset of accepted) {
     if (track.kind === 'video' && asset.kind === 'video' && asset.hasAudio) {
       const videoIndex = L.tracksOf(state.project, 'video').findIndex((item) => item.id === trackId);
       const audio = L.tracksOf(state.project, 'audio')[videoIndex];

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -145,6 +145,32 @@ function projectDurationFrames(project) {
   return end;
 }
 
+/** Match a new default project's canvas to its first video.
+ *
+ *  The long edge stays at the chosen default, so a 4K phone recording does
+ *  not silently turn a FHD project into a 4K project. A project whose size was
+ *  already changed is left alone. */
+function settingsForFirstVideo(project, asset, defaults) {
+  if (!project || !project.settings || !asset || asset.kind !== 'video') return null;
+  const hasItems = project.tracks.some(
+    (track) => track.clips.length > 0 || (track.visualItems || []).length > 0
+  );
+  if (hasItems || asset.width <= 0 || asset.height <= 0) return null;
+
+  const defaultWidth = Math.max(16, Number(defaults && defaults.width) || 1920);
+  const defaultHeight = Math.max(16, Number(defaults && defaults.height) || 1080);
+  const { width, height, rate } = project.settings;
+  if (width !== defaultWidth || height !== defaultHeight) return null;
+  if (width * asset.height === height * asset.width) return null;
+
+  const longEdge = Math.max(width, height);
+  const even = (value) => Math.max(16, Math.round(value / 2) * 2);
+  const next = asset.width >= asset.height
+    ? { width: longEdge, height: even((longEdge * asset.height) / asset.width) }
+    : { width: even((longEdge * asset.width) / asset.height), height: longEdge };
+  return { ...next, rate };
+}
+
 /** Sorted, unique clip boundaries from the target track, or from every enabled
  *  track when none is targeted. */
 function editPoints(project, targetTrackId) {
@@ -332,6 +358,7 @@ const exported = {
   clipDuration,
   clipEnd,
   projectDurationFrames,
+  settingsForFirstVideo,
   editPoints,
   previousEditPoint,
   nextEditPoint,

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -81,6 +81,44 @@ test('a hidden track does not stretch the timeline', () => {
   assert.strictEqual(L.projectDurationFrames(project), 300);
 });
 
+test('the first vertical video turns a default FHD project vertical', () => {
+  const project = projectOf([], [track('t1', 'video', 'V1')]);
+  const vertical = { ...VIDEO, width: 2160, height: 3840 };
+  assert.deepStrictEqual(
+    L.settingsForFirstVideo(project, vertical, { width: 1920, height: 1080 }),
+    { width: 1080, height: 1920, rate: T.fps(30) }
+  );
+});
+
+test('first-video sizing preserves an explicit project shape and an active edit', () => {
+  const vertical = { ...VIDEO, width: 2160, height: 3840 };
+  const custom = projectOf([], [track('t1', 'video', 'V1')]);
+  custom.settings.width = 1080;
+  custom.settings.height = 1080;
+  assert.strictEqual(
+    L.settingsForFirstVideo(custom, vertical, { width: 1920, height: 1080 }),
+    null
+  );
+
+  const active = projectOf(
+    [VIDEO],
+    [track('t1', 'video', 'V1', [clip('c1', 'v', 0, 0, 300)])]
+  );
+  assert.strictEqual(
+    L.settingsForFirstVideo(active, vertical, { width: 1920, height: 1080 }),
+    null
+  );
+});
+
+test('first-video sizing keeps the default long edge and uses even dimensions', () => {
+  const project = projectOf([], [track('t1', 'video', 'V1')]);
+  const oddAspect = { ...VIDEO, width: 1001, height: 1999 };
+  const settings = L.settingsForFirstVideo(project, oddAspect, { width: 1920, height: 1080 });
+  assert.strictEqual(settings.height, 1920);
+  assert.strictEqual(settings.width % 2, 0);
+  assert.ok(settings.width < settings.height);
+});
+
 test('a muted audio track drops out of the length too', () => {
   const audio = track('t2', 'audio', 'A1', [clip('c1', 'm', 0, 0, 900)]);
   const project = projectOf([SOUND], [audio]);


### PR DESCRIPTION
# 구현

빈 기본 project에 첫 video clip 배치 시 원본 비율로 canvas 자동 전환
- test.mp4 2160×3840 재현, FHD 긴 변을 유지한 1080×1920 적용, JS 101개와 Rust edit 54개 통과

# 어려웠던 점

display 해상도 문제와 project aspect ratio 불일치 증상 분리
- 현재 1226×768 app window에서 기본 16:9는 중앙에 과도하게 축소, 1080×1920 적용 후 native preview 정상 표시

# 리스크

빈 project에 여러 영상을 한 번에 배치하면 첫 번째 video가 canvas 비율 결정
- 기존 item 또는 명시적 해상도 변경이 있으면 자동 전환하지 않음

Issue #865
