### PR TITLE
feat: add global request timeout

### DIFF
--- a/product/akbun-requesthttp/workspace/package-lock.json
+++ b/product/akbun-requesthttp/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-requesthttp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2",

--- a/product/akbun-requesthttp/workspace/package.json
+++ b/product/akbun-requesthttp/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Desktop HTTP client: send requests, organize folders, inspect responses, and import curl or .http files",
   "author": "akbun",

--- a/product/akbun-requesthttp/workspace/src/app.js
+++ b/product/akbun-requesthttp/workspace/src/app.js
@@ -37,13 +37,7 @@ async function loadPersisted() {
 }
 
 function engineSettings() {
-  return {
-    // The web engine cannot skip verification; keep the desktop toggle from
-    // leaking into a persisted state the web build then displays as active.
-    verifySsl: api.canToggleSsl ? state.settings.verifySsl : true,
-    timeoutSecs: state.settings.timeoutSecs,
-    followRedirects: state.settings.followRedirects,
-  };
+  return L.createEngineSettings(state.settings, api.canToggleSsl);
 }
 
 // ---------------------------------------------------------------- sidebar

--- a/product/akbun-requesthttp/workspace/src/index.html
+++ b/product/akbun-requesthttp/workspace/src/index.html
@@ -118,8 +118,9 @@
       desktop app for that.</span>
     </label>
     <label class="setting">
-      Timeout (seconds)
+      Global request client timeout (seconds)
       <input type="number" id="setting-timeout" min="1" max="600" />
+      <span class="hint">A timeout of at least 1 minute is recommended for AI requests.</span>
     </label>
     <label class="setting">
       <input type="checkbox" id="setting-follow-redirects" />

--- a/product/akbun-requesthttp/workspace/src/lib.js
+++ b/product/akbun-requesthttp/workspace/src/lib.js
@@ -15,7 +15,7 @@ function createState() {
   return {
     folders: [createFolder('Default', true)],
     globalVariables: [],
-    settings: { verifySsl: true, timeoutSecs: 30, followRedirects: true },
+    settings: { verifySsl: true, timeoutSecs: 60, followRedirects: true },
   };
 }
 
@@ -74,6 +74,14 @@ function normalizeRequest(request) {
     headers: Array.isArray(request.headers) ? request.headers : [],
     localVariables: Array.isArray(request.localVariables) ? request.localVariables : [],
   });
+}
+
+function createEngineSettings(settings, canToggleSsl) {
+  return {
+    verifySsl: canToggleSsl ? settings.verifySsl : true,
+    timeoutSecs: settings.timeoutSecs,
+    followRedirects: settings.followRedirects,
+  };
 }
 
 function duplicateRequest(request) {
@@ -322,6 +330,7 @@ const exported = {
   createFolder,
   createRequest,
   normalizeState,
+  createEngineSettings,
   duplicateRequest,
   varsToMap,
   substitute,

--- a/product/akbun-requesthttp/workspace/test/lib.test.js
+++ b/product/akbun-requesthttp/workspace/test/lib.test.js
@@ -23,6 +23,17 @@ test('createState always includes an empty default folder', () => {
     isDefault: true,
     requests: [],
   });
+  assert.strictEqual(state.settings.timeoutSecs, 60);
+});
+
+test('createEngineSettings applies the global timeout to every request', () => {
+  const settings = { verifySsl: false, timeoutSecs: 90, followRedirects: false };
+  assert.deepStrictEqual(L.createEngineSettings(settings, true), settings);
+  assert.deepStrictEqual(L.createEngineSettings(settings, false), {
+    verifySsl: true,
+    timeoutSecs: 90,
+    followRedirects: false,
+  });
 });
 
 test('normalizeState migrates flat requests into the default folder', () => {

--- a/product/akbun-requesthttp/workspace/test/proxy.test.js
+++ b/product/akbun-requesthttp/workspace/test/proxy.test.js
@@ -41,6 +41,12 @@ test('specToInit drops the body for GET and follows redirects by default', async
   assert.strictEqual(init.redirect, 'follow');
 });
 
+test('requestTimeoutMs uses the global timeout and defaults to 60 seconds', async () => {
+  const { requestTimeoutMs } = await proxyModule;
+  assert.strictEqual(requestTimeoutMs({ timeoutSecs: 90 }), 90_000);
+  assert.strictEqual(requestTimeoutMs({}), 60_000);
+});
+
 test('resultFrom matches the desktop engine response shape', async () => {
   const { resultFrom } = await proxyModule;
   // A string body would make Response add its own content-type header.

--- a/product/akbun-requesthttp/workspace/worker/index.js
+++ b/product/akbun-requesthttp/workspace/worker/index.js
@@ -3,7 +3,7 @@
 // cannot call arbitrary origins itself. TLS verification cannot be disabled
 // here — that is a desktop-only setting.
 
-import { validateSpec, specToInit, resultFrom } from './proxy.js';
+import { validateSpec, specToInit, requestTimeoutMs, resultFrom } from './proxy.js';
 
 export default {
   async fetch(request, env) {
@@ -40,7 +40,7 @@ async function proxy(request) {
   try {
     response = await fetch(spec.url, {
       ...specToInit(spec, settings),
-      signal: AbortSignal.timeout(1000 * (settings.timeoutSecs || 30)),
+      signal: AbortSignal.timeout(requestTimeoutMs(settings)),
     });
   } catch (error) {
     return json({ error: String(error) }, 502);

--- a/product/akbun-requesthttp/workspace/worker/proxy.js
+++ b/product/akbun-requesthttp/workspace/worker/proxy.js
@@ -30,6 +30,11 @@ export function specToInit(spec, settings) {
   return init;
 }
 
+export function requestTimeoutMs(settings) {
+  const seconds = Number(settings && settings.timeoutSecs);
+  return 1000 * (Number.isFinite(seconds) && seconds >= 1 ? seconds : 60);
+}
+
 // The same response shape the desktop Rust engine returns.
 export function resultFrom(response, bodyText, elapsedMs, sizeBytes) {
   return {


### PR DESCRIPTION
# 구현

Settings의 전역 client timeout을 desktop과 web 요청 엔진에 적용하고 60초 기본값과 AI 요청 안내 추가
- npm test 23개 통과

# 리스크

기존 사용자가 저장한 timeout 값 유지
- 신규 상태에만 60초 기본값 적용, 명시적인 사용자 설정 보존

Issue #902