### PR TITLE
fix(akbun-makevideo): preview 배치 계산을 geometry.js로 모으고 point 단위로 넘기기

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-one-geometry-in-points-for-the-monitor.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-one-geometry-in-points-for-the-monitor.md
@@ -1,0 +1,26 @@
+---
+type: Decision
+title: preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다
+description: page가 devicePixelRatio를 곱하고 Rust가 backing scale로 나누던 왕복과 크기 변화만 감지하던 ResizeObserver를 없애고, geometry.js 하나에서 계산해 point로 넘기기로 한 결정.
+tags: [makevideo, viewport, preview, macos, appkit]
+timestamp: 2026-08-11T00:00:00Z
+---
+
+# preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다
+
+## 결정
+
+* stage box 계산은 `src/geometry.js` 한 곳에 두고, media element preview와 native monitor가 같은 입력(panel box + project 해상도)으로 각자 호출. 한쪽이 다른 쪽이 그려 놓은 결과를 재측정하지 않음
+* IPC로 넘기는 좌표 단위는 physical pixel이 아니라 point(CSS pixel). swapchain에 필요한 physical size는 view가 `convertRectToBacking`으로 직접 답함
+* 배치 갱신은 stage의 ResizeObserver가 아니라 monitor가 이미 돌리는 animation frame에서 매 프레임 재측정. 보낼지 여부는 `samePlace` 비교가 정함
+* 맞출 자리가 없는 panel은 최소 크기가 아니라 빈 box로 답하고, native view는 숨김
+
+## 이유
+
+* page가 `devicePixelRatio`를 곱하고 Rust가 backing scale로 나누던 두 변환은 서로 상쇄되는 왕복이었음. 두 값이 어긋나는 순간(다른 scale factor의 display로 창을 옮긴 뒤 box 크기는 그대로라 재전송이 없을 때) 좌표와 크기가 한꺼번에 배로 틀어져 monitor가 panel 밖에 그려짐
+* ResizeObserver는 크기에만 반응함. 옆 panel이 넓어지거나 inspector가 열려 stage가 크기 그대로 이동하면 native view는 이전 자리에 남는데, webview 위에 있는 native view는 page의 `overflow: hidden`으로 잘리지 않아 timeline 위를 덮음. 움직이는 이유를 나열해 관찰자를 붙이는 방식은 목록이 끝나지 않음
+* `Math.max(80, ...)`처럼 폭과 높이에 각각 걸린 최소값은 작은 panel에서 비율을 깨뜨리고 box를 panel보다 크게 만들었음. 두 증상(비율이 안 맞음, preview를 벗어남)이 같은 한 줄에서 나옴
+
+## Citations
+
+1. [native view 좌표는 superview에게 원점을 물어본다](./2026-08-native-view-asks-its-superview-for-the-origin.md)

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -8,3 +8,4 @@
 * [그래픽 장치를 쓰는지 하나로 preview와 playback과 render를 함께 정한다](2026-08-one-axis-for-the-graphics-device.md) - compositor 설정을 GPU와 CPU 둘로 줄이고 playback 설정을 없앤 결정.
 * [재생 끊김은 경로별 계측으로 원인을 분리](2026-08-playback-stutter-is-measured-by-stage.md) - 공급과 표시와 A/V 지연을 따로 보고 구조 교체를 미룬 결정.
 * [경계 stub은 실제 API 이름만 가진다](2026-08-seam-stubs-carry-only-real-api-names.md) - 무엇에나 답하는 Proxy stub이 없는 메서드 호출을 숨긴 뒤 정한 규칙.
+* [preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다](2026-08-one-geometry-in-points-for-the-monitor.md) - devicePixelRatio 왕복과 크기만 보는 ResizeObserver를 없애고 배치 계산을 한 곳에 모은 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-11
+
+* [preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다](decisions/2026-08-one-geometry-in-points-for-the-monitor.md) 결정 기록. native monitor가 preview 밖에 그려지고 비율이 어긋나던 원인을 좌표 왕복과 크기만 보는 관찰자로 좁히고 geometry.js로 계산을 모음.
+
 ## 2026-08-10
 
 * [첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다](decisions/2026-08-first-video-defines-default-canvas-shape.md) 결정 기록. 9:16 영상이 기본 16:9 preview에서 과도하게 축소된 사례를 바탕으로 비율 자동 채택 범위를 정함.

--- a/product/akbun-makevideo/wiki/architecture/preview.md
+++ b/product/akbun-makevideo/wiki/architecture/preview.md
@@ -33,6 +33,17 @@ That exact frame is the other half of this engine: when the playhead stops, the 
 
 **Neither half runs on the native monitor.** There the frame under a stopped playhead and the frames during playback come out of one compositor onto one surface, so there is nothing for a second path to draw and nothing for a badge to tell apart. The exact frame is not asked for and the badge stays hidden.
 
+## Where the stage goes
+
+`src/geometry.js`, and not here. The project's shape is fitted into the preview
+panel and centred, with no minimum size in either direction — a floor on one
+axis and not the other stretches the picture, and a box larger than its panel is
+not clipped at all on the [native monitor](./viewport.md). An unfittable panel
+is an empty box rather than a small one.
+
+The same function places the native view, so the two engines cannot disagree
+about where the picture is or what shape it is.
+
 ## Preview quality
 
 Set in Settings and defaulted to **Half**. It changes the layout scale:

--- a/product/akbun-makevideo/wiki/architecture/viewport.md
+++ b/product/akbun-makevideo/wiki/architecture/viewport.md
@@ -147,10 +147,55 @@ over it — a sheet, an open menu. One rule, and it costs nothing at the moment
 that matters: nobody has the settings sheet open while they are watching
 playback.
 
-Everything platform specific is `src-tauri/src/viewport/`, and it is three
-functions: make a view, place it, hide it. The swapchain, the compositing and
-every decision about when to draw are the same code everywhere, so a Windows
-build replaces that directory and nothing else.
+Everything platform specific is `src-tauri/src/viewport/`, and it is four
+functions: make a view, place it, hide it, and say how big its backing store
+is. The swapchain, the compositing and every decision about when to draw are
+the same code everywhere, so a Windows build replaces that directory and
+nothing else.
+
+## Where the view goes is one calculation, in points
+
+`src/geometry.js` answers "where is the stage" and nothing else does. The media
+element stack and the native view are laid out from the same call on the same
+inputs — the preview panel's box and the project's shape — rather than one of
+them measuring what the other one drew.
+
+Two things follow from that, and both were bugs before it:
+
+- **Units are points**, all the way across the IPC boundary. A CSS pixel in the
+  page and an AppKit point inside that page's WebView are the same length, so
+  `setFrame` takes the numbers as they arrive. The page used to multiply by
+  `devicePixelRatio` and Rust used to divide by the view's backing scale, which
+  is a round trip that lands where it started only while the two agree. When
+  they did not — a window moved to a display with a different scale factor,
+  with no resize to trigger a re-send — every coordinate was scaled at once and
+  the monitor was drawn outside the panel.
+- **Physical pixels are asked of the view**, in the same main thread hop that
+  moved it and after the move rather than before. That is the only reading that
+  knows which display the window ended up on, and it is all a swapchain needs.
+
+There are no minimum sizes in the fit. A stage held up to a floor is wider than
+the panel holding it, and a native view is not in the page's stacking order, so
+the panel's `overflow: hidden` does not clip what hangs over — it is drawn on
+top of the timeline. A floor on the width but not the height also stretches the
+picture. A panel with no room in it gets an empty box and the view is hidden,
+which is the fifth input to the visibility rule below.
+
+## The box is re-measured every frame
+
+The monitor already runs an animation frame to poll the playhead, so the panel
+is measured there and `samePlace` decides whether anything needs sending. A
+drag is one command per pixel the box actually moved.
+
+This replaced a `ResizeObserver` on the stage, which fires on size and not on
+position. A sibling panel widening, the inspector opening, the timeline growing,
+a scrollbar appearing: each moves the stage without resizing it, and each left
+the native view at its previous position with nothing to clip it. Enumerating
+the reasons a box can move is a list nobody finishes.
+
+The same loop finishes an attach that found no room. A window lays out over
+several frames when a project opens, and giving up there used to be a silent
+fallback to the media element preview for the rest of the session.
 
 ## The live and exact split is gone
 

--- a/product/akbun-makevideo/wiki/development.md
+++ b/product/akbun-makevideo/wiki/development.md
@@ -65,7 +65,8 @@ What is covered:
 - `crates/present/src/transport.rs` — the two halves of a seek moving together, including that the second seek of a session is waited for as carefully as the first
 - `crates/present/src/fallback.rs` — which engine runs, and that choosing the media elements is not reported as a failure
 - `crates/present/src/soak.rs` — the scheduler meter, including that a source slower than the frame rate makes the run fail and that the run gives up inside its own budget
-- `test/monitor.test.js` — the page's half of the viewport: a stage box converted to physical pixels, and a fallback told apart from a preference
+- `test/geometry.test.js` — where the picture goes: a box that keeps the project's shape, never reaches past the panel it was fitted into, and is empty rather than small when there is no room
+- `test/monitor.test.js` — *when* the page places a view: a stage that moved without resizing, a panel dragged shut, an attach finished once there is room, and a fallback told apart from a preference
 - `crates/compositor/tests/render.rs` — a real render end to end, and that the preview frame matches the frame the render wrote at the same instant
 
 ### What the tests cannot tell you

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -50,10 +50,13 @@ enum Command {
     Play,
     Pause,
     Seek(i64),
-    /// The panel moved or the window resized. Carried to the loop rather than
-    /// done where it was noticed, because only the thread drawing on a surface
-    /// may reconfigure it.
-    Place(MonitorPlace),
+    /// The panel moved or the window resized, and the surface is now this many
+    /// physical pixels. Carried to the loop rather than done where it was
+    /// noticed, because only the thread drawing on a surface may reconfigure
+    /// it — and it carries the size rather than the placement, because the size
+    /// is what the view answered *after* it was moved, which is the only
+    /// reading that accounts for the display it ended up on.
+    Resize(u32, u32),
     /// The timeline changed under a paused playhead: redraw the still.
     Redraw,
     Stop,
@@ -217,7 +220,7 @@ impl Session {
             return Err("this machine has no graphics device, so the monitor cannot draw".into());
         }
         let viewport = Viewport::attach(window, place)?;
-        let (surface_width, surface_height) = place.surface_size();
+        let (surface_width, surface_height) = viewport.surface_size();
         let sink = SurfaceSink::new(
             Arc::clone(&config.compositor),
             viewport.target()?,
@@ -283,8 +286,10 @@ impl Session {
     /// next frame, because only the thread drawing on a surface may reconfigure
     /// it. Doing the second one here would be a data race wgpu cannot see.
     pub fn place(&self, place: MonitorPlace) {
-        self.viewport.lock().unwrap().place(place);
-        let _ = self.control.send(Command::Place(place));
+        let resized = self.viewport.lock().unwrap().place(place);
+        if let Some((width, height)) = resized {
+            let _ = self.control.send(Command::Resize(width, height));
+        }
     }
 
     /// Show or hide the view. The page hides it before drawing anything over
@@ -370,8 +375,7 @@ fn run(mut state: Loop) {
                 state.shared.position.store(frame, Ordering::Relaxed);
                 continue;
             }
-            Ok(Command::Place(place)) => {
-                let (width, height) = place.surface_size();
+            Ok(Command::Resize(width, height)) => {
                 state.sink.resize(width, height);
                 continue;
             }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -198,19 +198,27 @@ pub fn attach(window: &tauri::WebviewWindow, place: MonitorPlace) -> Result<Inne
     })
 }
 
-pub fn place(inner: &Inner, at: MonitorPlace) {
+/// Move both views and answer what the picture's size in physical pixels now
+/// is.
+///
+/// The size is read in the same main thread hop that moved the view, and after
+/// the move rather than before. A window dragged onto a display with a
+/// different scale factor changes that number without changing the box, so a
+/// reading taken anywhere else is a reading of the display it used to be on.
+pub fn place(inner: &Inner, at: MonitorPlace) -> (u32, u32) {
     let view = inner.view;
     let container = inner.container;
-    // Placement is best effort: a window that has gone during a resize is a
-    // window nobody is looking at.
-    let _ = on_webview(&inner.window, move |_, host| {
+    on_webview(&inner.window, move |_, host| {
         // SAFETY: both views are alive until `detach` releases the container.
         let container = unsafe { container.ptr().as_ref() };
         container.setFrame(rect(host, at.stage));
         let view = unsafe { view.ptr().as_ref() };
         view.setFrame(child_rect(container, at));
-        Ok(())
-    });
+        Ok(backing_size(view))
+    })
+    // Placement is best effort: a window that has gone during a resize is a
+    // window nobody is looking at. A surface still may not be sized at zero.
+    .unwrap_or((1, 1))
 }
 
 pub fn set_visible(inner: &Inner, visible: bool) {
@@ -246,36 +254,43 @@ pub fn target(inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
 
 /// The page's rectangle as AppKit's inside the WebView.
 ///
-/// Two conversions in one place. The y origin is converted against the
-/// superview's own coordinate origin — `WKWebView` is flipped, so a top-left
-/// `y` passes through unchanged there — and the numbers arriving are physical
-/// pixels while AppKit wants points. The WebView's own bounds against its
-/// backing size is where that ratio comes from, rather than asking the screen,
-/// which can be the wrong one when the window straddles two displays.
+/// One conversion, and it is the y origin: the superview is asked which corner
+/// it measures from — `WKWebView` is flipped, so a top-left `y` passes through
+/// unchanged there — and nothing else is touched. The numbers arriving are
+/// points, which is what `setFrame` takes, because a CSS pixel in the page and
+/// an AppKit point in a view inside that page's WebView are the same length.
+///
+/// There used to be a second conversion here, dividing by the view's backing
+/// scale to undo a multiplication the page had done by `devicePixelRatio`.
+/// Two conversions that cancel are not a conversion; they are an agreement
+/// between two numbers measured in different places, and the frames where they
+/// disagreed put the monitor at twice its offset and twice its size.
 fn rect(host: &NSView, at: Place) -> NSRect {
-    let scale = backing_scale(host);
-    let (x, y, width, height) = (
-        at.x / scale,
-        at.y / scale,
-        at.width.max(1.0) / scale,
-        at.height.max(1.0) / scale,
-    );
+    let width = at.width.max(1.0);
+    let height = at.height.max(1.0);
     NSRect::new(
-        NSPoint::new(x, origin_y(host.isFlipped(), host.bounds().size.height, y, height)),
+        NSPoint::new(
+            at.x,
+            origin_y(host.isFlipped(), host.bounds().size.height, at.y, height),
+        ),
         NSSize::new(width, height),
     )
 }
 
+/// The picture inside the container that clips it, so its origin is relative to
+/// the stage rather than to the WebView.
 fn child_rect(container: &NSView, at: MonitorPlace) -> NSRect {
-    let scale = backing_scale(container);
-    let x = (at.content.x - at.stage.x) / scale;
-    let top = (at.content.y - at.stage.y) / scale;
-    let width = at.content.width.max(1.0) / scale;
-    let height = at.content.height.max(1.0) / scale;
+    let width = at.content.width.max(1.0);
+    let height = at.content.height.max(1.0);
     NSRect::new(
         NSPoint::new(
-            x,
-            origin_y(container.isFlipped(), container.bounds().size.height, top, height),
+            at.content.x - at.stage.x,
+            origin_y(
+                container.isFlipped(),
+                container.bounds().size.height,
+                at.content.y - at.stage.y,
+                height,
+            ),
         ),
         NSSize::new(width, height),
     )
@@ -306,16 +321,29 @@ mod tests {
     }
 }
 
-fn backing_scale(content: &NSView) -> f64 {
-    let bounds = content.bounds();
-    if bounds.size.width <= 0.0 {
-        return 1.0;
-    }
-    let backing = content.convertRectToBacking(bounds);
-    let scale = backing.size.width / bounds.size.width;
-    if scale.is_finite() && scale > 0.0 {
-        scale
-    } else {
-        1.0
-    }
+/// The picture view's own size in physical pixels.
+///
+/// `convertRectToBacking` answers for the display the view is on, which is the
+/// whole reason the swapchain size is asked of the view rather than computed
+/// from a ratio the page carried across. The view has been in the window since
+/// `attach` put it there, because a view with no window answers with whatever
+/// the main screen happens to be.
+fn backing_size(view: &NSView) -> (u32, u32) {
+    let backing = view.convertRectToBacking(view.bounds());
+    (
+        backing.size.width.max(1.0).round() as u32,
+        backing.size.height.max(1.0).round() as u32,
+    )
+}
+
+/// The same reading without moving anything, for the one caller that has just
+/// attached a view and not placed it yet.
+pub fn surface_size(inner: &Inner) -> (u32, u32) {
+    let view = inner.view;
+    on_webview(&inner.window, move |_, _| {
+        // SAFETY: messaged on the main thread, and the view is alive until
+        // `detach` releases it.
+        Ok(backing_size(unsafe { view.ptr().as_ref() }))
+    })
+    .unwrap_or((1, 1))
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/mod.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/mod.rs
@@ -45,12 +45,24 @@ mod unsupported;
 #[cfg(not(target_os = "macos"))]
 use unsupported as platform;
 
-/// Where the monitor sits inside the window, in **physical** pixels.
+/// Where the monitor sits inside the WebView, in **points**.
 ///
-/// Physical because that is what a native view is placed in and what a
-/// swapchain is sized in. The page measures in CSS pixels and multiplies by
-/// `devicePixelRatio` before sending, which is the same conversion the drag and
-/// drop handler already does in the other direction.
+/// Points, because that is the one unit both sides already have without
+/// converting: a CSS pixel in the page and an AppKit point in a view inside
+/// that page's `WKWebView` are the same length, so `getBoundingClientRect()`
+/// values are an `NSRect` with the y origin flipped and nothing else done to
+/// them.
+///
+/// It used to be physical pixels, which meant the page multiplied by
+/// `devicePixelRatio` and this side divided by the view's backing scale. Those
+/// two cancel, so the whole conversion was a round trip that only landed where
+/// it started while the page's cached ratio and the window's real one agreed —
+/// and when they did not, every coordinate was scaled at once and the monitor
+/// was drawn outside the panel.
+///
+/// Physical pixels are still what a swapchain is sized in. That number is asked
+/// of the view itself, in [`Viewport::surface_size`], on the side that can know
+/// which display the window is on.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Place {
@@ -62,9 +74,9 @@ pub struct Place {
 
 /// The clipped monitor box and the larger picture inside it.
 ///
-/// Both rectangles use physical window pixels. The page keeps the transform in
-/// CSS pixels so cursor math stays in one coordinate system, then converts the
-/// two rectangles together at the IPC boundary.
+/// Both in points, both measured from the WebView's top left, and both computed
+/// from one measurement in `geometry.js` so they cannot describe two different
+/// moments.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MonitorPlace {
@@ -73,26 +85,12 @@ pub struct MonitorPlace {
 }
 
 impl MonitorPlace {
-    pub fn surface_size(&self) -> (u32, u32) {
-        self.content.surface_size()
-    }
-
     pub fn is_visible(&self) -> bool {
         self.stage.is_visible() && self.content.is_visible()
     }
 }
 
 impl Place {
-    /// The size to configure a swapchain at, never zero. A surface configured
-    /// at zero is a validation error on every backend, and a stage box can
-    /// genuinely be zero for a moment while the window is being laid out.
-    pub fn surface_size(&self) -> (u32, u32) {
-        (
-            (self.width.max(1.0).round() as u32).max(1),
-            (self.height.max(1.0).round() as u32).max(1),
-        )
-    }
-
     /// Whether this is worth drawing on at all.
     pub fn is_visible(&self) -> bool {
         self.width >= 1.0 && self.height >= 1.0
@@ -117,13 +115,35 @@ impl Viewport {
         })
     }
 
-    /// Move or resize it. Cheap, and safe to call with what it already is.
-    pub fn place(&mut self, place: MonitorPlace) {
+    /// Move or resize it, and answer the size the surface on it should now be.
+    ///
+    /// `None` when the box is what it already was. Both halves of this are main
+    /// thread calls that the caller waits on, and the page re-measures its
+    /// panel on every animation frame, so a placement that changes nothing has
+    /// to cost nothing.
+    pub fn place(&mut self, place: MonitorPlace) -> Option<(u32, u32)> {
         if place == self.place {
-            return;
+            return None;
         }
         self.place = place;
-        platform::place(&self.inner, place);
+        let (width, height) = platform::place(&self.inner, place);
+        Some((width.max(1), height.max(1)))
+    }
+
+    /// The picture view's size in **physical** pixels, which is what a
+    /// swapchain is configured at.
+    ///
+    /// Asked of the view rather than worked out from a ratio the page sent,
+    /// because the view is the only thing that knows which display it is on.
+    /// Read *after* the view has been moved, so a window dragged onto a display
+    /// with a different scale factor is a size that already accounts for it.
+    ///
+    /// Never zero: a surface configured at zero is a validation error on every
+    /// backend, and the box genuinely is zero for a moment while a window is
+    /// being laid out.
+    pub fn surface_size(&self) -> (u32, u32) {
+        let (width, height) = platform::surface_size(&self.inner);
+        (width.max(1), height.max(1))
     }
 
     /// Show or hide it. The page hides it before drawing anything over the
@@ -159,42 +179,47 @@ impl Drop for Viewport {
 mod tests {
     use super::*;
 
-    #[test]
-    fn a_surface_is_never_configured_at_zero() {
-        let place = Place {
+    fn place(width: f64, height: f64) -> Place {
+        Place {
             x: 0.0,
             y: 0.0,
-            width: 0.0,
-            height: 0.0,
-        };
-        assert_eq!(place.surface_size(), (1, 1));
-        assert!(!place.is_visible());
-    }
-
-    #[test]
-    fn a_fractional_box_rounds_to_whole_pixels() {
-        let place = Place {
-            x: 10.5,
-            y: 20.25,
-            width: 640.4,
-            height: 360.6,
-        };
-        assert_eq!(place.surface_size(), (640, 361));
-        assert!(place.is_visible());
+            width,
+            height,
+        }
     }
 
     /// A collapsed panel is a real state — the window can be dragged small
-    /// enough — and it has to read as "nothing to draw" rather than as a size.
+    /// enough, and the page answers an unfittable panel with an empty box on
+    /// purpose — and it has to read as "nothing to draw" rather than as a size.
     #[test]
     fn a_collapsed_stage_is_not_visible() {
         for (width, height) in [(0.0, 100.0), (100.0, 0.0), (0.5, 0.5)] {
-            let place = Place {
-                x: 0.0,
-                y: 0.0,
-                width,
-                height,
-            };
-            assert!(!place.is_visible(), "{width}x{height}");
+            assert!(!place(width, height).is_visible(), "{width}x{height}");
         }
+        assert!(place(640.0, 360.0).is_visible());
+    }
+
+    /// Both rectangles have to be worth drawing on. The picture is the one a
+    /// surface is made for and the stage is the one that clips it, so a zero
+    /// either side is a session with nothing on screen.
+    #[test]
+    fn a_monitor_needs_both_of_its_boxes() {
+        let good = place(640.0, 360.0);
+        let empty = place(0.0, 0.0);
+        assert!(MonitorPlace {
+            stage: good,
+            content: good
+        }
+        .is_visible());
+        assert!(!MonitorPlace {
+            stage: empty,
+            content: good
+        }
+        .is_visible());
+        assert!(!MonitorPlace {
+            stage: good,
+            content: empty
+        }
+        .is_visible());
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/unsupported.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/unsupported.rs
@@ -19,7 +19,13 @@ pub fn attach(_window: &tauri::WebviewWindow, _place: MonitorPlace) -> Result<In
     Err("the native monitor is macOS only so far; playback uses media elements here".into())
 }
 
-pub fn place(_inner: &Inner, _at: MonitorPlace) {}
+pub fn place(_inner: &Inner, _at: MonitorPlace) -> (u32, u32) {
+    (1, 1)
+}
+
+pub fn surface_size(_inner: &Inner) -> (u32, u32) {
+    (1, 1)
+}
 
 pub fn set_visible(_inner: &Inner, _visible: bool) {}
 

--- a/product/akbun-makevideo/workspace/src/geometry.js
+++ b/product/akbun-makevideo/workspace/src/geometry.js
@@ -1,0 +1,230 @@
+'use strict';
+
+(function () {
+
+// Where the picture goes, as arithmetic over plain objects.
+//
+// One function answers "where is the stage", and everything that needs the
+// answer — the media element preview laying out its stack, the native monitor
+// placing a view over the webview — asks this rather than measuring what the
+// other one did. Two measurements of the same box taken a frame apart was the
+// shape this replaced, and a frame apart is exactly when they disagree.
+//
+// # Units
+//
+// CSS pixels throughout, measured from the top left of the WebView. That is
+// what `getBoundingClientRect()` returns and what an AppKit frame inside a
+// flipped `WKWebView` takes, so nothing here converts anything and no number
+// crosses the IPC boundary in a unit the far side has to guess at.
+//
+// The old path multiplied by `window.devicePixelRatio` on the way out and
+// divided by the view's backing scale on the way in. For placement those two
+// cancel — it was a round trip that only came back where it started while the
+// page's ratio and the window's agreed. They stop agreeing whenever the window
+// is on a display the page's cached ratio is not about, and then every
+// coordinate is scaled by two or a half at once: the view lands at double the
+// offset *and* double the size, which is a picture drawn well outside the
+// panel. Physical pixels are still needed to size a swapchain, and that number
+// is now asked of the view itself, on the side that can know which display the
+// window is actually on.
+//
+// # Why a box that does not fit is empty rather than small
+//
+// A native view is not in the page's stacking order, so `overflow: hidden` on
+// the panel does not clip it. A stage held up to some minimum width is wider
+// than the panel holding it, and what spills is not clipped by anything — it is
+// drawn over the timeline. So there are no minimum sizes here. A panel with no
+// room in it has no picture in it, and `isDrawable` is how that is said.
+//
+// Minimums also break the shape. A width held up to a floor while the height
+// falls past it is a stretched picture, which is the other half of the same
+// bug.
+
+const STAGE_PADDING = 14;
+
+const DEFAULT_SHAPE = Object.freeze({ width: 1920, height: 1080 });
+
+const EMPTY = Object.freeze({ left: 0, top: 0, width: 0, height: 0 });
+
+const FIT_ZOOM = 1;
+const MAX_ZOOM = 4;
+const ZOOM_STEP = 1.25;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(value, max));
+}
+
+function positive(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+/** A box on whole pixels that is never bigger than the one it was measured
+ *  from.
+ *
+ *  Rounding the origin and the size separately is what lets a box end up a
+ *  pixel past its container: two independent roundings, each free to go up.
+ *  Rounding the two *edges* and taking the size from them leaves the right and
+ *  bottom edges where they were measured. */
+function pixelBox(left, top, width, height) {
+  if (![left, top, width, height].every(Number.isFinite)) return EMPTY;
+  const x = Math.round(left);
+  const y = Math.round(top);
+  return {
+    left: x,
+    top: y,
+    width: Math.max(0, Math.round(left + width) - x),
+    height: Math.max(0, Math.round(top + height) - y),
+  };
+}
+
+/** Whether there is enough of a box to draw on. A stage box is genuinely zero
+ *  while a window is being laid out and while a panel is dragged shut, and both
+ *  have to read as "nothing to show" rather than as a size. */
+function isDrawable(box) {
+  return Boolean(box) && box.width >= 1 && box.height >= 1;
+}
+
+/** The project's pixel shape, which is all the fit needs from it. */
+function shapeOf(project) {
+  const settings = (project && project.settings) || null;
+  return {
+    width: positive(settings && settings.width, DEFAULT_SHAPE.width),
+    height: positive(settings && settings.height, DEFAULT_SHAPE.height),
+  };
+}
+
+/** Fit the project's shape inside `panel` and centre it there.
+ *
+ *  `panel` is the preview panel as `getBoundingClientRect()` gives it, so the
+ *  answer is in the same coordinates and can be handed straight to a native
+ *  view without another measurement. */
+function stageBoxOf(panel, project, padding) {
+  if (!panel) return EMPTY;
+  const pad = Number.isFinite(padding) ? Math.max(0, padding) : STAGE_PADDING;
+  const room = {
+    width: (Number(panel.width) || 0) - pad * 2,
+    height: (Number(panel.height) || 0) - pad * 2,
+  };
+  if (!(room.width > 0) || !(room.height > 0)) return EMPTY;
+
+  const shape = shapeOf(project);
+  const fit = Math.min(room.width / shape.width, room.height / shape.height);
+  if (!Number.isFinite(fit) || fit <= 0) return EMPTY;
+
+  const width = shape.width * fit;
+  const height = shape.height * fit;
+  return pixelBox(
+    (Number(panel.left) || 0) + pad + (room.width - width) / 2,
+    (Number(panel.top) || 0) + pad + (room.height - height) / 2,
+    width,
+    height
+  );
+}
+
+function fittedViewport() {
+  return { zoom: FIT_ZOOM, x: 0, y: 0 };
+}
+
+/** Hold the enlarged picture against the stage edges, so panning can never
+ *  expose a strip of nothing beside it. */
+function clampViewport(viewport, stage) {
+  const zoom = clamp(positive(viewport && viewport.zoom, FIT_ZOOM), FIT_ZOOM, MAX_ZOOM);
+  const width = Math.max(0, Number(stage && stage.width) || 0);
+  const height = Math.max(0, Number(stage && stage.height) || 0);
+  return {
+    zoom,
+    x: clamp(Number(viewport && viewport.x) || 0, width - width * zoom, 0),
+    y: clamp(Number(viewport && viewport.y) || 0, height - height * zoom, 0),
+  };
+}
+
+/** Zoom about `cursor`, which is a point inside the stage box, keeping
+ *  whatever the project shows there under it. */
+function zoomViewport(viewport, stage, cursor, zoom) {
+  const current = clampViewport(viewport, stage);
+  const next = clamp(positive(zoom, FIT_ZOOM), FIT_ZOOM, MAX_ZOOM);
+  const at = cursor || { x: 0, y: 0 };
+  const sourceX = ((Number(at.x) || 0) - current.x) / current.zoom;
+  const sourceY = ((Number(at.y) || 0) - current.y) / current.zoom;
+  return clampViewport(
+    {
+      zoom: next,
+      x: (Number(at.x) || 0) - sourceX * next,
+      y: (Number(at.y) || 0) - sourceY * next,
+    },
+    stage
+  );
+}
+
+/** The enlarged picture, in the same coordinates as the stage it sits in. At
+ *  the fitted zoom this is the stage box exactly. */
+function contentBoxOf(stage, viewport) {
+  if (!isDrawable(stage)) return EMPTY;
+  const held = clampViewport(viewport || fittedViewport(), stage);
+  return pixelBox(
+    stage.left + held.x,
+    stage.top + held.y,
+    stage.width * held.zoom,
+    stage.height * held.zoom
+  );
+}
+
+/** A box as the wire carries it. Same numbers, same units — the shape differs
+ *  only because a rectangle addressed by its origin is what a native view is
+ *  placed with. */
+function placeOf(box) {
+  return {
+    x: box.left,
+    y: box.top,
+    width: box.width,
+    height: box.height,
+  };
+}
+
+/** Everything the native monitor is placed with, from the panel it lives in.
+ *
+ *  Two rectangles: the stage, which clips, and the picture inside it, which
+ *  zoom makes larger than the clip. Both are derived here in one pass from one
+ *  measurement, so they cannot describe two different moments. */
+function monitorPlaceOf(panel, project, viewport) {
+  const stage = stageBoxOf(panel, project);
+  return {
+    stage: placeOf(stage),
+    content: placeOf(contentBoxOf(stage, viewport)),
+  };
+}
+
+/** Whether two placements are the same box, so a resize that fires on every
+ *  frame of a drag does not become a command for every one of them. */
+function samePlace(a, b) {
+  if (!a || !b) return false;
+  if (a.stage || b.stage) {
+    return samePlace(a.stage, b.stage) && samePlace(a.content, b.content);
+  }
+  return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+}
+
+const exported = {
+  STAGE_PADDING,
+  FIT_ZOOM,
+  MAX_ZOOM,
+  ZOOM_STEP,
+  isDrawable,
+  shapeOf,
+  stageBoxOf,
+  contentBoxOf,
+  fittedViewport,
+  clampViewport,
+  zoomViewport,
+  placeOf,
+  monitorPlaceOf,
+  samePlace,
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = exported;
+} else {
+  globalThis.geometryLib = exported;
+}
+})();

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -484,6 +484,7 @@
 
   <script src="api.js"></script>
   <script src="time.js"></script>
+  <script src="geometry.js"></script>
   <script src="timeline.js"></script>
   <script src="shortcuts.js"></script>
   <script src="quality.js"></script>

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -26,84 +26,22 @@
 const T =
   typeof module !== 'undefined' && module.exports ? require('./time.js') : globalThis.timeLib;
 
-/** The stage box as physical pixels inside the window.
- *
- *  Physical, because that is what a native view is placed in and what a
- *  swapchain is sized in. CSS pixels and physical pixels are the same number
- *  only on a display nobody at this desk has, and the difference is invisible
- *  until the picture is a quarter of the size of its box.
- *
- *  This is the page's half of the platform layer, and it is the half most
- *  likely to be wrong, so it is a function over two plain objects rather than
- *  something that needs a window to test. */
-function placeOf(box, ratio) {
-  const scale = Number.isFinite(ratio) && ratio > 0 ? ratio : 1;
-  return {
-    x: Math.round(box.left * scale),
-    y: Math.round(box.top * scale),
-    width: Math.max(0, Math.round(box.width * scale)),
-    height: Math.max(0, Math.round(box.height * scale)),
-  };
-}
+// Every rectangle this module sends comes out of `geometry.js`. Placing a
+// native view is the half of the platform layer most likely to be silently
+// wrong, so the arithmetic lives in a file with no window in it and this one
+// only decides *when* to ask.
+const GEO =
+  typeof module !== 'undefined' && module.exports
+    ? require('./geometry.js')
+    : globalThis.geometryLib;
 
-const FIT_ZOOM = 1;
-const MAX_ZOOM = 4;
-const ZOOM_STEP = 1.25;
-
-function clamp(value, min, max) {
-  return Math.max(min, Math.min(value, max));
-}
-
-function fittedViewport() {
-  return { zoom: FIT_ZOOM, x: 0, y: 0 };
-}
-
-function clampViewport(viewport, box) {
-  const zoom = clamp(viewport.zoom, FIT_ZOOM, MAX_ZOOM);
-  return {
-    zoom,
-    x: clamp(viewport.x, box.width - box.width * zoom, 0),
-    y: clamp(viewport.y, box.height - box.height * zoom, 0),
-  };
-}
-
-function zoomViewport(viewport, box, cursor, zoom) {
-  const nextZoom = clamp(zoom, FIT_ZOOM, MAX_ZOOM);
-  const sourceX = (cursor.x - viewport.x) / viewport.zoom;
-  const sourceY = (cursor.y - viewport.y) / viewport.zoom;
-  return clampViewport({
-    zoom: nextZoom,
-    x: cursor.x - sourceX * nextZoom,
-    y: cursor.y - sourceY * nextZoom,
-  }, box);
-}
-
-function monitorPlaceOf(box, viewport, ratio) {
-  const stage = placeOf(box, ratio);
-  const content = placeOf({
-    left: box.left + viewport.x,
-    top: box.top + viewport.y,
-    width: box.width * viewport.zoom,
-    height: box.height * viewport.zoom,
-  }, ratio);
-  return { stage, content };
-}
-
-/** Whether two placements are the same box, so a resize observer firing on
- *  every frame of a drag does not send a command for every one of them. */
-function samePlace(a, b) {
-  if (!a || !b) return false;
-  if (a.stage || b.stage) {
-    return samePlace(a.stage, b.stage) && samePlace(a.content, b.content);
-  }
-  return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
-}
+const { samePlace } = GEO;
 
 /** Whether the native view should be on screen right now.
  *
  *  The view sits **over** the webview and is not in the page's stacking order,
  *  so anything the page draws on the stage would be behind it. That makes
- *  visibility one rule with four inputs rather than a call at each of the
+ *  visibility one rule with five inputs rather than a call at each of the
  *  places that happens to cover it — which is how the asset preview ended up
  *  hidden behind a paused monitor.
  *
@@ -113,9 +51,14 @@ function samePlace(a, b) {
  *    its way.
  *  - `hasContent`: the timeline has something on it. An empty one puts the
  *    "drop media here" hint on the stage, and that is drawn by the page too.
- *  - `covered`: a sheet or an open menu is over the stage. */
+ *  - `covered`: a sheet or an open menu is over the stage.
+ *  - `roomy`: the panel is big enough to fit a picture in. A panel dragged
+ *    shut has no box, and a view cannot be placed at nothing — it would be a
+ *    pixel of black in the corner rather than an absence. */
 function shouldShowMonitor(state) {
-  return Boolean(state.native && state.timeline && state.hasContent && !state.covered);
+  return Boolean(
+    state.native && state.timeline && state.hasContent && state.roomy && !state.covered
+  );
 }
 
 /** What the page should do with the answer to `playbackAttach`.
@@ -136,6 +79,10 @@ function readChoice(answer) {
 
 function createMonitor(options) {
   const { preview, stage, api, onTick, onNotice } = options;
+  // The panel, not the stage element. The box is computed from the room
+  // available rather than read back off the element the page laid out, so the
+  // native view is never a frame behind what the page did — see `layout()`.
+  const panel = options.wrap || stage;
   const L = globalThis.timelineLib;
 
   let native = false;
@@ -147,9 +94,10 @@ function createMonitor(options) {
   let position = 0;
   let playing = false;
   let attaching = null;
+  let attachWanted = false;
   let mediaRefreshPending = false;
   let refreshingMedia = null;
-  let viewport = fittedViewport();
+  let viewport = GEO.fittedViewport();
 
   function timelineMode() {
     return preview.mode() === 'timeline';
@@ -176,13 +124,18 @@ function createMonitor(options) {
 
   /** Send the view's visibility only when it actually changes. The renderer
    *  asks on every timeline redraw, and one command per redraw would be a
-   *  round trip for every keystroke that moves a clip. */
-  function syncVisibility() {
+   *  round trip for every keystroke that moves a clip.
+   *
+   *  `box` is passed in by the callers that have just measured one, so a frame
+   *  that both places the view and checks whether it should be on screen is one
+   *  layout read rather than two. */
+  function syncVisibility(box) {
     if (!native) return;
     const wanted = shouldShowMonitor({
       native,
       timeline: timelineMode(),
       hasContent: total() > 0,
+      roomy: GEO.isDrawable(box === undefined ? stageBox() : box),
       covered: covered || editing,
     });
     if (wanted === lastVisible) return;
@@ -190,11 +143,27 @@ function createMonitor(options) {
     api.playbackVisible(wanted).catch(() => {});
   }
 
+  /** The stage box as it is right now, from the panel and the project.
+   *
+   *  Measuring the panel rather than the stage element is what makes this
+   *  independent of whether the page has laid out yet: the same inputs go into
+   *  `preview.layout()`, so both answers describe the same moment even on the
+   *  frame a project's resolution changes. */
+  function stageBox() {
+    return panel ? GEO.stageBoxOf(panel.getBoundingClientRect(), getProject()) : null;
+  }
+
   function currentPlace() {
-    if (!stage) return null;
-    const box = stage.getBoundingClientRect();
-    viewport = clampViewport(viewport, box);
-    return monitorPlaceOf(box, viewport, window.devicePixelRatio);
+    const box = stageBox();
+    if (!box) return null;
+    // Held here rather than inside the measurement. A panel shrinking has to
+    // pull an enlarged picture back against its edges, and a getter that
+    // quietly rewrites the pan state is a measurement with a side effect.
+    viewport = GEO.clampViewport(viewport, box);
+    return {
+      stage: GEO.placeOf(box),
+      content: GEO.placeOf(GEO.contentBoxOf(box, viewport)),
+    };
   }
 
   /** Ask Rust for a monitor, and take whatever it gives back.
@@ -204,7 +173,9 @@ function createMonitor(options) {
    *  reason, which is the whole point of keeping that preview. */
   async function attach() {
     if (!api || !api.available) return false;
+    attachWanted = true;
     if (options.pageOverlayActive && options.pageOverlayActive()) {
+      attachWanted = false;
       native = false;
       lastPlace = null;
       lastVisible = null;
@@ -212,7 +183,12 @@ function createMonitor(options) {
       return false;
     }
     const place = currentPlace();
+    // No room yet. The window is still being laid out, or the panel is dragged
+    // shut. Giving up here permanently was a silent fallback to the media
+    // elements for the whole session, so the want is remembered and the
+    // animation frame asks again once there is a box to attach to.
     if (!place || place.stage.width < 1 || place.stage.height < 1) return native;
+    attachWanted = false;
     // One at a time. The layout settles over several frames when a project
     // opens, and a second attach mid-flight would start a session the first one
     // is about to replace.
@@ -248,6 +224,10 @@ function createMonitor(options) {
   async function release() {
     if (!api || !api.available) return;
     native = false;
+    // Including a want that was still waiting for room. Releasing is the page
+    // saying it does not have a monitor any more, and the retry would hand it
+    // one back on the next frame.
+    attachWanted = false;
     lastPlace = null;
     lastVisible = null;
     covered = false;
@@ -287,15 +267,23 @@ function createMonitor(options) {
     return drivingNatively() ? playing : preview.isPlaying();
   }
 
-  /** Tell Rust where the box is now. Cheap enough to call on every layout, and
-   *  it compares before sending so a drag is one command per pixel rather than
-   *  one per frame. */
+  /** Tell Rust where the box is now, and whether there is still room for it.
+   *
+   *  Called on every animation frame, so it compares before sending: a drag is
+   *  one command per pixel the box actually moved rather than one per frame.
+   *  Returns the box it measured, so the frame loop can use it again without a
+   *  second layout read. */
   function place() {
-    if (!drivingNatively()) return;
+    const box = stageBox();
+    if (!drivingNatively()) return box;
+    // A panel dragged shut is a reason to get out of the way, and it is the one
+    // reason that is a measurement rather than a flag somebody set.
+    syncVisibility(box);
     const next = currentPlace();
-    if (!next || samePlace(next, lastPlace)) return;
+    if (!next || samePlace(next, lastPlace)) return box;
     lastPlace = next;
     api.playbackPlace(next).catch(() => {});
+    return box;
   }
 
   /** Read the playhead back.
@@ -332,19 +320,29 @@ function createMonitor(options) {
     if (wasPlaying && !playing && onTick) onTick(position, false);
   }
 
+  /** The box is re-measured on every animation frame, and `place()` compares
+   *  before it sends.
+   *
+   *  This replaced a `ResizeObserver` on the stage element, which only fires
+   *  when the box changes *size*. Everything that moves the stage without
+   *  resizing it — a sibling panel widening, the timeline growing, a scrollbar
+   *  appearing, the inspector opening — left the native view at the previous
+   *  position, and a native view is over the webview and clipped by nothing, so
+   *  it sat over the timeline until something happened to resize it. Listing
+   *  the reasons a box can move is a list nobody finishes; measuring is one
+   *  layout read per frame in a loop that already runs every frame.
+   *
+   *  The retry beside it is the other half: an attach that found no room is
+   *  finished here rather than being a fallback for the rest of the session. */
   function frame() {
+    const box = place();
+    if (attachWanted && !attaching && GEO.isDrawable(box)) {
+      void Promise.resolve(attach()).catch(() => {});
+    }
     poll();
     requestAnimationFrame(frame);
   }
   if (typeof requestAnimationFrame === 'function') requestAnimationFrame(frame);
-
-  // The stage box moves for reasons the page never sends a command about: a
-  // panel being dragged, the preview quality changing the layout, the window
-  // being zoomed. The native view is placed in the window and not laid out by
-  // the page, so something has to notice.
-  if (stage && typeof ResizeObserver === 'function') {
-    new ResizeObserver(() => place()).observe(stage);
-  }
 
   return {
     attach,
@@ -496,35 +494,37 @@ function createMonitor(options) {
     },
 
     zoomIn(cursor) {
-      return this.zoomTo(viewport.zoom * ZOOM_STEP, cursor);
+      return this.zoomTo(viewport.zoom * GEO.ZOOM_STEP, cursor);
     },
 
     zoomOut(cursor) {
-      return this.zoomTo(viewport.zoom / ZOOM_STEP, cursor);
+      return this.zoomTo(viewport.zoom / GEO.ZOOM_STEP, cursor);
     },
 
+    /** `cursor` is a point inside the stage box, which is what the page's
+     *  wheel handler measures against the stage element. */
     zoomTo(zoom, cursor) {
-      if (!drivingNatively() || !stage) return false;
-      const box = stage.getBoundingClientRect();
+      if (!drivingNatively()) return false;
+      const box = stageBox();
+      if (!GEO.isDrawable(box)) return false;
       const at = cursor || { x: box.width / 2, y: box.height / 2 };
-      viewport = zoomViewport(viewport, box, at, zoom);
+      viewport = GEO.zoomViewport(viewport, box, at, zoom);
       place();
       return true;
     },
 
     fit() {
       if (!drivingNatively()) return false;
-      viewport = fittedViewport();
+      viewport = GEO.fittedViewport();
       place();
       return true;
     },
 
     panBy(dx, dy) {
-      if (!drivingNatively() || !stage || viewport.zoom <= FIT_ZOOM) return false;
-      const next = clampViewport(
-        { ...viewport, x: viewport.x + dx, y: viewport.y + dy },
-        stage.getBoundingClientRect()
-      );
+      if (!drivingNatively() || viewport.zoom <= GEO.FIT_ZOOM) return false;
+      const box = stageBox();
+      if (!GEO.isDrawable(box)) return false;
+      const next = GEO.clampViewport({ ...viewport, x: viewport.x + dx, y: viewport.y + dy }, box);
       if (next.x === viewport.x && next.y === viewport.y) return false;
       viewport = next;
       place();
@@ -538,8 +538,8 @@ function createMonitor(options) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { createMonitor, placeOf, monitorPlaceOf, samePlace, readChoice, shouldShowMonitor, fittedViewport, clampViewport, zoomViewport };
+  module.exports = { createMonitor, readChoice, shouldShowMonitor };
 } else {
-  globalThis.monitorLib = { createMonitor, placeOf, monitorPlaceOf, samePlace, readChoice, shouldShowMonitor, fittedViewport, clampViewport, zoomViewport };
+  globalThis.monitorLib = { createMonitor, readChoice, shouldShowMonitor };
 }
 })();

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -26,6 +26,11 @@ const QUALITY = {
 const T =
   typeof module !== 'undefined' && module.exports ? require('./time.js') : globalThis.timeLib;
 
+const GEO =
+  typeof module !== 'undefined' && module.exports
+    ? require('./geometry.js')
+    : globalThis.geometryLib;
+
 const RATE_SYNC_THRESHOLD = 0.04;
 const HARD_SYNC_THRESHOLD = 1;
 const MAX_RATE_ADJUSTMENT = 0.05;
@@ -87,23 +92,36 @@ function createPreview(options) {
     return T.framesToSeconds(positionFrames, rate());
   }
 
-  /** Fit the project shape into the panel, then lay the media out at the
-   *  quality scale and scale it back up so it still fills that box. */
+  /** Size the stage to the fitted box, then lay the media out at the quality
+   *  scale and scale it back up so it still fills that box.
+   *
+   *  The box itself comes from `geometry.js` and not from here, because the
+   *  native monitor places a view on the same box and the two must not be two
+   *  different calculations. The panel centres the stage in CSS, which is the
+   *  same centring `stageBoxOf` did in arithmetic, so only the size is written
+   *  and the position follows.
+   *
+   *  Scaling back up uses the ratio the rounded inner box actually is rather
+   *  than `1 / factor`. Rounding 641 at half quality gives 321, and doubling
+   *  that is 642 — a pixel of the stack hanging past the stage on every odd
+   *  width. */
   function layout() {
     if (!wrap) return;
-    const { width, height } = settings();
-    const box = wrap.getBoundingClientRect();
-    const availableWidth = Math.max(80, box.width - 28);
-    const availableHeight = Math.max(45, box.height - 28);
-    const fit = Math.min(availableWidth / width, availableHeight / height);
-    const displayWidth = Math.max(80, Math.round(width * fit));
-    const displayHeight = Math.max(45, Math.round(height * fit));
-    stage.style.width = `${displayWidth}px`;
-    stage.style.height = `${displayHeight}px`;
+    const box = GEO.stageBoxOf(wrap.getBoundingClientRect(), getProject());
+    stage.style.width = `${box.width}px`;
+    stage.style.height = `${box.height}px`;
+    if (!GEO.isDrawable(box)) {
+      inner.style.width = '0px';
+      inner.style.height = '0px';
+      inner.style.transform = 'none';
+      return;
+    }
     const factor = QUALITY[quality].scale;
-    inner.style.width = `${Math.max(2, Math.round(displayWidth * factor))}px`;
-    inner.style.height = `${Math.max(2, Math.round(displayHeight * factor))}px`;
-    inner.style.transform = `scale(${1 / factor})`;
+    const innerWidth = Math.max(1, Math.round(box.width * factor));
+    const innerHeight = Math.max(1, Math.round(box.height * factor));
+    inner.style.width = `${innerWidth}px`;
+    inner.style.height = `${innerHeight}px`;
+    inner.style.transform = `scale(${box.width / innerWidth}, ${box.height / innerHeight})`;
   }
 
   function makeElement(asset, wantsPicture) {

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -3372,6 +3372,9 @@ async function boot() {
   preview = globalThis.monitorLib.createMonitor({
     preview: mediaPreview,
     stage: dom.stage,
+    // The panel is what the native place is computed from, so the view and the
+    // page's own stage come out of one calculation rather than two.
+    wrap: dom.stageWrap,
     api: window.api,
     getProject: () => state.project,
     pageOverlayActive: () => G.visible(state.settings),

--- a/product/akbun-makevideo/workspace/test/geometry.test.js
+++ b/product/akbun-makevideo/workspace/test/geometry.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const G = require('../src/geometry.js');
+
+// Where the picture goes. All of it is arithmetic over plain objects, which is
+// the point of the module: the two things that place a picture — the media
+// element stack in the page and a native view over the webview — used to work
+// it out separately, and the ways that goes wrong are silent. A box a pixel
+// past its panel looks like nothing until the thing in it is not clipped by
+// CSS, and then it is drawn over the timeline.
+
+const HD = { settings: { width: 1920, height: 1080 } };
+const SQUARE = { settings: { width: 1000, height: 1000 } };
+const PAD = G.STAGE_PADDING;
+
+/** A panel of the given size at the origin, plus its padding, so a test can
+ *  name the room it means rather than the room plus fourteen twice. */
+function panel(width, height, left = 0, top = 0) {
+  return { left, top, width: width + PAD * 2, height: height + PAD * 2 };
+}
+
+test('the project shape decides the box, and it is centred in the panel', () => {
+  const box = G.stageBoxOf(panel(800, 600), HD);
+  assert.deepStrictEqual(box, {
+    left: PAD,
+    top: PAD + (600 - 450) / 2,
+    width: 800,
+    height: 450,
+  });
+});
+
+test('a panel narrower than it is tall fits against the other edge', () => {
+  const box = G.stageBoxOf(panel(400, 600), HD);
+  assert.strictEqual(box.width, 400);
+  assert.strictEqual(box.height, 225);
+  assert.strictEqual(box.left, PAD);
+  assert.strictEqual(box.top, Math.round(PAD + (600 - 225) / 2));
+});
+
+test('the panel offset is carried through, because the answer is placed as it is', () => {
+  // The box is handed straight to a native view without a second measurement,
+  // so it has to be in the coordinates it was measured in rather than relative
+  // to the panel.
+  const box = G.stageBoxOf(panel(800, 600, 320, 96), HD);
+  assert.strictEqual(box.left, 320 + PAD);
+  assert.strictEqual(box.top, 96 + PAD + 75);
+});
+
+// The bug this module was written for. A stage held up to a minimum size is
+// wider than the panel holding it, and a native view is not in the page's
+// stacking order, so the panel's `overflow: hidden` does not clip it — what
+// hangs over the edge is drawn over the timeline.
+test('a panel with no room in it has no box, rather than a small one', () => {
+  for (const [width, height] of [[0, 600], [800, 0], [-100, 600], [2, 2]]) {
+    const box = G.stageBoxOf({ left: 0, top: 0, width, height }, HD);
+    assert.ok(!G.isDrawable(box), `${width}x${height}`);
+  }
+});
+
+test('a box never reaches past the panel it was fitted into', () => {
+  // Sizes chosen to land on fractions: the failure is a rounded origin and a
+  // rounded size each going up, which is a pixel over on the far edge.
+  for (let width = 101; width < 400; width += 7) {
+    for (let height = 97; height < 300; height += 11) {
+      const room = panel(width, height, 10.5, 20.25);
+      const box = G.stageBoxOf(room, HD);
+      if (!G.isDrawable(box)) continue;
+      assert.ok(box.left >= Math.floor(room.left), `${width}x${height} left`);
+      assert.ok(
+        box.left + box.width <= Math.ceil(room.left + room.width),
+        `${width}x${height} right`
+      );
+      assert.ok(
+        box.top + box.height <= Math.ceil(room.top + room.height),
+        `${width}x${height} bottom`
+      );
+    }
+  }
+});
+
+test('the shape survives rounding to whole pixels', () => {
+  // Within a pixel each way. A width held to a floor while the height falls
+  // past it is the stretched picture this replaced.
+  for (let width = 60; width < 900; width += 13) {
+    const box = G.stageBoxOf(panel(width, width), HD);
+    if (!G.isDrawable(box)) continue;
+    const wanted = box.width * (1080 / 1920);
+    assert.ok(Math.abs(box.height - wanted) <= 1, `${width}: ${box.width}x${box.height}`);
+  }
+});
+
+test('a square project is not given a widescreen box', () => {
+  const box = G.stageBoxOf(panel(800, 600), SQUARE);
+  assert.strictEqual(box.width, 600);
+  assert.strictEqual(box.height, 600);
+});
+
+test('a project with no usable settings is treated as 1080p', () => {
+  const expected = G.stageBoxOf(panel(800, 600), HD);
+  for (const project of [null, {}, { settings: {} }, { settings: { width: 0, height: -4 } }]) {
+    assert.deepStrictEqual(G.stageBoxOf(panel(800, 600), project), expected, String(project));
+    assert.deepStrictEqual(G.shapeOf(project), { width: 1920, height: 1080 });
+  }
+});
+
+test('a panel that is not there is not a box', () => {
+  assert.ok(!G.isDrawable(G.stageBoxOf(null, HD)));
+  assert.ok(!G.isDrawable(G.stageBoxOf({ width: NaN, height: NaN }, HD)));
+});
+
+test('the fitted picture is the stage box exactly', () => {
+  const box = G.stageBoxOf(panel(800, 600, 40, 20), HD);
+  assert.deepStrictEqual(G.contentBoxOf(box, G.fittedViewport()), box);
+});
+
+test('zoom enlarges the picture and leaves the clip alone', () => {
+  const place = G.monitorPlaceOf(panel(800, 600), HD, { zoom: 2, x: -100, y: -40 });
+  assert.deepStrictEqual(place.stage, { x: PAD, y: PAD + 75, width: 800, height: 450 });
+  assert.deepStrictEqual(place.content, {
+    x: PAD - 100,
+    y: PAD + 75 - 40,
+    width: 1600,
+    height: 900,
+  });
+});
+
+test('zooming at the cursor keeps the source point under it', () => {
+  const box = { left: 0, top: 0, width: 640, height: 360 };
+  assert.deepStrictEqual(G.zoomViewport(G.fittedViewport(), box, { x: 480, y: 270 }, 2), {
+    zoom: 2,
+    x: -480,
+    y: -270,
+  });
+});
+
+test('panning cannot expose space past an enlarged picture edge', () => {
+  const box = { left: 0, top: 0, width: 640, height: 360 };
+  assert.deepStrictEqual(G.clampViewport({ zoom: 2, x: 20, y: -999 }, box), {
+    zoom: 2,
+    x: 0,
+    y: -360,
+  });
+});
+
+test('zoom is held between fit and the maximum', () => {
+  const box = { left: 0, top: 0, width: 640, height: 360 };
+  assert.strictEqual(G.clampViewport({ zoom: 0.1, x: 0, y: 0 }, box).zoom, G.FIT_ZOOM);
+  assert.strictEqual(G.clampViewport({ zoom: 99, x: 0, y: 0 }, box).zoom, G.MAX_ZOOM);
+});
+
+// A panel dragged narrower under an enlarged picture leaves a pan offset that
+// was legal against the old box and is not against the new one. Holding it at
+// the point it is used means the caller cannot forget to.
+test('a shrinking box pulls an enlarged picture back against its edges', () => {
+  const wide = { left: 0, top: 0, width: 800, height: 450 };
+  const narrow = { left: 0, top: 0, width: 200, height: 112 };
+  const panned = G.clampViewport({ zoom: 2, x: -700, y: -400 }, wide);
+  assert.deepStrictEqual(G.clampViewport(panned, narrow), { zoom: 2, x: -200, y: -112 });
+});
+
+test('the same box twice is recognised, so a drag is not a command per frame', () => {
+  const box = { x: 1, y: 2, width: 3, height: 4 };
+  assert.ok(G.samePlace(box, { ...box }));
+  assert.ok(!G.samePlace(box, { ...box, x: 2 }));
+  assert.ok(!G.samePlace(box, { ...box, width: 5 }));
+  assert.ok(!G.samePlace(null, box));
+  assert.ok(!G.samePlace(box, null));
+});
+
+test('a monitor placement compares both of its rectangles', () => {
+  const place = G.monitorPlaceOf(panel(800, 600), HD, G.fittedViewport());
+  assert.ok(G.samePlace(place, G.monitorPlaceOf(panel(800, 600), HD, G.fittedViewport())));
+  assert.ok(!G.samePlace(place, G.monitorPlaceOf(panel(800, 600), HD, { zoom: 2, x: 0, y: 0 })));
+  assert.ok(!G.samePlace(place, G.monitorPlaceOf(panel(400, 600), HD, G.fittedViewport())));
+});
+
+// Same panel, same project: the media element stack and the native view are
+// laid out from one answer, so there is nothing left for them to disagree
+// about. Measuring one off the other is what put them a frame apart.
+test('the page and the native view are given the same box', () => {
+  const room = panel(801, 601, 33, 17);
+  const box = G.stageBoxOf(room, HD);
+  assert.deepStrictEqual(G.monitorPlaceOf(room, HD, G.fittedViewport()).stage, G.placeOf(box));
+});

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -3,80 +3,24 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const {
-  createMonitor, placeOf, monitorPlaceOf, samePlace, readChoice,
-  fittedViewport, clampViewport, zoomViewport,
-} = require('../src/monitor.js');
+const { createMonitor, readChoice } = require('../src/monitor.js');
 
-// The page's half of the native viewport. Everything here is arithmetic over
-// plain objects on purpose: the rest of monitor.js needs a window, an IPC
-// bridge and a graphics device, and the parts that can be got wrong silently —
-// a box in the wrong units, a fallback reported as a failure — are all in here.
+// The page's half of the native viewport: *when* to place a view, not where.
+// Where is geometry.js, and it is tested there.
+//
+// Everything below drives the router itself. The rest of monitor.js needs a
+// window, an IPC bridge and a graphics device, so what is exercised here is the
+// part that can be got wrong silently — a command sent for a box that did not
+// move, an attach that gave up on a panel that had not been laid out yet, a
+// fallback reported as a failure.
 
-test('a box is converted to physical pixels', () => {
-  const box = { left: 100, top: 50, width: 640, height: 360 };
-  assert.deepStrictEqual(placeOf(box, 1), { x: 100, y: 50, width: 640, height: 360 });
-});
+/** A panel big enough to fit a picture in, which is all the monitor needs from
+ *  the page to place a view over it. */
+function panelStub(width = 640, height = 360, left = 0, top = 0) {
+  return { getBoundingClientRect: () => ({ left, top, width, height }) };
+}
 
-test('a retina display doubles every number, not only the size', () => {
-  // The offset matters as much as the size. A view sized for the display and
-  // positioned for CSS pixels lands in the top left quarter of where it should
-  // be, which is the shape of this mistake when it happens.
-  const box = { left: 100, top: 50, width: 640, height: 360 };
-  assert.deepStrictEqual(placeOf(box, 2), { x: 200, y: 100, width: 1280, height: 720 });
-});
-
-test('a fractional layout lands on whole pixels', () => {
-  const box = { left: 10.4, top: 20.6, width: 100.5, height: 50.2 };
-  const place = placeOf(box, 1.5);
-  for (const value of Object.values(place)) {
-    assert.strictEqual(value, Math.round(value));
-  }
-});
-
-test('a missing or nonsense ratio is treated as one', () => {
-  const box = { left: 4, top: 8, width: 16, height: 32 };
-  const expected = { x: 4, y: 8, width: 16, height: 32 };
-  for (const ratio of [undefined, null, 0, -2, NaN, Infinity]) {
-    assert.deepStrictEqual(placeOf(box, ratio), expected, String(ratio));
-  }
-});
-
-test('a collapsed box never becomes a negative size', () => {
-  const place = placeOf({ left: 0, top: 0, width: -10, height: -10 }, 2);
-  assert.strictEqual(place.width, 0);
-  assert.strictEqual(place.height, 0);
-});
-
-test('the native monitor keeps a clipped stage and a scaled picture separate', () => {
-  const box = { left: 100, top: 50, width: 640, height: 360 };
-  const place = monitorPlaceOf(box, { zoom: 2, x: -100, y: -40 }, 2);
-  assert.deepStrictEqual(place.stage, { x: 200, y: 100, width: 1280, height: 720 });
-  assert.deepStrictEqual(place.content, { x: 0, y: 20, width: 2560, height: 1440 });
-});
-
-test('zooming at the cursor keeps the source point under it', () => {
-  const box = { width: 640, height: 360 };
-  const cursor = { x: 480, y: 270 };
-  const viewport = zoomViewport(fittedViewport(), box, cursor, 2);
-  assert.deepStrictEqual(viewport, { zoom: 2, x: -480, y: -270 });
-});
-
-test('panning cannot expose space past an enlarged monitor edge', () => {
-  const box = { width: 640, height: 360 };
-  assert.deepStrictEqual(
-    clampViewport({ zoom: 2, x: 20, y: -999 }, box),
-    { zoom: 2, x: 0, y: -360 }
-  );
-});
-
-test('panning against an edge does not place the unchanged viewport', async (t) => {
-  const previousWindow = global.window;
-  t.after(() => {
-    if (previousWindow === undefined) delete global.window;
-    else global.window = previousWindow;
-  });
-  global.window = { devicePixelRatio: 1 };
+test('panning against an edge does not place the unchanged viewport', async () => {
   const places = [];
   const preview = {
     mode: () => 'timeline',
@@ -91,10 +35,7 @@ test('panning against an edge does not place the unchanged viewport', async (t) 
     playbackVisible: async () => {},
     playbackPlace: async (place) => places.push(place),
   };
-  const stage = {
-    getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }),
-  };
-  const monitor = createMonitor({ preview, stage, api });
+  const monitor = createMonitor({ preview, wrap: panelStub(), api });
 
   await monitor.attach();
   monitor.zoomTo(2);
@@ -104,13 +45,7 @@ test('panning against an edge does not place the unchanged viewport', async (t) 
   assert.strictEqual(places.length, placeCount);
 });
 
-test('the native monitor yields to the editor-only selection pass', async (t) => {
-  const previousWindow = global.window;
-  t.after(() => {
-    if (previousWindow === undefined) delete global.window;
-    else global.window = previousWindow;
-  });
-  global.window = { devicePixelRatio: 1 };
+test('the native monitor yields to the editor-only selection pass', async () => {
   const visibility = [];
   const monitor = createMonitor({
     preview: {
@@ -120,7 +55,7 @@ test('the native monitor yields to the editor-only selection pass', async (t) =>
       clear: () => {},
       clearExact: () => {},
     },
-    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    wrap: panelStub(),
     api: {
       available: true,
       playbackAttach: async () => ({ engine: 'native' }),
@@ -135,13 +70,7 @@ test('the native monitor yields to the editor-only selection pass', async (t) =>
   assert.deepStrictEqual(visibility, [true, false, true]);
 });
 
-test('a page overlay keeps the preview in the webview', async (t) => {
-  const previousWindow = global.window;
-  t.after(() => {
-    if (previousWindow === undefined) delete global.window;
-    else global.window = previousWindow;
-  });
-  global.window = { devicePixelRatio: 1 };
+test('a page overlay keeps the preview in the webview', async () => {
   let attached = 0;
   const seeks = [];
   let overlayActive = false;
@@ -154,7 +83,7 @@ test('a page overlay keeps the preview in the webview', async (t) => {
       clearExact: () => {},
       seek: (frame) => seeks.push(frame),
     },
-    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    wrap: panelStub(),
     api: {
       available: true,
       playbackAttach: async () => {
@@ -175,13 +104,7 @@ test('a page overlay keeps the preview in the webview', async (t) => {
   assert.deepStrictEqual(seeks, [1]);
 });
 
-test('leaving native editing clears the page exact frame', async (t) => {
-  const previousWindow = global.window;
-  t.after(() => {
-    if (previousWindow === undefined) delete global.window;
-    else global.window = previousWindow;
-  });
-  global.window = { devicePixelRatio: 1 };
+test('leaving native editing clears the page exact frame', async () => {
   let cleared = 0;
   const monitor = createMonitor({
     preview: {
@@ -191,7 +114,7 @@ test('leaving native editing clears the page exact frame', async (t) => {
       clear: () => {},
       clearExact: () => { cleared += 1; },
     },
-    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    wrap: panelStub(),
     api: {
       available: true,
       playbackAttach: async () => ({ engine: 'native' }),
@@ -207,13 +130,182 @@ test('leaving native editing clears the page exact frame', async (t) => {
   assert.strictEqual(cleared, beforeClear + 1);
 });
 
-test('the same box twice is recognised, so a drag is not a command per frame', () => {
-  const box = { x: 1, y: 2, width: 3, height: 4 };
-  assert.ok(samePlace(box, { ...box }));
-  assert.ok(!samePlace(box, { ...box, x: 2 }));
-  assert.ok(!samePlace(box, { ...box, width: 5 }));
-  assert.ok(!samePlace(null, box));
-  assert.ok(!samePlace(box, null));
+// --- the box moving without changing size ----------------------------------
+//
+// This is the failure the placement was rewritten for. A `ResizeObserver` on
+// the stage fires on size and not on position, so a panel widening beside the
+// preview, the inspector opening, or a scrollbar appearing left the native view
+// where it was. It is over the webview and clipped by nothing, so it stayed on
+// top of the timeline until something happened to resize it.
+
+/** A panel whose box the test can move between calls, standing in for every
+ *  reason a page can move a box without resizing it. */
+function movablePanel(box) {
+  const state = { ...box };
+  return {
+    element: { getBoundingClientRect: () => ({ ...state }) },
+    moveTo(left, top) {
+      state.left = left;
+      state.top = top;
+    },
+    resizeTo(width, height) {
+      state.width = width;
+      state.height = height;
+    },
+  };
+}
+
+async function nativeMonitorOn(panel) {
+  const places = [];
+  let attachedAt = null;
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => {},
+    },
+    wrap: panel.element,
+    api: {
+      available: true,
+      playbackAttach: async (place) => {
+        attachedAt = place;
+        return { engine: 'native' };
+      },
+      playbackVisible: async () => {},
+      playbackPlace: async (place) => places.push(place),
+    },
+  });
+  await monitor.attach();
+  return { monitor, places, attachedAt: () => attachedAt };
+}
+
+test('a stage that moves without resizing is placed again', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  const { monitor, places, attachedAt } = await nativeMonitorOn(panel);
+  const before = attachedAt().stage;
+
+  panel.moveTo(240, 80);
+  monitor.place();
+  assert.strictEqual(places.length, 1);
+  const after = places[0].stage;
+  assert.deepStrictEqual(
+    { dx: after.x - before.x, dy: after.y - before.y },
+    { dx: 240, dy: 80 }
+  );
+  assert.strictEqual(after.width, before.width);
+  assert.strictEqual(after.height, before.height);
+});
+
+test('the same box twice is one command, so a drag is not a command per frame', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  const { monitor, places } = await nativeMonitorOn(panel);
+
+  panel.resizeTo(600, 360);
+  monitor.place();
+  monitor.place();
+  monitor.place();
+  assert.strictEqual(places.length, 1);
+});
+
+test('the placement keeps the project shape as the panel changes', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => {},
+    },
+    wrap: panel.element,
+    getProject: () => ({ settings: { width: 1000, height: 1000 } }),
+    api: {
+      available: true,
+      playbackAttach: async (place) => {
+        assert.strictEqual(place.stage.width, place.stage.height);
+        return { engine: 'native' };
+      },
+      playbackVisible: async () => {},
+      playbackPlace: async (place) => {
+        assert.strictEqual(place.stage.width, place.stage.height);
+      },
+    },
+  });
+
+  await monitor.attach();
+  for (const [width, height] of [[900, 360], [200, 700], [1200, 1200]]) {
+    panel.resizeTo(width, height);
+    monitor.place();
+  }
+});
+
+test('a panel dragged shut takes the view off screen, and reopening puts it back', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  const visibility = [];
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => {},
+    },
+    wrap: panel.element,
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async (visible) => visibility.push(visible),
+      playbackPlace: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  assert.deepStrictEqual(visibility, [true]);
+
+  panel.resizeTo(0, 0);
+  monitor.place();
+  assert.deepStrictEqual(visibility, [true, false]);
+
+  panel.resizeTo(640, 360);
+  monitor.place();
+  assert.deepStrictEqual(visibility, [true, false, true]);
+});
+
+// A panel with no room in it used to be a permanent fallback to the media
+// elements: attach gave up and nothing asked again. The layout genuinely does
+// settle over several frames when a project opens.
+test('an attach with no room to draw in is finished once there is', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 0, height: 0 });
+  let attached = 0;
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => {},
+    },
+    wrap: panel.element,
+    api: {
+      available: true,
+      playbackAttach: async () => {
+        attached += 1;
+        return { engine: 'native' };
+      },
+      playbackVisible: async () => {},
+      playbackPlace: async () => {},
+    },
+  });
+
+  assert.strictEqual(await monitor.attach(), false);
+  assert.strictEqual(attached, 0);
+  assert.strictEqual(monitor.usesNativeMonitor(), false);
+
+  panel.resizeTo(640, 360);
+  assert.strictEqual(await monitor.attach(), true);
+  assert.strictEqual(attached, 1);
 });
 
 test('a native monitor is used and reports nothing', () => {
@@ -269,13 +361,7 @@ test('the router answers everything the page asks a preview for', () => {
   assert.deepStrictEqual(missing, []);
 });
 
-test('a ready proxy waits for playback to stop before replacing the native session', async (t) => {
-  const previousWindow = global.window;
-  t.after(() => {
-    if (previousWindow === undefined) delete global.window;
-    else global.window = previousWindow;
-  });
-  global.window = { devicePixelRatio: 1 };
+test('a ready proxy waits for playback to stop before replacing the native session', async () => {
   const calls = [];
   const preview = {
     mode: () => 'timeline',
@@ -302,7 +388,7 @@ test('a ready proxy waits for playback to stop before replacing the native sessi
   };
   const monitor = createMonitor({
     preview,
-    stage: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 640, height: 360 }) },
+    wrap: panelStub(),
     api,
     getProject: () => ({ settings: { rate: { numerator: 30, denominator: 1 } } }),
   });
@@ -388,7 +474,9 @@ test('with no monitor attached the transport reaches the media elements', () => 
 
 const { shouldShowMonitor } = require('../src/monitor.js');
 
-const showing = { native: true, timeline: true, hasContent: true, covered: false };
+const showing = {
+  native: true, timeline: true, hasContent: true, roomy: true, covered: false,
+};
 
 test('a native monitor showing a timeline with clips on it is visible', () => {
   assert.strictEqual(shouldShowMonitor(showing), true);
@@ -404,6 +492,12 @@ test('an empty timeline hides the view, or it covers the drop hint', () => {
 
 test('a sheet or an open menu hides the view', () => {
   assert.strictEqual(shouldShowMonitor({ ...showing, covered: true }), false);
+});
+
+// A panel dragged shut has no box to place a view at, and a view placed at
+// nothing is a pixel of black in the corner rather than an absence.
+test('a panel with no room in it hides the view', () => {
+  assert.strictEqual(shouldShowMonitor({ ...showing, roomy: false }), false);
 });
 
 test('with no native session there is nothing to show', () => {

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -8,14 +8,39 @@ const vm = require('node:vm');
 
 test('classic page scripts do not leak conflicting declarations', () => {
   const context = vm.createContext({});
-  for (const name of ['time.js', 'timeline.js', 'shortcuts.js', 'quality.js', 'preview.js']) {
+  const names = [
+    'time.js', 'geometry.js', 'timeline.js', 'shortcuts.js', 'quality.js',
+    'preview.js', 'transform.js', 'guides.js', 'monitor.js',
+  ];
+  for (const name of names) {
     const file = path.join(__dirname, '..', 'src', name);
     vm.runInContext(fs.readFileSync(file, 'utf8'), context, { filename: file });
   }
 
   assert.ok(context.timeLib);
+  assert.ok(context.geometryLib);
   assert.ok(context.timelineLib);
   assert.ok(context.shortcutLib);
   assert.ok(context.qualityLib);
   assert.ok(context.previewLib);
+  assert.ok(context.monitorLib);
+});
+
+// Each of these is loaded with a `<script>` tag and reached through its one
+// global. A file left out of index.html is a global that is not there when the
+// file needing it runs, which is a TypeError on the first frame and a dead
+// page — the whole editor, not the one control that needed it.
+test('every library the page loads is a script tag on the page', () => {
+  const page = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+  const loaded = [...page.matchAll(/<script src="([^"]+)"><\/script>/g)].map((match) => match[1]);
+  const sources = fs
+    .readdirSync(path.join(__dirname, '..', 'src'))
+    .filter((name) => name.endsWith('.js'));
+
+  assert.deepStrictEqual(sources.filter((name) => !loaded.includes(name)), []);
+  // Order matters as much as presence: a global is read when the file using it
+  // is evaluated, so a dependency loaded after its dependant is not there yet.
+  assert.ok(loaded.indexOf('geometry.js') < loaded.indexOf('preview.js'));
+  assert.ok(loaded.indexOf('geometry.js') < loaded.indexOf('monitor.js'));
+  assert.ok(loaded.indexOf('preview.js') < loaded.indexOf('renderer.js'));
 });


### PR DESCRIPTION
# 구현

stage box 계산을 src/geometry.js 하나로 모으고, IPC 좌표를 point로 넘기며, 배치 갱신을 animation frame 재측정으로 교체
- 페이지 테스트 117개 통과(geometry 18개 신규), app crate cargo check와 cargo test --lib 통과

# 어려웠던 점

증상 두 개가 서로 다른 버그로 보였으나 원인이 셋으로 갈라져 있었고, 셋 다 조용히 실패하는 종류였음
- 좌표 왕복은 두 값이 같을 때만 맞아서 대부분의 실행에서 정상으로 보였고, ResizeObserver는 크기가 안 바뀌면 아예 안 불렸으며, 폭과 높이에 따로 걸린 최소값은 작은 panel에서만 드러남

# 리스크


배치 계산이 매 animation frame마다 panel을 getBoundingClientRect로 읽음
- 프레임당 layout read 한 번이고 전송은 samePlace가 막지만, 재생 중 프로파일에서 문제가 보이면 측정 주기를 낮추는 것이 다음 수단

Issue #875

