### PR TITLE
docs: add answers to LLM serving quizzes

### DIFF
--- a/computer_science/ai/study-llmserving/ch3/02_basic/README.md
+++ b/computer_science/ai/study-llmserving/ch3/02_basic/README.md
@@ -186,7 +186,9 @@ docker compose logs -f serving
 3. Ubuntu에서 `nvidia-smi` → GPU 사용률이 **띄엄띄엄 튐**. 사이사이가 tokenize/HTTP 처리 시간
 4. worker 프로세스만 `kill -9` → API는 살아 있지만 요청이 영원히 멈춤 (격리의 양면)
 
-## 스스로 답해보기
+## 퀴즈
 
-- q2: process 격리의 **주된** 이유는 장애 격리인가 GPU 활용률인가?
-- q3: 동시 100 요청에서 GPU가 노는 이유를 연산 관점에서 설명할 수 있나?
+- q2. process 격리의 **주된** 이유는 장애 격리인가 GPU 활용률인가?
+  - 정답: GPU 활용률이다. model 실행을 웹·tokenize 같은 CPU 작업과 분리해 GPU의 대기 시간을 줄인다.
+- q3. 동시 100 요청에서 GPU가 노는 이유를 연산 관점에서 설명할 수 있나?
+  - 정답: 단일 worker가 요청을 하나씩 실행해 동시 요청이 batch 연산으로 합쳐지지 않는다. 요청 사이의 tokenize·큐·HTTP 처리 중에는 GPU가 기다린다.

--- a/computer_science/ai/study-llmserving/ch3/03_batching/README.md
+++ b/computer_science/ai/study-llmserving/ch3/03_batching/README.md
@@ -60,8 +60,11 @@ HTTP 요청은 [03_batching.http](./03_batching.http)에서 실행한다.
 3. batch 안에서 짧은 prompt가 긴 prompt를 **기다림** (padding + 동기화). 이게 latency 대가
 4. `bench_batching.py`에 길이가 크게 다른 prompt를 섞어보면 padding 낭비가 커지는 걸 볼 수 있음
 
-## 스스로 답해보기
+## 퀴즈
 
-- q4: 다른 사용자의 prompt를 한 batch에 섞으려면 최소한 무엇을 더 들고 있어야 하나?
-- q5: batching은 **누구의** latency를 희생해 전체 throughput을 사는가?
-- q10: `batch_size=4`, prompt 5개 → 최소 몇 번의 batch 실행인가?
+- q4. 다른 사용자의 prompt를 한 batch에 섞으려면 최소한 무엇을 더 들고 있어야 하나?
+  - 정답: 각 prompt와 결과를 원래 요청에 연결할 `request_id`가 필요하다.
+- q5. batching은 **누구의** latency를 희생해 전체 throughput을 사는가?
+  - 정답: batch가 채워지길 기다리는 요청과 같은 batch에서 긴 prompt의 처리를 기다리는 짧은 요청의 latency를 희생한다.
+- q10. `batch_size=4`, prompt 5개를 처리하려면 최소 몇 번의 batch 실행이 필요한가?
+  - 정답: 2번이다. 첫 batch에서 4개, 두 번째 batch에서 1개를 처리한다.

--- a/computer_science/ai/study-llmserving/ch3/04_streaming/README.md
+++ b/computer_science/ai/study-llmserving/ch3/04_streaming/README.md
@@ -69,8 +69,11 @@ outputs = self.model(input_ids=..., attention_mask=..., use_cache=False)
 - 즉 토큰이 늘수록 step 비용이 커짐. `--count 1`로 `MAX_TOKENS=60`을 주면 뒤로 갈수록 느려지는 게 보임
 - **여기가 5·7장(KV cache 관리)이 들어올 자리**
 
-## 스스로 답해보기
+## 퀴즈
 
-- q6: "전체 생성"과 "토큰 1개 생성"의 차이가 시스템 전체에 어떻게 파급되나?
-- q7: background thread와 async event loop를 잇는 다리는 무엇인가? 왜 공유 변수로는 안 되나?
-- q14: 완료 sequence 제거 코드가 왜 `get_next_batch()` 밖에 있나?
+- q6. "전체 생성"과 "토큰 1개 생성"의 차이가 시스템 전체에 어떻게 파급되나?
+  - 정답: 전체 생성은 한 요청이 완료될 때까지 batch 자리를 점유한다. 토큰 1개씩 생성하면 매 step마다 완료 요청을 제거하고 대기 요청을 채울 수 있어 streaming과 continuous batching이 가능하다.
+- q7. background thread와 async event loop를 잇는 다리는 무엇인가? 왜 공유 변수로는 안 되나?
+  - 정답: `asyncio.run_coroutine_threadsafe()`와 요청별 `asyncio.Queue`다. 공유 변수만 쓰면 thread-safe한 전달과 event loop 깨우기, 요청별 순서 보장을 처리할 수 없다.
+- q14. 완료 sequence 제거 코드가 왜 `get_next_batch()` 밖에 있나?
+  - 정답: `get_next_batch()`는 빈 batch 자리를 채우는 함수이고, 완료 여부는 토큰 생성 step 뒤에 결정된다. 실행 결과를 처리하는 쪽에서 완료 sequence를 제거해야 역할과 변경 시점이 맞다.

--- a/computer_science/ai/study-llmserving/ch3/05_vllm/README.md
+++ b/computer_science/ai/study-llmserving/ch3/05_vllm/README.md
@@ -92,7 +92,9 @@ HTTP 요청은 [05_vllm.http](./05_vllm.http)에서 실행한다.
 3. `max_num_seqs`를 1로 낮추면 vLLM도 우리 구현 수준으로 내려감 → **framework가 마법이 아니라 설정이 일한다는 증거**
 4. server mode는 `/v1/completions`, `/v1/chat/completions` 같은 OpenAI 호환 API를 그냥 제공 → k8s Deployment로 바로 뜰 수 있는 형태
 
-## 스스로 답해보기
+## 퀴즈
 
-- q9: "vLLM 쓰면 되니까 내부는 몰라도 된다"에 근거 2개로 반박
-- library mode vs server mode 중 우리 조직 상황에 맞는 건? (언어 다양성 / 독립 스케일링 / 실행 흐름 제어)
+- q9. "vLLM 쓰면 되니까 내부는 몰라도 된다"에 근거 2개로 반박하라.
+  - 정답: `max_num_seqs` 같은 동시 처리 설정은 batching 원리를 알아야 조정할 수 있다. 성능과 메모리 문제도 continuous batching, PagedAttention, KV cache의 동작을 알아야 원인을 분석할 수 있다.
+- library mode와 server mode 중 조직 상황에 맞는 방식을 고르는 기준은 무엇인가?
+  - 정답: 여러 언어에서 사용하거나 model server를 독립적으로 배포·스케일링하려면 server mode가 적합하다. Python 애플리케이션에서 생성 실행 흐름을 직접 제어하려면 library mode가 적합하다.

--- a/computer_science/ai/study-llmserving/ch3/06_multimodel/README.md
+++ b/computer_science/ai/study-llmserving/ch3/06_multimodel/README.md
@@ -132,9 +132,13 @@ HTTP 요청은 [06_multimodel.http](./06_multimodel.http)에서 실행한다.
 4. Triton wrapper 패턴: 내 서비스는 cache·metadata·web만, 추론은 통째로 위임
 5. `config.pbtxt`의 input/output 이름(`data_0`, `fc6_1`)이 클라이언트 코드에 그대로 나타남 → 계약(contract)
 
-## 스스로 답해보기
+## 퀴즈
 
-- q6(퀴즈): LRU eviction이 왜 필요한가?
-- q7(퀴즈): Triton의 두 API 종류와 각각의 역할
-- q9(질문): `max_models=2`에 3개 model 균등 트래픽 → 무슨 일이? (직접 확인했음)
-- q12(퀴즈): 고객사 1,000곳 model, 동시 200개. 첫 요청 UX 문제를 어떻게 완화하나?
+- q6. LRU eviction이 왜 필요한가?
+  - 정답: 제한된 메모리에 모든 model을 올릴 수 없으므로 오래 사용하지 않은 model을 내려 새 model의 공간을 확보해야 한다.
+- q7. Triton의 두 API 종류와 각각의 역할은 무엇인가?
+  - 정답: management API는 model을 load·unload하고 상태를 관리한다. inference API는 입력을 전달하고 추론 결과를 받는다.
+- q9. `max_models=2`에 3개 model의 균등 트래픽이 들어오면 무슨 일이 생기는가?
+  - 정답: 매 요청마다 필요한 model이 직전에 축출된 상태가 되어 miss와 재로딩이 반복된다. hit rate가 0에 수렴하고 cold start latency가 계속 발생한다.
+- q12. 고객사 1,000곳의 model 중 200개가 동시에 사용될 때 첫 요청 UX를 어떻게 완화하는가?
+  - 정답: 최근 사용량이나 예약·예측 정보를 기준으로 활성 model을 미리 load한다. 나머지는 비동기 load 상태와 재시도 안내를 제공하고, 자주 쓰는 model은 eviction 대상에서 보호한다.

--- a/computer_science/ai/study-llmserving/ch3/07_tradeoff/README.md
+++ b/computer_science/ai/study-llmserving/ch3/07_tradeoff/README.md
@@ -140,8 +140,11 @@ kind delete cluster --name ch03        # Mac
 # /usr/local/bin/k3s-uninstall.sh      # Ubuntu
 ```
 
-## 스스로 답해보기
+## 퀴즈
 
-- q10: cost-optimized가 reactive라서 생기는 근본 한계는? latency-optimized는 대신 무엇을 포기하나?
-- q13(퀴즈): cost에서 특정 model latency가 튄다. 원인 2개와 완화책 각각 1개
-- EKS 경험과 대응: cost ≒ bin-packing + cluster-autoscaler / latency ≒ 워크로드별 노드그룹 + 최소 replica 고정. 실제로 같은 trade-off인가?
+- q10. cost-optimized가 reactive라서 생기는 근본 한계는 무엇인가? latency-optimized는 대신 무엇을 포기하는가?
+  - 정답: cost-optimized는 요청이 온 뒤 model 위치를 학습하고 load하므로 첫 요청의 cold start를 피할 수 없다. latency-optimized는 model을 미리 띄워 이 지연을 없애는 대신 유휴 리소스와 운영 대상 수를 늘린다.
+- q13. cost-optimized에서 특정 model의 latency가 튀는 원인 2개와 완화책을 각각 1개씩 제시하라.
+  - 정답: LRU 축출 후 재로딩이 원인이면 cache를 늘리거나 hot model을 보호한다. 라우팅 map 갱신 전 잘못된 backend로 가는 것이 원인이면 polling 주기를 줄이거나 load·unload 이벤트로 map을 갱신한다.
+- EKS의 cost 설계와 latency 설계도 같은 trade-off인가?
+  - 정답: 같은 비용과 지연의 trade-off다. bin-packing과 cluster autoscaler는 유휴 비용을 줄이는 대신 scale-out 대기와 자원 경합을 만들고, 워크로드별 노드 그룹과 최소 replica 고정은 빠르고 예측 가능한 응답을 위해 유휴 비용을 부담한다.


### PR DESCRIPTION
# 구현

3장 6개 학습 문서의 복습 섹션을 퀴즈와 정답 형식으로 변경
- 전체 문항에 본문 근거를 반영한 짧은 정답 추가, git diff --check 통과

Issue #898