### PR TITLE
akbun-k8supgradeview: 현재 클러스터 상태 표시

### DIFF
--- a/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/kubectl.ts
@@ -195,6 +195,18 @@ export async function getNodes(): Promise<NodeInfo[]> {
   return items.map(toNodeInfo);
 }
 
+/** 현재 context가 가리키는 cluster 이름. context 이름과 달라질 수 있어 cluster를 직접 읽는다. */
+export async function getCurrentCluster(): Promise<string> {
+  const stdout = await runKubectl([
+    "config",
+    "view",
+    "--minify",
+    "--output",
+    "jsonpath={.contexts[0].context.cluster}",
+  ]);
+  return stdout.trim();
+}
+
 /**
  * 노드의 schedule 가능 여부를 바꾼다. cordon과 uncordon은 반대 동작이라
  * 하나의 함수로 두고 boolean으로 가른다. 화면의 버튼도 같은 이유로 하나다.

--- a/product/akbun-k8supgradeview/workspace/src/main/main.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/main.ts
@@ -9,6 +9,7 @@ import {
   getKarpenterLogs,
   getKarpenterResources,
   getKarpenterVersions,
+  getCurrentCluster,
   getNamespaces,
   getNodes,
   getPods,
@@ -65,6 +66,7 @@ async function confirmCordon(nodeName: string, cordon: boolean): Promise<boolean
 }
 
 function registerIpcHandlers(): void {
+  ipcMain.handle("kubectl:current-cluster", () => getCurrentCluster());
   ipcMain.handle("kubectl:nodes", () => getNodes());
   // 취소를 눌렀는지 renderer가 알아야 새로고침 여부를 정할 수 있어 boolean을 돌려준다.
   ipcMain.handle("kubectl:set-node-cordon", async (_event, nodeName: unknown, cordon: unknown) => {

--- a/product/akbun-k8supgradeview/workspace/src/main/preload.ts
+++ b/product/akbun-k8supgradeview/workspace/src/main/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("api", {
+  getCurrentCluster: () => ipcRenderer.invoke("kubectl:current-cluster"),
   getNodes: () => ipcRenderer.invoke("kubectl:nodes"),
   getPods: (nodeName?: string) => ipcRenderer.invoke("kubectl:pods", nodeName),
   describePod: (namespace: string, name: string) =>

--- a/product/akbun-k8supgradeview/workspace/src/renderer/index.html
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/index.html
@@ -88,6 +88,9 @@
 
   <div id="content">
   <div id="error-banner" class="hidden"></div>
+  <header id="app-header">
+    <p id="cluster-status" class="cluster-status" aria-live="polite">Cluster: 확인 중…</p>
+  </header>
 
   <main>
     <!-- Nodes tab -->

--- a/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/renderer.ts
@@ -91,6 +91,7 @@ interface OverprovisionOptions {
 }
 
 interface Api {
+  getCurrentCluster(): Promise<string>;
   getNodes(): Promise<NodeInfo[]>;
   getPods(nodeName?: string): Promise<PodInfo[]>;
   describePod(namespace: string, name: string): Promise<string>;
@@ -354,6 +355,22 @@ function clearError(): void {
   $("#error-banner").classList.add("hidden");
 }
 
+function renderClusterStatus(clusterName: string): void {
+  const status = $("#cluster-status");
+  const connected = Boolean(clusterName);
+  status.textContent = connected ? `Cluster: ${clusterName}` : "Cluster: Disconnected";
+  status.classList.toggle("disconnected", !connected);
+  status.title = connected ? clusterName : "현재 Kubernetes 클러스터에 연결할 수 없습니다.";
+}
+
+async function refreshClusterStatus(): Promise<void> {
+  try {
+    renderClusterStatus(await api.getCurrentCluster());
+  } catch {
+    renderClusterStatus("");
+  }
+}
+
 // kubectl과 비슷한 형식으로 age를 표시한다. 예: 45s, 30m, 12h, 5d
 function formatAge(creationTimestamp: string): string {
   if (!creationTimestamp) return "";
@@ -605,6 +622,7 @@ function renderNodePods(): void {
 }
 
 async function refreshNodes(): Promise<void> {
+  void refreshClusterStatus();
   try {
     clearError();
     allNodes = await api.getNodes();
@@ -1028,6 +1046,7 @@ async function submitSettings(): Promise<void> {
   try {
     const saved = await api.saveSettings(readSettingsForm());
     fillSettingsForm(saved);
+    void refreshClusterStatus();
     // 조회 대상이 바뀌었을 수 있으므로 karpenter 탭들을 다시 열 때 새로 불러오게 한다.
     karpenterLoaded = false;
     nodePoolsLoaded = false;

--- a/product/akbun-k8supgradeview/workspace/src/renderer/style.css
+++ b/product/akbun-k8supgradeview/workspace/src/renderer/style.css
@@ -156,8 +156,29 @@ body {
   overflow-y: auto;
 }
 
+#app-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px 0;
+}
+
+.cluster-status {
+  margin: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cluster-status.disconnected {
+  color: var(--danger);
+}
+
 main {
-  padding: 16px 20px;
+  padding: 12px 20px 16px;
 }
 
 .tab {

--- a/product/akbun-k8supgradeview/workspace/test/current-cluster.test.js
+++ b/product/akbun-k8supgradeview/workspace/test/current-cluster.test.js
@@ -1,0 +1,58 @@
+/**
+ * 활성 context의 이름이 아니라 그 context가 가리키는 cluster 이름을 읽는다.
+ *
+ * 실행: npm test (dist/를 읽으므로 build가 먼저 돈다)
+ */
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "akbun-k8supgradeview-cluster-test-"));
+
+const Module = require("node:module");
+const resolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (request === "electron") return "electron-stub";
+  return resolveFilename.call(this, request, ...rest);
+};
+require.cache["electron-stub"] = {
+  id: "electron-stub",
+  filename: "electron-stub",
+  loaded: true,
+  exports: { app: { getPath: () => workDir } },
+};
+
+const { saveSettings } = require("../dist/main/settings.js");
+const { getCurrentCluster } = require("../dist/main/kubectl.js");
+
+Module._resolveFilename = resolveFilename;
+delete require.cache["electron-stub"];
+
+const argsPath = path.join(workDir, "args.txt");
+
+function useRecordingKubectl(clusterName) {
+  const scriptPath = path.join(workDir, "fake-kubectl");
+  const script = `#!/bin/bash\necho "$@" > ${JSON.stringify(argsPath)}\nprintf '%s\\n' ${JSON.stringify(clusterName)}\n`;
+  fs.writeFileSync(scriptPath, script, { mode: 0o755 });
+  saveSettings({
+    kubectlCommand: scriptPath,
+    karpenterNamespace: "karpenter",
+    karpenterPodLabelSelector: "app.kubernetes.io/name=karpenter",
+    karpenterLogSinceMinutes: 15,
+  });
+}
+
+test.after(() => fs.rmSync(workDir, { recursive: true, force: true }));
+
+test("현재 context가 가리키는 cluster 이름을 읽는다", async () => {
+  useRecordingKubectl("production-cluster");
+
+  assert.strictEqual(await getCurrentCluster(), "production-cluster");
+  assert.strictEqual(
+    fs.readFileSync(argsPath, "utf8").trim(),
+    "config view --minify --output jsonpath={.contexts[0].context.cluster}"
+  );
+});


### PR DESCRIPTION
# 구현

현재 context가 가리키는 cluster 이름과 연결 해제 상태를 상단에 표시
- npm test 54개 통과

# 어려웠던 점

클러스터 조회 실패가 기존 노드 조회 오류 흐름을 가리지 않도록 상태를 별도 비동기 조회
- 실패 시 오류 배너 대신 Disconnected 표시

# 리스크

kubeconfig에 활성 context가 없으면 실제 연결 상태와 관계없이 Disconnected 표시
- 표시할 cluster 이름 자체를 확인할 수 없는 경우

Issue #885