### PR TITLE
feat: 요청 폴더와 HTTP 파일 가져오기

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@
 - [mermaid를 렌더링하고 PNG로 저장하는 웹 페이지 (mermaid.akbun.com)](./product/akbun-rendermermaid/) (26.8.4)
 - [OpenAPI 스펙을 탐색하는 API 뷰어 웹 페이지 (akbun-openapiviewer)](./product/akbun-openapiviewer/) (26.8.5)
 - [AWS profile로 로그인해 EC2를 조회하는 macOS 데스크톱 앱 (akbun-awsviewer)](./product/akbun-awsviewer/) (26.8.6)
-- [HTTP 요청, 북마크, 공통 변수, curl 변환, 시나리오 실행 데스크톱 앱 (akbun-requesthttp)](./product/akbun-requesthttp/) (26.8.6)
+- [HTTP 요청, 폴더 관리, 공통 변수, curl 변환, .http 가져오기 데스크톱 앱 (akbun-requesthttp)](./product/akbun-requesthttp/) (26.8.6)
 - [제품 목록을 모아 저장소로 보내는 카탈로그 웹 페이지 (products.akbun.com)](./product/akbun-productcatalog/) (26.8.10)
 
 ## Dockerfile

--- a/product/README.md
+++ b/product/README.md
@@ -16,7 +16,7 @@
 | [hprof-oom-analyzer](./hprof-oom-analyzer/) | JVM heap dump(hprof)에서 OOM 원인을 찾는 데스크톱 도구 |
 | [akbun-k8supgradeview](./akbun-k8supgradeview/) | EKS 업그레이드 작업용 노드/파드 조회 Electron 데스크톱 앱 |
 | [akbun-rendermermaid](./akbun-rendermermaid/) | mermaid 코드를 왼쪽에 쓰면 오른쪽에 렌더링하고 PNG로 저장하는 웹 페이지 |
-| [akbun-requesthttp](./akbun-requesthttp/) | HTTP(S) 요청, 응답 확인, 북마크, 공통 변수, curl 변환, 시나리오 실행을 갖춘 데스크톱 HTTP 클라이언트 |
+| [akbun-requesthttp](./akbun-requesthttp/) | HTTP(S) 요청, 응답 확인, 폴더 관리, 공통 변수, curl 변환, .http 가져오기를 갖춘 데스크톱 HTTP 클라이언트 |
 | [akbun-openapiviewer](./akbun-openapiviewer/) | OpenAPI 스펙을 붙여넣거나 파일로 열어 API 목록과 상세를 탐색하는 웹 페이지 |
 | [akbun-productcatalog](./akbun-productcatalog/) | product 디렉터리의 제품을 카드로 모아 저장소로 보내는 카탈로그 웹 페이지 |
 | [akbun-mactaskbar](./akbun-mactaskbar/) | 메뉴바 아이콘을 구간으로 나눠 숨기고 목록으로 보는 macOS 메뉴바 관리 앱 |

--- a/product/akbun-requesthttp/README.md
+++ b/product/akbun-requesthttp/README.md
@@ -6,10 +6,10 @@ Desktop HTTP client for calling and checking APIs by hand: compose an HTTP(S) re
 
 - Send HTTP(S) requests: method, URL, headers, body
 - Response view: status, elapsed time, size, headers, body with JSON pretty print
-- Save, duplicate, and reload requests from the sidebar
+- Organize every saved request under a folder; the permanent Default folder catches unassigned requests
+- Import a `.http` file into a same-named folder, with each parsed request saved below it
 - Global variables shared across requests and local variables scoped to one request
 - curl both ways: copy the current request as a curl command, or paste a curl command to fill the editor
-- Scenario runs: chain saved requests in order, assert status and body content per step, and extract JSON values into variables for later steps
 - Settings window: TLS certificate verification on/off, timeout, redirect following, updates
 - Turning TLS verification off exists for networks where HTTPS inspection or self-signed certificates make verification impossible; it is desktop-only
 - Self update from Settings (desktop)

--- a/product/akbun-requesthttp/adr/2026-08-page-owns-state.md
+++ b/product/akbun-requesthttp/adr/2026-08-page-owns-state.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Bookmarked requests, variables, scenarios and settings live in one JSON object owned by the page. Persistence is two commands (`load_state`, `save_state`) that move the serialized string to `state.json` in the app data directory on desktop, and to localStorage on web. Neither shell parses the blob.
+Request folders, variables and settings live in one JSON object owned by the page. Persistence is two commands (`load_state`, `save_state`) that move the serialized string to `state.json` in the app data directory on desktop, and to localStorage on web. Neither shell parses the blob.
 
 ## Reason
 

--- a/product/akbun-requesthttp/adr/2026-08-web-build-worker-proxy.md
+++ b/product/akbun-requesthttp/adr/2026-08-web-build-worker-proxy.md
@@ -8,7 +8,7 @@ The web version is the unmodified `src/` page served as Worker static assets, pl
 
 - The browser cannot be the engine: CORS blocks arbitrary origins. Moving the fetch into the worker removes CORS entirely, because the page only ever calls its own origin.
 - Workers cannot disable TLS verification, so the one desktop-only feature degrades honestly instead of pretending: the toggle is disabled on web with a note pointing at the desktop app.
-- One page for both shells means every feature (bookmarks, variables, curl, scenarios) exists on the web for free, with localStorage standing in for the state file.
+- One page for both shells means every feature (request folders, variables, curl and `.http` import) exists on the web for free, with localStorage standing in for the state file.
 - Deploying as a Worker follows the pattern the other web products in this repository already use: `wrangler.json` in the workspace, a Cloudflare build connected to the repository, nothing to release from CI.
 
 Accepted risk: `/api/proxy` is reachable by anyone who finds the deployed URL, making it a generic fetch endpoint. The worker checks the Origin header, which stops other sites embedding it but not a curl user. That is the ceiling for a static page with no accounts — this product deliberately has none — and Cloudflare rate limiting is the backstop. Workers also cannot reach private networks, so the proxy exposes nothing internal.

--- a/product/akbun-requesthttp/wiki/architecture.md
+++ b/product/akbun-requesthttp/wiki/architecture.md
@@ -15,9 +15,8 @@ The page owns one state object and both shells persist it as an opaque JSON stri
 
 ```json
 {
-  "requests": [{ "id": "", "name": "", "method": "GET", "url": "", "headers": [], "body": "", "localVariables": [] }],
+  "folders": [{ "id": "", "name": "", "isDefault": false, "requests": [{ "id": "", "name": "", "method": "GET", "url": "", "headers": [], "body": "", "localVariables": [] }] }],
   "globalVariables": [{ "key": "", "value": "" }],
-  "scenarios": [{ "id": "", "name": "", "steps": [] }],
   "settings": { "verifySsl": true, "timeoutSecs": 30, "followRedirects": true }
 }
 ```
@@ -25,8 +24,7 @@ The page owns one state object and both shells persist it as an opaque JSON stri
 - Desktop storage: `state.json` in the app data directory, written write-then-rename so a crash cannot destroy bookmarks.
 - Web storage: localStorage under `akbun-requesthttp-state`.
 - Saves are debounced 300 ms in `app.js`; Rust and the worker never interpret the blob.
-
-A scenario step is `{ requestId, expectStatus, bodyContains, extracts: [{ path, var }] }`. Assertions left empty are skipped.
+- `Default` always exists, cannot be deleted, and receives migrated flat requests and new requests with no chosen folder.
 
 ## The engine surface
 
@@ -44,14 +42,14 @@ The IPC surface is three commands: `send_request`, `load_state`, `save_state`.
 ## Key flows
 
 - Send: `app.js` resolves `{{variables}}` through `lib.js` (`resolveRequest`), hands the spec to `api.send`, renders the response. Request-local values override globals with the same name. Unknown variables stay visible as `{{name}}`.
-- Scenario run: steps run sequentially. Each step re-resolves its request so extracts from earlier steps apply, then `runAssertions` (status, body substring) and `applyExtracts` (JSON dot path into variables, persisted) run. Failures do not stop the run; each step shows PASS/FAIL/ERROR.
 - curl: `toCurl` renders the resolved request (adds `-k` when verification is off); `parseCurl` reads the common flag subset (`-X`, `-H`, `-d/--data*`, `--url`, `-A`) and imports into a fresh scratch request, never over a bookmark.
+- `.http` import: the page reads the selected file, `parseHttpFile` splits requests at `###`, and the imported folder uses the full filename. File variables become request-local variables.
 
 ## Where logic lives
 
 | File | Role | Tested by |
 |---|---|---|
-| `src/lib.js` | Variables, curl, extraction, assertions, formatting | `test/lib.test.js` |
+| `src/lib.js` | Folder migration, variables, curl/.http parsing, formatting | `test/lib.test.js` |
 | `worker/proxy.js` | Spec validation and fetch mapping for the web engine | `test/proxy.test.js` |
 | `src/app.js` | DOM glue only | Running the app |
 | `src/api.js` | Shell detection, engine and storage bindings, updater | Running the app |

--- a/product/akbun-requesthttp/wiki/development.md
+++ b/product/akbun-requesthttp/wiki/development.md
@@ -92,4 +92,5 @@ Two warnings that are easy to learn the hard way:
 - Response bodies are treated as text; binary responses display as lossy text. The size and status are still right.
 - `/api/proxy` on the web build is an origin-checked but otherwise open fetch endpoint — anyone scripting against the deployed URL can use it. Cloudflare rate limiting is the backstop; see the ADR before hardening further.
 - curl import covers the common flag subset (`-X`, `-H`, `-d`/`--data*`, `--url`, `-A`); form uploads (`-F`) and `@file` bodies are not represented.
+- `.http` import recognizes `###` separators, `# @name`/`// @name`, request lines, headers, bodies, and `@name = value` variables. Response-handler scripts and multipart file bodies are not represented.
 - The macOS build is unsigned: first launch needs `xattr -cr /Applications/akbun-requesthttp.app`, which the release notes state.

--- a/product/akbun-requesthttp/workspace/package-lock.json
+++ b/product/akbun-requesthttp/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-requesthttp",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2",

--- a/product/akbun-requesthttp/workspace/package.json
+++ b/product/akbun-requesthttp/workspace/package.json
@@ -1,8 +1,8 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
-  "description": "Desktop HTTP client: send requests, inspect responses, bookmarks, variables, curl import/export, scenario runs",
+  "description": "Desktop HTTP client: send requests, organize folders, inspect responses, and import curl or .http files",
   "author": "akbun",
   "license": "MIT",
   "scripts": {

--- a/product/akbun-requesthttp/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-requesthttp/workspace/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "akbun-requesthttp"
 version = "0.1.0"
-description = "Desktop HTTP client: requests, bookmarks, variables, curl, scenarios"
+description = "Desktop HTTP client: requests, folders, variables, curl, and .http import"
 authors = ["akbun"]
 license = "MIT"
 edition = "2021"

--- a/product/akbun-requesthttp/workspace/src/app.js
+++ b/product/akbun-requesthttp/workspace/src/app.js
@@ -8,15 +8,12 @@ const $ = (id) => document.getElementById(id);
 
 // The page owns the whole state; engines and storage are dumb.
 let state = L.createState();
-// The editor works on currentRequest. It is either a scratch request not in
-// state.requests yet, or a direct reference to a saved one (edits then
-// persist automatically).
+// The editor works on currentRequest. It is either a scratch request or a
+// direct reference to a request nested in one folder.
 let currentRequest = L.createRequest('');
-let currentScenarioId = null;
+let selectedFolderId = L.DEFAULT_FOLDER_ID;
 let lastResponse = null;
 let requestInFlight = false;
-// scenarioId -> per-step results of the last run, display only.
-const scenarioResults = {};
 
 // ------------------------------------------------------------- persistence
 
@@ -33,6 +30,7 @@ async function loadPersisted() {
     const raw = await api.loadState();
     if (!raw) return;
     state = L.normalizeState(JSON.parse(raw));
+    selectedFolderId = L.DEFAULT_FOLDER_ID;
   } catch (error) {
     console.error('load failed', error);
   }
@@ -50,122 +48,128 @@ function engineSettings() {
 
 // ---------------------------------------------------------------- sidebar
 
+function findRequestFolder(request) {
+  return state.folders.find((folder) => folder.requests.includes(request));
+}
+
+function findFolder(id) {
+  return state.folders.find((folder) => folder.id === id) || state.folders[0];
+}
+
+function selectRequest(request, folder) {
+  currentRequest = request;
+  selectedFolderId = folder.id;
+  lastResponse = null;
+  renderSidebar();
+  renderEditor();
+  renderResponse();
+}
+
 function renderSidebar() {
-  const requestList = $('request-list');
-  requestList.textContent = '';
-  for (const request of state.requests) {
-    const item = document.createElement('li');
-    if (request === currentRequest) item.className = 'active';
-    const method = document.createElement('span');
-    method.className = 'item-method';
-    method.textContent = request.method;
+  const root = $('folder-list');
+  root.textContent = '';
+  for (const folder of state.folders) {
+    const group = document.createElement('section');
+    group.className = 'folder-group';
+    const heading = document.createElement('div');
+    heading.className = 'folder-heading';
     const name = document.createElement('span');
-    name.className = 'item-name';
-    name.textContent = request.name;
-    const actions = document.createElement('details');
-    actions.className = 'item-actions';
-    const actionsToggle = document.createElement('summary');
-    actionsToggle.textContent = '⋯';
-    actionsToggle.title = 'Request actions';
-    actionsToggle.setAttribute('aria-label', `Actions for ${request.name}`);
-    const actionsMenu = document.createElement('div');
-    actionsMenu.className = 'item-actions-menu';
-    const duplicate = document.createElement('button');
-    duplicate.textContent = 'Duplicate Request';
-    duplicate.addEventListener('click', (event) => {
-      event.stopPropagation();
-      const copy = L.duplicateRequest(request);
-      const index = state.requests.indexOf(request);
-      state.requests.splice(index + 1, 0, copy);
-      currentRequest = copy;
-      persist();
-      showRequestView();
-      renderSidebar();
-      renderEditor();
-    });
-    const remove = document.createElement('button');
-    remove.textContent = 'Delete Request';
-    remove.addEventListener('click', async (event) => {
-      event.stopPropagation();
-      if (!(await api.ask(`Delete "${request.name}"?`))) return;
-      state.requests = state.requests.filter((r) => r !== request);
-      if (currentRequest === request) currentRequest = L.createRequest('');
-      persist();
-      renderSidebar();
-      renderEditor();
-    });
-    actionsMenu.append(duplicate, remove);
-    actions.append(actionsToggle, actionsMenu);
-    actions.addEventListener('click', (event) => event.stopPropagation());
-    actions.addEventListener('toggle', () => {
-      if (!actions.open) return;
-      requestList.querySelectorAll('.item-actions[open]').forEach((menu) => {
-        if (menu !== actions) menu.open = false;
+    name.className = 'folder-name';
+    name.textContent = folder.name;
+    const count = document.createElement('span');
+    count.className = 'folder-count';
+    count.textContent = String(folder.requests.length);
+    heading.append(name, count);
+    if (!folder.isDefault) {
+      const removeFolder = document.createElement('button');
+      removeFolder.className = 'folder-delete';
+      removeFolder.textContent = '✕';
+      removeFolder.title = `Delete ${folder.name}`;
+      removeFolder.addEventListener('click', async () => {
+        if (!(await api.ask(`Delete folder "${folder.name}" and its requests?`))) return;
+        if (folder.requests.includes(currentRequest)) {
+          currentRequest = L.createRequest('');
+          selectedFolderId = L.DEFAULT_FOLDER_ID;
+          lastResponse = null;
+        }
+        state.folders = state.folders.filter((item) => item !== folder);
+        persist();
+        renderSidebar();
+        renderEditor();
+        renderResponse();
       });
-    });
-    item.append(method, name, actions);
-    item.addEventListener('contextmenu', (event) => {
-      event.preventDefault();
-      actions.open = true;
-    });
-    item.addEventListener('click', () => {
-      currentRequest = request;
-      showRequestView();
-      renderSidebar();
-      renderEditor();
-    });
-    requestList.append(item);
-  }
+      heading.append(removeFolder);
+    }
 
-  const scenarioList = $('scenario-list');
-  scenarioList.textContent = '';
-  for (const scenario of state.scenarios) {
-    const item = document.createElement('li');
-    if (scenario.id === currentScenarioId) item.className = 'active';
-    const name = document.createElement('span');
-    name.className = 'item-name';
-    name.textContent = scenario.name;
-    const remove = document.createElement('button');
-    remove.className = 'item-delete';
-    remove.textContent = '✕';
-    remove.title = 'Delete';
-    remove.addEventListener('click', async (event) => {
-      event.stopPropagation();
-      if (!(await api.ask(`Delete "${scenario.name}"?`))) return;
-      state.scenarios = state.scenarios.filter((s) => s !== scenario);
-      if (currentScenarioId === scenario.id) {
-        currentScenarioId = null;
-        showRequestView();
-      }
-      persist();
-      renderSidebar();
-    });
-    item.append(name, remove);
-    item.addEventListener('click', () => {
-      currentScenarioId = scenario.id;
-      showScenarioView();
-      renderSidebar();
-      renderScenario();
-    });
-    scenarioList.append(item);
+    const requestList = document.createElement('ul');
+    requestList.className = 'request-list';
+    for (const request of folder.requests) {
+      requestList.append(renderRequestItem(folder, request, requestList));
+    }
+    group.append(heading, requestList);
+    root.append(group);
   }
 }
 
-function selectSidebarTab(tab) {
-  $('tab-requests').classList.toggle('active', tab === 'requests');
-  $('tab-scenarios').classList.toggle('active', tab === 'scenarios');
-  $('requests-pane').hidden = tab !== 'requests';
-  $('scenarios-pane').hidden = tab !== 'scenarios';
-}
-
-function showRequestView() {
-  $('request-view').hidden = false;
-  $('scenario-view').hidden = true;
-}
-
-function showScenarioView() {
-  $('request-view').hidden = true;
-  $('scenario-view').hidden = false;
+function renderRequestItem(folder, request, requestList) {
+  const item = document.createElement('li');
+  if (request === currentRequest) item.className = 'active';
+  const method = document.createElement('span');
+  method.className = 'item-method';
+  method.textContent = request.method;
+  const name = document.createElement('span');
+  name.className = 'item-name';
+  name.textContent = request.name;
+  const actions = document.createElement('details');
+  actions.className = 'item-actions';
+  const actionsToggle = document.createElement('summary');
+  actionsToggle.textContent = '⋯';
+  actionsToggle.title = 'Request actions';
+  actionsToggle.setAttribute('aria-label', `Actions for ${request.name}`);
+  const actionsMenu = document.createElement('div');
+  actionsMenu.className = 'item-actions-menu';
+  const duplicate = document.createElement('button');
+  duplicate.textContent = 'Duplicate Request';
+  duplicate.addEventListener('click', (event) => {
+    event.stopPropagation();
+    const copy = L.duplicateRequest(request);
+    const index = folder.requests.indexOf(request);
+    folder.requests.splice(index + 1, 0, copy);
+    selectRequest(copy, folder);
+    persist();
+  });
+  const remove = document.createElement('button');
+  remove.textContent = 'Delete Request';
+  remove.addEventListener('click', async (event) => {
+    event.stopPropagation();
+    if (!(await api.ask(`Delete "${request.name}"?`))) return;
+    folder.requests = folder.requests.filter((item) => item !== request);
+    if (currentRequest === request) {
+      currentRequest = L.createRequest('');
+      selectedFolderId = L.DEFAULT_FOLDER_ID;
+      lastResponse = null;
+    }
+    persist();
+    renderSidebar();
+    renderEditor();
+    renderResponse();
+  });
+  actionsMenu.append(duplicate, remove);
+  actions.append(actionsToggle, actionsMenu);
+  actions.addEventListener('click', (event) => event.stopPropagation());
+  actions.addEventListener('toggle', () => {
+    if (!actions.open) return;
+    requestList.querySelectorAll('.item-actions[open]').forEach((menu) => {
+      if (menu !== actions) menu.open = false;
+    });
+  });
+  item.append(method, name, actions);
+  item.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+    actions.open = true;
+  });
+  item.addEventListener('click', () => selectRequest(request, folder));
+  return item;
 }
 
 // ------------------------------------------------------------------ editor
@@ -205,6 +209,16 @@ function renderKvRows(container, list, onChange) {
 }
 
 function renderEditor() {
+  const savedFolder = findRequestFolder(currentRequest);
+  const folderSelect = $('request-folder');
+  folderSelect.textContent = '';
+  for (const folder of state.folders) {
+    const option = document.createElement('option');
+    option.value = folder.id;
+    option.textContent = folder.name;
+    folderSelect.append(option);
+  }
+  folderSelect.value = savedFolder ? savedFolder.id : selectedFolderId;
   $('request-name').value = currentRequest.name;
   $('method').value = currentRequest.method;
   $('url').value = currentRequest.url;
@@ -214,6 +228,17 @@ function renderEditor() {
 }
 
 function bindEditor() {
+  $('request-folder').addEventListener('change', (event) => {
+    const targetFolder = findFolder(event.target.value);
+    const savedFolder = findRequestFolder(currentRequest);
+    selectedFolderId = targetFolder.id;
+    if (savedFolder && savedFolder !== targetFolder) {
+      savedFolder.requests = savedFolder.requests.filter((request) => request !== currentRequest);
+      targetFolder.requests.push(currentRequest);
+      persist();
+      renderSidebar();
+    }
+  });
   $('request-name').addEventListener('input', (event) => {
     currentRequest.name = event.target.value;
     persist();
@@ -242,9 +267,8 @@ function bindEditor() {
   });
   $('btn-save-request').addEventListener('click', () => {
     if (!currentRequest.name) currentRequest.name = currentRequest.url || 'Untitled';
-    if (!state.requests.includes(currentRequest)) state.requests.push(currentRequest);
+    if (!findRequestFolder(currentRequest)) findFolder(selectedFolderId).requests.push(currentRequest);
     persist();
-    selectSidebarTab('requests');
     renderSidebar();
     renderEditor();
   });
@@ -353,215 +377,59 @@ function bindCurl() {
   $('btn-do-import-curl').addEventListener('click', () => {
     const parsed = L.parseCurl($('curl-input').value);
     if (!parsed.url) return;
-    // Imports always land in a fresh scratch request, never over a bookmark.
     currentRequest = Object.assign(L.createRequest(parsed.url), parsed);
+    selectedFolderId = L.DEFAULT_FOLDER_ID;
     $('curl-dialog').close();
-    showRequestView();
     renderSidebar();
     renderEditor();
   });
 }
 
-// --------------------------------------------------------------- scenarios
+// -------------------------------------------------------------------- .http
 
-function findScenario(id) {
-  return state.scenarios.find((s) => s.id === id);
-}
-
-function renderScenario() {
-  const scenario = findScenario(currentScenarioId);
-  if (!scenario) return;
-  $('scenario-name').value = scenario.name;
-  const stepsRoot = $('steps');
-  stepsRoot.textContent = '';
-  const results = scenarioResults[scenario.id] || [];
-  scenario.steps.forEach((step, index) => {
-    stepsRoot.append(renderStep(scenario, step, index, results[index]));
-  });
-}
-
-function renderStep(scenario, step, index, result) {
-  const item = document.createElement('li');
-  item.className = 'step';
-
-  const head = document.createElement('div');
-  head.className = 'row';
-  const select = document.createElement('select');
-  const placeholder = document.createElement('option');
-  placeholder.value = '';
-  placeholder.textContent = '— saved request —';
-  select.append(placeholder);
-  for (const request of state.requests) {
-    const option = document.createElement('option');
-    option.value = request.id;
-    option.textContent = `${request.method} ${request.name}`;
-    select.append(option);
-  }
-  select.value = step.requestId || '';
-  select.addEventListener('change', () => {
-    step.requestId = select.value;
-    persist();
-  });
-  const badge = document.createElement('span');
-  badge.className = 'badge';
-  if (result) {
-    if (result.error) {
-      badge.textContent = 'ERROR';
-      badge.classList.add('fail');
-    } else {
-      badge.textContent = result.passed ? `PASS ${result.status}` : `FAIL ${result.status}`;
-      badge.classList.add(result.passed ? 'pass' : 'fail');
-    }
-  }
-  const spacer = document.createElement('span');
-  spacer.className = 'spacer';
-  const remove = document.createElement('button');
-  remove.className = 'small';
-  remove.textContent = '✕';
-  remove.addEventListener('click', () => {
-    scenario.steps.splice(index, 1);
-    persist();
-    renderScenario();
-  });
-  head.append(select, badge, spacer, remove);
-
-  const asserts = document.createElement('div');
-  asserts.className = 'row';
-  const expectStatus = document.createElement('input');
-  expectStatus.placeholder = 'expected status (e.g. 200)';
-  expectStatus.value = step.expectStatus;
-  expectStatus.addEventListener('input', () => {
-    step.expectStatus = expectStatus.value.trim();
-    persist();
-  });
-  const bodyContains = document.createElement('input');
-  bodyContains.placeholder = 'body contains…';
-  bodyContains.value = step.bodyContains;
-  bodyContains.addEventListener('input', () => {
-    step.bodyContains = bodyContains.value;
-    persist();
-  });
-  asserts.append(expectStatus, bodyContains);
-
-  const extracts = document.createElement('div');
-  extracts.className = 'kv-rows';
-  step.extracts.forEach((rule, ruleIndex) => {
-    const row = document.createElement('div');
-    row.className = 'kv-row';
-    const path = document.createElement('input');
-    path.placeholder = 'json path, e.g. data.token';
-    path.value = rule.path || '';
-    path.addEventListener('input', () => {
-      rule.path = path.value.trim();
-      persist();
-    });
-    const name = document.createElement('input');
-    name.placeholder = 'to variable';
-    name.value = rule.var || '';
-    name.addEventListener('input', () => {
-      rule.var = name.value.trim();
-      persist();
-    });
-    const drop = document.createElement('button');
-    drop.className = 'small';
-    drop.textContent = '✕';
-    drop.addEventListener('click', () => {
-      step.extracts.splice(ruleIndex, 1);
-      persist();
-      renderScenario();
-    });
-    row.append(path, name, drop);
-    extracts.append(row);
-  });
-  const addExtract = document.createElement('button');
-  addExtract.className = 'small';
-  addExtract.textContent = '+ Extract';
-  addExtract.addEventListener('click', () => {
-    step.extracts.push({ path: '', var: '' });
-    persist();
-    renderScenario();
-  });
-
-  item.append(head, asserts, extracts, addExtract);
-
-  if (result) {
-    if (result.error) {
-      const error = document.createElement('p');
-      error.className = 'failures';
-      error.textContent = result.error;
-      item.append(error);
-    }
-    if (result.failures && result.failures.length) {
-      const failures = document.createElement('p');
-      failures.className = 'failures';
-      failures.textContent = result.failures.join(' · ');
-      item.append(failures);
-    }
-    if (result.extracted && result.extracted.length) {
-      const extracted = document.createElement('p');
-      extracted.className = 'extracted';
-      extracted.textContent =
-        'extracted ' + result.extracted.map((e) => `${e.key}=${e.value}`).join(', ');
-      item.append(extracted);
-    }
-  }
-  return item;
-}
-
-async function runScenario() {
-  const scenario = findScenario(currentScenarioId);
-  if (!scenario || scenario.steps.length === 0) return;
-  const results = [];
-  scenarioResults[scenario.id] = results;
-  renderScenario();
-  for (const step of scenario.steps) {
-    const request = state.requests.find((r) => r.id === step.requestId);
-    if (!request) {
-      results.push({ error: 'no request selected for this step' });
-      renderScenario();
-      continue;
-    }
-    // Resolved fresh per step, so extracts from earlier steps apply.
-    const resolved = L.resolveRequest(request, state.globalVariables);
+function bindHttpImport() {
+  $('btn-import-http').addEventListener('click', () => $('http-file-input').click());
+  $('http-file-input').addEventListener('change', async (event) => {
+    const file = event.target.files[0];
+    event.target.value = '';
+    if (!file) return;
     try {
-      const response = await api.send(resolved, engineSettings());
-      const verdict = L.runAssertions(step, response);
-      const extracted = L.applyExtracts(step, response, state.globalVariables);
-      results.push({
-        passed: verdict.passed,
-        failures: verdict.failures,
-        extracted,
-        status: response.status,
-      });
-      if (extracted.length) persist();
+      const requests = L.parseHttpFile(await file.text());
+      if (requests.length === 0) {
+        await api.message('No HTTP requests found in this file.');
+        return;
+      }
+      const folder = L.createFolder(L.httpFolderName(file.name));
+      folder.requests.push(...requests);
+      state.folders.push(folder);
+      selectRequest(requests[0], folder);
+      persist();
     } catch (error) {
-      results.push({ error: String(error) });
+      await api.message(`Cannot import the HTTP file.\n\n${error}`);
     }
-    renderScenario();
-  }
-}
-
-function bindScenario() {
-  $('scenario-name').addEventListener('input', (event) => {
-    const scenario = findScenario(currentScenarioId);
-    if (!scenario) return;
-    scenario.name = event.target.value;
-    persist();
-    renderSidebar();
   });
-  $('btn-add-step').addEventListener('click', () => {
-    const scenario = findScenario(currentScenarioId);
-    if (!scenario) return;
-    scenario.steps.push(L.createStep(''));
-    persist();
-    renderScenario();
-  });
-  $('btn-run-scenario').addEventListener('click', runScenario);
 }
 
 // ----------------------------------------------------------------- dialogs
 
 function bindDialogs() {
+  $('btn-new-folder').addEventListener('click', () => {
+    $('folder-name').value = '';
+    $('folder-dialog').showModal();
+    $('folder-name').focus();
+  });
+  $('btn-close-folder').addEventListener('click', () => $('folder-dialog').close());
+  $('btn-create-folder').addEventListener('click', () => {
+    const name = $('folder-name').value.trim();
+    if (!name) return;
+    const folder = L.createFolder(name);
+    state.folders.push(folder);
+    selectedFolderId = folder.id;
+    persist();
+    $('folder-dialog').close();
+    renderSidebar();
+    renderEditor();
+  });
   $('btn-global-variables').addEventListener('click', () => {
     renderKvRows($('global-variables-rows'), state.globalVariables, persist);
     $('global-variables-dialog').showModal();
@@ -602,8 +470,6 @@ function bindDialogs() {
 
 (async function init() {
   await loadPersisted();
-  $('tab-requests').addEventListener('click', () => selectSidebarTab('requests'));
-  $('tab-scenarios').addEventListener('click', () => selectSidebarTab('scenarios'));
   document.addEventListener('click', () => {
     document.querySelectorAll('.item-actions[open]').forEach((menu) => {
       menu.open = false;
@@ -611,25 +477,18 @@ function bindDialogs() {
   });
   $('btn-new-request').addEventListener('click', () => {
     currentRequest = L.createRequest('');
-    showRequestView();
+    selectedFolderId = L.DEFAULT_FOLDER_ID;
+    lastResponse = null;
     renderSidebar();
     renderEditor();
-  });
-  $('btn-new-scenario').addEventListener('click', () => {
-    const scenario = L.createScenario('');
-    state.scenarios.push(scenario);
-    currentScenarioId = scenario.id;
-    persist();
-    showScenarioView();
-    renderSidebar();
-    renderScenario();
+    renderResponse();
   });
   $('btn-update').addEventListener('click', () => api.checkUpdate());
   if (api.platform === 'web') $('btn-update').hidden = true;
   bindEditor();
   bindResponse();
   bindCurl();
-  bindScenario();
+  bindHttpImport();
   bindDialogs();
   renderSidebar();
   renderEditor();

--- a/product/akbun-requesthttp/workspace/src/index.html
+++ b/product/akbun-requesthttp/workspace/src/index.html
@@ -17,25 +17,21 @@
 
   <div id="layout">
     <aside id="sidebar">
-      <nav id="sidebar-tabs">
-        <button id="tab-requests" class="active">Requests</button>
-        <button id="tab-scenarios">Scenarios</button>
-      </nav>
-      <div id="requests-pane">
+      <div class="sidebar-actions">
         <button id="btn-new-request" class="new-item">+ New request</button>
-        <ul id="request-list"></ul>
+        <button id="btn-new-folder" class="new-item">+ Folder</button>
+        <button id="btn-import-http" class="new-item">Import .http</button>
+        <input id="http-file-input" type="file" accept=".http,text/plain" hidden />
       </div>
-      <div id="scenarios-pane" hidden>
-        <button id="btn-new-scenario" class="new-item">+ New scenario</button>
-        <ul id="scenario-list"></ul>
-      </div>
+      <div id="folder-list"></div>
     </aside>
 
     <main id="main">
       <section id="request-view">
         <div class="row name-row">
+          <select id="request-folder" title="Request folder"></select>
           <input id="request-name" placeholder="Request name" />
-          <button id="btn-save-request" title="Bookmark this request in the sidebar">Save</button>
+          <button id="btn-save-request" title="Save this request in the selected folder">Save</button>
           <button id="btn-copy-curl" title="Copy the resolved request as a curl command">Copy as curl</button>
           <button id="btn-import-curl" title="Fill the editor from a pasted curl command">Import curl</button>
         </div>
@@ -84,21 +80,18 @@
         </section>
       </section>
 
-      <section id="scenario-view" hidden>
-        <div class="row name-row">
-          <input id="scenario-name" placeholder="Scenario name" />
-          <button id="btn-run-scenario">Run</button>
-          <button id="btn-add-step" class="small">+ Step</button>
-        </div>
-        <p class="hint">
-          Steps run top to bottom against saved requests. A step can assert the
-          status and a body substring, and extract JSON values into global variables
-          for the steps after it.
-        </p>
-        <ol id="steps"></ol>
-      </section>
     </main>
   </div>
+
+  <dialog id="folder-dialog">
+    <h2>New Folder</h2>
+    <input id="folder-name" placeholder="Folder name" />
+    <div class="row dialog-actions">
+      <span class="spacer"></span>
+      <button id="btn-close-folder">Cancel</button>
+      <button id="btn-create-folder">Create</button>
+    </div>
+  </dialog>
 
   <dialog id="global-variables-dialog">
     <h2>Global Variables</h2>

--- a/product/akbun-requesthttp/workspace/src/lib.js
+++ b/product/akbun-requesthttp/workspace/src/lib.js
@@ -1,8 +1,10 @@
 'use strict';
 
-// Pure logic shared by the desktop app and the web build: variable
-// substitution, curl import/export, response value extraction and scenario
-// assertions. No DOM, no Tauri, no fetch — node tests this file directly.
+// Pure logic shared by the desktop app and the web build: state migration,
+// variable substitution, and curl/.http import. No DOM, no Tauri, no fetch —
+// node tests this file directly.
+
+const DEFAULT_FOLDER_ID = 'default';
 
 function newId() {
   return Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
@@ -11,10 +13,18 @@ function newId() {
 // One state object owns everything the app persists.
 function createState() {
   return {
-    requests: [],
+    folders: [createFolder('Default', true)],
     globalVariables: [],
-    scenarios: [],
     settings: { verifySsl: true, timeoutSecs: 30, followRedirects: true },
+  };
+}
+
+function createFolder(name, isDefault = false) {
+  return {
+    id: isDefault ? DEFAULT_FOLDER_ID : newId(),
+    name: name || 'Untitled folder',
+    isDefault,
+    requests: [],
   };
 }
 
@@ -33,17 +43,37 @@ function createRequest(name) {
 function normalizeState(loaded) {
   const source = loaded || {};
   const state = createState();
-  state.requests = Array.isArray(source.requests)
-    ? source.requests.map((request) => Object.assign(createRequest(''), request, {
-      localVariables: Array.isArray(request.localVariables) ? request.localVariables : [],
+  const folders = Array.isArray(source.folders)
+    ? source.folders.map((folder) => Object.assign(createFolder(folder.name), folder, {
+      isDefault: folder.id === DEFAULT_FOLDER_ID || folder.isDefault === true,
+      requests: Array.isArray(folder.requests) ? folder.requests.map(normalizeRequest) : [],
     }))
     : [];
+  const loadedDefault = folders.find((folder) => folder.isDefault);
+  const defaultFolder = loadedDefault || state.folders[0];
+  defaultFolder.id = DEFAULT_FOLDER_ID;
+  defaultFolder.name = 'Default';
+  defaultFolder.isDefault = true;
+  const oldRequests = Array.isArray(source.requests) ? source.requests.map(normalizeRequest) : [];
+  defaultFolder.requests.push(...oldRequests);
+  const namedFolders = folders.filter((folder) => folder !== loadedDefault);
+  for (const folder of namedFolders) {
+    if (folder.id === DEFAULT_FOLDER_ID) folder.id = newId();
+    folder.isDefault = false;
+  }
+  state.folders = [defaultFolder, ...namedFolders];
   state.globalVariables = Array.isArray(source.globalVariables)
     ? source.globalVariables
     : Array.isArray(source.variables) ? source.variables : [];
-  state.scenarios = Array.isArray(source.scenarios) ? source.scenarios : [];
   state.settings = Object.assign(state.settings, source.settings || {});
   return state;
+}
+
+function normalizeRequest(request) {
+  return Object.assign(createRequest(''), request, {
+    headers: Array.isArray(request.headers) ? request.headers : [],
+    localVariables: Array.isArray(request.localVariables) ? request.localVariables : [],
+  });
 }
 
 function duplicateRequest(request) {
@@ -53,14 +83,6 @@ function duplicateRequest(request) {
     headers: request.headers.map((header) => Object.assign({}, header)),
     localVariables: (request.localVariables || []).map((variable) => Object.assign({}, variable)),
   });
-}
-
-function createScenario(name) {
-  return { id: newId(), name: name || 'Untitled scenario', steps: [] };
-}
-
-function createStep(requestId) {
-  return { requestId, expectStatus: '', bodyContains: '', extracts: [] };
 }
 
 // ---------------------------------------------------------------- variables
@@ -202,58 +224,77 @@ function parseCurl(command) {
   return request;
 }
 
-// ---------------------------------------------------- scenario run helpers
+// -------------------------------------------------------------------- .http
 
-// "a.b.0.c" walks objects and arrays. Returns undefined when the path
-// leaves the data.
-function getByPath(value, path) {
-  let current = value;
-  for (const key of String(path).split('.')) {
-    if (current == null) return undefined;
-    current = current[key];
-  }
-  return current;
+function httpFolderName(fileName) {
+  const base = String(fileName || '').split(/[\\/]/).pop() || '';
+  return base || 'Imported';
 }
 
-// A step passes when every filled-in assertion holds.
-function runAssertions(step, response) {
-  const failures = [];
-  if (step.expectStatus !== '' && step.expectStatus != null) {
-    const expected = Number(step.expectStatus);
-    if (!Number.isFinite(expected)) {
-      failures.push(`expected status "${step.expectStatus}" is not a number`);
-    } else if (response.status !== expected) {
-      failures.push(`status ${response.status}, expected ${expected}`);
+function parseHttpFile(content) {
+  const text = String(content || '').replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
+  const variables = [];
+  for (const line of text.split('\n')) {
+    const match = line.match(/^\s*@([\w.-]+)\s*=\s*(.*?)\s*$/);
+    if (match) upsertVariable(variables, match[1], match[2]);
+  }
+
+  const sections = [];
+  let label = '';
+  let lines = [];
+  for (const line of text.split('\n')) {
+    const separator = line.match(/^\s*###(?:\s+(.*?))?\s*$/);
+    if (separator) {
+      sections.push({ label, lines });
+      label = separator[1] || '';
+      lines = [];
+    } else {
+      lines.push(line);
     }
   }
-  if (step.bodyContains) {
-    if (!String(response.body).includes(step.bodyContains)) {
-      failures.push(`body does not contain "${step.bodyContains}"`);
-    }
-  }
-  return { passed: failures.length === 0, failures };
+  sections.push({ label, lines });
+
+  return sections
+    .map((section) => parseHttpSection(section, variables))
+    .filter(Boolean);
 }
 
-// Pulls values out of a JSON response body into variables, so later steps
-// can use them as {{name}}. Returns what was extracted.
-function applyExtracts(step, response, variables) {
-  const extracted = [];
-  if (!step.extracts || step.extracts.length === 0) return extracted;
-  let parsed;
-  try {
-    parsed = JSON.parse(response.body);
-  } catch {
-    return extracted;
+function parseHttpSection(section, variables) {
+  const methodPattern = /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS|TRACE|CONNECT)\s+(\S+?)(?:\s+HTTP\/\d(?:\.\d+)?)?\s*$/i;
+  let name = '';
+  let requestLineIndex = -1;
+  let method = '';
+  let url = '';
+
+  section.lines.forEach((line, index) => {
+    if (requestLineIndex !== -1) return;
+    const nameMatch = line.match(/^\s*(?:#|\/{2})\s*@name\s+(.+?)\s*$/i);
+    if (nameMatch) name = nameMatch[1];
+    const requestMatch = line.trim().match(methodPattern);
+    if (requestMatch) {
+      requestLineIndex = index;
+      method = requestMatch[1].toUpperCase();
+      url = requestMatch[2];
+    }
+  });
+  if (requestLineIndex === -1) return null;
+
+  const headers = [];
+  let cursor = requestLineIndex + 1;
+  while (cursor < section.lines.length && section.lines[cursor].trim() !== '') {
+    const header = section.lines[cursor].match(/^\s*([^:#][^:]*):\s*(.*)$/);
+    if (header) headers.push({ key: header[1].trim(), value: header[2].trim() });
+    cursor += 1;
   }
-  for (const rule of step.extracts) {
-    if (!rule.path || !rule.var) continue;
-    const value = getByPath(parsed, rule.path);
-    if (value === undefined) continue;
-    const text = typeof value === 'string' ? value : JSON.stringify(value);
-    upsertVariable(variables, rule.var, text);
-    extracted.push({ key: rule.var, value: text });
-  }
-  return extracted;
+  while (cursor < section.lines.length && section.lines[cursor].trim() === '') cursor += 1;
+  const body = section.lines.slice(cursor).join('\n').trimEnd();
+  const request = createRequest(name || section.label || `${method} ${url}`);
+  request.method = method;
+  request.url = url;
+  request.headers = headers;
+  request.body = body;
+  request.localVariables = variables.map((variable) => Object.assign({}, variable));
+  return request;
 }
 
 // ------------------------------------------------------------- formatting
@@ -275,13 +316,13 @@ function prettyBody(body, headers) {
 }
 
 const exported = {
+  DEFAULT_FOLDER_ID,
   newId,
   createState,
+  createFolder,
   createRequest,
   normalizeState,
   duplicateRequest,
-  createScenario,
-  createStep,
   varsToMap,
   substitute,
   resolveRequest,
@@ -290,9 +331,8 @@ const exported = {
   toCurl,
   tokenize,
   parseCurl,
-  getByPath,
-  runAssertions,
-  applyExtracts,
+  httpFolderName,
+  parseHttpFile,
   formatSize,
   prettyBody,
 };

--- a/product/akbun-requesthttp/workspace/src/style.css
+++ b/product/akbun-requesthttp/workspace/src/style.css
@@ -79,21 +79,38 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
   overflow-y: auto;
 }
 
-#sidebar-tabs { display: flex; }
-#sidebar-tabs button {
-  flex: 1;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  background: none;
-  padding: 8px 0;
+.sidebar-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  padding: 8px;
+  border-bottom: 1px solid var(--border);
 }
-#sidebar-tabs button.active { border-bottom-color: var(--accent); font-weight: 600; }
+.sidebar-actions #btn-new-request { grid-column: 1 / -1; }
+.new-item { margin: 0; }
 
-.new-item { margin: 8px; }
-
-#request-list, #scenario-list { list-style: none; margin: 0; padding: 0 8px 8px; }
-#request-list li, #scenario-list li {
+.folder-group { padding: 6px 8px 0; }
+.folder-heading {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  padding: 2px 4px;
+  color: var(--fg-dim);
+}
+.folder-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.folder-count { font-size: 11px; }
+.folder-delete { border: none; background: none; padding: 0 2px; color: inherit; }
+.request-list { list-style: none; margin: 0; padding: 2px 0 4px 8px; }
+.request-list li {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -102,8 +119,8 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
   cursor: pointer;
   min-width: 0;
 }
-#request-list li:hover, #scenario-list li:hover { background: var(--code-bg); }
-#request-list li.active, #scenario-list li.active { background: var(--accent); color: var(--accent-fg); }
+.request-list li:hover { background: var(--code-bg); }
+.request-list li.active { background: var(--accent); color: var(--accent-fg); }
 .item-method { font-size: 10px; font-weight: 700; color: var(--fg-dim); width: 38px; flex-shrink: 0; }
 li.active .item-method { color: var(--accent-fg); }
 .item-name { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -149,6 +166,7 @@ li.active .item-method { color: var(--accent-fg); }
 .row { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; flex-wrap: wrap; }
 .spacer { flex: 1; }
 .name-row input { flex: 1; min-width: 120px; }
+.name-row #request-folder { max-width: 180px; }
 .send-row #url { flex: 1; min-width: 200px; }
 #btn-send { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 .request-progress {
@@ -209,21 +227,6 @@ pre {
 
 .hint { color: var(--fg-dim); font-size: 12px; }
 
-#steps { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-.step {
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px;
-  background: var(--bg-panel);
-}
-.step .row { margin-bottom: 4px; }
-.step select { max-width: 260px; }
-.step .badge { font-weight: 700; }
-.step .badge.pass { color: var(--ok); }
-.step .badge.fail { color: var(--bad); }
-.step .failures { color: var(--bad); font-size: 12px; margin: 2px 0 0; }
-.step .extracted { color: var(--fg-dim); font-size: 12px; margin: 2px 0 0; }
-
 dialog {
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -234,6 +237,8 @@ dialog {
 }
 dialog::backdrop { background: rgba(0, 0, 0, 0.4); }
 dialog h2 { margin: 0 0 8px; font-size: 15px; }
+#folder-name { width: 100%; }
+.dialog-actions { margin-top: 8px; margin-bottom: 0; }
 
 .setting { display: block; margin-bottom: 12px; }
 .setting .hint { display: block; margin-top: 2px; }

--- a/product/akbun-requesthttp/workspace/test/lib.test.js
+++ b/product/akbun-requesthttp/workspace/test/lib.test.js
@@ -14,16 +14,40 @@ test('substitute replaces known variables and leaves unknown ones visible', () =
   );
 });
 
-test('normalizeState migrates variables to global variables and initializes request locals', () => {
+test('createState always includes an empty default folder', () => {
+  const state = L.createState();
+  assert.strictEqual(state.folders.length, 1);
+  assert.deepStrictEqual(state.folders[0], {
+    id: L.DEFAULT_FOLDER_ID,
+    name: 'Default',
+    isDefault: true,
+    requests: [],
+  });
+});
+
+test('normalizeState migrates flat requests into the default folder', () => {
   const state = L.normalizeState({
     requests: [{ id: 'r1', name: 'One', method: 'GET', url: '', headers: [], body: '' }],
     variables: [{ key: 'host', value: 'https://old.example.com' }],
+    scenarios: [{ id: 'removed' }],
   });
   assert.deepStrictEqual(state.globalVariables, [
     { key: 'host', value: 'https://old.example.com' },
   ]);
-  assert.deepStrictEqual(state.requests[0].localVariables, []);
+  assert.strictEqual(state.folders[0].id, L.DEFAULT_FOLDER_ID);
+  assert.strictEqual(state.folders[0].name, 'Default');
+  assert.deepStrictEqual(state.folders[0].requests[0].localVariables, []);
+  assert.strictEqual(Object.hasOwn(state, 'requests'), false);
+  assert.strictEqual(Object.hasOwn(state, 'scenarios'), false);
   assert.strictEqual(Object.hasOwn(state, 'variables'), false);
+});
+
+test('normalizeState restores the default folder when only named folders were saved', () => {
+  const state = L.normalizeState({
+    folders: [{ id: 'team', name: 'Team API', requests: [] }],
+  });
+  assert.strictEqual(state.folders[0].id, L.DEFAULT_FOLDER_ID);
+  assert.strictEqual(state.folders[1].name, 'Team API');
 });
 
 test('duplicateRequest copies mutable fields and appends copy to the name', () => {
@@ -132,63 +156,58 @@ test('parseCurl skips unknown flags without losing the url', () => {
   assert.strictEqual(parsed.method, 'GET');
 });
 
-// ---------------------------------------------------------------- scenario
+// -------------------------------------------------------------------- .http
 
-test('getByPath walks objects and arrays', () => {
-  const data = { items: [{ id: 7, tags: ['a', 'b'] }] };
-  assert.strictEqual(L.getByPath(data, 'items.0.id'), 7);
-  assert.strictEqual(L.getByPath(data, 'items.0.tags.1'), 'b');
-  assert.strictEqual(L.getByPath(data, 'items.9.id'), undefined);
+test('httpFolderName keeps the imported file name', () => {
+  assert.strictEqual(L.httpFolderName('/tmp/github.http'), 'github.http');
+  assert.strictEqual(L.httpFolderName('service.HTTP'), 'service.HTTP');
 });
 
-test('runAssertions checks status and body substring only when filled in', () => {
-  const response = { status: 201, body: '{"ok":true}' };
+test('parseHttpFile creates a request for each separator section', () => {
+  const requests = L.parseHttpFile(`
+@host = https://api.example.com
+@token = secret
+
+### List users
+GET {{host}}/users HTTP/1.1
+Authorization: Bearer {{token}}
+
+### Create user
+# @name create-user
+POST {{host}}/users
+Content-Type: application/json
+
+{"name":"akbun"}
+`);
+  assert.strictEqual(requests.length, 2);
   assert.deepStrictEqual(
-    L.runAssertions({ expectStatus: '201', bodyContains: '"ok"' }, response),
-    { passed: true, failures: [] }
+    {
+      name: requests[0].name,
+      method: requests[0].method,
+      url: requests[0].url,
+      headers: requests[0].headers,
+      body: requests[0].body,
+      localVariables: requests[0].localVariables,
+    },
+    {
+      name: 'List users',
+      method: 'GET',
+      url: '{{host}}/users',
+      headers: [{ key: 'Authorization', value: 'Bearer {{token}}' }],
+      body: '',
+      localVariables: [
+        { key: 'host', value: 'https://api.example.com' },
+        { key: 'token', value: 'secret' },
+      ],
+    }
   );
-  const failed = L.runAssertions({ expectStatus: '200', bodyContains: 'nope' }, response);
-  assert.strictEqual(failed.passed, false);
-  assert.strictEqual(failed.failures.length, 2);
-  assert.deepStrictEqual(L.runAssertions({ expectStatus: '', bodyContains: '' }, response), {
-    passed: true,
-    failures: [],
-  });
+  assert.strictEqual(requests[1].name, 'create-user');
+  assert.strictEqual(requests[1].method, 'POST');
+  assert.strictEqual(requests[1].body, '{"name":"akbun"}');
 });
 
-test('runAssertions reports a non-numeric expected status instead of comparing NaN', () => {
-  const verdict = L.runAssertions({ expectStatus: 'ok', bodyContains: '' }, { status: 200, body: '' });
-  assert.strictEqual(verdict.passed, false);
-  assert.deepStrictEqual(verdict.failures, ['expected status "ok" is not a number']);
-});
-
-test('applyExtracts pulls JSON values into variables', () => {
-  const variables = [];
-  const step = {
-    extracts: [
-      { path: 'data.token', var: 'token' },
-      { path: 'data.count', var: 'count' },
-      { path: 'data.missing', var: 'nope' },
-    ],
-  };
-  const response = { body: '{"data":{"token":"t9","count":3}}' };
-  const extracted = L.applyExtracts(step, response, variables);
-  assert.deepStrictEqual(variables, [
-    { key: 'token', value: 't9' },
-    { key: 'count', value: '3' },
-  ]);
-  assert.strictEqual(extracted.length, 2);
-});
-
-test('applyExtracts does nothing on a non-JSON body', () => {
-  const variables = [];
-  const extracted = L.applyExtracts(
-    { extracts: [{ path: 'a', var: 'a' }] },
-    { body: '<html>' },
-    variables
-  );
-  assert.deepStrictEqual(extracted, []);
-  assert.deepStrictEqual(variables, []);
+test('parseHttpFile ignores sections without a request', () => {
+  assert.deepStrictEqual(L.parseHttpFile('### Notes\n# nothing here'), []);
 });
 
 // ------------------------------------------------------------- formatting

--- a/product/products.json
+++ b/product/products.json
@@ -1,6 +1,6 @@
 {
   "repoBase": "https://github.com/choisungwook/portfolio/tree/master/product",
-  "updated": "2026-08-11",
+  "updated": "2026-08-15",
   "products": [
     {
       "id": "akbun-productcatalog",
@@ -14,7 +14,7 @@
     {
       "id": "akbun-requesthttp",
       "name": "akbun-requesthttp",
-      "description": "HTTP(S) 요청, 응답 확인, 북마크, 공통 변수, curl 변환, 시나리오 실행을 갖춘 데스크톱 HTTP 클라이언트",
+      "description": "HTTP(S) 요청, 응답 확인, 폴더 관리, 공통 변수, curl 변환, .http 가져오기를 갖춘 데스크톱 HTTP 클라이언트",
       "kind": "desktop",
       "tags": ["tauri", "http"],
       "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-requesthttp",


### PR DESCRIPTION
# 구현

시나리오 제거, 폴더 기반 요청 저장, .http 다중 요청 가져오기
- 기존 평면 요청의 Default 폴더 마이그레이션과 Node 테스트 21개 통과

# 어려웠던 점

기존 저장 데이터를 잃지 않는 중첩 폴더 구조 전환
- 고정 Default 폴더 정규화 후 기존 평면 요청 병합

# 리스크

.http 문법 일부만 지원
- 응답 처리 스크립트와 multipart 파일 본문 제외

Issue #900