### PR TITLE
feat: makepresentation 도형 텍스트, 창 안 메뉴, 슬라이드 순서

### DIFF
--- a/product/akbun-makepresentation/README.md
+++ b/product/akbun-makepresentation/README.md
@@ -4,14 +4,17 @@ Desktop slide deck editor for the slides actually used in blog posts and talks: 
 
 ## What it does
 
-- Slides: add, delete, duplicate, switch, thumbnail panel
+- Slides: add, delete, duplicate, switch, reorder by drag or by Cmd+Up/Down, thumbnail panel
 - Per-slide background color from its own panel card, with presets, a custom color and apply-to-all
 - Shapes: rectangle, ellipse, line, arrow, freehand pen
 - Text boxes with font family, size, color, bold, italic, underline and alignment
+- Text written inside a rectangle or an ellipse, centered, with the same font controls
 - Per-shape line color, width, style (solid/dashed/dotted) and fill
-- Multi-object group and ungroup, with grouped move and duplicate
+- Multi-object group and ungroup from the right-click menu or the panel, with grouped move and duplicate
+- Its own File, Edit and View menus in the window rather than in the system menu bar
 - Image borders and interactive crop handles with a shaded outside area
 - Optional arrowhead at the end of a freehand stroke
+- Line and arrow ends chosen per side: none, triangle, open arrow, circle, diamond
 - Zoom from 50% to 400%, from the status bar or the keyboard
 - Slide numbers, toggled from the status bar
 - Undo and redo, multi-object selection, copy and paste, duplicate
@@ -30,18 +33,22 @@ Cmd on macOS, Ctrl on Windows and Linux.
 | Cmd+C, Cmd+V | Copy selected objects, or paste the latest system clipboard text or image |
 | Cmd+D | Duplicate the selected objects, or the whole slide when nothing is selected |
 | Cmd+S | Save |
+| Cmd+N, Cmd+O | New deck, open a deck |
+| Cmd+Up / Cmd+Down | Move the current slide one place earlier or later |
 | Cmd+B, Cmd+I, Cmd+U | Bold, italic, underline the selected text box, or the style new ones start with |
 | Cmd++ / Cmd+- | Zoom in / out |
 | Cmd+0 | Fit the slide to the window |
 | Shift while drawing | Square or circle; lines and arrows snap to 45 degrees |
 | Shift while dragging | Move on one axis only |
+| Shift+click | Add an object to the selection, or drop it out. Over empty space it keeps the selection |
 | Drag on an empty slide | Select every object fully enclosed by the dragged area |
 | Cmd+drag | Drag a copy and leave the original in place |
 | Cmd+Shift+drag | Same, with the copy kept on one axis |
 | V R O L A P T | Select, rectangle, ellipse, line, arrow, pen, text |
 | Arrows | Nudge the selection by 1px, or 10px with Shift |
-| Delete, Backspace | Delete the selection. Inside a text box being edited they delete a character instead |
-| Double click on a text box | Edit its text |
+| Delete, Backspace | Delete the selection, or the current slide when the slide panel has focus. Inside a text box being edited they delete a character instead |
+| Double click on a shape | Edit its text |
+| Typing over a selected shape | Starts writing in it. The tool letters come back once nothing is selected |
 
 ## Directory layout
 

--- a/product/akbun-makepresentation/adr/2026-08-menus-in-the-window.md
+++ b/product/akbun-makepresentation/adr/2026-08-menus-in-the-window.md
@@ -1,0 +1,19 @@
+# The menus live in the window, except the clipboard items macOS needs
+
+## Decision
+
+File, Edit and View are built in the page and drawn under the toolbar. The system menu bar keeps two submenus and nothing else: the application menu, and an Edit menu holding only Cut, Copy, Paste and Select All.
+
+## Reason
+
+On a Mac the menu bar sits at the top of the screen, far from a window that is usually not maximized. Every command the editor has is about the deck in front of the user, so the menu that offers them belongs next to it. Keeping them in the page also means one implementation of each command: the menu item and the keyboard shortcut call the same function, and the page owns both.
+
+Two things could not move.
+
+The application menu is not ours to remove. macOS draws it whatever the app does, and without it there is no Quit.
+
+The clipboard items are load-bearing. WKWebView takes Cmd+C, Cmd+V and Cmd+X from the menu bar's key equivalents, so an app with no Cut/Copy/Paste items is an app where copy and paste stop working inside the page. Those four items exist for that reason alone; the editor's own copy and paste handlers are what actually run.
+
+Undo and Redo were deliberately left out of that Edit menu for the mirror image of the same reason. The predefined items own Cmd+Z, and the webview would answer it as text undo, so the deck's undo would never see the key. Undo lives in the window's Edit menu, where the page can hear it.
+
+`file-command` and `guidelines-changed` used to carry menu clicks from Rust into the page. Nothing emits them now. The listeners stay because the shell may want to drive a command again later, and they cost one line each.

--- a/product/akbun-makepresentation/adr/index.md
+++ b/product/akbun-makepresentation/adr/index.md
@@ -7,3 +7,4 @@
 | [2026-08-pdf-from-rasterized-slides.md](./2026-08-pdf-from-rasterized-slides.md) | The page rasterizes slides; Rust wraps JPEGs into the pdf |
 | [2026-08-updater-fixed-tag-endpoint.md](./2026-08-updater-fixed-tag-endpoint.md) | The updater polls a fixed per-product tag, not releases/latest |
 | [2026-08-background-is-a-slide-field.md](./2026-08-background-is-a-slide-field.md) | The slide background is a field on the slide, not a page-sized shape |
+| [2026-08-menus-in-the-window.md](./2026-08-menus-in-the-window.md) | The menus live in the window; only the clipboard items macOS needs stay in the menu bar |

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
@@ -106,8 +106,18 @@ pub struct Shape {
     pub rotation: f64,
     #[serde(default)]
     pub pen_arrow: bool,
+    /// One of none | triangle | arrow | oval | diamond, which are the pptx
+    /// `a:headEnd`/`a:tailEnd` type names, so a round trip is a rename.
+    #[serde(default = "default_arrow_end")]
+    pub arrow_start: String,
+    #[serde(default = "default_arrow_end")]
+    pub arrow_end: String,
     #[serde(default)]
     pub group_id: String,
+}
+
+pub fn default_arrow_end() -> String {
+    "none".into()
 }
 
 fn default_stroke() -> String {
@@ -169,6 +179,8 @@ impl Default for Shape {
             crop_bottom: 0.0,
             rotation: 0.0,
             pen_arrow: false,
+            arrow_start: default_arrow_end(),
+            arrow_end: default_arrow_end(),
             group_id: String::new(),
         }
     }

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
@@ -409,7 +409,9 @@ fn pic_xml(shape: &Shape, id: u64, rid: u64) -> String {
     )
 }
 
-fn line_xml(shape: &Shape, arrow: bool) -> String {
+/// `pen_arrow` is the pen's single "head at the far end" flag. Every other
+/// shape names its two ends itself.
+fn line_xml(shape: &Shape, pen_arrow: bool) -> String {
     let w = emu(shape.stroke_width).max(1);
     if shape.stroke == "none" {
         return format!("<a:ln w=\"{w}\"><a:noFill/></a:ln>");
@@ -419,15 +421,41 @@ fn line_xml(shape: &Shape, arrow: bool) -> String {
         "dot" => "<a:prstDash val=\"sysDot\"/>",
         _ => "",
     };
-    let head = if arrow {
-        "<a:tailEnd type=\"triangle\"/>"
+    // An unknown end name is written as no end at all.
+    let ends = if pen_arrow {
+        "<a:tailEnd type=\"triangle\"/>".to_string()
     } else {
-        ""
+        format!(
+            "{}{}",
+            end_xml("headEnd", &shape.arrow_start),
+            end_xml("tailEnd", &shape.arrow_end)
+        )
     };
     format!(
-        "<a:ln w=\"{w}\"><a:solidFill><a:srgbClr val=\"{}\"/></a:solidFill>{dash}{head}</a:ln>",
+        "<a:ln w=\"{w}\"><a:solidFill><a:srgbClr val=\"{}\"/></a:solidFill>{dash}{ends}</a:ln>",
         hex(&shape.stroke)
     )
+}
+
+const ARROW_ENDS: [&str; 4] = ["triangle", "arrow", "oval", "diamond"];
+
+/// The five ends this editor draws. `stealth` is PowerPoint's other filled
+/// head and reads as a triangle here; anything else it might write is dropped
+/// rather than guessed at.
+fn read_arrow_end(end: &Option<String>) -> String {
+    match end.as_deref() {
+        Some("stealth") => "triangle".into(),
+        Some(name) if ARROW_ENDS.contains(&name) => name.into(),
+        _ => "none".into(),
+    }
+}
+
+fn end_xml(tag: &str, end: &str) -> String {
+    if ARROW_ENDS.contains(&end) {
+        format!("<a:{tag} type=\"{end}\"/>")
+    } else {
+        String::new()
+    }
 }
 
 fn fill_xml(fill: &str) -> String {
@@ -480,15 +508,22 @@ fn text_body(shape: &Shape) -> String {
             xml_escape(line)
         ));
     }
+    // A text box is nothing but its text, so it gets no inset. Text inside a
+    // rect or an ellipse keeps the same 8px off the outline that the editor
+    // draws it at, or the two disagree by that much on every round trip.
+    let inset = if shape.kind == "text" {
+        0
+    } else {
+        (8.0 * crate::EMU_PER_PX) as i64
+    };
     format!(
-        "<p:txBody><a:bodyPr wrap=\"square\" anchor=\"{anchor}\" lIns=\"0\" tIns=\"0\" rIns=\"0\" bIns=\"0\"><a:noAutofit/></a:bodyPr><a:lstStyle/>{paragraphs}</p:txBody>"
+        "<p:txBody><a:bodyPr wrap=\"square\" anchor=\"{anchor}\" lIns=\"{inset}\" tIns=\"{inset}\" rIns=\"{inset}\" bIns=\"{inset}\"><a:noAutofit/></a:bodyPr><a:lstStyle/>{paragraphs}</p:txBody>"
     )
 }
 
 fn shape_xml(shape: &Shape, id: u64) -> String {
     match shape.kind.as_str() {
         "line" | "arrow" => {
-            let arrow = shape.kind == "arrow";
             let (x, w) = if shape.w < 0.0 {
                 (shape.x + shape.w, -shape.w)
             } else {
@@ -503,7 +538,7 @@ fn shape_xml(shape: &Shape, id: u64) -> String {
                 "<p:cxnSp><p:nvCxnSpPr><p:cNvPr id=\"{id}\" name=\"Line {id}\"/><p:cNvCxnSpPr/><p:nvPr/></p:nvCxnSpPr>\
 <p:spPr>{}<a:prstGeom prst=\"line\"><a:avLst/></a:prstGeom>{}</p:spPr></p:cxnSp>",
                 xfrm(x, y, w, h, shape.w < 0.0, shape.h < 0.0),
-                line_xml(shape, arrow)
+                line_xml(shape, false)
             )
         }
         "pen" => {
@@ -539,9 +574,17 @@ fn shape_xml(shape: &Shape, id: u64) -> String {
         // rect and ellipse
         _ => {
             let prst = if shape.kind == "ellipse" { "ellipse" } else { "rect" };
+            // Text written inside the outline goes in the shape's own txBody,
+            // which is what PowerPoint puts there too, so it stays attached to
+            // the shape instead of becoming a box sitting on top of it.
+            let text = if shape.text.is_empty() {
+                String::new()
+            } else {
+                text_body(shape)
+            };
             format!(
                 "<p:sp><p:nvSpPr><p:cNvPr id=\"{id}\" name=\"Shape {id}\"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr>\
-<p:spPr>{}<a:prstGeom prst=\"{prst}\"><a:avLst/></a:prstGeom>{}{}</p:spPr></p:sp>",
+<p:spPr>{}<a:prstGeom prst=\"{prst}\"><a:avLst/></a:prstGeom>{}{}</p:spPr>{text}</p:sp>",
                 xfrm(shape.x, shape.y, shape.w, shape.h, false, false),
                 fill_xml(&shape.fill),
                 line_xml(shape, false)
@@ -1084,6 +1127,8 @@ struct Pending {
     stroke_w: Option<i64>,
     dash: Option<String>,
     arrow: bool,
+    head_end: Option<String>,
+    tail_end: Option<String>,
     fill: Option<String>,
     text: String,
     font_size: Option<f64>,
@@ -1404,8 +1449,14 @@ fn handle_element(
         }
         "prstDash" => p.dash = get(b"val"),
         "tailEnd" | "headEnd" => {
-            if get(b"type").map(|t| t != "none").unwrap_or(false) {
+            let end = get(b"type");
+            if end.as_deref().map(|t| t != "none").unwrap_or(false) {
                 p.arrow = true;
+            }
+            if local == "headEnd" {
+                p.head_end = end;
+            } else {
+                p.tail_end = end;
             }
         }
         "rPr" => {
@@ -1671,13 +1722,22 @@ fn finish(p: Pending, ctx: &SlideCtx, default: Option<&Shape>) -> Option<Shape> 
         }
     } else if !p.is_pic && is_line {
         shape.kind = if p.arrow { "arrow" } else { "line" }.into();
+        // headEnd sits at the start of the geometry and tailEnd at its end.
+        // The flips below move the start point, not which end is which.
+        shape.arrow_start = read_arrow_end(&p.head_end);
+        shape.arrow_end = read_arrow_end(&p.tail_end);
         // Stored as start -> end; flips say which corner of the box starts.
         shape.x = px(if p.flip_h { p.x + p.cx } else { p.x });
         shape.y = px(if p.flip_v { p.y + p.cy } else { p.y });
         shape.w = px(if p.flip_h { -p.cx } else { p.cx });
         shape.h = px(if p.flip_v { -p.cy } else { p.cy });
     } else if !p.is_pic {
-        shape.kind = if p.tx_box || (!p.text.trim().is_empty() && p.stroke.is_none()) {
+        // Text alone on the slide is a text box. Text on something that also
+        // draws an outline or a fill is that shape's own text, now that a rect
+        // and an ellipse can carry text of their own.
+        shape.kind = if p.tx_box
+            || (!p.text.trim().is_empty() && p.stroke.is_none() && p.fill.is_none())
+        {
             "text".into()
         } else if p.prst.as_deref() == Some("ellipse") {
             "ellipse".into()
@@ -1799,6 +1859,9 @@ mod tests {
                             stroke_width: 3.0,
                             dash: "dash".into(),
                             group_id: "diagram".into(),
+                            text: "inside the box".into(),
+                            text_align: "center".into(),
+                            vertical_align: "center".into(),
                             ..Shape::default()
                         },
                         Shape {
@@ -1817,6 +1880,8 @@ mod tests {
                             w: -200.0,
                             h: 120.0,
                             stroke: "#1971c2".into(),
+                            arrow_start: "oval".into(),
+                            arrow_end: "diamond".into(),
                             ..Shape::default()
                         },
                         Shape {
@@ -1900,7 +1965,11 @@ mod tests {
                     assert!(close(a.x, b.x) && close(a.y, b.y));
                     assert!(close(a.w, b.w) && close(a.h, b.h));
                 }
-                if a.kind == "text" {
+                if a.kind == "line" || a.kind == "arrow" {
+                    assert_eq!(a.arrow_start, b.arrow_start);
+                    assert_eq!(a.arrow_end, b.arrow_end);
+                }
+                if a.kind == "text" || !a.text.is_empty() {
                     assert!(close(a.font_size, b.font_size));
                     assert_eq!(a.text_color, b.text_color);
                     assert_eq!(a.font_family, b.font_family);

--- a/product/akbun-makepresentation/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/src/lib.rs
@@ -1,120 +1,39 @@
 mod commands;
 
-#[cfg(desktop)]
-const FILE_NEW_ID: &str = "file-new";
-#[cfg(desktop)]
-const FILE_OPEN_ID: &str = "file-open";
-#[cfg(desktop)]
-const FILE_SAVE_ID: &str = "file-save";
-#[cfg(desktop)]
-const FILE_SAVE_AS_ID: &str = "file-save-as";
-#[cfg(desktop)]
-const FILE_EXPORT_PDF_ID: &str = "file-export-pdf";
-#[cfg(desktop)]
-const FILE_EXPORT_PNG_ID: &str = "file-export-png";
-#[cfg(desktop)]
-const FILE_COMMAND_EVENT: &str = "file-command";
-#[cfg(desktop)]
-const GUIDELINES_MENU_ID: &str = "view-guidelines";
-#[cfg(desktop)]
-const GUIDELINES_EVENT: &str = "guidelines-changed";
-
+// The app carries its own File/Edit/View menus in the window, so the system
+// menu bar holds nothing but what macOS insists on: an application menu with
+// Quit, and the standard edit items. Those edit items are not decoration —
+// WKWebView routes Cmd+C, Cmd+V and Cmd+A through them, and without them
+// copy and paste stop working inside the page.
 #[cfg(desktop)]
 fn install_menu(app: &tauri::App) -> tauri::Result<()> {
-    use tauri::menu::{
-        CheckMenuItemBuilder, Menu, MenuItemBuilder, MenuItemKind, PredefinedMenuItem,
-        SubmenuBuilder, WINDOW_SUBMENU_ID,
-    };
-    use tauri::Emitter;
+    use tauri::menu::{Menu, SubmenuBuilder};
 
-    let menu = Menu::default(app.handle())?;
-    let new_item = MenuItemBuilder::with_id(FILE_NEW_ID, "New")
-        .accelerator("CmdOrCtrl+N")
-        .build(app)?;
-    let open_item = MenuItemBuilder::with_id(FILE_OPEN_ID, "Open…")
-        .accelerator("CmdOrCtrl+O")
-        .build(app)?;
-    let save_item = MenuItemBuilder::with_id(FILE_SAVE_ID, "Save")
-        .accelerator("CmdOrCtrl+S")
-        .build(app)?;
-    let save_as_item = MenuItemBuilder::with_id(FILE_SAVE_AS_ID, "PowerPoint (.pptx)…")
-        .accelerator("CmdOrCtrl+Shift+S")
-        .build(app)?;
-    let export_pdf = MenuItemBuilder::with_id(FILE_EXPORT_PDF_ID, "Export PDF…").build(app)?;
-    let export_png = MenuItemBuilder::with_id(FILE_EXPORT_PNG_ID, "Export PNG…").build(app)?;
-    let save_as = SubmenuBuilder::new(app, "Save As")
-        .item(&save_as_item)
+    let menu = Menu::new(app.handle())?;
+    let app_menu = SubmenuBuilder::new(app, "akbun-makepresentation")
+        .hide()
+        .hide_others()
+        .show_all()
         .separator()
-        .item(&export_pdf)
-        .item(&export_png)
+        .quit()
         .build()?;
-    let file_separator = PredefinedMenuItem::separator(app)?;
+    menu.append(&app_menu)?;
 
-    let guidelines = CheckMenuItemBuilder::with_id(GUIDELINES_MENU_ID, "Guidelines")
-        .checked(false)
-        .build(app)?;
-    let items = menu.items()?;
-    let file = items.iter().find_map(|item| match item {
-        MenuItemKind::Submenu(submenu)
-            if submenu.text().map(|text| text == "File").unwrap_or(false) =>
-        {
-            Some(submenu.clone())
-        }
-        _ => None,
-    });
-    if let Some(file) = file {
-        file.prepend_items(&[&new_item, &open_item, &file_separator, &save_item, &save_as])?;
-    } else {
-        let file = SubmenuBuilder::new(app, "File")
-            .item(&new_item)
-            .item(&open_item)
-            .separator()
-            .item(&save_item)
-            .item(&save_as)
+    // Clipboard only. Undo and Redo are deliberately absent: their predefined
+    // items own Cmd+Z, and the webview would take it as text undo, so the
+    // deck's own undo would never see the key. The window's Edit menu has it.
+    #[cfg(target_os = "macos")]
+    {
+        let edit = SubmenuBuilder::new(app, "Edit")
+            .cut()
+            .copy()
+            .paste()
+            .select_all()
             .build()?;
-        menu.insert(&file, usize::from(cfg!(target_os = "macos")))?;
+        menu.append(&edit)?;
     }
 
-    let view = items.iter().find_map(|item| match item {
-        MenuItemKind::Submenu(submenu)
-            if submenu.text().map(|text| text == "View").unwrap_or(false) =>
-        {
-            Some(submenu.clone())
-        }
-        _ => None,
-    });
-
-    if let Some(view) = view {
-        view.append(&guidelines)?;
-    } else {
-        let view = SubmenuBuilder::new(app, "View").item(&guidelines).build()?;
-        let position = items
-            .iter()
-            .position(|item| item.id() == WINDOW_SUBMENU_ID)
-            .unwrap_or(items.len());
-        menu.insert(&view, position)?;
-    }
     app.set_menu(menu)?;
-
-    let guidelines_item = guidelines.clone();
-    app.on_menu_event(move |app, event| {
-        let file_command = match event.id().as_ref() {
-            FILE_NEW_ID => Some("new"),
-            FILE_OPEN_ID => Some("open"),
-            FILE_SAVE_ID => Some("save"),
-            FILE_SAVE_AS_ID => Some("save-as"),
-            FILE_EXPORT_PDF_ID => Some("export-pdf"),
-            FILE_EXPORT_PNG_ID => Some("export-png"),
-            _ => None,
-        };
-        if let Some(command) = file_command {
-            let _ = app.emit_to("main", FILE_COMMAND_EVENT, command);
-        } else if event.id() == GUIDELINES_MENU_ID {
-            if let Ok(checked) = guidelines_item.is_checked() {
-                let _ = app.emit_to("main", GUIDELINES_EVENT, checked);
-            }
-        }
-    });
     Ok(())
 }
 

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -32,6 +32,14 @@ const DEFAULT_STYLE = {
 
 const BOXY = new Set(['rect', 'ellipse', 'text', 'image']);
 const SHAPE_KINDS = new Set(['rect', 'ellipse', 'line', 'arrow', 'pen', 'text', 'image']);
+
+// A shape that can hold text of its own. A text box is the whole shape; a
+// rect or an ellipse draws its text inside the outline.
+const TEXTUAL = new Set(['rect', 'ellipse']);
+
+// The five pptx line ends, under their pptx names, so a round trip through
+// `a:headEnd`/`a:tailEnd` is a rename and nothing else.
+const ARROW_ENDS = ['none', 'triangle', 'arrow', 'oval', 'diamond'];
 const MAX_CLIPBOARD_SHAPES = 100;
 const MAX_GEOMETRY = 1_000_000;
 
@@ -52,6 +60,10 @@ function slideBackground(slide) {
 
 function createShape(kind, x, y, style) {
   const s = Object.assign({}, DEFAULT_STYLE, style);
+  // Text inside a box wants to sit in the middle of it. A text box is its own
+  // box, so it keeps the top-left start every other editor gives it.
+  const align = TEXTUAL.has(kind) ? 'center' : s.textAlign;
+  const verticalAlign = TEXTUAL.has(kind) ? 'center' : s.verticalAlign;
   return {
     kind,
     x,
@@ -71,8 +83,8 @@ function createShape(kind, x, y, style) {
     bold: s.bold,
     italic: s.italic,
     underline: s.underline,
-    textAlign: s.textAlign,
-    verticalAlign: s.verticalAlign,
+    textAlign: align,
+    verticalAlign,
     cropLeft: 0,
     cropTop: 0,
     cropRight: 0,
@@ -80,6 +92,8 @@ function createShape(kind, x, y, style) {
     rotation: 0,
     groupId: '',
     penArrow: false,
+    arrowStart: 'none',
+    arrowEnd: kind === 'arrow' ? 'triangle' : 'none',
   };
 }
 
@@ -137,6 +151,9 @@ function normalizeClipboardShape(value) {
     shape.groupId = value.groupId;
   }
   if (typeof value.penArrow === 'boolean') shape.penArrow = value.penArrow;
+  for (const name of ['arrowStart', 'arrowEnd']) {
+    if (ARROW_ENDS.includes(value[name])) shape[name] = value[name];
+  }
   if (['left', 'center', 'right'].includes(value.textAlign)) {
     shape.textAlign = value.textAlign;
   }
@@ -412,6 +429,19 @@ function deleteSlide(deck, index) {
   return Math.min(index, deck.slides.length - 1);
 }
 
+// Move one slide to another position and answer where it landed. An index
+// outside the deck clamps rather than throwing, so a drag past either end of
+// the panel and a Cmd+Arrow at the last slide both do the obvious thing.
+function moveSlide(deck, from, to) {
+  const last = deck.slides.length - 1;
+  if (!Number.isInteger(from) || from < 0 || from > last) return from;
+  const at = Math.max(0, Math.min(Math.round(to), last));
+  if (at === from) return from;
+  const [slide] = deck.slides.splice(from, 1);
+  deck.slides.splice(at, 0, slide);
+  return at;
+}
+
 function duplicateSlide(deck, index) {
   deck.slides.splice(index + 1, 0, structuredClone(deck.slides[index]));
   return index + 1;
@@ -491,6 +521,46 @@ function rotateSvg(shape, markup) {
   return `<g transform="rotate(${shape.rotation} ${cx} ${cy})">${markup}</g>`;
 }
 
+// How far the text inside a rect or an ellipse keeps off its outline. A text
+// box has no outline to keep off, so it gets none.
+const TEXT_PADDING = 8;
+
+// The box a shape lays its own text out in. Same one the overlay textarea
+// uses, so glyphs do not jump when editing starts or ends.
+function textBox(shape) {
+  const b = shapeBBox(shape);
+  if (!TEXTUAL.has(shape.kind)) return { x: b.x, y: b.y, w: b.w, h: b.h };
+  const pad = Math.min(TEXT_PADDING, b.w / 4, b.h / 4);
+  return { x: b.x + pad, y: b.y + pad, w: Math.max(0, b.w - pad * 2), h: Math.max(0, b.h - pad * 2) };
+}
+
+// Glyphs for whatever text a shape carries, laid out in `box`. Shared by the
+// text box and by the text a rect or an ellipse holds inside its outline, so
+// the two wrap, align and anchor the same way.
+function shapeTextSvg(shape) {
+  if (!String(shape.text || '')) return '';
+  const inner = textBox(shape);
+  const lines = wrapTextLines(shape.text, inner.w, shape.fontSize);
+  const lineHeight = shape.fontSize * 1.3;
+  const blockHeight = lines.length * lineHeight;
+  let y = inner.y + shape.fontSize;
+  if (shape.verticalAlign === 'center') y += Math.max(0, (inner.h - blockHeight) / 2);
+  if (shape.verticalAlign === 'bottom') y += Math.max(0, inner.h - blockHeight);
+  const align = shape.textAlign || 'left';
+  const x = align === 'center'
+    ? inner.x + inner.w / 2
+    : align === 'right' ? inner.x + inner.w : inner.x;
+  const anchor = align === 'center' ? 'middle' : align === 'right' ? 'end' : 'start';
+  const spans = lines
+    .map(
+      (line, i) =>
+        `<tspan x="${x}" dy="${i === 0 ? 0 : '1.3em'}">${escapeXml(line) || ' '}</tspan>`
+    )
+    .join('');
+  const decoration = shape.underline ? ' text-decoration="underline"' : '';
+  return `<text x="${x}" y="${y}" font-size="${shape.fontSize}" fill="${shape.textColor}" text-anchor="${anchor}" font-weight="${shape.bold ? '700' : '400'}" font-style="${shape.italic ? 'italic' : 'normal'}"${decoration} ${fontAttr(shape)}>${spans}</text>`;
+}
+
 // Markup for one shape. `options.hideText` suppresses the glyphs while the
 // overlay textarea is editing that shape.
 function renderShapeSvg(shape, options) {
@@ -498,14 +568,15 @@ function renderShapeSvg(shape, options) {
   switch (shape.kind) {
     case 'rect': {
       const b = shapeBBox(shape);
-      return `<rect x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" fill="${shape.fill}" ${strokeAttrs(shape)}/>`;
+      const outline = `<rect x="${b.x}" y="${b.y}" width="${b.w}" height="${b.h}" fill="${shape.fill}" ${strokeAttrs(shape)}/>`;
+      return rotateSvg(shape, outline + (hideText ? '' : shapeTextSvg(shape)));
     }
     case 'ellipse': {
       const b = shapeBBox(shape);
-      return `<ellipse cx="${b.x + b.w / 2}" cy="${b.y + b.h / 2}" rx="${b.w / 2}" ry="${b.h / 2}" fill="${shape.fill}" ${strokeAttrs(shape)}/>`;
+      const outline = `<ellipse cx="${b.x + b.w / 2}" cy="${b.y + b.h / 2}" rx="${b.w / 2}" ry="${b.h / 2}" fill="${shape.fill}" ${strokeAttrs(shape)}/>`;
+      return rotateSvg(shape, outline + (hideText ? '' : shapeTextSvg(shape)));
     }
     case 'line':
-      return `<line x1="${shape.x}" y1="${shape.y}" x2="${shape.x + shape.w}" y2="${shape.y + shape.h}" ${strokeAttrs(shape)} stroke-linecap="round"/>`;
     case 'arrow':
       return arrowSvg(shape);
     case 'pen': {
@@ -514,26 +585,7 @@ function renderShapeSvg(shape, options) {
     }
     case 'text': {
       if (hideText) return '';
-      const lines = wrapTextLines(shape.text, shape.w, shape.fontSize);
-      const lineHeight = shape.fontSize * 1.3;
-      const blockHeight = lines.length * lineHeight;
-      let y = shape.y + shape.fontSize;
-      if (shape.verticalAlign === 'center') y += Math.max(0, (shape.h - blockHeight) / 2);
-      if (shape.verticalAlign === 'bottom') y += Math.max(0, shape.h - blockHeight);
-      const align = shape.textAlign || 'left';
-      const x = align === 'center'
-        ? shape.x + shape.w / 2
-        : align === 'right' ? shape.x + shape.w : shape.x;
-      const anchor = align === 'center' ? 'middle' : align === 'right' ? 'end' : 'start';
-      const spans = lines
-        .map(
-          (line, i) =>
-            `<tspan x="${x}" dy="${i === 0 ? 0 : '1.3em'}">${escapeXml(line) || ' '}</tspan>`
-        )
-        .join('');
-      const decoration = shape.underline ? ' text-decoration="underline"' : '';
-      const markup = `<text x="${x}" y="${y}" font-size="${shape.fontSize}" fill="${shape.textColor}" text-anchor="${anchor}" font-weight="${shape.bold ? '700' : '400'}" font-style="${shape.italic ? 'italic' : 'normal'}"${decoration} ${fontAttr(shape)}>${spans}</text>`;
-      return rotateSvg(shape, markup);
+      return rotateSvg(shape, shapeTextSvg(shape));
     }
     case 'image': {
       const src = String(shape.src || '');
@@ -575,33 +627,93 @@ function penArrowSvg(shape) {
   return `<polygon points="${end[0]},${end[1]} ${p1} ${p2}" fill="${shape.stroke}"/>`;
 }
 
+// The end a shape draws at a given tip, and how far back along the shaft that
+// end reaches. The shaft is shortened by that much so it never pokes out
+// through a filled tip.
+//
+// (ux,uy) points outward, away from the shaft and towards the tip.
+function arrowEndSvg(end, x, y, ux, uy, size, shape) {
+  const color = shape.stroke === 'none' ? '#1a1a1a' : shape.stroke;
+  const back = (distance) => [x - ux * distance, y - uy * distance];
+  switch (end) {
+    case 'triangle': {
+      const [bx, by] = back(size);
+      // Widening a shortened head keeps it visible on a stubby arrow, where a
+      // head proportional to its own length would be narrower than the shaft
+      // it sits on. An unclamped head is already wider, so nothing moves.
+      const half = Math.max(size * 0.45, shape.strokeWidth);
+      return {
+        markup: `<polygon points="${x},${y} ${bx - uy * half},${by + ux * half} ${bx + uy * half},${by - ux * half}" fill="${color}"/>`,
+        inset: size,
+      };
+    }
+    case 'arrow': {
+      // Two open barbs. They meet at the tip, so the shaft can run the whole
+      // way and nothing has to be shortened.
+      const [bx, by] = back(size);
+      const half = Math.max(size * 0.5, shape.strokeWidth);
+      return {
+        markup:
+          `<polyline points="${bx - uy * half},${by + ux * half} ${x},${y} ${bx + uy * half},${by - ux * half}"` +
+          ` fill="none" stroke="${color}" stroke-width="${shape.strokeWidth}" stroke-linecap="round" stroke-linejoin="round"/>`,
+        inset: 0,
+      };
+    }
+    case 'oval': {
+      const r = Math.max(size * 0.35, shape.strokeWidth);
+      const [cx, cy] = back(r);
+      return {
+        markup: `<circle cx="${cx}" cy="${cy}" r="${r}" fill="${color}"/>`,
+        inset: r * 2,
+      };
+    }
+    case 'diamond': {
+      const [cx, cy] = back(size / 2);
+      const [bx, by] = back(size);
+      const half = Math.max(size * 0.35, shape.strokeWidth);
+      return {
+        markup: `<polygon points="${x},${y} ${cx - uy * half},${cy + ux * half} ${bx},${by} ${cx + uy * half},${cy - ux * half}" fill="${color}"/>`,
+        inset: size,
+      };
+    }
+    default:
+      return { markup: '', inset: 0 };
+  }
+}
+
+// One renderer for line and arrow. The two differ only in the end they start
+// life with, so a line given an end draws it and an arrow given none stops
+// drawing one.
 function arrowSvg(shape) {
   const x1 = shape.x, y1 = shape.y;
   const x2 = shape.x + shape.w, y2 = shape.y + shape.h;
   const length = Math.hypot(shape.w, shape.h);
-  // A zero length arrow has no direction to point in. Drawing nothing beats
+  // A zero length line has no direction to point in. Drawing nothing beats
   // drawing the dot a round cap would leave behind; the handles still select it.
   if (!length) return '';
   const ux = shape.w / length, uy = shape.h / length;
-  // Never more than half the arrow, so the base of the head stays in front of
-  // the tail. Past that the shaft is drawn backwards and its far end shows up
-  // as a dot sitting behind the arrow.
-  const head = Math.min(length / 2, Math.max(10, shape.strokeWidth * 4));
-  // Shorten the line so it does not poke through the head tip.
-  const bx = x2 - ux * head, by = y2 - uy * head;
-  // Widening a shortened head keeps it visible on a stubby arrow, where a head
-  // proportional to its own length would be narrower than the shaft it sits on.
-  // A head that is not clamped is already wider than this, so nothing moves.
-  const half = Math.max(head * 0.45, shape.strokeWidth);
-  const p1 = `${bx - uy * half},${by + ux * half}`;
-  const p2 = `${bx + uy * half},${by - ux * half}`;
-  // Both ends of the shaft take the default butt cap, which stops exactly on
-  // the endpoint. The other two both overshoot it by half a stroke, and that
-  // overshoot reads as a bead stuck on the end of the arrow: round leaves a
-  // semicircle, square a rectangle.
+  const start = ARROW_ENDS.includes(shape.arrowStart) ? shape.arrowStart : 'none';
+  const end = ARROW_ENDS.includes(shape.arrowEnd) ? shape.arrowEnd : 'none';
+  const decorated = (start !== 'none' ? 1 : 0) + (end !== 'none' ? 1 : 0);
+  // Never more than half the line for both ends together, so the two bases
+  // stay clear of each other. Past that the shaft is drawn backwards and its
+  // far end shows up as a stray dot behind the head.
+  const size = Math.min(
+    length / 2 / Math.max(1, decorated),
+    Math.max(10, shape.strokeWidth * 4)
+  );
+  const head = arrowEndSvg(end, x2, y2, ux, uy, size, shape);
+  const tail = arrowEndSvg(start, x1, y1, -ux, -uy, size, shape);
+  // A bare line keeps the round cap it always had; a decorated end takes the
+  // default butt cap, which stops exactly on the endpoint. Round and square
+  // both overshoot by half a stroke, and that overshoot reads as a bead stuck
+  // on the end of the arrow.
+  const cap = decorated ? '' : ' stroke-linecap="round"';
   return (
-    `<line x1="${x1}" y1="${y1}" x2="${bx}" y2="${by}" ${strokeAttrs(shape)}/>` +
-    `<polygon points="${x2},${y2} ${p1} ${p2}" fill="${shape.stroke === 'none' ? '#1a1a1a' : shape.stroke}"/>`
+    `<line x1="${x1 + ux * tail.inset}" y1="${y1 + uy * tail.inset}"` +
+    ` x2="${x2 - ux * head.inset}" y2="${y2 - uy * head.inset}" ${strokeAttrs(shape)}${cap}/>` +
+    tail.markup +
+    head.markup
   );
 }
 
@@ -698,6 +810,9 @@ const exported = {
   SLIDE_H,
   DEFAULT_STYLE,
   DEFAULT_BACKGROUND,
+  ARROW_ENDS,
+  TEXTUAL,
+  textBox,
   ZOOM_STEPS,
   ZOOM_FIT,
   zoomIn,
@@ -724,6 +839,7 @@ const exported = {
   resizeShape,
   addSlide,
   deleteSlide,
+  moveSlide,
   duplicateSlide,
   slideNumberShape,
   escapeXml,

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -7,6 +7,49 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <!-- The menus live in the window rather than in the macOS menu bar, so the
+       app carries its own commands wherever it is on screen. Every item is a
+       data-command, so one handler routes all of them. -->
+  <nav id="menubar">
+    <div class="menu">
+      <button class="menu-title" data-menu="file" aria-haspopup="true" aria-expanded="false">File</button>
+      <div class="menu-panel" data-menu-panel="file" hidden>
+        <button data-command="new">New<span class="accel">⌘N</span></button>
+        <button data-command="open">Open…<span class="accel">⌘O</span></button>
+        <hr />
+        <button data-command="save">Save<span class="accel">⌘S</span></button>
+        <button data-command="save-as">PowerPoint (.pptx)…<span class="accel">⇧⌘S</span></button>
+        <hr />
+        <button data-command="export-pdf">Export PDF…</button>
+        <button data-command="export-png">Export PNG…</button>
+      </div>
+    </div>
+    <div class="menu">
+      <button class="menu-title" data-menu="edit" aria-haspopup="true" aria-expanded="false">Edit</button>
+      <div class="menu-panel" data-menu-panel="edit" hidden>
+        <button data-command="undo">Undo<span class="accel">⌘Z</span></button>
+        <button data-command="redo">Redo<span class="accel">⇧⌘Z</span></button>
+        <hr />
+        <button data-command="duplicate">Duplicate<span class="accel">⌘D</span></button>
+        <button data-command="delete">Delete<span class="accel">⌫</span></button>
+        <hr />
+        <button data-command="group">Group</button>
+        <button data-command="ungroup">Ungroup</button>
+      </div>
+    </div>
+    <div class="menu">
+      <button class="menu-title" data-menu="view" aria-haspopup="true" aria-expanded="false">View</button>
+      <div class="menu-panel" data-menu-panel="view" hidden>
+        <button data-command="guidelines">Guidelines</button>
+        <button data-command="numbers">Slide numbers</button>
+        <hr />
+        <button data-command="zoom-in">Zoom in<span class="accel">⌘+</span></button>
+        <button data-command="zoom-out">Zoom out<span class="accel">⌘-</span></button>
+        <button data-command="zoom-fit">Fit to window<span class="accel">⌘0</span></button>
+      </div>
+    </div>
+  </nav>
+
   <header id="toolbar">
     <div class="group tools">
       <button data-tool="select" title="Select (V)">Select</button>
@@ -91,6 +134,30 @@
         <div class="prop-row" id="props-pen-arrow">
           <label for="prop-pen-arrow">End arrow</label>
           <input type="checkbox" id="prop-pen-arrow" />
+        </div>
+        <!-- The values are the pptx names for the same five ends, so what is
+             picked here is what is written to the file. -->
+        <div id="props-arrow-ends">
+          <div class="prop-row">
+            <label for="prop-arrow-start">Start end</label>
+            <select id="prop-arrow-start">
+              <option value="none">None</option>
+              <option value="triangle">Triangle</option>
+              <option value="arrow">Open arrow</option>
+              <option value="oval">Circle</option>
+              <option value="diamond">Diamond</option>
+            </select>
+          </div>
+          <div class="prop-row">
+            <label for="prop-arrow-end">Finish end</label>
+            <select id="prop-arrow-end">
+              <option value="none">None</option>
+              <option value="triangle">Triangle</option>
+              <option value="arrow">Open arrow</option>
+              <option value="oval">Circle</option>
+              <option value="diamond">Diamond</option>
+            </select>
+          </div>
         </div>
       </div>
       <div id="props-text">
@@ -183,6 +250,8 @@
   <div id="present" hidden></div>
 
   <div id="context-menu" hidden>
+    <button id="context-group">Group</button>
+    <button id="context-ungroup">Ungroup</button>
     <button id="context-save-image">Save as Image</button>
   </div>
 

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -1672,8 +1672,11 @@ const MENU_COMMANDS = {
   'zoom-fit': () => setZoom(L.ZOOM_FIT),
 };
 
+// The name is not always ours: this also runs whatever the shell sends over
+// the file-command event. A plain lookup would find inherited keys, and
+// `constructor` would be called as if it were a command.
 function runCommand(command) {
-  if (MENU_COMMANDS[command]) MENU_COMMANDS[command]();
+  if (Object.hasOwn(MENU_COMMANDS, command)) MENU_COMMANDS[command]();
 }
 
 function hideMenus() {

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -207,14 +207,22 @@ function cropOverlaySvg() {
 }
 
 function renderThumbs() {
-  $('thumbs').innerHTML = state.deck.slides
+  const thumbs = $('thumbs');
+  // The panel takes focus so Backspace can mean "delete this slide" there and
+  // keep meaning "delete this object" on the canvas.
+  const focused = document.activeElement && thumbs.contains(document.activeElement);
+  thumbs.innerHTML = state.deck.slides
     .map(
       (s, i) =>
-        `<div class="thumb${i === state.current ? ' active' : ''}" data-slide="${i}">` +
+        `<div class="thumb${i === state.current ? ' active' : ''}" data-slide="${i}" draggable="true" tabindex="${i === state.current ? '0' : '-1'}">` +
         `${L.renderSlideSvg(s, { number: state.showNumbers ? i + 1 : 0 })}` +
         `<span class="num">${i + 1}</span></div>`
     )
     .join('');
+  // innerHTML threw away the element that had focus, so hand it back to the
+  // thumb that replaced it. Without this a Cmd+Arrow reorder moves focus to
+  // the body and the next press does nothing.
+  if (focused) thumbs.querySelector(`[data-slide="${state.current}"]`)?.focus();
 }
 
 function renderProps() {
@@ -224,11 +232,14 @@ function renderProps() {
 
   const showFill = kind === 'rect' || kind === 'ellipse' || kind === 'defaults';
   const showStroke = kind !== 'text';
-  const showText = kind === 'text' || kind === 'defaults';
+  const showText = kind === 'text' || L.TEXTUAL.has(kind) || kind === 'defaults';
 
   $('props-fill').hidden = !showFill;
   $('props-stroke').hidden = !showStroke;
   $('props-text').hidden = !showText;
+  $('props-arrow-ends').hidden = !(kind === 'line' || kind === 'arrow');
+  $('prop-arrow-start').value = L.ARROW_ENDS.includes(source.arrowStart) ? source.arrowStart : 'none';
+  $('prop-arrow-end').value = L.ARROW_ENDS.includes(source.arrowEnd) ? source.arrowEnd : 'none';
   $('btn-delete-shape').hidden = !shape;
   $('btn-group').hidden = state.selection.length < 2;
   $('btn-ungroup').hidden = !state.selection.some((index) => slide().shapes[index]?.groupId);
@@ -438,17 +449,8 @@ canvas.addEventListener('pointerdown', (event) => {
   }
 
   const index = hitShape ? slide().shapes.indexOf(hitShape) : -1;
+  const additive = event.shiftKey && !(event.metaKey || event.ctrlKey);
   if (index >= 0) {
-
-    // Shift-click changes only this object's membership. It does not begin a
-    // drag, so repeated Shift-clicks can build or shrink a selection without
-    // moving an object by a pixel.
-    if (event.shiftKey && !(event.metaKey || event.ctrlKey)) {
-      selectMany(L.toggleSelection(state.selection, index, slide().shapes.length));
-      renderCanvas();
-      renderProps();
-      return;
-    }
 
     // Opening a text box for editing is decided here rather than from a
     // dblclick event, because the browser never reports one: pointerup
@@ -458,7 +460,7 @@ canvas.addEventListener('pointerdown', (event) => {
     // preventDefault keeps the focus the overlay is about to take. Without
     // it the press moves focus back to the page, and from there Backspace
     // deletes the box being typed into instead of a character.
-    if (isSecondPress(index) && slide().shapes[index].kind === 'text') {
+    if (isSecondPress(index) && canEditText(slide().shapes[index])) {
       event.preventDefault();
       selectOnly(index);
       renderCanvas();
@@ -467,7 +469,16 @@ canvas.addEventListener('pointerdown', (event) => {
       return;
     }
 
-    if (!state.selection.includes(index)) selectMany(L.groupIndicesFor(slide().shapes, index));
+    // Shift changes this object's membership, but only on a press that never
+    // travels. Deciding that on pointerup instead of here is what lets Shift
+    // do both jobs at once: a Shift-drag of a selected line moves it on one
+    // axis, and a Shift-click of it still drops it out of the selection.
+    const wasSelected = state.selection.includes(index);
+    if (additive) {
+      if (!wasSelected) selectMany([...state.selection, ...L.groupIndicesFor(slide().shapes, index)]);
+    } else if (!wasSelected) {
+      selectMany(L.groupIndicesFor(slide().shapes, index));
+    }
 
     // Cmd/Ctrl+drag drags a copy and leaves the original where it was, the
     // way PowerPoint does. Add Shift and the copy travels on one axis.
@@ -490,11 +501,23 @@ canvas.addEventListener('pointerdown', (event) => {
       moved: false,
       duplicated,
       originalSelection,
+      // Only an already-selected object can be dropped by a Shift-click. One
+      // that was just added by the same press has to stay.
+      toggleIndex: additive && wasSelected ? index : -1,
     };
     canvas.setPointerCapture(event.pointerId);
   } else {
-    clearSelection();
-    state.drag = { mode: 'marquee', x0: p.x, y0: p.y, x1: p.x, y1: p.y };
+    // Shift over empty space keeps what is selected and adds to it. Clearing
+    // instead is what made a missed Shift-click throw the selection away.
+    if (!additive) clearSelection();
+    state.drag = {
+      mode: 'marquee',
+      x0: p.x,
+      y0: p.y,
+      x1: p.x,
+      y1: p.y,
+      baseSelection: additive ? [...state.selection] : [],
+    };
     canvas.setPointerCapture(event.pointerId);
   }
   renderCanvas();
@@ -561,7 +584,15 @@ canvas.addEventListener('pointerup', () => {
     // no size. Handing it to the touch rule would select whichever unfilled
     // shape the pointer happened to be standing inside, so a click meant to
     // deselect would select instead.
-    if (rect.w > 2 || rect.h > 2) selectMany(L.shapeIndicesInRect(slide().shapes, rect));
+    if (rect.w > 2 || rect.h > 2) {
+      selectMany([
+        ...drag.baseSelection,
+        ...L.shapeIndicesInRect(slide().shapes, rect),
+      ]);
+    }
+  } else if (drag.mode === 'move' && !drag.moved && drag.toggleIndex >= 0) {
+    // A Shift-press that never moved: the click half of Shift-click.
+    selectMany(L.toggleSelection(state.selection, drag.toggleIndex, slide().shapes.length));
   } else if (drag.mode === 'resize' || drag.mode === 'crop' || drag.moved) {
     markDirty();
   } else if (drag.duplicated) {
@@ -579,14 +610,22 @@ canvas.addEventListener('pointerup', () => {
 // The overlay has to look like the glyphs it hides, or every text box jumps
 // the moment editing starts or ends. A missing shape means the box being
 // edited is already gone, the same case commitTextEdit guards against.
+// A text box, and any shape that draws text inside its own outline.
+function canEditText(shape) {
+  return !!shape && (shape.kind === 'text' || L.TEXTUAL.has(shape.kind));
+}
+
 function styleTextEditor(shape) {
   if (!shape) return;
   const scale = canvas.getBoundingClientRect().width / L.SLIDE_W;
   const lines = (shape.text || '').split('\n').length;
-  textEditor.style.left = `${shape.x * scale}px`;
-  textEditor.style.top = `${shape.y * scale}px`;
-  textEditor.style.width = `${Math.max(shape.w, 120) * scale}px`;
-  textEditor.style.height = `${Math.max(shape.h, shape.fontSize * 1.3 * lines) * scale}px`;
+  // The same inset the glyphs are drawn at, so text does not jump sideways
+  // when editing starts inside a rect or an ellipse.
+  const box = L.textBox(shape);
+  textEditor.style.left = `${box.x * scale}px`;
+  textEditor.style.top = `${box.y * scale}px`;
+  textEditor.style.width = `${Math.max(box.w, 120) * scale}px`;
+  textEditor.style.height = `${Math.max(box.h, shape.fontSize * 1.3 * lines) * scale}px`;
   textEditor.style.fontSize = `${shape.fontSize * scale}px`;
   textEditor.style.fontFamily = `${shape.fontFamily || 'Helvetica'}, sans-serif`;
   textEditor.style.color = shape.textColor;
@@ -596,12 +635,15 @@ function styleTextEditor(shape) {
   textEditor.style.textAlign = shape.textAlign || 'left';
 }
 
-function startTextEdit(index) {
+// `seed` is the character that opened the box by being typed while the shape
+// was selected. It is the first thing in the box, not a replacement for what
+// is already there.
+function startTextEdit(index, seed) {
   const shape = slide().shapes[index];
   state.editingIndex = index;
   renderCanvas();
 
-  textEditor.value = shape.text;
+  textEditor.value = seed ? shape.text + seed : shape.text;
   styleTextEditor(shape);
   textEditor.hidden = false;
   // Deferred so it wins over whatever focus change the triggering click
@@ -632,12 +674,17 @@ function commitTextEdit() {
   // compares the new text with itself, which is never a change, and then an
   // edit reaches neither the undo history nor the dirty marker.
   const text = textEditor.value.replace(/\s+$/, '');
-  const removed = text === '';
+  // Emptying a text box removes it, because the box is nothing but its text.
+  // Emptying the text in a rect leaves the rect: the outline is the object
+  // and the text was only something written on it.
+  const removed = text === '' && shape.kind === 'text';
   const changed = !removed && text !== shape.text;
 
   if (removed) {
     slide().shapes.splice(index, 1);
     clearSelection();
+  } else if (changed && L.TEXTUAL.has(shape.kind)) {
+    shape.text = text;
   } else if (changed) {
     shape.text = text;
     const lines = text.split('\n').length;
@@ -682,6 +729,11 @@ document.addEventListener('keydown', (event) => {
     event.preventDefault();
     return;
   }
+  if (event.key === 'Escape' && [...document.querySelectorAll('.menu-panel')].some((panel) => !panel.hidden)) {
+    hideMenus();
+    event.preventDefault();
+    return;
+  }
   if (state.presenting) {
     if (event.key === 'ArrowRight' || event.key === ' ' || event.key === 'PageDown') presentStep(1);
     else if (event.key === 'ArrowLeft' || event.key === 'PageUp') presentStep(-1);
@@ -716,12 +768,18 @@ document.addEventListener('keydown', (event) => {
   // for these, so Shift only picks the redo branch.
   if (event.metaKey || event.ctrlKey) {
     const key = event.key.toLowerCase();
-    if (key === 's') saveFile(event.shiftKey);
+    // New and Open used to reach the page as system menu accelerators. With
+    // the menus in the window there is no accelerator, so the keys land here.
+    if (key === 'n') newDeck();
+    else if (key === 'o') openFile();
+    else if (key === 's') saveFile(event.shiftKey);
     else if (key === 'z' && event.shiftKey) redo();
     else if (key === 'z') undo();
     else if (key === 'y') redo();
     else if (key === 'c' || key === 'v') return;
     else if (key === 'd') duplicateSelection();
+    else if (key === 'arrowup') moveCurrentSlide(state.current - 1);
+    else if (key === 'arrowdown') moveCurrentSlide(state.current + 1);
     else if (TEXT_STYLE_KEYS[key]) toggleTextStyle(TEXT_STYLE_KEYS[key]);
     else return;
     event.preventDefault();
@@ -729,7 +787,10 @@ document.addEventListener('keydown', (event) => {
   }
 
   if (event.key === 'Delete' || event.key === 'Backspace') {
-    deleteSelectedShape();
+    // Which thing the key deletes is decided by where the focus is, so the
+    // two meanings never have to guess at each other.
+    if ($('slides').contains(target)) deleteCurrentSlide();
+    else deleteSelectedShape();
     event.preventDefault();
     return;
   }
@@ -751,6 +812,20 @@ document.addEventListener('keydown', (event) => {
     event.preventDefault();
     return;
   }
+  // Typing over a selected shape starts writing in it, the way it does in
+  // PowerPoint. That costs the tool shortcuts while such a shape is selected;
+  // Escape drops the selection and gives them back.
+  if (
+    state.selection.length === 1 &&
+    canEditText(selectedShape()) &&
+    event.key.length === 1 &&
+    event.key !== ' '
+  ) {
+    event.preventDefault();
+    startTextEdit(state.selected, event.key);
+    return;
+  }
+
   const tool = TOOL_KEYS[event.key.toLowerCase()];
   if (tool) setTool(tool);
 });
@@ -971,6 +1046,12 @@ async function loadSystemFonts() {
 }
 
 function showContextMenu(x, y) {
+  // Group needs more than one object; ungroup needs one that is in a group.
+  // Hiding rather than disabling keeps the menu as short as the moment allows.
+  $('context-group').hidden = state.selection.length < 2;
+  $('context-ungroup').hidden = !state.selection.some(
+    (index) => slide().shapes[index]?.groupId
+  );
   contextMenu.hidden = false;
   contextMenu.style.left = `${x}px`;
   contextMenu.style.top = `${y}px`;
@@ -1010,18 +1091,22 @@ document.addEventListener('contextmenu', (event) => {
 document.addEventListener('pointerdown', (event) => {
   if (!contextMenu.contains(event.target)) hideContextMenu();
   if (!fontPicker.contains(event.target)) hideFontMenu();
+  if (!$('menubar').contains(event.target)) hideMenus();
 });
 window.addEventListener('blur', () => {
   hideContextMenu();
   hideFontMenu();
+  hideMenus();
 });
 window.addEventListener('resize', () => {
   hideContextMenu();
   hideFontMenu();
+  hideMenus();
 });
 $('stage-scroll').addEventListener('scroll', () => {
   hideContextMenu();
   hideFontMenu();
+  hideMenus();
 });
 $('props').addEventListener('scroll', hideFontMenu);
 
@@ -1084,6 +1169,14 @@ async function saveSelectionAsImage() {
 }
 
 $('context-save-image').addEventListener('click', saveSelectionAsImage);
+$('context-group').addEventListener('click', () => {
+  hideContextMenu();
+  groupSelection();
+});
+$('context-ungroup').addEventListener('click', () => {
+  hideContextMenu();
+  ungroupSelection();
+});
 
 $('prop-font-family').addEventListener('click', () => {
   if (fontMenu.hidden) showFontMenu();
@@ -1202,6 +1295,8 @@ $('prop-width').addEventListener('input', (e) =>
 );
 $('prop-dash').addEventListener('change', (e) => applyProp({ dash: e.target.value }));
 $('prop-pen-arrow').addEventListener('change', (e) => applyProp({ penArrow: e.target.checked }));
+$('prop-arrow-start').addEventListener('change', (e) => applyProp({ arrowStart: e.target.value }));
+$('prop-arrow-end').addEventListener('change', (e) => applyProp({ arrowEnd: e.target.value }));
 $('btn-group').addEventListener('click', groupSelection);
 $('btn-ungroup').addEventListener('click', ungroupSelection);
 $('btn-crop').addEventListener('click', toggleCrop);
@@ -1219,7 +1314,7 @@ $('btn-delete-shape').addEventListener('click', deleteSelectedShape);
 
 function textStyleTarget() {
   const shape = selectedShape();
-  if (shape) return shape.kind === 'text' ? shape : null;
+  if (shape) return canEditText(shape) ? shape : null;
   return state.defaults;
 }
 
@@ -1256,7 +1351,68 @@ $('thumbs').addEventListener('click', (event) => {
   state.current = Number(thumb.dataset.slide);
   clearSelection();
   renderAll();
+  $('thumbs').querySelector(`[data-slide="${state.current}"]`)?.focus();
 });
+
+// --- slide reorder -------------------------------------------------------
+//
+// Drag and drop in the panel, and Cmd+Up/Down for the same move from the
+// keyboard. Both land in moveSlide, so the two cannot disagree about where a
+// slide ends up.
+
+function moveCurrentSlide(to) {
+  const at = L.moveSlide(state.deck, state.current, to);
+  if (at === state.current) return;
+  state.current = at;
+  clearSelection();
+  markDirty();
+  renderAll();
+}
+
+let dragSlideFrom = -1;
+
+$('thumbs').addEventListener('dragstart', (event) => {
+  const thumb = event.target.closest('[data-slide]');
+  if (!thumb) return;
+  dragSlideFrom = Number(thumb.dataset.slide);
+  event.dataTransfer.effectAllowed = 'move';
+  // Firefox refuses to start a drag without payload, and the index is already
+  // in dragSlideFrom, so this is only there to make the drag legal.
+  event.dataTransfer.setData('text/plain', String(dragSlideFrom));
+});
+
+$('thumbs').addEventListener('dragover', (event) => {
+  if (dragSlideFrom < 0) return;
+  event.preventDefault();
+  event.dataTransfer.dropEffect = 'move';
+  const thumb = event.target.closest('[data-slide]');
+  for (const element of $('thumbs').querySelectorAll('.thumb')) {
+    element.classList.toggle('drop-target', element === thumb);
+  }
+});
+
+$('thumbs').addEventListener('dragleave', (event) => {
+  event.target.closest('[data-slide]')?.classList.remove('drop-target');
+});
+
+$('thumbs').addEventListener('drop', (event) => {
+  const thumb = event.target.closest('[data-slide]');
+  event.preventDefault();
+  const from = dragSlideFrom;
+  endSlideDrag();
+  if (from < 0 || !thumb) return;
+  state.current = from;
+  moveCurrentSlide(Number(thumb.dataset.slide));
+});
+
+function endSlideDrag() {
+  dragSlideFrom = -1;
+  for (const element of $('thumbs').querySelectorAll('.drop-target')) {
+    element.classList.remove('drop-target');
+  }
+}
+
+$('thumbs').addEventListener('dragend', endSlideDrag);
 
 $('btn-add-slide').addEventListener('click', () => {
   state.current = L.addSlide(state.deck, state.current);
@@ -1265,7 +1421,10 @@ $('btn-add-slide').addEventListener('click', () => {
   renderAll();
 });
 
-$('btn-del-slide').addEventListener('click', async () => {
+// An empty slide goes without asking; one with work on it does not. Same
+// answer whether the delete came from the button or from Backspace in the
+// panel.
+async function deleteCurrentSlide() {
   const empty = slide().shapes.length === 0;
   if (!empty) {
     const sure = await window.api.ask(`Delete slide ${state.current + 1}?`, {
@@ -1278,7 +1437,9 @@ $('btn-del-slide').addEventListener('click', async () => {
   clearSelection();
   markDirty();
   renderAll();
-});
+}
+
+$('btn-del-slide').addEventListener('click', deleteCurrentSlide);
 
 // --- file operations -----------------------------------------------------------------------
 
@@ -1488,28 +1649,96 @@ window.api.onGuidelinesChanged((enabled) => {
 
 // --- toolbar and application menu ------------------------------------------------------------------
 
-window.api.onFileCommand((command) => {
-  const actions = {
-    new: newDeck,
-    open: openFile,
-    save: () => saveFile(false),
-    'save-as': () => saveFile(true),
-    'export-pdf': exportPdf,
-    'export-png': exportPng,
-  };
-  if (actions[command]) actions[command]();
+// Every menu item, by the data-command in the markup. The keyboard shortcuts
+// call the same functions, so a command cannot behave one way from the menu
+// and another from the key.
+const MENU_COMMANDS = {
+  new: newDeck,
+  open: openFile,
+  save: () => saveFile(false),
+  'save-as': () => saveFile(true),
+  'export-pdf': exportPdf,
+  'export-png': exportPng,
+  undo,
+  redo,
+  duplicate: duplicateSelection,
+  delete: deleteSelectedShape,
+  group: groupSelection,
+  ungroup: ungroupSelection,
+  guidelines: toggleGuidelines,
+  numbers: toggleNumbers,
+  'zoom-in': () => setZoom(L.zoomIn(state.zoom)),
+  'zoom-out': () => setZoom(L.zoomOut(state.zoom)),
+  'zoom-fit': () => setZoom(L.ZOOM_FIT),
+};
+
+function runCommand(command) {
+  if (MENU_COMMANDS[command]) MENU_COMMANDS[command]();
+}
+
+function hideMenus() {
+  for (const panel of document.querySelectorAll('.menu-panel')) panel.hidden = true;
+  for (const title of document.querySelectorAll('.menu-title')) {
+    title.setAttribute('aria-expanded', 'false');
+  }
+}
+
+function openMenu(name) {
+  hideMenus();
+  $('menubar').querySelector(`[data-menu-panel="${name}"]`).hidden = false;
+  $('menubar').querySelector(`[data-menu="${name}"]`).setAttribute('aria-expanded', 'true');
+  // The two toggles are the only items whose state is worth showing, and it
+  // only has to be right at the moment the menu opens.
+  $('menubar').querySelector('[data-command="guidelines"]')
+    .classList.toggle('checked', state.showGuidelines);
+  $('menubar').querySelector('[data-command="numbers"]')
+    .classList.toggle('checked', state.showNumbers);
+}
+
+$('menubar').addEventListener('click', (event) => {
+  const title = event.target.closest('.menu-title');
+  if (title) {
+    const open = title.getAttribute('aria-expanded') === 'true';
+    if (open) hideMenus();
+    else openMenu(title.dataset.menu);
+    return;
+  }
+  const item = event.target.closest('[data-command]');
+  if (!item) return;
+  hideMenus();
+  runCommand(item.dataset.command);
 });
+
+// Sliding along the bar with one menu already open switches menus, the way a
+// menu bar does everywhere else.
+$('menubar').addEventListener('pointerover', (event) => {
+  const title = event.target.closest('.menu-title');
+  if (!title) return;
+  const anyOpen = [...document.querySelectorAll('.menu-panel')].some((panel) => !panel.hidden);
+  if (anyOpen) openMenu(title.dataset.menu);
+});
+
+// The app no longer has a system menu bar, so the events it used to send now
+// come from these items. The handler stays for anything the shell still emits.
+window.api.onFileCommand(runCommand);
 $('btn-present').addEventListener('click', enterPresent);
 
 function setNumbersButton() {
   $('btn-numbers').classList.toggle('active', state.showNumbers);
 }
 
-$('btn-numbers').addEventListener('click', () => {
+function toggleNumbers() {
   state.showNumbers = !state.showNumbers;
   setNumbersButton();
   renderAll();
-});
+}
+
+function toggleGuidelines() {
+  state.showGuidelines = !state.showGuidelines;
+  renderCanvas();
+}
+
+$('btn-numbers').addEventListener('click', toggleNumbers);
 $('btn-update').addEventListener('click', () => window.api.checkUpdate());
 for (const button of document.querySelectorAll('[data-tool]')) {
   button.addEventListener('click', () => setTool(button.dataset.tool));

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -89,13 +89,17 @@ body {
   display: none;
 }
 
+/* The left padding is the checkmark's seat. Reserving it on every item
+   rather than only on the checked one is what keeps a label from jumping
+   sideways when its toggle flips. */
 .menu-panel button {
+  position: relative;
   display: flex;
   justify-content: space-between;
   gap: 24px;
   width: 100%;
   border: 0;
-  padding: 5px 10px;
+  padding: 5px 10px 5px 24px;
   text-align: left;
   white-space: nowrap;
 }
@@ -113,7 +117,7 @@ body {
 .menu-panel button.checked::before {
   content: '✓';
   position: absolute;
-  margin-left: -14px;
+  left: 9px;
 }
 
 .menu-panel hr {

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -44,6 +44,88 @@ body {
   user-select: none;
 }
 
+/* --- menu bar ---
+   The app's own File/Edit/View, in the window rather than in the system menu
+   bar. A panel is anchored to its title and floats over the canvas. */
+
+#menubar {
+  display: flex;
+  gap: 2px;
+  padding: 2px 8px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.menu {
+  position: relative;
+}
+
+.menu-title {
+  border: 0;
+  background: transparent;
+  padding: 3px 10px;
+  border-radius: 5px;
+}
+
+.menu-title:hover,
+.menu-title[aria-expanded='true'] {
+  background: var(--accent-soft);
+}
+
+.menu-panel {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  z-index: 30;
+  min-width: 220px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+}
+
+.menu-panel[hidden] {
+  display: none;
+}
+
+.menu-panel button {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  width: 100%;
+  border: 0;
+  padding: 5px 10px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.menu-panel button[hidden] {
+  display: none;
+}
+
+.menu-panel button:hover,
+.menu-panel button:focus-visible {
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.menu-panel button.checked::before {
+  content: '✓';
+  position: absolute;
+  margin-left: -14px;
+}
+
+.menu-panel hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 4px 6px;
+}
+
+.accel {
+  color: var(--muted);
+}
+
 /* --- toolbar --- */
 
 #toolbar {
@@ -137,6 +219,19 @@ main {
 
 .thumb.active {
   border-color: var(--accent);
+}
+
+/* Focus is what tells Backspace to delete the slide rather than the selected
+   object, so it has to be visible. */
+.thumb:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Where a dragged slide would land. */
+.thumb.drop-target {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .thumb .num {

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -476,3 +476,132 @@ test('filterFonts searches installed family names without case sensitivity', () 
   ]);
   assert.deepStrictEqual(L.filterFonts(fonts, ''), fonts);
 });
+
+// --- arrow ends ---------------------------------------------------------
+
+test('an arrow starts with a head and a line starts bare', () => {
+  assert.strictEqual(L.createShape('arrow', 0, 0, {}).arrowEnd, 'triangle');
+  assert.strictEqual(L.createShape('arrow', 0, 0, {}).arrowStart, 'none');
+  assert.strictEqual(L.createShape('line', 0, 0, {}).arrowEnd, 'none');
+});
+
+test('renderShapeSvg draws the end each side asks for', () => {
+  const shape = L.createShape('line', 0, 0, {});
+  L.dragShape(shape, 0, 0, 200, 0);
+  shape.arrowStart = 'oval';
+  shape.arrowEnd = 'diamond';
+  const svg = L.renderShapeSvg(shape);
+  assert.ok(svg.includes('<circle'), 'the circle end');
+  // The diamond is the only polygon here, and it has four corners.
+  const diamond = svg.match(/<polygon points="([^"]+)"/);
+  assert.ok(diamond, 'the diamond end');
+  assert.strictEqual(diamond[1].trim().split(/\s+/).length, 4);
+});
+
+test('an open arrow end is stroked, not filled', () => {
+  const shape = L.createShape('arrow', 0, 0, {});
+  L.dragShape(shape, 0, 0, 200, 0);
+  shape.arrowEnd = 'arrow';
+  const svg = L.renderShapeSvg(shape);
+  assert.ok(svg.includes('<polyline'));
+  assert.ok(!svg.includes('<polygon'));
+});
+
+test('an unknown end name draws nothing rather than throwing', () => {
+  const shape = L.createShape('arrow', 0, 0, {});
+  L.dragShape(shape, 0, 0, 200, 0);
+  shape.arrowEnd = 'javascript:alert(1)';
+  const svg = L.renderShapeSvg(shape);
+  assert.ok(!svg.includes('alert'));
+  assert.ok(svg.includes('<line'));
+});
+
+// Two ends both clamped to half the line would meet in the middle and the
+// shaft would be drawn backwards.
+test('two ends together never take more than half a short line', () => {
+  const shape = L.createShape('arrow', 0, 0, { strokeWidth: 20 });
+  L.dragShape(shape, 0, 0, 40, 0);
+  shape.arrowStart = 'triangle';
+  const [, x1, x2] = L.renderShapeSvg(shape).match(/<line x1="([\d.]+)"[^>]*x2="([\d.]+)"/);
+  assert.ok(Number(x2) - Number(x1) >= 20 - 0.001, `shaft ${x1}..${x2}`);
+});
+
+test('parseClipboardShapes keeps known arrow ends and drops the rest', () => {
+  const [good] = L.parseClipboardShapes(JSON.stringify([
+    { kind: 'arrow', x: 0, y: 0, w: 10, h: 10, arrowStart: 'diamond', arrowEnd: 'nope' },
+  ]));
+  assert.strictEqual(good.arrowStart, 'diamond');
+  assert.strictEqual(good.arrowEnd, 'triangle');
+});
+
+// --- text inside a shape ------------------------------------------------
+
+test('a rect and an ellipse center the text they are given', () => {
+  const rect = L.createShape('rect', 0, 0, {});
+  assert.strictEqual(rect.textAlign, 'center');
+  assert.strictEqual(rect.verticalAlign, 'center');
+  // A text box is its own box and keeps the top-left start.
+  const text = L.createShape('text', 0, 0, {});
+  assert.strictEqual(text.textAlign, 'left');
+  assert.strictEqual(text.verticalAlign, 'top');
+});
+
+test('renderShapeSvg draws a rect and its text, and the outline alone when hidden', () => {
+  const shape = L.createShape('rect', 0, 0, {});
+  L.dragShape(shape, 0, 0, 200, 100);
+  shape.text = 'in the box';
+  const svg = L.renderShapeSvg(shape);
+  assert.ok(svg.includes('<rect'));
+  assert.ok(svg.includes('in the box'));
+  assert.ok(!L.renderShapeSvg(shape, { hideText: true }).includes('in the box'));
+});
+
+test('an empty rect draws no text element at all', () => {
+  const shape = L.createShape('rect', 0, 0, {});
+  L.dragShape(shape, 0, 0, 200, 100);
+  assert.ok(!L.renderShapeSvg(shape).includes('<text'));
+});
+
+test('text inside a shape keeps off the outline, a text box does not', () => {
+  const rect = L.createShape('rect', 0, 0, {});
+  L.dragShape(rect, 0, 0, 200, 100);
+  const box = L.textBox(rect);
+  assert.strictEqual(box.x, 8);
+  assert.strictEqual(box.w, 184);
+
+  const text = L.createShape('text', 0, 0, {});
+  L.dragShape(text, 0, 0, 200, 100);
+  assert.strictEqual(L.textBox(text).x, 0);
+});
+
+// A shape too small to hold the padding would otherwise get a negative box.
+test('the text box of a tiny shape never goes negative', () => {
+  const shape = L.createShape('rect', 0, 0, {});
+  L.dragShape(shape, 0, 0, 10, 6);
+  const box = L.textBox(shape);
+  assert.ok(box.w >= 0 && box.h >= 0, JSON.stringify(box));
+});
+
+// --- slide order ---------------------------------------------------------
+
+test('moveSlide moves a slide and answers where it landed', () => {
+  const deck = { slides: [{ id: 0 }, { id: 1 }, { id: 2 }] };
+  assert.strictEqual(L.moveSlide(deck, 0, 2), 2);
+  assert.deepStrictEqual(deck.slides.map((s) => s.id), [1, 2, 0]);
+  assert.strictEqual(L.moveSlide(deck, 2, 0), 0);
+  assert.deepStrictEqual(deck.slides.map((s) => s.id), [0, 1, 2]);
+});
+
+test('moveSlide clamps past either end instead of losing a slide', () => {
+  const deck = { slides: [{ id: 0 }, { id: 1 }] };
+  assert.strictEqual(L.moveSlide(deck, 0, -5), 0);
+  assert.strictEqual(L.moveSlide(deck, 0, 99), 1);
+  assert.deepStrictEqual(deck.slides.map((s) => s.id), [1, 0]);
+  assert.strictEqual(deck.slides.length, 2);
+});
+
+test('moveSlide refuses an index that is not on the deck', () => {
+  const deck = { slides: [{ id: 0 }, { id: 1 }] };
+  assert.strictEqual(L.moveSlide(deck, 7, 0), 7);
+  assert.strictEqual(deck.slides.length, 2);
+});


### PR DESCRIPTION
# 구현

도형 안 텍스트, 화살표 양끝 5종, 슬라이드 드래그·Cmd+위아래 순서 변경, 창 안 File/Edit/View 메뉴, Shift 선택 복구
- js 63개, rust 10개 테스트 통과. pptx 왕복 테스트에 도형 텍스트와 양끝 화살표 추가

# 어려웠던 점

시스템 메뉴바를 완전히 비우면 페이지 안에서 Cmd+C, Cmd+V가 멈춤
- WKWebView가 클립보드 명령을 메뉴바 key equivalent로 받는 구조라, Cut·Copy·Paste·Select All 4개만 남기고 Undo·Redo는 Cmd+Z 선점 때문에 제외

Shift 처리가 pointerdown에서 토글하고 return하는 구조여서 축 이동을 원천 차단하고 있었음
- 증상은 두 개(빈 곳 Shift 클릭 시 선택 해제, 직선 Shift 이동 불가)였지만 원인은 한 곳이라 드래그 시작 후 pointerup에서 토글하도록 뒤집음

# 리스크

도형이 선택된 상태에서 글자키가 텍스트 입력으로 들어가므로 그동안 도구 단축키(R, O, L, A, P, T)가 동작하지 않음
- 사용자가 선택한 진입 방식이고 Escape로 선택을 풀면 즉시 복귀

시스템 메뉴바에 Edit 메뉴가 남아 창 안 Edit 메뉴와 이름이 겹침
- 남은 항목은 텍스트 클립보드 전용이고 덱 명령은 창 안에만 있음. 제거하면 복사·붙여넣기가 깨짐

Issue #915