### PR TITLE
fix(akbun-makevideo): native preview 원점 보정

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-css-viewport-starts-at-native-bounds-origin.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-css-viewport-starts-at-native-bounds-origin.md
@@ -1,0 +1,23 @@
+---
+type: Decision
+title: CSS viewport 원점은 native bounds origin에서 시작한다
+description: getBoundingClientRect 좌표를 native subview frame으로 옮길 때 NSView bounds의 크기뿐 아니라 origin도 반영하기로 한 결정.
+tags: [makevideo, viewport, macos, appkit]
+timestamp: 2026-08-12T00:00:00Z
+---
+
+# CSS viewport 원점은 native bounds origin에서 시작한다
+
+## 결정
+
+* CSS viewport 좌표는 WKWebView frame의 0이 아니라 visible bounds의 origin을 기준으로 native frame에 더함
+* flipped 여부와 bounds origin을 함께 적용하고 x와 y 모두 같은 규칙 사용
+
+## 이유
+
+* `getBoundingClientRect()`는 보이는 viewport의 좌상단을 0으로 반환하지만 NSView subview frame은 superview bounds 좌표계에 놓임
+* bounds origin을 0으로 가정하면 native surface만 page preview보다 위로 이동하며, 크기와 비율이 같아도 서로 다른 자리에 표시됨
+
+## Citations
+
+1. [native view 좌표는 superview에게 원점을 물어본다](./2026-08-native-view-asks-its-superview-for-the-origin.md)

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -9,3 +9,4 @@
 * [재생 끊김은 경로별 계측으로 원인을 분리](2026-08-playback-stutter-is-measured-by-stage.md) - 공급과 표시와 A/V 지연을 따로 보고 구조 교체를 미룬 결정.
 * [경계 stub은 실제 API 이름만 가진다](2026-08-seam-stubs-carry-only-real-api-names.md) - 무엇에나 답하는 Proxy stub이 없는 메서드 호출을 숨긴 뒤 정한 규칙.
 * [preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다](2026-08-one-geometry-in-points-for-the-monitor.md) - devicePixelRatio 왕복과 크기만 보는 ResizeObserver를 없애고 배치 계산을 한 곳에 모은 결정.
+* [CSS viewport 원점은 native bounds origin에서 시작한다](2026-08-css-viewport-starts-at-native-bounds-origin.md) - page 좌표를 native frame으로 옮길 때 NSView bounds origin을 반영하는 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-12
+
+* [CSS viewport 원점은 native bounds origin에서 시작한다](decisions/2026-08-css-viewport-starts-at-native-bounds-origin.md) 결정 기록. 같은 크기의 media element와 native surface가 세로로 어긋난 원인을 WKWebView bounds origin 누락으로 좁힘.
+
 ## 2026-08-11
 
 * [preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다](decisions/2026-08-one-geometry-in-points-for-the-monitor.md) 결정 기록. native monitor가 preview 밖에 그려지고 비율이 어긋나던 원인을 좌표 왕복과 크기만 보는 관찰자로 좁히고 geometry.js로 계산을 모음.

--- a/product/akbun-makevideo/wiki/architecture/viewport.md
+++ b/product/akbun-makevideo/wiki/architecture/viewport.md
@@ -160,6 +160,11 @@ element stack and the native view are laid out from the same call on the same
 inputs — the preview panel's box and the project's shape — rather than one of
 them measuring what the other one drew.
 
+The page's zero is the visible WebView bounds, not necessarily coordinate zero
+inside its `NSView`. The native side adds `bounds.origin` before placing the
+subview; omitting it moves only the native picture while the page stage remains
+centred.
+
 Two things follow from that, and both were bugs before it:
 
 - **Units are points**, all the way across the IPC boundary. A CSS pixel in the

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.31.1",
+  "version": "0.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.31.1",
+      "version": "0.32.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -254,11 +254,13 @@ pub fn target(inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
 
 /// The page's rectangle as AppKit's inside the WebView.
 ///
-/// One conversion, and it is the y origin: the superview is asked which corner
-/// it measures from — `WKWebView` is flipped, so a top-left `y` passes through
-/// unchanged there — and nothing else is touched. The numbers arriving are
-/// points, which is what `setFrame` takes, because a CSS pixel in the page and
-/// an AppKit point in a view inside that page's WebView are the same length.
+/// One conversion, and it is the coordinate origin: the page starts at the
+/// visible top-left of the WebView, which is `bounds.origin` rather than zero.
+/// The superview is also asked which corner it measures from — `WKWebView` is
+/// flipped, so a top-left `y` grows down from that bounds origin. The numbers
+/// arriving are points, which is what `setFrame` takes, because a CSS pixel in
+/// the page and an AppKit point in a view inside that page's WebView are the
+/// same length.
 ///
 /// There used to be a second conversion here, dividing by the view's backing
 /// scale to undo a multiplication the page had done by `devicePixelRatio`.
@@ -266,12 +268,19 @@ pub fn target(inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
 /// between two numbers measured in different places, and the frames where they
 /// disagreed put the monitor at twice its offset and twice its size.
 fn rect(host: &NSView, at: Place) -> NSRect {
+    let bounds = host.bounds();
     let width = at.width.max(1.0);
     let height = at.height.max(1.0);
     NSRect::new(
         NSPoint::new(
-            at.x,
-            origin_y(host.isFlipped(), host.bounds().size.height, at.y, height),
+            bounds.origin.x + at.x,
+            origin_y(
+                host.isFlipped(),
+                bounds.origin.y,
+                bounds.size.height,
+                at.y,
+                height,
+            ),
         ),
         NSSize::new(width, height),
     )
@@ -280,14 +289,16 @@ fn rect(host: &NSView, at: Place) -> NSRect {
 /// The picture inside the container that clips it, so its origin is relative to
 /// the stage rather than to the WebView.
 fn child_rect(container: &NSView, at: MonitorPlace) -> NSRect {
+    let bounds = container.bounds();
     let width = at.content.width.max(1.0);
     let height = at.content.height.max(1.0);
     NSRect::new(
         NSPoint::new(
-            at.content.x - at.stage.x,
+            bounds.origin.x + at.content.x - at.stage.x,
             origin_y(
                 container.isFlipped(),
-                container.bounds().size.height,
+                bounds.origin.y,
+                bounds.size.height,
                 at.content.y - at.stage.y,
                 height,
             ),
@@ -296,13 +307,19 @@ fn child_rect(container: &NSView, at: MonitorPlace) -> NSRect {
     )
 }
 
-/// A frame origin for a box whose top edge is `top` points below the
-/// superview's top, in whichever coordinate origin that superview uses.
-fn origin_y(flipped: bool, superview_height: f64, top: f64, height: f64) -> f64 {
+/// A frame origin for a box whose top edge is `top` points below the visible
+/// bounds, in whichever coordinate origin that superview uses.
+fn origin_y(
+    flipped: bool,
+    bounds_origin: f64,
+    superview_height: f64,
+    top: f64,
+    height: f64,
+) -> f64 {
     if flipped {
-        top
+        bounds_origin + top
     } else {
-        superview_height - top - height
+        bounds_origin + superview_height - top - height
     }
 }
 
@@ -310,14 +327,20 @@ fn origin_y(flipped: bool, superview_height: f64, top: f64, height: f64) -> f64 
 mod tests {
     use super::origin_y;
 
-    /// WKWebView is flipped, so a top-left `y` passes through unchanged; the
-    /// plain container is not, so its children flip against its height. The
-    /// first case is the one the monitor actually lives in — getting it wrong
-    /// mirrors the picture to the far side of the window.
+    /// WKWebView is flipped, so a top-left `y` grows down from its bounds
+    /// origin; the plain container is not, so its children flip against its
+    /// height. The first case is the one the monitor actually lives in —
+    /// getting it wrong mirrors the picture to the far side of the window.
     #[test]
     fn origin_matches_the_superview_coordinate_origin() {
-        assert_eq!(origin_y(true, 800.0, 50.0, 200.0), 50.0);
-        assert_eq!(origin_y(false, 800.0, 50.0, 200.0), 550.0);
+        assert_eq!(origin_y(true, 0.0, 800.0, 50.0, 200.0), 50.0);
+        assert_eq!(origin_y(false, 0.0, 800.0, 50.0, 200.0), 550.0);
+    }
+
+    #[test]
+    fn origin_starts_at_the_visible_bounds() {
+        assert_eq!(origin_y(true, 32.0, 800.0, 50.0, 200.0), 82.0);
+        assert_eq!(origin_y(false, 32.0, 800.0, 50.0, 200.0), 582.0);
     }
 }
 


### PR DESCRIPTION
# 구현

WKWebView visible bounds origin을 native preview frame 좌표에 반영하고 0.32.1로 patch bump
- Computer Use로 test.mp4 비교, Node 117개·Rust 15개 테스트와 cargo check 통과

# 어려웠던 점

PR #876 이후 크기와 9:16 비율은 일치했으나 native surface만 약 31 CSS px 위로 이동
- CPU media element와 GPU native surface를 같은 프로젝트에서 비교해 bounds origin 누락으로 원인 분리

# 리스크

AppKit native subview 좌표 변환 경로만 변경
- bounds origin이 0인 창은 기존 결과 유지, non-zero inset이 있는 창만 원점 보정

Issue #879