### PR TITLE
fix: GPU Program Monitor 좌표와 재생 품질 수정

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-native-monitor-is-a-window-overlay.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-native-monitor-is-a-window-overlay.md
@@ -1,0 +1,30 @@
+---
+type: Decision
+title: native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다
+description: Metal view를 WebKit 내부가 아닌 window content view에 두고 WKWebView 좌표를 AppKit API로 변환하는 결정.
+tags: [makevideo, viewport, macos, appkit, gpu]
+timestamp: 2026-08-12T00:00:00Z
+---
+
+# native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다
+
+## 결정
+
+* Metal container를 WKWebView 하위가 아닌 window content view의 sibling overlay로 배치
+* `getBoundingClientRect()` 결과는 CSS point 단위로 유지
+* `convertRect:toView:`로 WKWebView 좌표를 overlay 좌표로 변환
+* native 배치 IPC는 직렬화하고 대기 중인 좌표는 최신 값만 유지
+* `devicePixelRatio`는 배율 변경 신호로만 사용하고 backing size는 AppKit view에서 조회
+
+## 이유
+
+* WebKit 내부에 Metal layer를 넣으면 WebKit compositing layer와 native layer의 좌표·clip 수명이 결합됨
+* `bounds.origin` 한 값을 보정해도 title bar, flipped axis, ancestor transform을 모두 설명하지 못함
+* AppKit view conversion은 실제 view hierarchy를 기준으로 전체 변환을 한 번에 적용
+* CPU preview와 GPU preview는 모두 project 비율을 유지하며 GPU 차이는 영상 비율이 아닌 native surface 배치 문제였음
+
+## 대체안
+
+* `translateZ(0)`과 `z-index`는 별도 native Metal view의 좌표를 수정하지 못해 제외
+* CSS 좌표에 `devicePixelRatio`를 곱하는 방식은 point와 physical pixel을 혼합하므로 제외
+* WKWebView `bounds.origin` 수동 보정만으로 고정하는 방식은 WebKit hierarchy 변화에 취약해 제외

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,7 @@
 
 ## 목록
 
+* [native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다](2026-08-native-monitor-is-a-window-overlay.md) - GPU surface를 WebKit hierarchy에서 분리하고 실제 view 사이 좌표 변환을 AppKit에 맡긴 결정.
 * [첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다](2026-08-first-video-defines-default-canvas-shape.md) - 첫 영상 비율을 채택하되 기본 긴 변 해상도를 유지하는 결정.
 * [native view 좌표는 superview에게 원점을 물어본다](2026-08-native-view-asks-its-superview-for-the-origin.md) - WKWebView가 flipped view라 bottom-left 가정이 monitor를 뒤집힌 위치에 놓은 뒤 정한 규칙.
 * [filter graph 렌더는 rasterize한 still을 overlay로 굽는다](2026-08-graph-render-overlays-rasterized-stills.md) - CPU 렌더와 폴백에서 text/shape가 빠지던 것을 자체 raster + overlay로 해결한 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-12
 
+* [native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다](decisions/2026-08-native-monitor-is-a-window-overlay.md) 결정 기록. GPU preview 오프셋을 WebKit 내부 layer 문제가 아닌 window overlay 좌표 변환 문제로 분리함.
 * [CSS viewport 원점은 native bounds origin에서 시작한다](decisions/2026-08-css-viewport-starts-at-native-bounds-origin.md) 결정 기록. 같은 크기의 media element와 native surface가 세로로 어긋난 원인을 WKWebView bounds origin 누락으로 좁힘.
 
 ## 2026-08-11

--- a/product/akbun-makevideo/wiki/architecture/viewport.md
+++ b/product/akbun-makevideo/wiki/architecture/viewport.md
@@ -160,16 +160,17 @@ element stack and the native view are laid out from the same call on the same
 inputs — the preview panel's box and the project's shape — rather than one of
 them measuring what the other one drew.
 
-The page's zero is the visible WebView bounds, not necessarily coordinate zero
-inside its `NSView`. The native side adds `bounds.origin` before placing the
-subview; omitting it moves only the native picture while the page stage remains
-centred.
+The page's zero is the visible WebView bounds. The Metal view is a sibling
+overlay in the window content view, outside WebKit's private view hierarchy.
+The native side forms a rectangle in visible WebView coordinates and asks
+AppKit to convert it into the overlay; it does not guess `bounds.origin`, title
+bar offsets, flipped axes or ancestor transforms.
 
 Two things follow from that, and both were bugs before it:
 
 - **Units are points**, all the way across the IPC boundary. A CSS pixel in the
-  page and an AppKit point inside that page's WebView are the same length, so
-  `setFrame` takes the numbers as they arrive. The page used to multiply by
+  page and an AppKit point are the same length, so only the coordinate space is
+  converted. The page used to multiply by
   `devicePixelRatio` and Rust used to divide by the view's backing scale, which
   is a round trip that lands where it started only while the two agree. When
   they did not — a window moved to a display with a different scale factor,
@@ -178,6 +179,9 @@ Two things follow from that, and both were bugs before it:
 - **Physical pixels are asked of the view**, in the same main thread hop that
   moved it and after the move rather than before. That is the only reading that
   knows which display the window ended up on, and it is all a swapchain needs.
+- **Scale changes are placement events**, even when the CSS rectangle is
+  unchanged. `devicePixelRatio` is sent only as a change signal; AppKit remains
+  the authority for the Metal backing size.
 
 There are no minimum sizes in the fit. A stage held up to a floor is wider than
 the panel holding it, and a native view is not in the page's stacking order, so
@@ -189,8 +193,9 @@ which is the fifth input to the visibility rule below.
 ## The box is re-measured every frame
 
 The monitor already runs an animation frame to poll the playhead, so the panel
-is measured there and `samePlace` decides whether anything needs sending. A
-drag is one command per pixel the box actually moved.
+is measured there and `samePlace` decides whether anything needs sending.
+Placement IPC is serialized and collapses waiting measurements to the newest
+box, so a slow native call cannot finish with an older frame.
 
 This replaced a `ResizeObserver` on the stage, which fires on size and not on
 position. A sibling panel widening, the inspector opening, the timeline growing,

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,12 +1,13 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",
   "license": "MIT",
   "scripts": {
     "start": "tauri dev",
+    "build:alpha": "tauri build --debug --bundles app --config src-tauri/tauri.alpha.conf.json",
     "test": "node --test test/*.test.js",
     "test:time": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-time",
     "test:edit": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-edit",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/probe.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/probe.rs
@@ -19,7 +19,7 @@ pub fn args(path: &str) -> Vec<String> {
         "-v".into(),
         "error".into(),
         "-show_entries".into(),
-        "stream=codec_type,width,height:format=duration".into(),
+        "stream=codec_type,width,height:stream_side_data=rotation:format=duration".into(),
         "-of".into(),
         "default=noprint_wrappers=1".into(),
         path.into(),
@@ -35,6 +35,7 @@ pub fn parse(text: &str) -> Probed {
     let mut current_type = "";
     let mut pending_width = 0u32;
     let mut pending_height = 0u32;
+    let mut pending_rotation = 0i32;
     let mut have_video = false;
 
     for line in text.lines() {
@@ -45,8 +46,8 @@ pub fn parse(text: &str) -> Probed {
             "codec_type" => {
                 // The previous block is finished, so commit what it carried.
                 if current_type == "video" && !have_video && pending_width > 0 {
-                    probed.width = pending_width;
-                    probed.height = pending_height;
+                    (probed.width, probed.height) =
+                        display_size(pending_width, pending_height, pending_rotation);
                     have_video = true;
                 }
                 current_type = match value {
@@ -59,9 +60,11 @@ pub fn parse(text: &str) -> Probed {
                 };
                 pending_width = 0;
                 pending_height = 0;
+                pending_rotation = 0;
             }
             "width" => pending_width = value.parse().unwrap_or(0),
             "height" => pending_height = value.parse().unwrap_or(0),
+            "rotation" => pending_rotation = value.parse().unwrap_or(0),
             // N/A for a still image, and for a stream with no known length.
             "duration" => {
                 if let Ok(seconds) = value.parse::<f64>() {
@@ -74,10 +77,18 @@ pub fn parse(text: &str) -> Probed {
         }
     }
     if current_type == "video" && !have_video && pending_width > 0 {
-        probed.width = pending_width;
-        probed.height = pending_height;
+        (probed.width, probed.height) =
+            display_size(pending_width, pending_height, pending_rotation);
     }
     probed
+}
+
+fn display_size(width: u32, height: u32, rotation: i32) -> (u32, u32) {
+    if rotation.rem_euclid(180) == 90 {
+        (height, width)
+    } else {
+        (width, height)
+    }
 }
 
 #[cfg(test)]
@@ -104,6 +115,24 @@ mod tests {
     fn a_silent_video_is_not_given_an_audio_stream_it_does_not_have() {
         let probed = parse("codec_type=video\nwidth=640\nheight=360\nduration=2.0\n");
         assert!(!probed.has_audio);
+    }
+
+    #[test]
+    fn display_rotation_swaps_the_stored_video_dimensions() {
+        for rotation in [-90, 90, 270] {
+            let probed = parse(&format!(
+                "codec_type=video\nwidth=1920\nheight=1080\nrotation={rotation}\nduration=3.0\n"
+            ));
+            assert_eq!((probed.width, probed.height), (1080, 1920));
+        }
+    }
+
+    #[test]
+    fn a_half_turn_keeps_the_stored_video_dimensions() {
+        let probed = parse(
+            "codec_type=video\nwidth=1920\nheight=1080\nrotation=180\nduration=3.0\n",
+        );
+        assert_eq!((probed.width, probed.height), (1920, 1080));
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -1584,8 +1584,23 @@ pub fn open_project(
 ) -> Result<DocumentState, String> {
     let text =
         std::fs::read_to_string(&path).map_err(|error| format!("cannot open {path}: {error}"))?;
-    let project: Project =
+    let mut project: Project =
         serde_json::from_str(&text).map_err(|error| format!("{path} is not a project: {error}"))?;
+    let configured = state.settings.lock().unwrap().ffmpeg_dir.clone();
+    let ffprobe = find_tool(&app, "ffprobe", &configured);
+    if ffprobe.is_some() {
+        for asset in &mut project.assets {
+            let measured = probe_asset(ffprobe.as_ref(), &asset.path);
+            if measured.width > 0 && measured.height > 0 {
+                asset.width = measured.width;
+                asset.height = measured.height;
+            }
+            if measured.duration_ms > 0 {
+                asset.duration_ms = measured.duration_ms;
+            }
+            asset.has_audio = measured.has_audio;
+        }
+    }
     // The scope grant is in memory only, so a project opened in a new run has
     // to grant its media again or every preview is blank.
     for asset in &project.assets {
@@ -2285,14 +2300,14 @@ fn start_session(
     let hwaccel = acceleration(state, Some(&ffmpeg))
         .available
         .and_then(|candidate| candidate.hwaccel);
-    let config = PlaybackConfig::new(
-        compositor,
-        ffmpeg,
-        project.settings.width.max(2),
-        project.settings.height.max(2),
-    )
-    .with_proxies(proxy_paths)
-    .with_hwaccel(hwaccel);
+    let (preview_width, preview_height) = native_preview_dimensions(
+        project.settings.width,
+        project.settings.height,
+        &settings.preview_quality,
+    );
+    let config = PlaybackConfig::new(compositor, ffmpeg, preview_width, preview_height)
+        .with_proxies(proxy_paths)
+        .with_hwaccel(hwaccel);
     Session::start(
         window,
         Arc::clone(&state.document),
@@ -2300,6 +2315,19 @@ fn start_session(
         place,
         frame.max(0),
     )
+}
+
+fn native_preview_dimensions(width: u32, height: u32, quality: &str) -> (u32, u32) {
+    let divisor = match quality {
+        "full" => 1,
+        "half" => 2,
+        _ => 4,
+    };
+    let scaled = |value: u32| {
+        let value = (value / divisor).max(2);
+        value - value % 2
+    };
+    (scaled(width), scaled(height))
 }
 
 /// Stop the native monitor and take its view down. The page falls back to its
@@ -2380,8 +2408,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        process_metrics_rows, process_tree_rss_bytes, srt_contents, srt_cues, srt_frame,
-        srt_timestamp, wanted_device, Settings,
+        native_preview_dimensions, process_metrics_rows, process_tree_rss_bytes, srt_contents,
+        srt_cues, srt_frame, srt_timestamp, wanted_device, Settings,
     };
     use makevideo_render::Rate;
 
@@ -2441,6 +2469,14 @@ mod tests {
         assert!(!settings.show_title_safe_area);
         assert!(!settings.show_rule_of_thirds);
         assert!(!settings.show_center_lines);
+    }
+
+    #[test]
+    fn native_monitor_honours_preview_quality() {
+        assert_eq!(native_preview_dimensions(1920, 1080, "full"), (1920, 1080));
+        assert_eq!(native_preview_dimensions(1920, 1080, "half"), (960, 540));
+        assert_eq!(native_preview_dimensions(1920, 1080, "quarter"), (480, 270));
+        assert_eq!(native_preview_dimensions(1080, 1920, "quarter"), (270, 480));
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -20,13 +20,6 @@ pub fn run() {
 
     builder
         .setup(|app| {
-            // The window is the whole app, so the webview console is where
-            // almost every bug shows up first. Debug builds only.
-            #[cfg(debug_assertions)]
-            if let Some(window) = app.get_webview_window("main") {
-                window.open_devtools();
-            }
-
             let handle = app.handle();
             let settings = store::load_settings(handle);
             commands::apply_theme(handle, &settings.theme);

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -105,6 +105,7 @@ pub struct Status {
     pub peak_present_ms: f64,
     pub last_late_ms: f64,
     pub peak_late_ms: f64,
+    pub viewport_geometry: String,
     pub failure: Option<String>,
 }
 
@@ -315,6 +316,7 @@ impl Session {
             peak_present_ms: milliseconds(self.counters.peak_present_us.load(Ordering::Relaxed)),
             last_late_ms: signed_milliseconds(self.counters.last_late_us.load(Ordering::Relaxed)),
             peak_late_ms: signed_milliseconds(self.counters.peak_late_us.load(Ordering::Relaxed)),
+            viewport_geometry: self.viewport.lock().unwrap().debug_geometry(),
             failure: self.shared.failure(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/macos.rs
@@ -15,16 +15,12 @@
 //! not an AppKit message: wgpu attaches a `CAMetalLayer` and then talks to
 //! Metal, which is safe from any thread.
 //!
-//! # Why the coordinates are (sometimes) flipped
+//! # One AppKit conversion owns the coordinate boundary
 //!
-//! AppKit's default origin is the **bottom** left of a view and the page's is
-//! the top left — but `WKWebView` overrides `isFlipped` to `YES`, so frames of
-//! its subviews are already measured from the top. Everything else in the app
-//! speaks the page's coordinates, so the conversion happens here, once, at the
-//! boundary — the same place the physical-pixel conversion happens — and it
-//! asks the superview which origin it uses rather than assuming one. Assuming
-//! bottom-left is exactly what put the monitor at the vertically mirrored
-//! position when the container moved from the content view into the WebView.
+//! The page measures from the visible viewport's top-left in `WKWebView`. The
+//! monitor is a sibling overlay in the window content view, so AppKit converts
+//! the rectangle between those two views. No title-bar offset or ancestor
+//! transform is reconstructed by hand.
 
 use super::{MonitorPlace, Place};
 use objc2::rc::Retained;
@@ -36,7 +32,7 @@ use raw_window_handle::{
     HasWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle,
 };
 use std::ptr::NonNull;
-use std::sync::mpsc::channel;
+use std::sync::{mpsc::channel, Arc, Mutex};
 
 pub struct Inner {
     /// Clips the enlarged Metal view to the monitor rectangle and lets pointer
@@ -45,6 +41,7 @@ pub struct Inner {
     /// A retained `NSView`. Released in `detach`, on the main thread.
     view: Handle,
     window: tauri::WebviewWindow,
+    geometry: Arc<Mutex<String>>,
 }
 
 struct PassThroughIvars;
@@ -55,6 +52,11 @@ define_class!(
     struct PassThroughView;
 
     impl PassThroughView {
+        #[unsafe(method(isFlipped))]
+        fn is_flipped(&self) -> bool {
+            true
+        }
+
         #[unsafe(method(hitTest:))]
         fn hit_test(&self, _point: NSPoint) -> Option<&NSView> {
             None
@@ -126,12 +128,9 @@ impl HasDisplayHandle for ViewTarget {
 
 /// Run `work` against the actual WebKit view and wait for what it returns.
 ///
-/// The page measures the stage from the WebView's top-left corner. Its
-/// `getBoundingClientRect()` values therefore only describe this view, not the
-/// window content view: title bars, future toolbars and an inset WebView would
-/// otherwise shift the native monitor outside the Program Monitor. Keeping the
-/// native container in the same `WKWebView` makes the two coordinate systems
-/// identical.
+/// The callback supplies the source coordinate system for AppKit's conversion
+/// into the window overlay. This keeps WebKit's private subview hierarchy out
+/// of the placement arithmetic.
 ///
 /// Waiting is deliberate. Attaching and placing are rare — a project opening,
 /// a panel resizing — and a caller that carried on without knowing whether the
@@ -162,39 +161,43 @@ where
         .map_err(|error| format!("the WebView never answered: {error}"))?
 }
 
+fn overlay_host(host: &NSView) -> Result<Retained<NSView>, String> {
+    host.window()
+        .and_then(|window| window.contentView())
+        .ok_or_else(|| "the WebView window has no content view".to_string())
+}
+
 pub fn attach(window: &tauri::WebviewWindow, place: MonitorPlace) -> Result<Inner, String> {
-    let handles = on_webview(window, move |main, host| {
-        let container = PassThroughView::new(main, rect(host, place.stage));
+    let ((container, view), report) = on_webview(window, move |main, host| {
+        let overlay = overlay_host(host)?;
+        let container = PassThroughView::new(main, overlay_rect(host, &overlay, place.stage));
         container.setWantsLayer(true);
         container.setClipsToBounds(true);
-        // Over the page, but *inside* its WebView. A `None` sibling with
-        // `Above` means "over all of them", which is the front. The page hides
-        // it before drawing anything on top; see the note in mod.rs for why it
-        // is not the other way round.
-        //
-        // Into the window *before* the child is measured: a view with no
-        // window answers `convertRectToBacking` with whatever the main screen
-        // happens to be, which is the wrong scale whenever this window is on
-        // another display.
-        host.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Above, None);
-        let view = NSView::initWithFrame(NSView::alloc(main), child_rect(&container, place));
+        // The overlay is outside WebKit's private view hierarchy. AppKit owns
+        // the conversion into this coordinate system, and `None` places it at
+        // the front of the window content view.
+        overlay.addSubview_positioned_relativeTo(&container, NSWindowOrderingMode::Above, None);
+        let view = NSView::initWithFrame(NSView::alloc(main), child_rect(place));
         // Metal draws into this view's layer, so it has to have one. wgpu
         // replaces it with a CAMetalLayer when it makes the surface; without
         // this the view is not layer backed and there is nothing to replace.
         view.setWantsLayer(true);
         container.addSubview(&view);
+        let report = geometry_report(host, &overlay, &container, &view, place);
         // Retained past the end of this block on purpose: the `Viewport` owns
         // it now and `detach` is what releases it.
         let pointer =
             NonNull::new(Retained::into_raw(view)).ok_or("the monitor view has no address")?;
         let container = NonNull::new(Retained::into_raw(container))
             .ok_or("the monitor container has no address")?;
-        Ok((Handle(container.cast()), Handle(pointer)))
+        let handles = (Handle(container.cast()), Handle(pointer));
+        Ok((handles, report))
     })?;
     Ok(Inner {
-        container: handles.0,
-        view: handles.1,
+        container,
+        view,
         window: window.clone(),
+        geometry: Arc::new(Mutex::new(report)),
     })
 }
 
@@ -208,17 +211,70 @@ pub fn attach(window: &tauri::WebviewWindow, place: MonitorPlace) -> Result<Inne
 pub fn place(inner: &Inner, at: MonitorPlace) -> (u32, u32) {
     let view = inner.view;
     let container = inner.container;
+    let geometry = Arc::clone(&inner.geometry);
     on_webview(&inner.window, move |_, host| {
+        let overlay = overlay_host(host)?;
         // SAFETY: both views are alive until `detach` releases the container.
         let container = unsafe { container.ptr().as_ref() };
-        container.setFrame(rect(host, at.stage));
+        container.setFrame(overlay_rect(host, &overlay, at.stage));
         let view = unsafe { view.ptr().as_ref() };
-        view.setFrame(child_rect(container, at));
+        view.setFrame(child_rect(at));
+        *geometry.lock().unwrap() = geometry_report(host, &overlay, container, view, at);
         Ok(backing_size(view))
     })
     // Placement is best effort: a window that has gone during a resize is a
     // window nobody is looking at. A surface still may not be sized at zero.
     .unwrap_or((1, 1))
+}
+
+pub fn debug_geometry(inner: &Inner) -> String {
+    inner.geometry.lock().unwrap().clone()
+}
+
+fn rect_text(rect: NSRect) -> String {
+    format!(
+        "({:.1},{:.1} {:.1}x{:.1})",
+        rect.origin.x, rect.origin.y, rect.size.width, rect.size.height
+    )
+}
+
+fn geometry_report(
+    host: &NSView,
+    overlay: &NSView,
+    container: &NSView,
+    view: &NSView,
+    requested: MonitorPlace,
+) -> String {
+    let content_layout = host
+        .window()
+        .map(|window| rect_text(window.contentLayoutRect()))
+        .unwrap_or_else(|| "unavailable".into());
+    format!(
+        "requested stage=({:.1},{:.1} {:.1}x{:.1}) content=({:.1},{:.1} {:.1}x{:.1}); host frame={} bounds={} visible={} safe={} flipped={}; overlay frame={} bounds={} flipped={}; contentLayout={}; container frame={} bounds={} flipped={}; view frame={} bounds={} flipped={}",
+        requested.stage.x,
+        requested.stage.y,
+        requested.stage.width,
+        requested.stage.height,
+        requested.content.x,
+        requested.content.y,
+        requested.content.width,
+        requested.content.height,
+        rect_text(host.frame()),
+        rect_text(host.bounds()),
+        rect_text(host.visibleRect()),
+        rect_text(host.safeAreaRect()),
+        host.isFlipped(),
+        rect_text(overlay.frame()),
+        rect_text(overlay.bounds()),
+        overlay.isFlipped(),
+        content_layout,
+        rect_text(container.frame()),
+        rect_text(container.bounds()),
+        container.isFlipped(),
+        rect_text(view.frame()),
+        rect_text(view.bounds()),
+        view.isFlipped(),
+    )
 }
 
 pub fn set_visible(inner: &Inner, visible: bool) {
@@ -252,80 +308,58 @@ pub fn target(inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
     ))))
 }
 
-/// The page's rectangle as AppKit's inside the WebView.
+/// The page's rectangle converted into the window overlay's coordinates.
 ///
-/// One conversion, and it is the coordinate origin: the page starts at the
-/// visible top-left of the WebView, which is `bounds.origin` rather than zero.
-/// The superview is also asked which corner it measures from — `WKWebView` is
-/// flipped, so a top-left `y` grows down from that bounds origin. The numbers
-/// arriving are points, which is what `setFrame` takes, because a CSS pixel in
-/// the page and an AppKit point in a view inside that page's WebView are the
-/// same length.
-///
-/// There used to be a second conversion here, dividing by the view's backing
-/// scale to undo a multiplication the page had done by `devicePixelRatio`.
-/// Two conversions that cancel are not a conversion; they are an agreement
-/// between two numbers measured in different places, and the frames where they
-/// disagreed put the monitor at twice its offset and twice its size.
-fn rect(host: &NSView, at: Place) -> NSRect {
-    let bounds = host.bounds();
+/// DOM viewport coordinates start at the WebView's safe content area. Tauri's
+/// macOS window uses a full-size content view, so the AppKit view can extend
+/// under the title bar while the page begins below it. `visibleRect` and
+/// `bounds` both start at zero in that state; `safeAreaRect` carries the title
+/// bar inset. Once the rectangle exists in that coordinate system,
+/// `convertRect_toView` carries every ancestor offset, flip and transform into
+/// the overlay. Physical pixels do not participate in placement.
+fn overlay_rect(host: &NSView, overlay: &NSView, at: Place) -> NSRect {
+    let viewport = host.safeAreaRect();
     let width = at.width.max(1.0);
     let height = at.height.max(1.0);
-    NSRect::new(
+    let inside_webview = NSRect::new(
         NSPoint::new(
-            bounds.origin.x + at.x,
-            origin_y(
-                host.isFlipped(),
-                bounds.origin.y,
-                bounds.size.height,
-                at.y,
-                height,
-            ),
+            viewport.origin.x + at.x,
+            top_origin(host.isFlipped(), viewport, at.y, height),
         ),
         NSSize::new(width, height),
-    )
+    );
+    host.convertRect_toView(inside_webview, Some(overlay))
 }
 
 /// The picture inside the container that clips it, so its origin is relative to
 /// the stage rather than to the WebView.
-fn child_rect(container: &NSView, at: MonitorPlace) -> NSRect {
-    let bounds = container.bounds();
+fn child_rect(at: MonitorPlace) -> NSRect {
     let width = at.content.width.max(1.0);
     let height = at.content.height.max(1.0);
     NSRect::new(
-        NSPoint::new(
-            bounds.origin.x + at.content.x - at.stage.x,
-            origin_y(
-                container.isFlipped(),
-                bounds.origin.y,
-                bounds.size.height,
-                at.content.y - at.stage.y,
-                height,
-            ),
-        ),
+        NSPoint::new(at.content.x - at.stage.x, at.content.y - at.stage.y),
         NSSize::new(width, height),
     )
 }
 
 /// A frame origin for a box whose top edge is `top` points below the visible
-/// bounds, in whichever coordinate origin that superview uses.
-fn origin_y(
-    flipped: bool,
-    bounds_origin: f64,
-    superview_height: f64,
-    top: f64,
-    height: f64,
-) -> f64 {
+/// viewport, in whichever coordinate origin that superview uses.
+fn top_origin(flipped: bool, visible: NSRect, top: f64, height: f64) -> f64 {
     if flipped {
-        bounds_origin + top
+        visible.origin.y + top
     } else {
-        bounds_origin + superview_height - top - height
+        visible.origin.y + visible.size.height - top - height
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::origin_y;
+    use super::top_origin;
+    use objc2_foundation::{NSPoint, NSRect, NSSize};
+
+    fn visible(x: f64, y: f64, width: f64, height: f64) -> NSRect {
+        NSRect::new(NSPoint::new(x, y), NSSize::new(width, height))
+    }
 
     /// WKWebView is flipped, so a top-left `y` grows down from its bounds
     /// origin; the plain container is not, so its children flip against its
@@ -333,14 +367,16 @@ mod tests {
     /// getting it wrong mirrors the picture to the far side of the window.
     #[test]
     fn origin_matches_the_superview_coordinate_origin() {
-        assert_eq!(origin_y(true, 0.0, 800.0, 50.0, 200.0), 50.0);
-        assert_eq!(origin_y(false, 0.0, 800.0, 50.0, 200.0), 550.0);
+        let rect = visible(0.0, 0.0, 1000.0, 800.0);
+        assert_eq!(top_origin(true, rect, 50.0, 200.0), 50.0);
+        assert_eq!(top_origin(false, rect, 50.0, 200.0), 550.0);
     }
 
     #[test]
-    fn origin_starts_at_the_visible_bounds() {
-        assert_eq!(origin_y(true, 32.0, 800.0, 50.0, 200.0), 82.0);
-        assert_eq!(origin_y(false, 32.0, 800.0, 50.0, 200.0), 582.0);
+    fn css_origin_starts_at_the_safe_content_origin() {
+        let rect = visible(12.0, 32.0, 1000.0, 800.0);
+        assert_eq!(top_origin(true, rect, 50.0, 200.0), 82.0);
+        assert_eq!(top_origin(false, rect, 50.0, 200.0), 582.0);
     }
 }
 

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/mod.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/mod.rs
@@ -45,13 +45,13 @@ mod unsupported;
 #[cfg(not(target_os = "macos"))]
 use unsupported as platform;
 
-/// Where the monitor sits inside the WebView, in **points**.
+/// Where the monitor sits in the visible WebView viewport, in **points**.
 ///
 /// Points, because that is the one unit both sides already have without
-/// converting: a CSS pixel in the page and an AppKit point in a view inside
-/// that page's `WKWebView` are the same length, so `getBoundingClientRect()`
-/// values are an `NSRect` with the y origin flipped and nothing else done to
-/// them.
+/// converting: a CSS pixel in the page and an AppKit point are the same length.
+/// The platform layer converts the rectangle from the `WKWebView` into the
+/// window overlay with AppKit's view conversion API; it does not reconstruct
+/// title-bar offsets, bounds origins or ancestor transforms.
 ///
 /// It used to be physical pixels, which meant the page multiplied by
 /// `devicePixelRatio` and this side divided by the view's backing scale. Those
@@ -74,7 +74,7 @@ pub struct Place {
 
 /// The clipped monitor box and the larger picture inside it.
 ///
-/// Both in points, both measured from the WebView's top left, and both computed
+/// Both in points, both measured from the visible WebView's top left, and both computed
 /// from one measurement in `geometry.js` so they cannot describe two different
 /// moments.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -82,6 +82,14 @@ pub struct Place {
 pub struct MonitorPlace {
     pub stage: Place,
     pub content: Place,
+    /// A page-side change signal, not a placement conversion. When it changes,
+    /// the native view is placed again and its real backing size is re-read.
+    #[serde(default = "default_backing_scale")]
+    pub backing_scale: f64,
+}
+
+fn default_backing_scale() -> f64 {
+    1.0
 }
 
 impl MonitorPlace {
@@ -167,6 +175,10 @@ impl Viewport {
     pub fn target(&self) -> Result<wgpu::SurfaceTarget<'static>, String> {
         platform::target(&self.inner)
     }
+
+    pub fn debug_geometry(&self) -> String {
+        platform::debug_geometry(&self.inner)
+    }
 }
 
 impl Drop for Viewport {
@@ -208,17 +220,20 @@ mod tests {
         let empty = place(0.0, 0.0);
         assert!(MonitorPlace {
             stage: good,
-            content: good
+            content: good,
+            backing_scale: 2.0,
         }
         .is_visible());
         assert!(!MonitorPlace {
             stage: empty,
-            content: good
+            content: good,
+            backing_scale: 2.0,
         }
         .is_visible());
         assert!(!MonitorPlace {
             stage: good,
-            content: empty
+            content: empty,
+            backing_scale: 2.0,
         }
         .is_visible());
     }

--- a/product/akbun-makevideo/workspace/src-tauri/src/viewport/unsupported.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/viewport/unsupported.rs
@@ -34,3 +34,7 @@ pub fn detach(_inner: &Inner) {}
 pub fn target(_inner: &Inner) -> Result<wgpu::SurfaceTarget<'static>, String> {
     Err("there is no native view on this platform".into())
 }
+
+pub fn debug_geometry(_inner: &Inner) -> String {
+    "unsupported platform".into()
+}

--- a/product/akbun-makevideo/workspace/src-tauri/tauri.alpha.conf.json
+++ b/product/akbun-makevideo/workspace/src-tauri/tauri.alpha.conf.json
@@ -1,0 +1,16 @@
+{
+  "productName": "akbun-makevideo-alpha",
+  "identifier": "io.akbun.makevideo.alpha",
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "akbun-makevideo-alpha"
+      }
+    ]
+  },
+  "bundle": {
+    "targets": ["app"],
+    "createUpdaterArtifacts": false
+  }
+}

--- a/product/akbun-makevideo/workspace/src/geometry.js
+++ b/product/akbun-makevideo/workspace/src/geometry.js
@@ -200,7 +200,11 @@ function monitorPlaceOf(panel, project, viewport) {
 function samePlace(a, b) {
   if (!a || !b) return false;
   if (a.stage || b.stage) {
-    return samePlace(a.stage, b.stage) && samePlace(a.content, b.content);
+    return (
+      samePlace(a.stage, b.stage) &&
+      samePlace(a.content, b.content) &&
+      a.backingScale === b.backingScale
+    );
   }
   return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
 }

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -95,6 +95,8 @@ function createMonitor(options) {
   let playing = false;
   let attaching = null;
   let attachWanted = false;
+  let placing = null;
+  let pendingPlace = null;
   let mediaRefreshPending = false;
   let refreshingMedia = null;
   let viewport = GEO.fittedViewport();
@@ -163,6 +165,12 @@ function createMonitor(options) {
     return {
       stage: GEO.placeOf(box),
       content: GEO.placeOf(GEO.contentBoxOf(box, viewport)),
+      // A change here makes Rust re-read the real backing size from the view.
+      // It is a notification only; placement remains in CSS pixels/points.
+      backingScale:
+        typeof window !== 'undefined' && Number.isFinite(window.devicePixelRatio)
+          ? window.devicePixelRatio
+          : 1,
     };
   }
 
@@ -273,6 +281,28 @@ function createMonitor(options) {
    *  one command per pixel the box actually moved rather than one per frame.
    *  Returns the box it measured, so the frame loop can use it again without a
    *  second layout read. */
+  async function flushPlace() {
+    while (pendingPlace) {
+      const next = pendingPlace;
+      pendingPlace = null;
+      try {
+        await api.playbackPlace(next);
+      } catch (_error) {
+        // A later frame will measure again. Placement failure must not stop
+        // playback or leave an unhandled rejection in the page.
+      }
+    }
+  }
+
+  function queuePlace(next) {
+    pendingPlace = next;
+    if (placing) return;
+    placing = flushPlace().finally(() => {
+      placing = null;
+      if (pendingPlace) queuePlace(pendingPlace);
+    });
+  }
+
   function place() {
     const box = stageBox();
     if (!drivingNatively()) return box;
@@ -282,7 +312,10 @@ function createMonitor(options) {
     const next = currentPlace();
     if (!next || samePlace(next, lastPlace)) return box;
     lastPlace = next;
-    api.playbackPlace(next).catch(() => {});
+    // One IPC call at a time. Resize can measure several boxes before Rust has
+    // placed the first one; keeping only the latest pending box prevents an
+    // older reply from becoming the final native frame.
+    queuePlace(next);
     return box;
   }
 

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -201,6 +201,7 @@ let mediaPreview = null;
 let qualityMonitor = null;
 let visualDrag = null;
 let editorOverlayActive = false;
+let stageResizeObserver = null;
 
 // --- helpers ---------------------------------------------------------------
 
@@ -437,6 +438,7 @@ function playbackDebugLines(status) {
     `Native source: ${status.starved} starved, ${status.failedFrames} display failures`,
     `Native display call: ${millisecondsText(status.lastPresentMs)} last, ${millisecondsText(status.peakPresentMs)} peak`,
     `Native A/V lateness: ${millisecondsText(status.lastLateMs)} last, ${millisecondsText(status.peakLateMs)} peak`,
+    `Native viewport: ${status.viewportGeometry || 'unavailable'}`,
   ];
 }
 
@@ -2690,6 +2692,7 @@ function collectShortcutOverrides() {
 function applySettings(next) {
   const wasCompositor = state.settings.compositor;
   const wasDevice = state.settings.gpuDevice;
+  const wasPreviewQuality = state.settings.previewQuality;
   const usedProxies = state.settings.proxyEnabled;
   const usedGuides = G.visible(state.settings);
   state.settings = next;
@@ -2707,12 +2710,20 @@ function applySettings(next) {
   // This is also what attaches the first time. The page's own compositor value
   // is not one the setting can hold, so bootstrap landing *is* a change and
   // lands here — which is why there is no separate attach after it.
-  if (wasCompositor !== next.compositor || wasDevice !== next.gpuDevice) attachMonitor(true);
-  else if (usedGuides !== G.visible(next)) attachMonitor(true);
-  else if (usedProxies !== next.proxyEnabled) {
-    if (preview.usesNativeMonitor()) attachMonitor(true);
+  let monitorUpdate = null;
+  if (
+    wasCompositor !== next.compositor ||
+    wasDevice !== next.gpuDevice ||
+    wasPreviewQuality !== next.previewQuality
+  ) {
+    monitorUpdate = attachMonitor(true);
+  } else if (usedGuides !== G.visible(next)) {
+    monitorUpdate = attachMonitor(true);
+  } else if (usedProxies !== next.proxyEnabled) {
+    if (preview.usesNativeMonitor()) monitorUpdate = attachMonitor(true);
     else preview.redraw();
   }
+  return monitorUpdate || Promise.resolve();
 }
 
 /** Ask Rust for a monitor, or give the one that is running a new box.
@@ -3095,10 +3106,12 @@ function wireTransport() {
     const previous = state.settings.previewQuality;
     state.settings.previewQuality = dom.previewQuality.value;
     preview.setQuality(state.settings.previewQuality);
-    persistSettings(() => {
+    void persistSettings(() => {
       state.settings.previewQuality = previous;
       dom.previewQuality.value = previous;
       preview.setQuality(previous);
+    }).then(() => {
+      if (preview.usesNativeMonitor()) return attachMonitor(true);
     });
   });
   dom.stage.addEventListener('wheel', (event) => {
@@ -3392,7 +3405,16 @@ async function boot() {
     },
   });
 
-  applySettings(state.settings);
+  if (typeof ResizeObserver === 'function') {
+    stageResizeObserver = new ResizeObserver(() => {
+      renderStageOverlay();
+      drawStageVisuals();
+      preview.place();
+    });
+    stageResizeObserver.observe(dom.stage);
+  }
+
+  await applySettings(state.settings);
   globalThis.makevideoQuality = globalThis.qualityLib.createQualityHarness({
     monitor: qualityMonitor,
     preview,
@@ -3447,7 +3469,7 @@ async function boot() {
   try {
     state.boot = await window.api.bootstrap();
     state.settings = { ...DEFAULT_SETTINGS, ...state.boot.settings };
-    applySettings(state.settings);
+    await applySettings(state.settings);
     updateToolWarning();
     refresh();
   } catch (error) {
@@ -3483,9 +3505,7 @@ async function boot() {
   }
 }
 
-// lib.rs opens the devtools in debug builds because the window is the whole
-// app, and nearly every question asked there is a question about this state.
-// One name, so nothing else on the page is shadowed.
+// One name, so diagnostics in Web Inspector do not shadow anything else on the page.
 globalThis.makevideo = {
   state,
   refresh,

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -209,6 +209,67 @@ test('the same box twice is one command, so a drag is not a command per frame', 
   assert.strictEqual(places.length, 1);
 });
 
+test('a backing scale change places the unchanged viewport again', async () => {
+  const previousWindow = global.window;
+  global.window = { devicePixelRatio: 1 };
+  try {
+    const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+    const { monitor, places } = await nativeMonitorOn(panel);
+
+    global.window.devicePixelRatio = 2;
+    monitor.place();
+    assert.strictEqual(places.length, 1);
+    assert.strictEqual(places[0].backingScale, 2);
+  } finally {
+    if (previousWindow === undefined) delete global.window;
+    else global.window = previousWindow;
+  }
+});
+
+test('slow native placement keeps only the newest measured box', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  const places = [];
+  let attachedAt;
+  let finishFirst;
+  const firstPlace = new Promise((resolve) => { finishFirst = resolve; });
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => {},
+      clear: () => {},
+      clearExact: () => {},
+    },
+    wrap: panel.element,
+    api: {
+      available: true,
+      playbackAttach: async (place) => {
+        attachedAt = place;
+        return { engine: 'native' };
+      },
+      playbackVisible: async () => {},
+      playbackPlace: async (place) => {
+        places.push(place);
+        if (places.length === 1) await firstPlace;
+      },
+    },
+  });
+
+  await monitor.attach();
+  panel.moveTo(100, 0);
+  monitor.place();
+  panel.moveTo(200, 0);
+  monitor.place();
+  panel.moveTo(300, 0);
+  monitor.place();
+  assert.strictEqual(places.length, 1);
+
+  finishFirst();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.strictEqual(places.length, 2);
+  assert.strictEqual(places[1].stage.x - attachedAt.stage.x, 300);
+});
+
 test('the placement keeps the project shape as the panel changes', async () => {
   const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
   const monitor = createMonitor({


### PR DESCRIPTION
# 구현

WKWebView safe area 좌표 변환, clipping native Metal overlay, Preview Quality 해상도 동기화
- 1080×1920 새 프로젝트 GPU 전체 재생 102 presented, 0 skipped, 0 display failures, JavaScript 119개와 Rust 352개 통과

# 어려웠던 점

bounds와 visibleRect 모두 타이틀바 32px inset 미반영
- AppKit 진단값에서 DOM 요청 y 91과 safe area origin 32 확인 후 safeAreaRect 기반 변환으로 교체

# 리스크

네이티브 오버레이가 WebView CSS stacking context 외부에 위치
- 메뉴와 sheet 표시 중 native view 숨김 계약 유지 필요

Issue #881