### PR TITLE
카탈로그 카드를 저장소 대신 제품으로 보내기

### DIFF
--- a/.claude/commands/repo-pr-create.md
+++ b/.claude/commands/repo-pr-create.md
@@ -22,7 +22,7 @@ allowed-tools: Bash, Read, Glob, Grep
 
 [product/products.json](../../product/products.json)은 <https://products.akbun.com> 이 GitHub raw로 읽는 제품 목록이다. master에 들어가는 순간 사이트에 반영되므로, product를 건드린 PR이 이 파일을 빼먹으면 사이트가 그 자리에서 낡는다.
 
-- 새 product 디렉터리를 만들었으면 `products` 배열 맨 앞에 항목을 추가한다. `id`는 디렉터리 이름, `released`는 오늘 날짜(YYYY-MM-DD), `kind`는 web, desktop, reference 중 하나다.
+- 새 product 디렉터리를 만들었으면 `products` 배열 맨 앞에 항목을 추가한다. `id`는 디렉터리 이름, `released`는 오늘 날짜(YYYY-MM-DD), `kind`는 web, desktop, backend, skin, reference 중 하나다. kind가 web이면 배포 도메인을 `site`에 반드시 적는다.
 - 기존 product의 설명이 바뀌었으면 그 항목의 `description`을 [product/README.md](../../product/README.md)의 같은 행과 같은 문장으로 맞춘다.
 - 배포 URL이 새로 생겼거나 바뀌었으면 `site`를 고친다.
 - 어느 쪽이든 문서 최상단의 `updated`를 오늘 날짜로 바꾼다.

--- a/product/akbun-openapiviewer/README.md
+++ b/product/akbun-openapiviewer/README.md
@@ -2,7 +2,7 @@
 
 A web page that shows an OpenAPI spec as a browsable API reference. Import a file or paste the document as JSON or YAML, read the API list on the left and each operation's detail on the right. No account, no upload, no server: the spec is parsed in the browser that opened the page.
 
-Deployed as a static Astro build on Cloudflare.
+Deployed as a static Astro build on Cloudflare at [openapiviewer.akbun.com](https://openapiviewer.akbun.com).
 
 ## What it does
 

--- a/product/akbun-productcatalog/README.md
+++ b/product/akbun-productcatalog/README.md
@@ -1,6 +1,6 @@
 # akbun-productcatalog
 
-A web page that lists every product in this repository's `product/` directory as a card. Search it, filter it by kind, and the button on each card opens that product's repository directory on GitHub.
+A web page that lists every product in this repository's `product/` directory as a card. Search it, filter it by kind, and the button on each card opens that product: its deployed page if it has one, its GitHub release page if it is something you install.
 
 The list is not compiled into the page. It is a JSON document read from GitHub raw at load, so adding a product is an edit to one file.
 
@@ -13,10 +13,12 @@ Deployed as a static Astro build on Cloudflare at [products.akbun.com](https://p
 | Catalog | `products.json` is fetched from GitHub raw on load. Editing it on GitHub changes the live page within the raw cache window, with no Cloudflare build in between |
 | Fallback | The same file is published with the site. When raw is unreachable, blocked or slow, the page loads the published copy instead and says which one it used in the footer |
 | Cards | Name, kind badge, description, tags and the release date, newest first. Undated entries sort last |
-| Repository button | Each card links to `product/<id>` on GitHub. The link is derived from the id, so an entry is four fields and no long URL. An entry that lives elsewhere sets `repo` and overrides it |
+| Buttons | The primary button is whatever puts the product in front of the reader: Site for a deployed page, Download for a release. Repository is always there, but demoted, because source is not what most people came for |
+| Repository button | Each card links to `product/<id>` on GitHub. The link is derived from the id, so an entry needs no long URL. An entry that lives elsewhere sets `repo` and overrides it |
 | Site button | Shown only for the products that have a deployed page of their own |
+| Download button | Shown for the products that ship a GitHub release. `download` is written out rather than derived, because the release tags do not all start with the directory name |
 | Search | Filters live on every keystroke, no Enter needed. Ctrl/Cmd + K focuses it, Escape clears it. Every word must match, over name, id, description, kind and tags |
-| Kind filter | Chips for web, desktop and reference, each carrying the count it would show. A chip with nothing behind it reads 0 and is disabled |
+| Kind filter | Chips for web, desktop, backend, skin and reference, each carrying the count it would show. A chip with nothing behind it reads 0 and is disabled |
 | Failure | A fetch that fails on both sources shows the reason and a Retry button, not an empty grid |
 | Theme | Light and dark from the system setting, with no toggle to get out of sync |
 
@@ -32,11 +34,14 @@ Deployed as a static Astro build on Cloudflare at [products.akbun.com](https://p
   "kind": "web",
   "tags": ["astro", "openapi"],
   "site": "https://openapi.example.com",
+  "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-openapiviewer",
   "released": "2026-08-05"
 }
 ```
 
-`id` is the only required field, and it is the directory name under `product/`. `kind` is one of `web`, `desktop`, `reference`. A product either runs in a browser or is installed, so those two carry everything that is a product; `reference` is for the layout libraries, which are neither. `site` and `released` are optional. The document's `repoBase` is the GitHub tree URL the id is appended to.
+`id` is the only required field, and it is the directory name under `product/`. `kind` is one of `web`, `desktop`, `backend`, `skin`, `reference`, and it says how the product reaches its user: opened at a URL, installed on a machine, run as a server by whoever wants it, or pasted into another service's admin page. `reference` is the shelf for the layout libraries, which are none of those. `site`, `download` and `released` are optional. The document's `repoBase` is the GitHub tree URL the id is appended to.
+
+A `web` entry must carry a `site`. A web product whose whole delivery is a URL, listed with nothing to open, is either mis-classified or missing its domain, and either way the card is one nobody can act on. A test over the published file fails rather than letting that reach the site.
 
 The description is the same sentence as the row in [product/README.md](../README.md), so the two move together when a product is added or renamed.
 

--- a/product/akbun-productcatalog/workspace/package.json
+++ b/product/akbun-productcatalog/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-productcatalog",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-productcatalog/workspace/src/lib/catalog.js
+++ b/product/akbun-productcatalog/workspace/src/lib/catalog.js
@@ -13,13 +13,16 @@ export const REMOTE_CATALOG_URL =
 export const DEFAULT_REPO_BASE = 'https://github.com/choisungwook/portfolio/tree/master/product';
 
 // The filter row. `all` is first and is the state the page opens in.
-// A product either runs in a browser or it is installed, so `web` and
-// `desktop` carry everything that is a product; `reference` is the shelf for
-// the two layout libraries, which are neither.
+// The split is by how the product reaches its user: `web` is opened at a URL,
+// `desktop` is installed on a machine, `backend` is a server someone runs
+// themselves, and `skin` is pasted into another service's admin page.
+// `reference` is the shelf for the layout libraries, which are none of those.
 export const KINDS = [
   { id: 'all', label: 'All' },
   { id: 'web', label: 'Web' },
   { id: 'desktop', label: 'Desktop' },
+  { id: 'backend', label: 'Backend' },
+  { id: 'skin', label: 'Skin' },
   { id: 'reference', label: 'Reference' },
 ];
 
@@ -74,6 +77,10 @@ function normalizeProduct(entry, index, repoBase) {
     released: String(entry.released ?? '').trim(),
     repo,
     site: safeUrl(entry.site, 'site', index),
+    // Someone who wants an installed product wants the installer, not the
+    // source. The release tag prefixes are not all the id (gitdesktop-v*,
+    // tistory-*), so this is a written URL rather than one derived like `repo`.
+    download: safeUrl(entry.download, 'download', index),
   };
 }
 

--- a/product/akbun-productcatalog/workspace/src/pages/index.astro
+++ b/product/akbun-productcatalog/workspace/src/pages/index.astro
@@ -14,7 +14,7 @@ import '../styles/global.css';
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>akbun products</title>
-  <meta name="description" content="악분이 만든 제품 목록. 카드를 검색하고 종류로 거르고, 버튼을 누르면 그 제품의 저장소로 간다.">
+  <meta name="description" content="악분이 만든 제품 목록. 카드를 검색하고 종류로 거르고, 버튼을 누르면 그 제품을 열거나 내려받는다.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <!-- The catalog is fetched from here on load, so the handshake is worth
@@ -26,7 +26,7 @@ import '../styles/global.css';
   <header class="app-header">
     <div class="app-title">
       <h1>akbun products</h1>
-      <p>만든 제품을 모아 둔 곳. 카드의 버튼이 그 제품의 저장소로 간다.</p>
+      <p>만든 제품을 모아 둔 곳. 카드의 버튼이 그 제품의 페이지나 내려받는 곳으로 간다.</p>
     </div>
     <a class="button ghost" href="https://github.com/choisungwook/portfolio"
        target="_blank" rel="noopener noreferrer">Portfolio repo</a>

--- a/product/akbun-productcatalog/workspace/src/scripts/main.js
+++ b/product/akbun-productcatalog/workspace/src/scripts/main.js
@@ -59,10 +59,19 @@ async function loadCatalog() {
   }
 }
 
+function link(href, label, ghost) {
+  return `<a class="button${ghost ? ' ghost' : ''}" href="${esc(href)}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+}
+
 function productCard(product) {
-  const site = product.site
-    ? `<a class="button ghost" href="${esc(product.site)}" target="_blank" rel="noopener noreferrer">사이트 열기</a>`
-    : '';
+  // The primary button is whatever gets the product in front of the reader:
+  // its page if it has one, its installer if it is installed. The repository
+  // stays reachable, but source is not what most people came for.
+  const actions = [];
+  if (product.site) actions.push(link(product.site, '사이트 열기', false));
+  if (product.download) actions.push(link(product.download, '다운로드', Boolean(product.site)));
+  actions.push(link(product.repo, '저장소', actions.length > 0));
+
   const tags = product.tags
     .map((tag) => `<li>${esc(tag)}</li>`)
     .join('');
@@ -79,8 +88,7 @@ function productCard(product) {
       <div class="card-foot">
         <span class="date">${esc(date)}</span>
         <div class="card-actions">
-          ${site}
-          <a class="button" href="${esc(product.repo)}" target="_blank" rel="noopener noreferrer">저장소</a>
+          ${actions.join('\n          ')}
         </div>
       </div>
     </article>

--- a/product/akbun-productcatalog/workspace/src/styles/global.css
+++ b/product/akbun-productcatalog/workspace/src/styles/global.css
@@ -19,6 +19,8 @@
   --danger-border: #F3C7C2;
   --k-web: #2F6FDD;
   --k-desktop: #1E8E5A;
+  --k-backend: #C0632A;
+  --k-skin: #C2377C;
   --k-reference: #7C5CD6;
   --font-title: 'Sora', sans-serif;
   --font-body: 'Outfit', sans-serif;
@@ -41,6 +43,8 @@
     --danger-border: #5C302C;
     --k-web: #7FB0FF;
     --k-desktop: #6FD3A3;
+    --k-backend: #F0A46B;
+    --k-skin: #F58BBB;
     --k-reference: #BCA5F5;
   }
 }
@@ -246,6 +250,8 @@ a { color: inherit; }
 
 .kind-web { color: var(--k-web); }
 .kind-desktop { color: var(--k-desktop); }
+.kind-backend { color: var(--k-backend); }
+.kind-skin { color: var(--k-skin); }
 .kind-reference { color: var(--k-reference); }
 
 .card-desc {

--- a/product/akbun-productcatalog/workspace/test/catalog.test.js
+++ b/product/akbun-productcatalog/workspace/test/catalog.test.js
@@ -63,7 +63,24 @@ test('parseCatalog fills the optional fields', () => {
   assert.equal(slo.description, '');
   assert.deepEqual(slo.tags, []);
   assert.equal(slo.released, '');
+  assert.equal(slo.download, '', 'a product with no release carries no download link');
   assert.equal(products[1].name, 'screenshot', 'an explicit name wins');
+});
+
+// The download link is written out rather than derived from the id, because
+// the release tags do not all start with the directory name.
+test('parseCatalog keeps the download link', () => {
+  const { products } = parseCatalog(doc({
+    products: [{ id: 'akbun-gitdesktop', download: 'https://github.com/choisungwook/portfolio/releases?q=gitdesktop' }],
+  }));
+  assert.match(products[0].download, /releases\?q=gitdesktop$/);
+});
+
+test('parseCatalog rejects a download link that is not http or https', () => {
+  assert.throws(
+    () => parseCatalog(doc({ products: [{ id: 'x', download: 'javascript:alert(1)' }] })),
+    /must be http or https/,
+  );
 });
 
 test('parseCatalog keeps an explicit repo override', () => {
@@ -151,6 +168,8 @@ test('kindCounts counts every chip, empty ones included', () => {
   assert.equal(counts.web, 2);
   assert.equal(counts.desktop, 1);
   assert.equal(counts.reference, 0, 'a chip with nothing behind it still reports zero');
+  assert.equal(counts.backend, 0);
+  assert.equal(counts.skin, 0);
 });
 
 test('shortDate reads as the README does', () => {
@@ -172,5 +191,18 @@ test('the published catalog parses', () => {
     assert.ok(product.description, `${product.id} has no description`);
     assert.ok(product.repo.startsWith('https://github.com/choisungwook/portfolio/'), product.id);
     assert.ok(KINDS.some((kind) => kind.id === product.kind), `${product.id} has kind ${product.kind}`);
+  }
+});
+
+// A web product is one whose whole delivery is a URL, so an entry marked web
+// with nothing to open is either mis-classified or missing its domain. Both
+// show up on the site as a card nobody can act on.
+test('every web product in the published catalog has a deployed domain', () => {
+  const raw = readFileSync(new URL('../../../products.json', import.meta.url), 'utf8');
+  const { products } = parseCatalog(raw);
+
+  for (const product of products) {
+    if (product.kind !== 'web') continue;
+    assert.ok(product.site, `${product.id} is kind web but has no site`);
   }
 });

--- a/product/products.json
+++ b/product/products.json
@@ -1,6 +1,6 @@
 {
   "repoBase": "https://github.com/choisungwook/portfolio/tree/master/product",
-  "updated": "2026-08-10",
+  "updated": "2026-08-11",
   "products": [
     {
       "id": "akbun-productcatalog",
@@ -17,6 +17,7 @@
       "description": "HTTP(S) 요청, 응답 확인, 북마크, 공통 변수, curl 변환, 시나리오 실행을 갖춘 데스크톱 HTTP 클라이언트",
       "kind": "desktop",
       "tags": ["tauri", "http"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-requesthttp",
       "released": "2026-08-06"
     },
     {
@@ -25,6 +26,7 @@
       "description": "AWS profile을 골라 IAM Identity Center로 로그인하고 EC2를 조회 전용으로 보는 macOS 데스크톱 앱",
       "kind": "desktop",
       "tags": ["tauri", "aws", "macos"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-awsviewer",
       "released": "2026-08-06"
     },
     {
@@ -33,6 +35,7 @@
       "description": "OpenAPI 스펙을 붙여넣거나 파일로 열어 API 목록과 상세를 탐색하는 웹 페이지",
       "kind": "web",
       "tags": ["astro", "openapi"],
+      "site": "https://openapiviewer.akbun.com",
       "released": "2026-08-05"
     },
     {
@@ -50,6 +53,7 @@
       "description": "멀티 트랙 타임라인, 미리보기, ffmpeg FHD/4K 렌더링을 갖춘 영상 편집 macOS 데스크톱 앱",
       "kind": "desktop",
       "tags": ["tauri", "macos", "ffmpeg"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-makevideo",
       "released": "2026-08-02"
     },
     {
@@ -58,6 +62,7 @@
       "description": "도형, 텍스트, pptx 열기/저장, pdf 내보내기, 발표 모드를 갖춘 슬라이드 편집 macOS 데스크톱 앱",
       "kind": "desktop",
       "tags": ["tauri", "macos"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-makepresentation",
       "released": "2026-08-02"
     },
     {
@@ -66,6 +71,7 @@
       "description": "직접 추가한 사진과 영상을 태그, 등급, 검색으로 찾는 Windows 데스크톱 앱",
       "kind": "desktop",
       "tags": ["tauri", "windows"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-folderview",
       "released": "2026-08-01"
     },
     {
@@ -74,6 +80,7 @@
       "description": "메뉴바 아이콘을 구간으로 나눠 숨기고 목록으로 보는 macOS 메뉴바 관리 앱",
       "kind": "desktop",
       "tags": ["swift", "macos"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-mactaskbar",
       "released": "2026-07-31"
     },
     {
@@ -82,14 +89,16 @@
       "description": "영역 캡처, 클립보드 복사, 미리보기 저장을 지원하는 macOS 메뉴바 스크린샷 앱",
       "kind": "desktop",
       "tags": ["electron", "macos"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-screenshot",
       "released": "2026-07-31"
     },
     {
       "id": "akbun-terraform-apply-remote",
       "name": "akbun-terraform-apply-remote",
       "description": "GitHub PR comment로 terraform plan/apply를 실행하는 자동화 서버",
-      "kind": "web",
+      "kind": "backend",
       "tags": ["rust", "terraform", "github"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-terraform-apply-remote",
       "released": "2026-07-29"
     },
     {
@@ -98,6 +107,7 @@
       "description": "EKS 업그레이드 작업용 노드/파드 조회 Electron 데스크톱 앱",
       "kind": "desktop",
       "tags": ["electron", "kubernetes", "eks"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-k8supgradeview",
       "released": "2026-07-26"
     },
     {
@@ -106,6 +116,7 @@
       "description": "git graph, 브랜치, worktree, GitHub PR을 보는 Electron 데스크톱 앱",
       "kind": "desktop",
       "tags": ["electron", "git", "github"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=gitdesktop",
       "released": "2026-07-25"
     },
     {
@@ -114,6 +125,7 @@
       "description": "언어 공부(쉐도잉)용 구간 반복 오디오 플레이어 Electron 앱",
       "kind": "desktop",
       "tags": ["electron", "audio"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=shadowing-player",
       "released": "2026-07-25"
     },
     {
@@ -122,14 +134,16 @@
       "description": "JVM heap dump(hprof)에서 OOM 원인을 찾는 데스크톱 도구",
       "kind": "desktop",
       "tags": ["electron", "jvm"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=hprof-oom-analyzer",
       "released": "2026-07-18"
     },
     {
       "id": "tistory-skin",
       "name": "tistory-skin",
       "description": "Tistory 블로그 스킨",
-      "kind": "web",
+      "kind": "skin",
       "tags": ["blog", "css"],
+      "download": "https://github.com/choisungwook/portfolio/releases?q=tistory",
       "released": "2026-04-04"
     },
     {

--- a/product/slo/README.md
+++ b/product/slo/README.md
@@ -1,6 +1,6 @@
 # SLO Downtime Calculator
 
 - SLO 가용성(예: 99.99%)을 입력하면 허용 다운타임을 보여주는 웹 도구입니다.
-- 도메인: slop.akbun.com
+- 도메인: slo.akbun.com
 
 ![result](./imgs/result.png "result")


### PR DESCRIPTION
# 구현

카드 주버튼을 사이트나 다운로드로 바꾸고, web 유형 5개 전부에 배포 도메인을 채우고, backend와 skin 유형 추가
- 릴리스가 있는 제품 13개에 download 링크 추가, 테스트 19개 통과, 빌드 후 실제 렌더링으로 버튼 배치 확인

# 어려웠던 점

release 목록 필터 URL이 tag 접두사를 그대로 넣으면 결과가 0
- q에 akbun-awsviewer-v를 넣으면 0건, akbun-awsviewer는 9건이라 -v를 뺀 형태로 확정

# 리스크

release 목록 필터라 이름이 겹치는 다른 제품의 릴리스가 함께 보일 수 있음
- shadowing-player가 akbun-shadowing-player까지 같이 잡음. 같은 제품의 옛 tag라 문제되지 않으나, 접두사가 겹치는 제품이 새로 생기면 download를 특정 tag로 좁혀야 함

openapiviewer.akbun.com은 저장소에 근거가 없어 사용자 답변으로만 확인함
- 도메인이 다르면 카드의 사이트 버튼이 죽으므로 배포 후 한 번 열어 볼 필요

Issue #869


---
_Generated by [Claude Code](https://claude.ai/code/session_01THmPP8vVnkNBy79tBqrjjp)_