### PR TITLE
Add makepresentation image and shape tools

### DIFF
--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -9,6 +9,9 @@ Desktop slide deck editor for the slides actually used in blog posts and talks: 
 - Shapes: rectangle, ellipse, line, arrow, freehand pen
 - Text boxes with font family, size, color, bold, italic, underline and alignment
 - Per-shape line color, width, style (solid/dashed/dotted) and fill
+- Multi-object group and ungroup, with grouped move and duplicate
+- Image borders and interactive crop handles with a shaded outside area
+- Optional arrowhead at the end of a freehand stroke
 - Zoom from 50% to 400%, from the status bar or the keyboard
 - Slide numbers, toggled from the status bar
 - Undo and redo, multi-object selection, copy and paste, duplicate

--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
@@ -43,7 +43,7 @@ pub fn default_background() -> String {
     "#ffffff".into()
 }
 
-/// One drawable thing. `kind` is rect | ellipse | line | arrow | pen | text.
+/// One drawable thing. `kind` is rect | ellipse | line | arrow | pen | text | image.
 ///
 /// rect/ellipse/text use x,y,w,h. line/arrow run from (x,y) to (x+w,y+h), so
 /// w and h may be negative. pen keeps absolute points and ignores x,y,w,h.
@@ -75,7 +75,7 @@ pub struct Shape {
     pub text: String,
     #[serde(default = "default_font_size")]
     pub font_size: f64,
-    #[serde(default = "default_stroke")]
+    #[serde(default = "default_text_color")]
     pub text_color: String,
     /// One family name, not a CSS stack, so it maps straight onto the pptx
     /// `a:latin` typeface.
@@ -104,10 +104,14 @@ pub struct Shape {
     pub crop_bottom: f64,
     #[serde(default)]
     pub rotation: f64,
+    #[serde(default)]
+    pub pen_arrow: bool,
+    #[serde(default)]
+    pub group_id: String,
 }
 
 fn default_stroke() -> String {
-    "#1a1a1a".into()
+    "#e03131".into()
 }
 fn default_stroke_width() -> f64 {
     2.0
@@ -120,6 +124,9 @@ fn default_none() -> String {
 }
 fn default_font_size() -> f64 {
     24.0
+}
+fn default_text_color() -> String {
+    "#1a1a1a".into()
 }
 fn default_font_family() -> String {
     "Helvetica".into()
@@ -148,7 +155,7 @@ impl Default for Shape {
             fill: default_none(),
             text: String::new(),
             font_size: default_font_size(),
-            text_color: default_stroke(),
+            text_color: default_text_color(),
             font_family: default_font_family(),
             src: String::new(),
             bold: false,
@@ -161,6 +168,8 @@ impl Default for Shape {
             crop_right: 0.0,
             crop_bottom: 0.0,
             rotation: 0.0,
+            pen_arrow: false,
+            group_id: String::new(),
         }
     }
 }

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
@@ -301,9 +301,22 @@ fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
     let mut rels = String::from(SLIDE_REL_LAYOUT);
     // rId1 is the layout; image relationships follow it.
     let mut next_rid = 2u64;
-    for (i, shape) in slide.shapes.iter().enumerate() {
+    let mut next_id = 2u64;
+    let mut open_group = String::new();
+    for shape in &slide.shapes {
+        if shape.group_id != open_group {
+            if !open_group.is_empty() {
+                shapes.push_str("</p:grpSp>");
+            }
+            if !shape.group_id.is_empty() {
+                shapes.push_str(&group_xml(next_id, &shape.group_id));
+                next_id += 1;
+            }
+            open_group = shape.group_id.clone();
+        }
         // id 1 (tree) is taken; shape ids start at 2.
-        let id = i as u64 + 2;
+        let id = next_id;
+        next_id += 1;
         if shape.kind == "image" {
             // An image whose data URL cannot be decoded is dropped rather
             // than written as a broken relationship.
@@ -318,6 +331,9 @@ fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
             shapes.push_str(&shape_xml(shape, id));
         }
     }
+    if !open_group.is_empty() {
+        shapes.push_str("</p:grpSp>");
+    }
     let xml = format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\
 <p:sld{NS}><p:cSld>{}<p:spTree>{EMPTY_TREE_HEADER}{shapes}</p:spTree></p:cSld>\
@@ -329,6 +345,18 @@ fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
 <Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">{rels}</Relationships>"
     );
     (xml, rels)
+}
+
+fn group_xml(id: u64, name: &str) -> String {
+    format!(
+        "<p:grpSp><p:nvGrpSpPr><p:cNvPr id=\"{id}\" name=\"{}\"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>\
+<p:grpSpPr><a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"{}\" cy=\"{}\"/><a:chOff x=\"0\" y=\"0\"/><a:chExt cx=\"{}\" cy=\"{}\"/></a:xfrm></p:grpSpPr>",
+        xml_escape(name),
+        emu(SLIDE_W),
+        emu(SLIDE_H),
+        emu(SLIDE_W),
+        emu(SLIDE_H),
+    )
 }
 
 /// The slide's `p:bg` element, empty for white. The master this writer emits
@@ -372,16 +400,20 @@ fn pic_xml(shape: &Shape, id: u64, rid: u64) -> String {
     format!(
         "<p:pic><p:nvPicPr><p:cNvPr id=\"{id}\" name=\"Picture {id}\"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr>\
 <p:blipFill><a:blip r:embed=\"rId{rid}\"/>{crop}<a:stretch><a:fillRect/></a:stretch></p:blipFill>\
-<p:spPr><a:xfrm{rotation}><a:off x=\"{}\" y=\"{}\"/><a:ext cx=\"{}\" cy=\"{}\"/></a:xfrm><a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom></p:spPr></p:pic>",
+<p:spPr><a:xfrm{rotation}><a:off x=\"{}\" y=\"{}\"/><a:ext cx=\"{}\" cy=\"{}\"/></a:xfrm><a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom>{}</p:spPr></p:pic>",
         emu(shape.x),
         emu(shape.y),
         emu(shape.w).max(1),
         emu(shape.h).max(1),
+        line_xml(shape, false),
     )
 }
 
 fn line_xml(shape: &Shape, arrow: bool) -> String {
     let w = emu(shape.stroke_width).max(1);
+    if shape.stroke == "none" {
+        return format!("<a:ln w=\"{w}\"><a:noFill/></a:ln>");
+    }
     let dash = match shape.dash.as_str() {
         "dash" => "<a:prstDash val=\"dash\"/>",
         "dot" => "<a:prstDash val=\"sysDot\"/>",
@@ -493,7 +525,7 @@ fn shape_xml(shape: &Shape, id: u64) -> String {
 <a:pathLst><a:path w=\"{path_w}\" h=\"{path_h}\">{path}</a:path></a:pathLst></a:custGeom>\
 <a:noFill/>{}</p:spPr></p:sp>",
                 xfrm(bx, by, bw, bh, false, false),
-                line_xml(shape, false)
+                line_xml(shape, shape.pen_arrow)
             )
         }
         "text" => {
@@ -1077,6 +1109,7 @@ struct Pending {
 
 #[derive(Clone, Default)]
 struct GroupTransform {
+    id: String,
     x: i64,
     y: i64,
     cx: i64,
@@ -1111,6 +1144,7 @@ fn parse_part(
     let mut stack: Vec<String> = Vec::new();
     let mut pending: Option<Pending> = None;
     let mut groups: Vec<GroupTransform> = Vec::new();
+    let mut group_sequence = 0u64;
 
     loop {
         let event = reader.read_event().map_err(|e| e.to_string())?;
@@ -1120,7 +1154,11 @@ fn parse_part(
                 let empty = matches!(event, Event::Empty(_));
 
                 if local == "grpSp" && !empty {
-                    groups.push(GroupTransform::default());
+                    group_sequence += 1;
+                    groups.push(GroupTransform {
+                        id: format!("group-{group_sequence}"),
+                        ..GroupTransform::default()
+                    });
                 } else if (local == "sp" || local == "cxnSp" || local == "pic") && !empty
                 {
                     pending = Some(Pending {
@@ -1130,6 +1168,12 @@ fn parse_part(
                     });
                 } else if let Some(p) = pending.as_mut() {
                     handle_element(p, &local, e, &stack, ctx);
+                } else if local == "cNvPr" && in_ctx(&stack, "grpSp") {
+                    if let Some(name) = attr(e, b"name") {
+                        if let Some(group) = groups.last_mut() {
+                            group.id = name;
+                        }
+                    }
                 } else if in_ctx(&stack, "grpSpPr") {
                     handle_group_element(groups.last_mut(), &local, e, &stack);
                 }
@@ -1180,6 +1224,9 @@ fn parse_part(
                         let default = placeholder_default(&p, ctx.defaults);
                         if let Some(mut shape) = finish(p, ctx, default) {
                             apply_group_transforms(&mut shape, &groups);
+                            if let Some(group) = groups.last() {
+                                shape.group_id = group.id.clone();
+                            }
                             if placeholders_are_visible || keys.is_empty() {
                                 if keys.is_empty()
                                     || shape.kind == "image"
@@ -1613,6 +1660,7 @@ fn finish(p: Pending, ctx: &SlideCtx, default: Option<&Shape>) -> Option<Shape> 
 
     if !p.is_pic && p.has_custgeom {
         shape.kind = "pen".into();
+        shape.pen_arrow = p.arrow;
         shape.points = p
             .path_pts
             .iter()
@@ -1750,6 +1798,7 @@ mod tests {
                             stroke: "#e03131".into(),
                             stroke_width: 3.0,
                             dash: "dash".into(),
+                            group_id: "diagram".into(),
                             ..Shape::default()
                         },
                         Shape {
@@ -1758,6 +1807,7 @@ mod tests {
                             y: 200.0,
                             w: 180.0,
                             h: 180.0,
+                            group_id: "diagram".into(),
                             ..Shape::default()
                         },
                         Shape {
@@ -1810,6 +1860,7 @@ mod tests {
                         stroke: "#862e9c".into(),
                         stroke_width: 4.0,
                         dash: "dot".into(),
+                        pen_arrow: true,
                         ..Shape::default()
                     }],
                     ..Slide::default()
@@ -1837,8 +1888,10 @@ mod tests {
                 assert_eq!(a.dash, b.dash);
                 assert_eq!(a.fill, b.fill);
                 assert_eq!(a.text, b.text);
+                assert_eq!(a.group_id, b.group_id);
                 assert!(close(a.stroke_width, b.stroke_width));
                 if a.kind == "pen" {
+                    assert_eq!(a.pen_arrow, b.pen_arrow);
                     assert_eq!(a.points.len(), b.points.len());
                     for (pa, pb) in a.points.iter().zip(&b.points) {
                         assert!(close(pa[0], pb[0]) && close(pa[1], pb[1]));

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -12,7 +12,7 @@ const SLIDE_H = 720;
 const DEFAULT_BACKGROUND = '#ffffff';
 
 const DEFAULT_STYLE = {
-  stroke: '#1a1a1a',
+  stroke: '#e03131',
   strokeWidth: 2,
   dash: 'solid',
   fill: 'none',
@@ -78,6 +78,8 @@ function createShape(kind, x, y, style) {
     cropRight: 0,
     cropBottom: 0,
     rotation: 0,
+    groupId: '',
+    penArrow: false,
   };
 }
 
@@ -131,6 +133,10 @@ function normalizeClipboardShape(value) {
   for (const name of ['bold', 'italic', 'underline']) {
     if (typeof value[name] === 'boolean') shape[name] = value[name];
   }
+  if (typeof value.groupId === 'string' && value.groupId.length <= 100) {
+    shape.groupId = value.groupId;
+  }
+  if (typeof value.penArrow === 'boolean') shape.penArrow = value.penArrow;
   if (['left', 'center', 'right'].includes(value.textAlign)) {
     shape.textAlign = value.textAlign;
   }
@@ -268,6 +274,61 @@ function moveShape(shape, dx, dy) {
     shape.x += dx;
     shape.y += dy;
   }
+}
+
+let groupSequence = 0;
+
+function nextGroupId() {
+  groupSequence += 1;
+  return `group-${Date.now()}-${groupSequence}`;
+}
+
+function groupShapes(shapes, indices) {
+  const valid = [...new Set(indices)].filter(
+    (index) => Number.isInteger(index) && index >= 0 && index < shapes.length
+  );
+  if (valid.length < 2) return '';
+  const id = nextGroupId();
+  for (const index of valid) shapes[index].groupId = id;
+  return id;
+}
+
+function ungroupShapes(shapes, indices) {
+  const ids = new Set(indices.map((index) => shapes[index] && shapes[index].groupId).filter(Boolean));
+  if (ids.size === 0) return false;
+  for (const shape of shapes) {
+    if (ids.has(shape.groupId)) shape.groupId = '';
+  }
+  return true;
+}
+
+function groupIndicesFor(shapes, index) {
+  const shape = shapes[index];
+  if (!shape || !shape.groupId) return Number.isInteger(index) ? [index] : [];
+  return shapes.reduce((indices, candidate, candidateIndex) => {
+    if (candidate.groupId === shape.groupId) indices.push(candidateIndex);
+    return indices;
+  }, []);
+}
+
+function cloneShapes(shapes) {
+  const groupIds = new Map();
+  return shapes.map((shape) => {
+    const copy = structuredClone(shape);
+    if (copy.groupId) {
+      if (!groupIds.has(copy.groupId)) groupIds.set(copy.groupId, nextGroupId());
+      copy.groupId = groupIds.get(copy.groupId);
+    }
+    return copy;
+  });
+}
+
+function setCrop(shape, side, fraction) {
+  const value = Math.max(0, Math.min(0.95, fraction));
+  const opposite = side === 'left' ? 'cropRight' : side === 'right' ? 'cropLeft' :
+    side === 'top' ? 'cropBottom' : 'cropTop';
+  const property = `crop${side[0].toUpperCase()}${side.slice(1)}`;
+  shape[property] = Math.round(Math.min(value, 0.95 - (shape[opposite] || 0)) * 1_000_000) / 1_000_000;
 }
 
 // Which resize handles a shape offers, with their positions.
@@ -439,7 +500,7 @@ function renderShapeSvg(shape, options) {
       return arrowSvg(shape);
     case 'pen': {
       const pts = shape.points.map((p) => `${p[0]},${p[1]}`).join(' ');
-      return `<polyline points="${pts}" fill="none" ${strokeAttrs(shape)} stroke-linecap="round" stroke-linejoin="round"/>`;
+      return `<polyline points="${pts}" fill="none" ${strokeAttrs(shape)} stroke-linecap="round" stroke-linejoin="round"/>${shape.penArrow ? penArrowSvg(shape) : ''}`;
     }
     case 'text': {
       if (hideText) return '';
@@ -471,12 +532,37 @@ function renderShapeSvg(shape, options) {
       const top = Math.max(0, Math.min(0.999, shape.cropTop || 0));
       const width = Math.max(0.001, 1 - left - Math.max(0, shape.cropRight || 0));
       const height = Math.max(0.001, 1 - top - Math.max(0, shape.cropBottom || 0));
-      const markup = `<svg x="${shape.x}" y="${shape.y}" width="${shape.w}" height="${shape.h}" viewBox="${left} ${top} ${width} ${height}" preserveAspectRatio="none" overflow="hidden"><image x="0" y="0" width="1" height="1" preserveAspectRatio="none" href="${href}"/></svg>`;
+      const markup = `<svg x="${shape.x}" y="${shape.y}" width="${shape.w}" height="${shape.h}" viewBox="${left} ${top} ${width} ${height}" preserveAspectRatio="none" overflow="hidden"><image x="0" y="0" width="1" height="1" preserveAspectRatio="none" href="${href}"/></svg><rect x="${shape.x}" y="${shape.y}" width="${shape.w}" height="${shape.h}" fill="none" ${strokeAttrs(shape)}/>`;
       return rotateSvg(shape, markup);
     }
     default:
       return '';
   }
+}
+
+function penArrowSvg(shape) {
+  if (shape.points.length < 2 || shape.stroke === 'none') return '';
+  const end = shape.points[shape.points.length - 1];
+  let start = shape.points[shape.points.length - 2];
+  for (let index = shape.points.length - 2; index >= 0; index -= 1) {
+    if (shape.points[index][0] !== end[0] || shape.points[index][1] !== end[1]) {
+      start = shape.points[index];
+      break;
+    }
+  }
+  const dx = end[0] - start[0];
+  const dy = end[1] - start[1];
+  const length = Math.hypot(dx, dy);
+  if (!length) return '';
+  const ux = dx / length;
+  const uy = dy / length;
+  const head = Math.min(length / 2, Math.max(10, shape.strokeWidth * 4));
+  const half = Math.max(head * 0.45, shape.strokeWidth);
+  const bx = end[0] - ux * head;
+  const by = end[1] - uy * head;
+  const p1 = `${bx - uy * half},${by + ux * half}`;
+  const p2 = `${bx + uy * half},${by - ux * half}`;
+  return `<polygon points="${end[0]},${end[1]} ${p1} ${p2}" fill="${shape.stroke}"/>`;
 }
 
 function arrowSvg(shape) {
@@ -612,6 +698,11 @@ const exported = {
   shapeIndicesInRect,
   toggleSelection,
   moveShape,
+  groupShapes,
+  ungroupShapes,
+  groupIndicesFor,
+  cloneShapes,
+  setCrop,
   handlesFor,
   resizeShape,
   addSlide,

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -95,6 +95,10 @@
             <option value="dot">Dotted</option>
           </select>
         </div>
+        <div class="prop-row" id="props-pen-arrow">
+          <label for="prop-pen-arrow">End arrow</label>
+          <input type="checkbox" id="prop-pen-arrow" />
+        </div>
       </div>
       <div id="props-text">
         <div class="prop-row">
@@ -155,6 +159,14 @@
             </button>
           </span>
         </div>
+      </div>
+      <div class="prop-row" id="props-image-crop">
+        <label>Image crop</label>
+        <button id="btn-crop">Crop</button>
+      </div>
+      <div class="btn-set">
+        <button id="btn-group">Group</button>
+        <button id="btn-ungroup">Ungroup</button>
       </div>
       <button id="btn-delete-shape">Delete shape</button>
     </aside>

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -20,6 +20,7 @@ const state = {
   presentIndex: 0,
   showNumbers: false,
   showGuidelines: false,
+  cropping: null,
   zoom: L.ZOOM_FIT,
 };
 
@@ -148,7 +149,36 @@ function renderCanvas() {
     slideNumberSvg(state.current) +
     guidelinesSvg() +
     (state.editingIndex < 0 ? selections : '') +
-    marqueeSvg();
+    marqueeSvg() +
+    (state.cropping ? cropOverlaySvg() : '');
+}
+
+function cropOverlaySvg() {
+  const shape = selectedShape();
+  if (!shape || shape.kind !== 'image') return '';
+  const left = shape.cropLeft || 0;
+  const top = shape.cropTop || 0;
+  const right = shape.cropRight || 0;
+  const bottom = shape.cropBottom || 0;
+  const x = shape.x + shape.w * left;
+  const y = shape.y + shape.h * top;
+  const w = shape.w * (1 - left - right);
+  const h = shape.h * (1 - top - bottom);
+  const handles = [
+    ['left', x, y + h / 2], ['right', x + w, y + h / 2],
+    ['top', x + w / 2, y], ['bottom', x + w / 2, y + h],
+  ].map(([side, hx, hy]) =>
+    `<rect x="${hx - 6}" y="${hy - 6}" width="12" height="12" class="crop-handle" data-crop-handle="${side}"/>`
+  ).join('');
+  const shades = [
+    [shape.x, shape.y, x - shape.x, shape.h],
+    [x + w, shape.y, shape.x + shape.w - (x + w), shape.h],
+    [x, shape.y, w, y - shape.y],
+    [x, y + h, w, shape.y + shape.h - (y + h)],
+  ].map(([sx, sy, sw, sh]) =>
+    `<rect x="${sx}" y="${sy}" width="${sw}" height="${sh}" class="crop-shade"/>`
+  ).join('');
+  return `<g class="crop-overlay">${shades}<rect x="${x}" y="${y}" width="${w}" height="${h}" class="crop-window"/>${handles}</g>`;
 }
 
 function renderThumbs() {
@@ -168,13 +198,19 @@ function renderProps() {
   const kind = shape ? shape.kind : 'defaults';
 
   const showFill = kind === 'rect' || kind === 'ellipse' || kind === 'defaults';
-  const showStroke = kind !== 'text' && kind !== 'image';
+  const showStroke = kind !== 'text';
   const showText = kind === 'text' || kind === 'defaults';
 
   $('props-fill').hidden = !showFill;
   $('props-stroke').hidden = !showStroke;
   $('props-text').hidden = !showText;
   $('btn-delete-shape').hidden = !shape;
+  $('btn-group').hidden = state.selection.length < 2;
+  $('btn-ungroup').hidden = !state.selection.some((index) => slide().shapes[index]?.groupId);
+  $('props-pen-arrow').hidden = kind !== 'pen';
+  $('props-image-crop').hidden = kind !== 'image';
+  $('btn-crop').classList.toggle('active', !!state.cropping);
+  $('prop-pen-arrow').checked = !!source.penArrow;
   $('props-hint').textContent = state.selection.length > 1
     ? `Selected: ${state.selection.length} objects`
     : shape
@@ -364,6 +400,19 @@ canvas.addEventListener('pointerdown', (event) => {
     return;
   }
 
+  const cropHandle = event.target.closest('[data-crop-handle]');
+  if (cropHandle && state.cropping && selectedShape()) {
+    state.drag = {
+      mode: 'crop',
+      side: cropHandle.dataset.cropHandle,
+      from: structuredClone(selectedShape()),
+      x0: p.x,
+      y0: p.y,
+    };
+    canvas.setPointerCapture(event.pointerId);
+    return;
+  }
+
   const group = event.target.closest('g[data-i]');
   if (group) {
     const index = Number(group.dataset.i);
@@ -395,14 +444,14 @@ canvas.addEventListener('pointerdown', (event) => {
       return;
     }
 
-    if (!state.selection.includes(index)) selectOnly(index);
+    if (!state.selection.includes(index)) selectMany(L.groupIndicesFor(slide().shapes, index));
 
     // Cmd/Ctrl+drag drags a copy and leaves the original where it was, the
     // way PowerPoint does. Add Shift and the copy travels on one axis.
     const duplicated = event.metaKey || event.ctrlKey;
     const originalSelection = [...state.selection];
     if (duplicated) {
-      const copies = selectedShapes().map((shape) => structuredClone(shape));
+      const copies = L.cloneShapes(selectedShapes());
       const first = slide().shapes.length;
       slide().shapes.push(...copies);
       selectMany(copies.map((_, offset) => first + offset));
@@ -446,6 +495,14 @@ canvas.addEventListener('pointermove', (event) => {
     if (!shape) return;
     Object.assign(shape, structuredClone(drag.from));
     L.resizeShape(shape, drag.from, drag.handle, dx, dy);
+  } else if (drag.mode === 'crop') {
+    const shape = selectedShape();
+    if (!shape) return;
+    Object.assign(shape, structuredClone(drag.from));
+    const fraction = drag.side === 'left' || drag.side === 'right' ? dx / shape.w : dy / shape.h;
+    const base = drag.side === 'left' ? drag.from.cropLeft : drag.side === 'right' ? drag.from.cropRight :
+      drag.side === 'top' ? drag.from.cropTop : drag.from.cropBottom;
+    L.setCrop(shape, drag.side, base + ((drag.side === 'left' || drag.side === 'top') ? fraction : -fraction));
   } else if (drag.mode === 'move') {
     // Shift keeps the move on whichever axis has travelled further.
     const straight = event.shiftKey;
@@ -478,7 +535,7 @@ canvas.addEventListener('pointerup', () => {
   } else if (drag.mode === 'marquee') {
     const rect = L.normalizeRect(drag.x0, drag.y0, drag.x1, drag.y1);
     selectMany(L.shapeIndicesInRect(slide().shapes, rect));
-  } else if (drag.mode === 'resize' || drag.moved) {
+  } else if (drag.mode === 'resize' || drag.mode === 'crop' || drag.moved) {
     markDirty();
   } else if (drag.duplicated) {
     // A Cmd+click that never moved keeps the original selection. The copies
@@ -681,7 +738,7 @@ const PASTE_OFFSET = 20;
 const SHAPE_CLIPBOARD_TYPE = 'application/x-akbun-makepresentation-shapes';
 
 function insertShapes(shapes, offset) {
-  const copies = shapes.map((shape) => structuredClone(shape));
+  const copies = L.cloneShapes(shapes);
   if (offset) {
     for (const copy of copies) L.moveShape(copy, offset, offset);
   }
@@ -926,6 +983,25 @@ function applyProp(patch) {
   renderProps();
 }
 
+function groupSelection() {
+  if (!L.groupShapes(slide().shapes, state.selection)) return;
+  markDirty();
+  renderAll();
+}
+
+function ungroupSelection() {
+  if (!L.ungroupShapes(slide().shapes, state.selection)) return;
+  markDirty();
+  renderAll();
+}
+
+function toggleCrop() {
+  const shape = selectedShape();
+  if (!shape || shape.kind !== 'image') return;
+  state.cropping = state.cropping ? null : { index: state.selected };
+  renderAll();
+}
+
 // --- slide background --------------------------------------------------------
 //
 // Deliberately not part of applyProp: it writes to the slide, never to a
@@ -985,6 +1061,10 @@ $('prop-width').addEventListener('input', (e) =>
   applyProp({ strokeWidth: Math.max(1, Number(e.target.value) || 1) })
 );
 $('prop-dash').addEventListener('change', (e) => applyProp({ dash: e.target.value }));
+$('prop-pen-arrow').addEventListener('change', (e) => applyProp({ penArrow: e.target.checked }));
+$('btn-group').addEventListener('click', groupSelection);
+$('btn-ungroup').addEventListener('click', ungroupSelection);
+$('btn-crop').addEventListener('click', toggleCrop);
 $('prop-font-size').addEventListener('input', (e) =>
   applyProp({ fontSize: Math.max(6, Number(e.target.value) || 24) })
 );

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -266,6 +266,28 @@ main {
   pointer-events: none;
 }
 
+.crop-overlay {
+  pointer-events: none;
+}
+
+.crop-shade {
+  fill: rgba(0, 0, 0, 0.5);
+}
+
+.crop-window {
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 2;
+  stroke-dasharray: 6 4;
+}
+
+.crop-handle {
+  fill: #ffffff;
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  pointer-events: all;
+}
+
 .guidelines {
   fill: none;
   stroke: var(--accent);

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -10,6 +10,13 @@ test('createDeck starts with one empty slide', () => {
   assert.deepStrictEqual(deck.slides[0].shapes, []);
 });
 
+test('new shapes use a red stroke and text keeps a dark text color', () => {
+  const rect = L.createShape('rect', 0, 0, {});
+  const text = L.createShape('text', 0, 0, {});
+  assert.strictEqual(rect.stroke, '#e03131');
+  assert.strictEqual(text.textColor, '#1a1a1a');
+});
+
 test('parseClipboardShapes normalizes valid shapes with safe defaults', () => {
   const rect = L.createShape('rect', 10, 20, { fill: '#abcdef' });
   rect.w = 100;
@@ -143,6 +150,28 @@ test('toggleSelection adds and removes one valid object without disturbing other
   assert.deepStrictEqual(L.toggleSelection([0, 2], 3, 3), [0, 2]);
   assert.deepStrictEqual(L.toggleSelection([0, 0, 2, -1, 3, 1.5], 1, 3), [0, 2, 1]);
   assert.deepStrictEqual(L.toggleSelection([0, 0, 2, -1, 3, 1.5], 3, 3), [0, 2]);
+});
+
+test('grouped objects select, ungroup, and clone independently', () => {
+  const shapes = [L.createShape('rect', 0, 0, {}), L.createShape('ellipse', 20, 20, {})];
+  const group = L.groupShapes(shapes, [0, 1]);
+  assert.ok(group);
+  assert.deepStrictEqual(L.groupIndicesFor(shapes, 1), [0, 1]);
+
+  const copies = L.cloneShapes(shapes);
+  assert.notStrictEqual(copies[0].groupId, group);
+  assert.strictEqual(copies[0].groupId, copies[1].groupId);
+
+  assert.strictEqual(L.ungroupShapes(shapes, [0]), true);
+  assert.strictEqual(shapes[0].groupId, '');
+  assert.strictEqual(shapes[1].groupId, '');
+});
+
+test('setCrop keeps opposing crop values inside the image', () => {
+  const image = L.createShape('image', 0, 0, {});
+  image.cropRight = 0.4;
+  L.setCrop(image, 'left', 0.9);
+  assert.strictEqual(image.cropLeft, 0.55);
 });
 
 test('moveShape shifts pen points', () => {
@@ -353,6 +382,18 @@ test('renderShapeSvg embeds and crops imported images', () => {
   assert.ok(svg.includes('<image'));
   assert.ok(svg.includes('href="data:image/png;base64,abc"'));
   assert.ok(svg.includes('viewBox="0.1 0 0.9 1"'));
+});
+
+test('renderShapeSvg draws an image border and a freehand end arrow', () => {
+  const image = L.createShape('image', 10, 20, { stroke: '#1971c2', strokeWidth: 3 });
+  image.w = 300;
+  image.h = 200;
+  assert.ok(L.renderShapeSvg(image).includes('stroke="#1971c2"'));
+
+  const pen = L.createShape('pen', 0, 0, {});
+  L.dragShape(pen, 0, 0, 100, 20);
+  pen.penArrow = true;
+  assert.ok(L.renderShapeSvg(pen).includes('<polygon'));
 });
 
 test('wrapTextLines wraps at word boundaries', () => {


### PR DESCRIPTION
# 구현

그룹·이미지·자유곡선 편집과 PPTX 왕복 반영
- node editor test 48개, cargo deck test 10개 통과

# 어려웠던 점

이미지 테두리와 그룹 상태의 PPTX 저장 경로 보완
- picture line 요소와 group shape 직렬화·파싱 추가

Issue #884