### PR TITLE
feat: add file export menu and system fonts

### DIFF
--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src-tauri/Cargo.lock
+++ b/product/akbun-makepresentation/workspace/src-tauri/Cargo.lock
@@ -22,6 +22,7 @@ name = "akbun-makepresentation"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "fontdb",
  "makepresentation-deck",
  "serde",
  "serde_json",
@@ -403,6 +404,15 @@ dependencies = [
  "bitflags 2.13.1",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -826,6 +836,29 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1740,6 +1773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,6 +1841,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2606,6 +2654,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3101,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -3977,6 +4040,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "typeid"

--- a/product/akbun-makepresentation/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-makepresentation/workspace/src-tauri/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # The page hands rendered slides over as data URLs for the pdf export.
 base64 = "0.22"
+fontdb = "0.23"
 
 # Desktop only. These have no mobile implementation and this app has no mobile
 # target, but keeping the cfg means a stray mobile build fails at resolve time

--- a/product/akbun-makepresentation/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/src/commands.rs
@@ -4,8 +4,21 @@
 use base64::Engine;
 use makepresentation_deck::{pdf, pptx, Deck};
 use serde::Deserialize;
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::{BufWriter, Write};
+
+#[tauri::command]
+pub fn list_system_fonts() -> Vec<String> {
+    let mut database = fontdb::Database::new();
+    database.load_system_fonts();
+    database
+        .faces()
+        .flat_map(|face| face.families.iter().map(|(name, _)| name.clone()))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
 
 #[tauri::command]
 pub fn open_deck(path: String) -> Result<Deck, String> {

--- a/product/akbun-makepresentation/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/src/lib.rs
@@ -1,6 +1,20 @@
 mod commands;
 
 #[cfg(desktop)]
+const FILE_NEW_ID: &str = "file-new";
+#[cfg(desktop)]
+const FILE_OPEN_ID: &str = "file-open";
+#[cfg(desktop)]
+const FILE_SAVE_ID: &str = "file-save";
+#[cfg(desktop)]
+const FILE_SAVE_AS_ID: &str = "file-save-as";
+#[cfg(desktop)]
+const FILE_EXPORT_PDF_ID: &str = "file-export-pdf";
+#[cfg(desktop)]
+const FILE_EXPORT_PNG_ID: &str = "file-export-png";
+#[cfg(desktop)]
+const FILE_COMMAND_EVENT: &str = "file-command";
+#[cfg(desktop)]
 const GUIDELINES_MENU_ID: &str = "view-guidelines";
 #[cfg(desktop)]
 const GUIDELINES_EVENT: &str = "guidelines-changed";
@@ -8,15 +22,59 @@ const GUIDELINES_EVENT: &str = "guidelines-changed";
 #[cfg(desktop)]
 fn install_menu(app: &tauri::App) -> tauri::Result<()> {
     use tauri::menu::{
-        CheckMenuItemBuilder, Menu, MenuItemKind, SubmenuBuilder, WINDOW_SUBMENU_ID,
+        CheckMenuItemBuilder, Menu, MenuItemBuilder, MenuItemKind, PredefinedMenuItem,
+        SubmenuBuilder, WINDOW_SUBMENU_ID,
     };
     use tauri::Emitter;
 
     let menu = Menu::default(app.handle())?;
+    let new_item = MenuItemBuilder::with_id(FILE_NEW_ID, "New")
+        .accelerator("CmdOrCtrl+N")
+        .build(app)?;
+    let open_item = MenuItemBuilder::with_id(FILE_OPEN_ID, "Open…")
+        .accelerator("CmdOrCtrl+O")
+        .build(app)?;
+    let save_item = MenuItemBuilder::with_id(FILE_SAVE_ID, "Save")
+        .accelerator("CmdOrCtrl+S")
+        .build(app)?;
+    let save_as_item = MenuItemBuilder::with_id(FILE_SAVE_AS_ID, "PowerPoint (.pptx)…")
+        .accelerator("CmdOrCtrl+Shift+S")
+        .build(app)?;
+    let export_pdf = MenuItemBuilder::with_id(FILE_EXPORT_PDF_ID, "Export PDF…").build(app)?;
+    let export_png = MenuItemBuilder::with_id(FILE_EXPORT_PNG_ID, "Export PNG…").build(app)?;
+    let save_as = SubmenuBuilder::new(app, "Save As")
+        .item(&save_as_item)
+        .separator()
+        .item(&export_pdf)
+        .item(&export_png)
+        .build()?;
+    let file_separator = PredefinedMenuItem::separator(app)?;
+
     let guidelines = CheckMenuItemBuilder::with_id(GUIDELINES_MENU_ID, "Guidelines")
         .checked(false)
         .build(app)?;
     let items = menu.items()?;
+    let file = items.iter().find_map(|item| match item {
+        MenuItemKind::Submenu(submenu)
+            if submenu.text().map(|text| text == "File").unwrap_or(false) =>
+        {
+            Some(submenu.clone())
+        }
+        _ => None,
+    });
+    if let Some(file) = file {
+        file.prepend_items(&[&new_item, &open_item, &file_separator, &save_item, &save_as])?;
+    } else {
+        let file = SubmenuBuilder::new(app, "File")
+            .item(&new_item)
+            .item(&open_item)
+            .separator()
+            .item(&save_item)
+            .item(&save_as)
+            .build()?;
+        menu.insert(&file, usize::from(cfg!(target_os = "macos")))?;
+    }
+
     let view = items.iter().find_map(|item| match item {
         MenuItemKind::Submenu(submenu)
             if submenu.text().map(|text| text == "View").unwrap_or(false) =>
@@ -40,11 +98,21 @@ fn install_menu(app: &tauri::App) -> tauri::Result<()> {
 
     let guidelines_item = guidelines.clone();
     app.on_menu_event(move |app, event| {
-        if event.id() != GUIDELINES_MENU_ID {
-            return;
-        }
-        if let Ok(checked) = guidelines_item.is_checked() {
-            let _ = app.emit_to("main", GUIDELINES_EVENT, checked);
+        let file_command = match event.id().as_ref() {
+            FILE_NEW_ID => Some("new"),
+            FILE_OPEN_ID => Some("open"),
+            FILE_SAVE_ID => Some("save"),
+            FILE_SAVE_AS_ID => Some("save-as"),
+            FILE_EXPORT_PDF_ID => Some("export-pdf"),
+            FILE_EXPORT_PNG_ID => Some("export-png"),
+            _ => None,
+        };
+        if let Some(command) = file_command {
+            let _ = app.emit_to("main", FILE_COMMAND_EVENT, command);
+        } else if event.id() == GUIDELINES_MENU_ID {
+            if let Ok(checked) = guidelines_item.is_checked() {
+                let _ = app.emit_to("main", GUIDELINES_EVENT, checked);
+            }
         }
     });
     Ok(())
@@ -82,6 +150,7 @@ pub fn run() {
             commands::save_deck,
             commands::export_pdf,
             commands::save_png,
+            commands::list_system_fonts,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/product/akbun-makepresentation/workspace/src/api.js
+++ b/product/akbun-makepresentation/workspace/src/api.js
@@ -23,6 +23,7 @@ if (!window.__TAURI__) {
     saveDeck: async () => {},
     exportPdf: async () => {},
     savePng: async () => {},
+    listSystemFonts: async () => ['Arial', 'Helvetica'],
     message: async (text) => alert(text),
     ask: async (text) => confirm(text),
     setTitle: (title) => {
@@ -38,6 +39,7 @@ if (!window.__TAURI__) {
       return () => document.removeEventListener('fullscreenchange', listener);
     },
     onGuidelinesChanged: () => Promise.resolve(() => {}),
+    onFileCommand: () => Promise.resolve(() => {}),
     checkUpdate: async () => {},
   };
   throw new Error('not running under Tauri; using the browser fallback api');
@@ -91,6 +93,7 @@ window.api = {
   saveDeck: (path, deck) => invoke('save_deck', { path, deck }),
   exportPdf: (path, pages) => invoke('export_pdf', { path, pages }),
   savePng: (path, dataUrl) => invoke('save_png', { path, dataUrl }),
+  listSystemFonts: () => invoke('list_system_fonts'),
 
   message: (text, opts) => message(text, opts),
   ask: (text, opts) => ask(text, opts),
@@ -100,5 +103,7 @@ window.api = {
     currentWindow.onResized(async () => handler(await currentWindow.isFullscreen())),
   onGuidelinesChanged: (handler) =>
     listen('guidelines-changed', (event) => handler(!!event.payload)),
+  onFileCommand: (handler) =>
+    listen('file-command', (event) => handler(event.payload)),
   checkUpdate,
 };

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -677,6 +677,12 @@ function zoomOut(zoom) {
   return smaller.length ? smaller[smaller.length - 1] : ZOOM_STEPS[0];
 }
 
+function filterFonts(fonts, query) {
+  const needle = String(query || '').trim().toLocaleLowerCase();
+  if (!needle) return [...fonts];
+  return fonts.filter((font) => font.toLocaleLowerCase().includes(needle));
+}
+
 const exported = {
   SLIDE_W,
   SLIDE_H,
@@ -686,6 +692,7 @@ const exported = {
   ZOOM_FIT,
   zoomIn,
   zoomOut,
+  filterFonts,
   createDeck,
   createSlide,
   slideBackground,

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -8,13 +8,6 @@
 </head>
 <body>
   <header id="toolbar">
-    <div class="group">
-      <button id="btn-new" title="New deck">New</button>
-      <button id="btn-open" title="Open a .pptx file">Open</button>
-      <button id="btn-save" title="Save (Cmd+S)">Save</button>
-      <button id="btn-save-as" title="Save under a new name">Save As</button>
-      <button id="btn-pdf" title="Export every slide as a PDF">PDF</button>
-    </div>
     <div class="group tools">
       <button data-tool="select" title="Select (V)">Select</button>
       <button data-tool="rect" title="Rectangle (R)">▭</button>
@@ -102,18 +95,17 @@
       </div>
       <div id="props-text">
         <div class="prop-row">
-          <label>Font</label>
-          <select id="prop-font-family">
-            <option value="Helvetica">Helvetica</option>
-            <option value="Arial">Arial</option>
-            <option value="Verdana">Verdana</option>
-            <option value="Georgia">Georgia</option>
-            <option value="Times New Roman">Times New Roman</option>
-            <option value="Courier New">Courier New</option>
-            <option value="Apple SD Gothic Neo">애플 SD 산돌고딕</option>
-            <option value="Malgun Gothic">맑은 고딕</option>
-            <option value="Batang">바탕</option>
-          </select>
+          <label for="prop-font-family">Font</label>
+          <div id="font-picker" class="font-picker">
+            <button id="prop-font-family" type="button" aria-haspopup="listbox" aria-expanded="false">
+              <span id="font-family-label">Helvetica</span>
+              <span aria-hidden="true">⌄</span>
+            </button>
+            <div id="font-menu" hidden>
+              <input id="font-search" type="search" placeholder="Search fonts" autocomplete="off" />
+              <div id="font-options" role="listbox"></div>
+            </div>
+          </div>
         </div>
         <div class="prop-row">
           <label>Font size</label>

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -30,6 +30,11 @@ const stageInner = $('stage-inner');
 const textEditor = $('text-editor');
 const present = $('present');
 const contextMenu = $('context-menu');
+const fontPicker = $('font-picker');
+const fontMenu = $('font-menu');
+const fontSearch = $('font-search');
+const fontOptions = $('font-options');
+let fontFamilies = ['Arial', 'Helvetica'];
 
 const slide = () => state.deck.slides[state.current];
 const selectedShape = () =>
@@ -238,15 +243,10 @@ function renderProps() {
     );
   }
 
-  // A pptx from another editor can name a font this list does not offer.
-  // Adding it keeps the select honest instead of silently showing the wrong
-  // family.
-  const fonts = $('prop-font-family');
   const family = source.fontFamily || 'Helvetica';
-  if (!Array.from(fonts.options).some((o) => o.value === family)) {
-    fonts.add(new Option(family, family));
-  }
-  fonts.value = family;
+  rememberFontFamily(family);
+  $('font-family-label').textContent = family;
+  $('font-family-label').style.fontFamily = `"${family}", sans-serif`;
 }
 
 function renderBackground() {
@@ -645,6 +645,11 @@ textEditor.addEventListener('keydown', (event) => {
 const TOOL_KEYS = { v: 'select', r: 'rect', o: 'ellipse', l: 'line', a: 'arrow', p: 'pen', t: 'text' };
 
 document.addEventListener('keydown', (event) => {
+  if (!fontMenu.hidden && event.key === 'Escape') {
+    hideFontMenu();
+    event.preventDefault();
+    return;
+  }
   if (!contextMenu.hidden && event.key === 'Escape') {
     hideContextMenu();
     event.preventDefault();
@@ -684,7 +689,7 @@ document.addEventListener('keydown', (event) => {
   // for these, so Shift only picks the redo branch.
   if (event.metaKey || event.ctrlKey) {
     const key = event.key.toLowerCase();
-    if (key === 's') saveFile(false);
+    if (key === 's') saveFile(event.shiftKey);
     else if (key === 'z' && event.shiftKey) redo();
     else if (key === 'z') undo();
     else if (key === 'y') redo();
@@ -864,6 +869,80 @@ function hideContextMenu() {
   contextMenu.hidden = true;
 }
 
+function rememberFontFamily(family) {
+  if (!fontFamilies.includes(family)) {
+    fontFamilies.push(family);
+    fontFamilies.sort((left, right) => left.localeCompare(right));
+  }
+}
+
+function renderFontOptions() {
+  const selected = selectedShape()?.fontFamily || state.defaults.fontFamily;
+  const matching = L.filterFonts(fontFamilies, fontSearch.value);
+  fontOptions.textContent = '';
+  const fragment = document.createDocumentFragment();
+  for (const family of matching) {
+    const option = document.createElement('button');
+    option.type = 'button';
+    option.dataset.font = family;
+    option.textContent = family;
+    option.style.fontFamily = `"${family}", sans-serif`;
+    option.classList.toggle('active', family === selected);
+    option.setAttribute('role', 'option');
+    option.setAttribute('aria-selected', String(family === selected));
+    fragment.append(option);
+  }
+  if (!matching.length) {
+    const empty = document.createElement('p');
+    empty.className = 'font-empty';
+    empty.textContent = 'No fonts found';
+    fragment.append(empty);
+  }
+  fontOptions.append(fragment);
+}
+
+function positionFontMenu() {
+  const trigger = $('prop-font-family').getBoundingClientRect();
+  const bounds = fontMenu.getBoundingClientRect();
+  const left = Math.max(
+    4,
+    Math.min(trigger.right - bounds.width, window.innerWidth - bounds.width - 4)
+  );
+  const below = trigger.bottom + 4;
+  const top = below + bounds.height <= window.innerHeight
+    ? below
+    : Math.max(4, trigger.top - bounds.height - 4);
+  fontMenu.style.left = `${left}px`;
+  fontMenu.style.top = `${top}px`;
+}
+
+function showFontMenu() {
+  fontMenu.hidden = false;
+  $('prop-font-family').setAttribute('aria-expanded', 'true');
+  fontSearch.value = '';
+  renderFontOptions();
+  positionFontMenu();
+  fontSearch.focus();
+}
+
+function hideFontMenu() {
+  fontMenu.hidden = true;
+  $('prop-font-family').setAttribute('aria-expanded', 'false');
+}
+
+async function loadSystemFonts() {
+  try {
+    const installed = await window.api.listSystemFonts();
+    fontFamilies = [...new Set(installed.filter(
+      (font) => typeof font === 'string' && font.trim()
+    ))].sort((left, right) => left.localeCompare(right));
+    rememberFontFamily(state.defaults.fontFamily);
+    renderProps();
+  } catch (error) {
+    console.error('Cannot load system fonts', error);
+  }
+}
+
 function showContextMenu(x, y) {
   contextMenu.hidden = false;
   contextMenu.style.left = `${x}px`;
@@ -903,10 +982,21 @@ document.addEventListener('contextmenu', (event) => {
 
 document.addEventListener('pointerdown', (event) => {
   if (!contextMenu.contains(event.target)) hideContextMenu();
+  if (!fontPicker.contains(event.target)) hideFontMenu();
 });
-window.addEventListener('blur', hideContextMenu);
-window.addEventListener('resize', hideContextMenu);
-$('stage-scroll').addEventListener('scroll', hideContextMenu);
+window.addEventListener('blur', () => {
+  hideContextMenu();
+  hideFontMenu();
+});
+window.addEventListener('resize', () => {
+  hideContextMenu();
+  hideFontMenu();
+});
+$('stage-scroll').addEventListener('scroll', () => {
+  hideContextMenu();
+  hideFontMenu();
+});
+$('props').addEventListener('scroll', hideFontMenu);
 
 function rasterizeShapes(shapes) {
   return new Promise((resolve, reject) => {
@@ -967,6 +1057,29 @@ async function saveSelectionAsImage() {
 }
 
 $('context-save-image').addEventListener('click', saveSelectionAsImage);
+
+$('prop-font-family').addEventListener('click', () => {
+  if (fontMenu.hidden) showFontMenu();
+  else hideFontMenu();
+});
+fontSearch.addEventListener('input', renderFontOptions);
+fontSearch.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    hideFontMenu();
+    $('prop-font-family').focus();
+  } else if (event.key === 'Enter') {
+    fontOptions.querySelector('[data-font]')?.click();
+  } else if (event.key === 'ArrowDown') {
+    fontOptions.querySelector('[data-font]')?.focus();
+  }
+});
+fontOptions.addEventListener('click', (event) => {
+  const option = event.target.closest('[data-font]');
+  if (!option) return;
+  applyProp({ fontFamily: option.dataset.font });
+  hideFontMenu();
+  $('prop-font-family').focus();
+});
 
 // --- property panel -------------------------------------------------------------------
 
@@ -1069,9 +1182,6 @@ $('prop-font-size').addEventListener('input', (e) =>
   applyProp({ fontSize: Math.max(6, Number(e.target.value) || 24) })
 );
 $('prop-text-color').addEventListener('input', (e) => applyProp({ textColor: e.target.value }));
-$('prop-font-family').addEventListener('change', (e) =>
-  applyProp({ fontFamily: e.target.value })
-);
 $('btn-delete-shape').addEventListener('click', deleteSelectedShape);
 
 // --- text formatting -----------------------------------------------------------
@@ -1217,9 +1327,9 @@ async function saveFile(alwaysAsk) {
   }
 }
 
-// Rasterize one slide for the pdf: SVG markup into an image, image onto a
-// canvas, canvas to JPEG. 1920x1080 is plenty for print at this slide size.
-function rasterizeSlide(s, number) {
+// Rasterize one slide at 1920x1080, which is enough for PDF pages and PNG
+// exports at this slide size.
+function rasterizeSlideCanvas(s, number) {
   return new Promise((resolve, reject) => {
     const svg = L.renderSlideSvg(s, { number });
     const url = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml' }));
@@ -1228,9 +1338,15 @@ function rasterizeSlide(s, number) {
       const raster = document.createElement('canvas');
       raster.width = 1920;
       raster.height = 1080;
-      raster.getContext('2d').drawImage(image, 0, 0, 1920, 1080);
+      const context = raster.getContext('2d');
+      if (!context) {
+        URL.revokeObjectURL(url);
+        reject(new Error('cannot create slide canvas'));
+        return;
+      }
+      context.drawImage(image, 0, 0, 1920, 1080);
       URL.revokeObjectURL(url);
-      resolve({ dataUrl: raster.toDataURL('image/jpeg', 0.92), width: 1920, height: 1080 });
+      resolve(raster);
     };
     image.onerror = () => {
       URL.revokeObjectURL(url);
@@ -1240,16 +1356,41 @@ function rasterizeSlide(s, number) {
   });
 }
 
+async function rasterizeSlideForPdf(s, number) {
+  const raster = await rasterizeSlideCanvas(s, number);
+  return { dataUrl: raster.toDataURL('image/jpeg', 0.92), width: 1920, height: 1080 };
+}
+
 async function exportPdf() {
   const path = await window.api.pickSave(suggestName('pdf'), 'pdf');
   if (!path) return;
   try {
     const pages = [];
     for (const [i, s] of state.deck.slides.entries()) {
-      pages.push(await rasterizeSlide(s, state.showNumbers ? i + 1 : 0));
+      pages.push(await rasterizeSlideForPdf(s, state.showNumbers ? i + 1 : 0));
     }
     await window.api.exportPdf(path, pages);
     await window.api.message('PDF saved.', { title: 'akbun-makepresentation' });
+  } catch (error) {
+    await window.api.message(String(error), { title: 'Export failed', kind: 'error' });
+  }
+}
+
+function suggestSlideImageName() {
+  const base = suggestName('pptx').replace(/\.pptx$/i, '');
+  return `${base}-slide-${state.current + 1}.png`;
+}
+
+async function exportPng() {
+  const path = await window.api.pickSave(suggestSlideImageName(), 'png');
+  if (!path) return;
+  try {
+    const raster = await rasterizeSlideCanvas(
+      slide(),
+      state.showNumbers ? state.current + 1 : 0
+    );
+    await window.api.savePng(path, raster.toDataURL('image/png'));
+    await window.api.message('PNG saved.', { title: 'akbun-makepresentation' });
   } catch (error) {
     await window.api.message(String(error), { title: 'Export failed', kind: 'error' });
   }
@@ -1318,13 +1459,19 @@ window.api.onGuidelinesChanged((enabled) => {
   renderCanvas();
 });
 
-// --- toolbar ---------------------------------------------------------------------------------------
+// --- toolbar and application menu ------------------------------------------------------------------
 
-$('btn-new').addEventListener('click', newDeck);
-$('btn-open').addEventListener('click', openFile);
-$('btn-save').addEventListener('click', () => saveFile(false));
-$('btn-save-as').addEventListener('click', () => saveFile(true));
-$('btn-pdf').addEventListener('click', exportPdf);
+window.api.onFileCommand((command) => {
+  const actions = {
+    new: newDeck,
+    open: openFile,
+    save: () => saveFile(false),
+    'save-as': () => saveFile(true),
+    'export-pdf': exportPdf,
+    'export-png': exportPng,
+  };
+  if (actions[command]) actions[command]();
+});
 $('btn-present').addEventListener('click', enterPresent);
 
 function setNumbersButton() {
@@ -1344,3 +1491,4 @@ for (const button of document.querySelectorAll('[data-tool]')) {
 setTool('select');
 setZoom(state.zoom);
 renderAll();
+loadSystemFonts();

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -47,13 +47,22 @@ body {
 /* --- toolbar --- */
 
 #toolbar {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
+}
+
+#toolbar .tools {
+  grid-column: 2;
+}
+
+#toolbar > .group:last-child {
+  grid-column: 3;
+  justify-self: end;
 }
 
 .group {
@@ -63,7 +72,8 @@ body {
 
 button,
 select,
-input[type='number'] {
+input[type='number'],
+input[type='search'] {
   font: inherit;
   color: var(--fg);
   background: var(--panel);
@@ -453,8 +463,64 @@ main {
 
 /* The font names are long, so the select gets a hard cap rather than pushing
    the panel wider. */
-.prop-row select {
+.prop-row select,
+.font-picker {
   max-width: 110px;
+}
+
+.font-picker {
+  position: relative;
+}
+
+#prop-font-family {
+  width: 110px;
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  overflow: hidden;
+}
+
+#font-family-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#font-menu {
+  position: fixed;
+  z-index: 30;
+  width: 240px;
+  max-height: 320px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+}
+
+#font-search {
+  width: 100%;
+  margin-bottom: 5px;
+  padding: 6px 8px;
+}
+
+#font-options {
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+#font-options button {
+  width: 100%;
+  border: 0;
+  padding: 6px 8px;
+  text-align: left;
+}
+
+#font-options button:hover,
+#font-options button:focus-visible,
+#font-options button.active {
+  background: var(--accent-soft);
+  outline: none;
 }
 
 input[type='color'] {

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -459,3 +459,12 @@ test('zoomIn and zoomOut walk the steps and stop at the ends', () => {
   assert.strictEqual(L.zoomIn(1.1), 1.25);
   assert.strictEqual(L.zoomOut(1.1), 1);
 });
+
+test('filterFonts searches installed family names without case sensitivity', () => {
+  const fonts = ['Apple SD Gothic Neo', 'Helvetica', 'Nanum Gothic'];
+  assert.deepStrictEqual(L.filterFonts(fonts, 'GOTHIC'), [
+    'Apple SD Gothic Neo',
+    'Nanum Gothic',
+  ]);
+  assert.deepStrictEqual(L.filterFonts(fonts, ''), fonts);
+});


### PR DESCRIPTION
# 구현

File 메뉴 통합, PDF와 현재 슬라이드 PNG 내보내기, 시스템 폰트 검색
- JavaScript 49개, Rust 10개 테스트와 전체 Tauri 컴파일 및 개발 앱 기동 통과

# 어려웠던 점

네이티브 메뉴 이벤트와 WebView 파일 작업 연결
- Tauri menu event를 renderer command로 변환해 기존 저장 로직 재사용

# 리스크

fontdb 시스템 폰트 스캔이 앱 시작 후 첫 목록 갱신에 시간 사용
- 비동기 1회 호출로 편집기 기동과 입력 흐름 차단 없음

Issue #906