### PR TITLE
akbun-requesthttp 요청 편집 흐름 개선

### DIFF
--- a/product/akbun-requesthttp/README.md
+++ b/product/akbun-requesthttp/README.md
@@ -6,13 +6,13 @@ Desktop HTTP client for calling and checking APIs by hand: compose an HTTP(S) re
 
 - Send HTTP(S) requests: method, URL, headers, body
 - Response view: status, elapsed time, size, headers, body with JSON pretty print
-- Save requests as bookmarks in the sidebar and reload them with one click
-- Shared variables, used anywhere as `{{name}}` in URL, headers and body
+- Save, duplicate, and reload requests from the sidebar
+- Global variables shared across requests and local variables scoped to one request
 - curl both ways: copy the current request as a curl command, or paste a curl command to fill the editor
 - Scenario runs: chain saved requests in order, assert status and body content per step, and extract JSON values into variables for later steps
-- Settings window: TLS certificate verification on/off, timeout, redirect following
+- Settings window: TLS certificate verification on/off, timeout, redirect following, updates
 - Turning TLS verification off exists for networks where HTTPS inspection or self-signed certificates make verification impossible; it is desktop-only
-- Self update from the Updates button (desktop)
+- Self update from Settings (desktop)
 - No accounts, no sync, no sharing: everything stays on the machine
 
 ## Desktop and web
@@ -22,7 +22,7 @@ Desktop HTTP client for calling and checking APIs by hand: compose an HTTP(S) re
 | HTTP engine | Rust (reqwest), no CORS limits | Worker-side fetch via `/api/proxy` |
 | TLS verification off | Yes, from Settings | Not possible |
 | Storage | JSON file in the app data directory | localStorage |
-| Update | Self update via the Updates button | Always the deployed version |
+| Update | Self update from Settings | Always the deployed version |
 
 ## Directory layout
 

--- a/product/akbun-requesthttp/wiki/architecture.md
+++ b/product/akbun-requesthttp/wiki/architecture.md
@@ -15,8 +15,8 @@ The page owns one state object and both shells persist it as an opaque JSON stri
 
 ```json
 {
-  "requests": [{ "id": "", "name": "", "method": "GET", "url": "", "headers": [], "body": "" }],
-  "variables": [{ "key": "", "value": "" }],
+  "requests": [{ "id": "", "name": "", "method": "GET", "url": "", "headers": [], "body": "", "localVariables": [] }],
+  "globalVariables": [{ "key": "", "value": "" }],
   "scenarios": [{ "id": "", "name": "", "steps": [] }],
   "settings": { "verifySsl": true, "timeoutSecs": 30, "followRedirects": true }
 }
@@ -43,7 +43,7 @@ The IPC surface is three commands: `send_request`, `load_state`, `save_state`.
 
 ## Key flows
 
-- Send: `app.js` resolves `{{variables}}` through `lib.js` (`resolveRequest`), hands the spec to `api.send`, renders the response. Unknown variables stay visible as `{{name}}`.
+- Send: `app.js` resolves `{{variables}}` through `lib.js` (`resolveRequest`), hands the spec to `api.send`, renders the response. Request-local values override globals with the same name. Unknown variables stay visible as `{{name}}`.
 - Scenario run: steps run sequentially. Each step re-resolves its request so extracts from earlier steps apply, then `runAssertions` (status, body substring) and `applyExtracts` (JSON dot path into variables, persisted) run. Failures do not stop the run; each step shows PASS/FAIL/ERROR.
 - curl: `toCurl` renders the resolved request (adds `-k` when verification is off); `parseCurl` reads the common flag subset (`-X`, `-H`, `-d/--data*`, `--url`, `-A`) and imports into a fresh scratch request, never over a bookmark.
 

--- a/product/akbun-requesthttp/workspace/package-lock.json
+++ b/product/akbun-requesthttp/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-requesthttp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2",

--- a/product/akbun-requesthttp/workspace/package.json
+++ b/product/akbun-requesthttp/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Desktop HTTP client: send requests, inspect responses, bookmarks, variables, curl import/export, scenario runs",
   "author": "akbun",

--- a/product/akbun-requesthttp/workspace/src/app.js
+++ b/product/akbun-requesthttp/workspace/src/app.js
@@ -32,9 +32,7 @@ async function loadPersisted() {
   try {
     const raw = await api.loadState();
     if (!raw) return;
-    const loaded = JSON.parse(raw);
-    state = Object.assign(L.createState(), loaded);
-    state.settings = Object.assign(L.createState().settings, loaded.settings || {});
+    state = L.normalizeState(JSON.parse(raw));
   } catch (error) {
     console.error('load failed', error);
   }
@@ -64,10 +62,29 @@ function renderSidebar() {
     const name = document.createElement('span');
     name.className = 'item-name';
     name.textContent = request.name;
+    const actions = document.createElement('details');
+    actions.className = 'item-actions';
+    const actionsToggle = document.createElement('summary');
+    actionsToggle.textContent = '⋯';
+    actionsToggle.title = 'Request actions';
+    actionsToggle.setAttribute('aria-label', `Actions for ${request.name}`);
+    const actionsMenu = document.createElement('div');
+    actionsMenu.className = 'item-actions-menu';
+    const duplicate = document.createElement('button');
+    duplicate.textContent = 'Duplicate Request';
+    duplicate.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const copy = L.duplicateRequest(request);
+      const index = state.requests.indexOf(request);
+      state.requests.splice(index + 1, 0, copy);
+      currentRequest = copy;
+      persist();
+      showRequestView();
+      renderSidebar();
+      renderEditor();
+    });
     const remove = document.createElement('button');
-    remove.className = 'item-delete';
-    remove.textContent = '✕';
-    remove.title = 'Delete';
+    remove.textContent = 'Delete Request';
     remove.addEventListener('click', async (event) => {
       event.stopPropagation();
       if (!(await api.ask(`Delete "${request.name}"?`))) return;
@@ -77,7 +94,20 @@ function renderSidebar() {
       renderSidebar();
       renderEditor();
     });
-    item.append(method, name, remove);
+    actionsMenu.append(duplicate, remove);
+    actions.append(actionsToggle, actionsMenu);
+    actions.addEventListener('click', (event) => event.stopPropagation());
+    actions.addEventListener('toggle', () => {
+      if (!actions.open) return;
+      requestList.querySelectorAll('.item-actions[open]').forEach((menu) => {
+        if (menu !== actions) menu.open = false;
+      });
+    });
+    item.append(method, name, actions);
+    item.addEventListener('contextmenu', (event) => {
+      event.preventDefault();
+      actions.open = true;
+    });
     item.addEventListener('click', () => {
       currentRequest = request;
       showRequestView();
@@ -180,6 +210,7 @@ function renderEditor() {
   $('url').value = currentRequest.url;
   $('body').value = currentRequest.body;
   renderKvRows($('headers-rows'), currentRequest.headers, persist);
+  renderKvRows($('local-variables-rows'), currentRequest.localVariables, persist);
 }
 
 function bindEditor() {
@@ -204,6 +235,10 @@ function bindEditor() {
   $('btn-add-header').addEventListener('click', () => {
     currentRequest.headers.push({ key: '', value: '' });
     renderKvRows($('headers-rows'), currentRequest.headers, persist);
+  });
+  $('btn-add-local-variable').addEventListener('click', () => {
+    currentRequest.localVariables.push({ key: '', value: '' });
+    renderKvRows($('local-variables-rows'), currentRequest.localVariables, persist);
   });
   $('btn-save-request').addEventListener('click', () => {
     if (!currentRequest.name) currentRequest.name = currentRequest.url || 'Untitled';
@@ -231,7 +266,7 @@ function setRequestLoading(loading) {
 
 async function sendRequest() {
   if (requestInFlight) return;
-  const resolved = L.resolveRequest(currentRequest, state.variables);
+  const resolved = L.resolveRequest(currentRequest, state.globalVariables);
   if (!resolved.url) {
     await api.message('URL is empty.');
     return;
@@ -296,7 +331,10 @@ function bindResponse() {
 
 function bindCurl() {
   $('btn-copy-curl').addEventListener('click', async () => {
-    const command = L.toCurl(L.resolveRequest(currentRequest, state.variables), engineSettings());
+    const command = L.toCurl(
+      L.resolveRequest(currentRequest, state.globalVariables),
+      engineSettings()
+    );
     try {
       await navigator.clipboard.writeText(command);
       await api.message('curl command copied.');
@@ -484,11 +522,11 @@ async function runScenario() {
       continue;
     }
     // Resolved fresh per step, so extracts from earlier steps apply.
-    const resolved = L.resolveRequest(request, state.variables);
+    const resolved = L.resolveRequest(request, state.globalVariables);
     try {
       const response = await api.send(resolved, engineSettings());
       const verdict = L.runAssertions(step, response);
-      const extracted = L.applyExtracts(step, response, state.variables);
+      const extracted = L.applyExtracts(step, response, state.globalVariables);
       results.push({
         passed: verdict.passed,
         failures: verdict.failures,
@@ -524,15 +562,17 @@ function bindScenario() {
 // ----------------------------------------------------------------- dialogs
 
 function bindDialogs() {
-  $('btn-variables').addEventListener('click', () => {
-    renderKvRows($('variables-rows'), state.variables, persist);
-    $('variables-dialog').showModal();
+  $('btn-global-variables').addEventListener('click', () => {
+    renderKvRows($('global-variables-rows'), state.globalVariables, persist);
+    $('global-variables-dialog').showModal();
   });
-  $('btn-add-variable').addEventListener('click', () => {
-    state.variables.push({ key: '', value: '' });
-    renderKvRows($('variables-rows'), state.variables, persist);
+  $('btn-add-global-variable').addEventListener('click', () => {
+    state.globalVariables.push({ key: '', value: '' });
+    renderKvRows($('global-variables-rows'), state.globalVariables, persist);
   });
-  $('btn-close-variables').addEventListener('click', () => $('variables-dialog').close());
+  $('btn-close-global-variables').addEventListener('click', () => {
+    $('global-variables-dialog').close();
+  });
 
   $('btn-settings').addEventListener('click', () => {
     $('setting-verify-ssl').checked = state.settings.verifySsl;
@@ -564,6 +604,11 @@ function bindDialogs() {
   await loadPersisted();
   $('tab-requests').addEventListener('click', () => selectSidebarTab('requests'));
   $('tab-scenarios').addEventListener('click', () => selectSidebarTab('scenarios'));
+  document.addEventListener('click', () => {
+    document.querySelectorAll('.item-actions[open]').forEach((menu) => {
+      menu.open = false;
+    });
+  });
   $('btn-new-request').addEventListener('click', () => {
     currentRequest = L.createRequest('');
     showRequestView();

--- a/product/akbun-requesthttp/workspace/src/index.html
+++ b/product/akbun-requesthttp/workspace/src/index.html
@@ -10,9 +10,8 @@
   <header id="toolbar">
     <span id="app-title">akbun-requesthttp</span>
     <div class="group">
-      <button id="btn-variables" title="Shared variables usable as {{name}}">Variables</button>
+      <button id="btn-global-variables" title="Variables shared by every request">Global Variables</button>
       <button id="btn-settings" title="TLS verification, timeout, redirects">Settings</button>
-      <button id="btn-update" title="Check for a newer version">Updates</button>
     </div>
   </header>
 
@@ -62,6 +61,12 @@
           <summary>Body</summary>
           <textarea id="body" rows="6" placeholder='{"raw": "body, sent as typed"}'></textarea>
         </details>
+        <details>
+          <summary>Local Variables</summary>
+          <p class="hint">Used only by this request. A local value overrides a global value with the same name.</p>
+          <div id="local-variables-rows" class="kv-rows"></div>
+          <button id="btn-add-local-variable" class="small">+ Local Variable</button>
+        </details>
 
         <section id="response" hidden>
           <div class="row">
@@ -87,7 +92,7 @@
         </div>
         <p class="hint">
           Steps run top to bottom against saved requests. A step can assert the
-          status and a body substring, and extract JSON values into variables
+          status and a body substring, and extract JSON values into global variables
           for the steps after it.
         </p>
         <ol id="steps"></ol>
@@ -95,14 +100,14 @@
     </main>
   </div>
 
-  <dialog id="variables-dialog">
-    <h2>Variables</h2>
-    <p class="hint">Use anywhere as {{name}} — URL, headers and body.</p>
-    <div id="variables-rows" class="kv-rows"></div>
+  <dialog id="global-variables-dialog">
+    <h2>Global Variables</h2>
+    <p class="hint">Shared by every request. Use as {{name}} in URL, headers and body.</p>
+    <div id="global-variables-rows" class="kv-rows"></div>
     <div class="row">
-      <button id="btn-add-variable" class="small">+ Variable</button>
+      <button id="btn-add-global-variable" class="small">+ Global Variable</button>
       <span class="spacer"></span>
-      <button id="btn-close-variables">Close</button>
+      <button id="btn-close-global-variables">Close</button>
     </div>
   </dialog>
 
@@ -128,6 +133,7 @@
       Follow redirects
     </label>
     <div class="row">
+      <button id="btn-update" title="Check for a newer version">Check for Updates…</button>
       <span class="spacer"></span>
       <button id="btn-close-settings">Close</button>
     </div>

--- a/product/akbun-requesthttp/workspace/src/lib.js
+++ b/product/akbun-requesthttp/workspace/src/lib.js
@@ -12,7 +12,7 @@ function newId() {
 function createState() {
   return {
     requests: [],
-    variables: [],
+    globalVariables: [],
     scenarios: [],
     settings: { verifySsl: true, timeoutSecs: 30, followRedirects: true },
   };
@@ -26,7 +26,33 @@ function createRequest(name) {
     url: '',
     headers: [],
     body: '',
+    localVariables: [],
   };
+}
+
+function normalizeState(loaded) {
+  const source = loaded || {};
+  const state = createState();
+  state.requests = Array.isArray(source.requests)
+    ? source.requests.map((request) => Object.assign(createRequest(''), request, {
+      localVariables: Array.isArray(request.localVariables) ? request.localVariables : [],
+    }))
+    : [];
+  state.globalVariables = Array.isArray(source.globalVariables)
+    ? source.globalVariables
+    : Array.isArray(source.variables) ? source.variables : [];
+  state.scenarios = Array.isArray(source.scenarios) ? source.scenarios : [];
+  state.settings = Object.assign(state.settings, source.settings || {});
+  return state;
+}
+
+function duplicateRequest(request) {
+  return Object.assign({}, request, {
+    id: newId(),
+    name: `${request.name} copy`,
+    headers: request.headers.map((header) => Object.assign({}, header)),
+    localVariables: (request.localVariables || []).map((variable) => Object.assign({}, variable)),
+  });
 }
 
 function createScenario(name) {
@@ -58,8 +84,11 @@ function substitute(text, map) {
 
 // A request ready to hand to an engine: every field substituted, empty
 // header rows dropped.
-function resolveRequest(request, variables) {
-  const map = varsToMap(variables);
+function resolveRequest(request, globalVariables) {
+  const map = Object.assign(
+    varsToMap(globalVariables),
+    varsToMap(request.localVariables || [])
+  );
   return {
     method: request.method,
     url: substitute(request.url, map),
@@ -249,6 +278,8 @@ const exported = {
   newId,
   createState,
   createRequest,
+  normalizeState,
+  duplicateRequest,
   createScenario,
   createStep,
   varsToMap,

--- a/product/akbun-requesthttp/workspace/src/style.css
+++ b/product/akbun-requesthttp/workspace/src/style.css
@@ -100,7 +100,7 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
   padding: 4px 6px;
   border-radius: 4px;
   cursor: pointer;
-  overflow: hidden;
+  min-width: 0;
 }
 #request-list li:hover, #scenario-list li:hover { background: var(--code-bg); }
 #request-list li.active, #scenario-list li.active { background: var(--accent); color: var(--accent-fg); }
@@ -108,6 +108,41 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
 li.active .item-method { color: var(--accent-fg); }
 .item-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .item-delete { border: none; background: none; padding: 0 2px; color: inherit; }
+.item-actions { position: relative; margin: 0; flex-shrink: 0; }
+.item-actions[open] { z-index: 3; }
+.item-actions summary {
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  list-style: none;
+  margin: 0;
+  padding: 0 4px;
+  color: inherit;
+}
+.item-actions summary::-webkit-details-marker { display: none; }
+.item-actions summary:hover { background: var(--border); }
+.item-actions-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  min-width: 150px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+}
+.item-actions-menu button {
+  border: none;
+  padding: 5px 8px;
+  text-align: left;
+  white-space: nowrap;
+  background: none;
+}
+.item-actions-menu button:hover { background: var(--code-bg); }
 
 #main { flex: 1; min-width: 0; padding: 10px; overflow-y: auto; }
 
@@ -123,6 +158,7 @@ li.active .item-method { color: var(--accent-fg); }
   color: var(--fg-dim);
   white-space: nowrap;
 }
+.request-progress[hidden] { display: none; }
 .spinner {
   width: 14px;
   height: 14px;

--- a/product/akbun-requesthttp/workspace/test/lib.test.js
+++ b/product/akbun-requesthttp/workspace/test/lib.test.js
@@ -14,6 +14,31 @@ test('substitute replaces known variables and leaves unknown ones visible', () =
   );
 });
 
+test('normalizeState migrates variables to global variables and initializes request locals', () => {
+  const state = L.normalizeState({
+    requests: [{ id: 'r1', name: 'One', method: 'GET', url: '', headers: [], body: '' }],
+    variables: [{ key: 'host', value: 'https://old.example.com' }],
+  });
+  assert.deepStrictEqual(state.globalVariables, [
+    { key: 'host', value: 'https://old.example.com' },
+  ]);
+  assert.deepStrictEqual(state.requests[0].localVariables, []);
+  assert.strictEqual(Object.hasOwn(state, 'variables'), false);
+});
+
+test('duplicateRequest copies mutable fields and appends copy to the name', () => {
+  const source = L.createRequest('List users');
+  source.headers.push({ key: 'X-One', value: '1' });
+  source.localVariables.push({ key: 'user', value: '7' });
+  const copy = L.duplicateRequest(source);
+  assert.strictEqual(copy.name, 'List users copy');
+  assert.notStrictEqual(copy.id, source.id);
+  assert.deepStrictEqual(copy.headers, source.headers);
+  assert.deepStrictEqual(copy.localVariables, source.localVariables);
+  assert.notStrictEqual(copy.headers, source.headers);
+  assert.notStrictEqual(copy.localVariables, source.localVariables);
+});
+
 test('resolveRequest substitutes url, headers and body, and drops empty header rows', () => {
   const request = {
     method: 'POST',
@@ -35,6 +60,20 @@ test('resolveRequest substitutes url, headers and body, and drops empty header r
     headers: [{ key: 'Authorization', value: 'Bearer t1' }],
     body: '{"user": "akbun"}',
   });
+});
+
+test('resolveRequest uses local variables before globals', () => {
+  const request = L.createRequest('Local override');
+  request.url = '{{host}}/{{user}}';
+  request.localVariables = [{ key: 'user', value: 'local-user' }];
+  const globals = [
+    { key: 'host', value: 'https://api.example.com' },
+    { key: 'user', value: 'global-user' },
+  ];
+  assert.strictEqual(
+    L.resolveRequest(request, globals).url,
+    'https://api.example.com/local-user'
+  );
 });
 
 test('upsertVariable updates in place or appends', () => {


### PR DESCRIPTION
# 구현

응답 로딩 상태, 요청 복제 메뉴, 전역·로컬 변수, Settings 업데이트 통합
- npm test 21개 통과, 버전 0.3.0

# 어려웠던 점

기존 저장 상태의 variables 스키마를 globalVariables로 바꾸면서 호환성 유지
- 로드 시 구형 variables를 globalVariables로 이관하고 요청별 localVariables 기본값 생성

# 리스크

같은 이름의 변수는 로컬 값이 전역 값을 가림
- 요청별 격리를 보장하기 위한 의도된 우선순위이며 architecture 문서에 기록

Issue #894