### PR TITLE
feat: 요청 폴더 접기

### DIFF
--- a/product/akbun-requesthttp/workspace/package.json
+++ b/product/akbun-requesthttp/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-requesthttp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Desktop HTTP client: send requests, organize folders, inspect responses, and import curl or .http files",
   "author": "akbun",

--- a/product/akbun-requesthttp/workspace/src/app.js
+++ b/product/akbun-requesthttp/workspace/src/app.js
@@ -14,6 +14,7 @@ let currentRequest = L.createRequest('');
 let selectedFolderId = L.DEFAULT_FOLDER_ID;
 let lastResponse = null;
 let requestInFlight = false;
+const collapsedFolderIds = new Set();
 
 // ------------------------------------------------------------- persistence
 
@@ -63,17 +64,32 @@ function renderSidebar() {
   const root = $('folder-list');
   root.textContent = '';
   for (const folder of state.folders) {
+    const isCollapsed = collapsedFolderIds.has(folder.id);
     const group = document.createElement('section');
     group.className = 'folder-group';
     const heading = document.createElement('div');
     heading.className = 'folder-heading';
+    const requestListId = `folder-requests-${folder.id}`;
+    const toggle = document.createElement('button');
+    toggle.className = 'folder-toggle';
+    toggle.type = 'button';
+    toggle.textContent = isCollapsed ? '▸' : '▾';
+    toggle.title = isCollapsed ? `Expand ${folder.name}` : `Collapse ${folder.name}`;
+    toggle.setAttribute('aria-label', toggle.title);
+    toggle.setAttribute('aria-controls', requestListId);
+    toggle.setAttribute('aria-expanded', String(!isCollapsed));
+    toggle.addEventListener('click', () => {
+      if (isCollapsed) collapsedFolderIds.delete(folder.id);
+      else collapsedFolderIds.add(folder.id);
+      renderSidebar();
+    });
     const name = document.createElement('span');
     name.className = 'folder-name';
     name.textContent = folder.name;
     const count = document.createElement('span');
     count.className = 'folder-count';
     count.textContent = String(folder.requests.length);
-    heading.append(name, count);
+    heading.append(toggle, name, count);
     if (!folder.isDefault) {
       const removeFolder = document.createElement('button');
       removeFolder.className = 'folder-delete';
@@ -96,7 +112,9 @@ function renderSidebar() {
     }
 
     const requestList = document.createElement('ul');
+    requestList.id = requestListId;
     requestList.className = 'request-list';
+    requestList.hidden = isCollapsed;
     for (const request of folder.requests) {
       requestList.append(renderRequestItem(folder, request, requestList));
     }
@@ -476,6 +494,10 @@ function bindDialogs() {
     renderSidebar();
     renderEditor();
     renderResponse();
+  });
+  $('btn-collapse-all').addEventListener('click', () => {
+    state.folders.forEach((folder) => collapsedFolderIds.add(folder.id));
+    renderSidebar();
   });
   $('btn-update').addEventListener('click', () => api.checkUpdate());
   if (api.platform === 'web') $('btn-update').hidden = true;

--- a/product/akbun-requesthttp/workspace/src/index.html
+++ b/product/akbun-requesthttp/workspace/src/index.html
@@ -21,6 +21,7 @@
         <button id="btn-new-request" class="new-item">+ New request</button>
         <button id="btn-new-folder" class="new-item">+ Folder</button>
         <button id="btn-import-http" class="new-item">Import .http</button>
+        <button id="btn-collapse-all" class="new-item">Collapse all</button>
         <input id="http-file-input" type="file" accept=".http,text/plain" hidden />
       </div>
       <div id="folder-list"></div>

--- a/product/akbun-requesthttp/workspace/src/style.css
+++ b/product/akbun-requesthttp/workspace/src/style.css
@@ -87,9 +87,14 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
   border-bottom: 1px solid var(--border);
 }
 .sidebar-actions #btn-new-request { grid-column: 1 / -1; }
+.sidebar-actions #btn-collapse-all { grid-column: 1 / -1; }
 .new-item { margin: 0; }
 
-.folder-group { padding: 6px 8px 0; }
+.folder-group {
+  padding: 6px 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+.folder-group:last-child { border-bottom: none; }
 .folder-heading {
   display: flex;
   align-items: center;
@@ -98,6 +103,15 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
   padding: 2px 4px;
   color: var(--fg-dim);
 }
+.folder-toggle {
+  width: 18px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  line-height: 1;
+}
+.folder-toggle:hover { background: var(--code-bg); }
 .folder-name {
   flex: 1;
   min-width: 0;
@@ -110,6 +124,7 @@ textarea, pre, code, #url { font-family: ui-monospace, 'SF Mono', Menlo, monospa
 .folder-count { font-size: 11px; }
 .folder-delete { border: none; background: none; padding: 0 2px; color: inherit; }
 .request-list { list-style: none; margin: 0; padding: 2px 0 4px 8px; }
+.request-list[hidden] { display: none; }
 .request-list li {
   display: flex;
   align-items: center;


### PR DESCRIPTION
# 구현

폴더별 request 목록 접기·펼치기와 모두 접기 버튼 추가
- 폴더 헤더 토글의 접근성 상태와 폴더 간 경계선 포함

# 리스크

앱 재시작 시 접힘 상태 초기화
- 저장 데이터 구조를 유지하고 현재 화면의 탐색 상태만 관리

Issue #904