### PR TITLE
fix: makepresentation 다중 선택 복구

### DIFF
--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -361,12 +361,14 @@ function toPoint(event) {
 
 canvas.addEventListener('pointerdown', (event) => {
   if (event.button !== 0) return;
+  if (state.editingIndex >= 0) textEditor.blur();
+  // WebKit otherwise starts a native text selection alongside marquee and
+  // Shift-click selection. That highlight can extend outside the marquee and
+  // makes the editor selection look as if it contains only the last object.
+  event.preventDefault();
   const p = toPoint(event);
 
   if (state.tool === 'text') {
-    // Without this the default focus action of the click lands after
-    // startTextEdit and blurs the textarea straight back to an empty commit.
-    event.preventDefault();
     const shape = L.createShape('text', p.x, p.y, state.defaults);
     shape.w = 320;
     shape.h = shape.fontSize * 1.4;

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -361,6 +361,10 @@ function toPoint(event) {
 
 canvas.addEventListener('pointerdown', (event) => {
   if (event.button !== 0) return;
+  const handleEl = event.target.closest('[data-handle]');
+  const cropHandle = event.target.closest('[data-crop-handle]');
+  const group = event.target.closest('g[data-i]');
+  const hitShape = group ? slide().shapes[Number(group.dataset.i)] : null;
   if (state.editingIndex >= 0) textEditor.blur();
   // WebKit otherwise starts a native text selection alongside marquee and
   // Shift-click selection. That highlight can extend outside the marquee and
@@ -389,7 +393,6 @@ canvas.addEventListener('pointerdown', (event) => {
     return;
   }
 
-  const handleEl = event.target.closest('[data-handle]');
   if (handleEl && state.selection.length === 1 && selectedShape()) {
     state.drag = {
       mode: 'resize',
@@ -402,7 +405,6 @@ canvas.addEventListener('pointerdown', (event) => {
     return;
   }
 
-  const cropHandle = event.target.closest('[data-crop-handle]');
   if (cropHandle && state.cropping && selectedShape()) {
     state.drag = {
       mode: 'crop',
@@ -415,9 +417,8 @@ canvas.addEventListener('pointerdown', (event) => {
     return;
   }
 
-  const group = event.target.closest('g[data-i]');
-  if (group) {
-    const index = Number(group.dataset.i);
+  const index = hitShape ? slide().shapes.indexOf(hitShape) : -1;
+  if (index >= 0) {
 
     // Shift-click changes only this object's membership. It does not begin a
     // drag, so repeated Shift-clicks can build or shrink a selection without

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -237,6 +237,8 @@ main {
   aspect-ratio: 16 / 9;
   background: #ffffff;
   box-shadow: 0 0 0 1px var(--border), 0 2px 12px rgba(0, 0, 0, 0.25);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 #canvas[data-tool='rect'],


### PR DESCRIPTION
# 구현

WebKit 기본 텍스트 선택 차단과 다중 선택 표시 복구
- JavaScript 49개, Rust 10개, 브라우저 영역·Shift 선택 시나리오 통과

# 어려웠던 점

편집기 객체 선택과 WebKit 네이티브 텍스트 선택의 동시 실행 분리
- 설치본에서 객체 8개 선택 상태와 영역 밖 제목 하이라이트가 동시에 발생함을 재현

# 리스크

포인터 기본 동작 차단 전 텍스트 편집 내용을 명시적으로 확정
- 편집 중 캔버스 클릭 시 내용 확정과 선택 전환 자동 검증 완료

Issue #908