### PR TITLE
akbun-makepresentation 슬라이드 메뉴와 크기 조절

### DIFF
--- a/product/akbun-makepresentation/knowledge/decisions/2026-08-slide-size-is-deck-geometry.md
+++ b/product/akbun-makepresentation/knowledge/decisions/2026-08-slide-size-is-deck-geometry.md
@@ -1,0 +1,20 @@
+---
+type: Decision
+title: 슬라이드 크기는 덱의 픽셀 좌표계
+description: 슬라이드 크기를 덱 단위 픽셀 값으로 저장하고 cm와 PPTX 단위를 경계에서 변환.
+tags: [desktop, editor, slide-size, pptx]
+timestamp: 2026-08-16T00:00:00Z
+---
+
+## 결정
+
+- slideWidth와 slideHeight를 덱의 기준 좌표계로 저장.
+- cm 입력은 96ppi로 픽셀 변환.
+- PPTX의 EMU 크기를 픽셀로 왕복해 원본 비율 유지.
+- 크기 변경 시 기존 도형 좌표와 크기 유지.
+
+## 이유
+
+- 편집 화면, 썸네일, 발표, 이미지와 문서 내보내기가 같은 좌표계 공유.
+- 1px당 9525EMU 변환으로 픽셀과 cm 모두 PPTX 실제 크기에 일관되게 대응.
+- 슬라이드 경계 변경과 콘텐츠 변형을 분리해 예기치 않은 도형 왜곡 방지.

--- a/product/akbun-makepresentation/knowledge/decisions/index.md
+++ b/product/akbun-makepresentation/knowledge/decisions/index.md
@@ -6,5 +6,6 @@ akbun-makepresentation 작업 중 내린 의사결정과 이유.
 * [Shift 리사이즈는 비율과 선의 축을 유지](2026-08-shift-resize-keeps-line-axis.md)
 * [전체 선택 단축키는 패널 포커스를 따름](2026-08-select-all-follows-pane-focus.md)
 * [사용자 프리셋은 로컬 설정으로 저장](2026-08-custom-presets-are-local-settings.md)
+* [슬라이드 크기는 덱의 픽셀 좌표계](2026-08-slide-size-is-deck-geometry.md)
 * [회전은 상자 중심의 렌더 변환이고 선택 오버레이도 같이 돈다](2026-08-rotation-is-a-render-transform.md)
 * [모든 선형 도형은 arrowStart와 arrowEnd 하나로 끝을 표현](2026-08-one-end-model-for-every-stroke.md)

--- a/product/akbun-makepresentation/knowledge/log.md
+++ b/product/akbun-makepresentation/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-16
 
+* **Creation**: [슬라이드 크기는 덱의 픽셀 좌표계](decisions/2026-08-slide-size-is-deck-geometry.md) 결정 기록.
 * **Update**: [Shift 리사이즈는 비율과 선의 축을 유지](decisions/2026-08-shift-resize-keeps-line-axis.md)를 정사각형 변환에서 비율 유지로 뒤집음.
 * **Creation**: [회전은 상자 중심의 렌더 변환이고 선택 오버레이도 같이 돈다](decisions/2026-08-rotation-is-a-render-transform.md) 결정 기록.
 * **Creation**: [모든 선형 도형은 arrowStart와 arrowEnd 하나로 끝을 표현](decisions/2026-08-one-end-model-for-every-stroke.md) 결정 기록.

--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.12.0",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/lib.rs
@@ -1,8 +1,7 @@
 //! The deck model shared with the page as JSON, plus pptx and pdf writers.
 //!
-//! Coordinates are pixels on a 1280x720 slide. pptx uses EMU with a slide of
-//! 12192000x6858000, which is exactly 9525 EMU per pixel, so the conversion
-//! is a single multiply with no rounding drift worth caring about.
+//! Coordinates are pixels. pptx uses 9525 EMU per pixel, so custom pixel and
+//! centimetre dimensions share one conversion without changing shape units.
 
 use serde::{Deserialize, Serialize};
 
@@ -13,10 +12,32 @@ pub const SLIDE_W: f64 = 1280.0;
 pub const SLIDE_H: f64 = 720.0;
 pub const EMU_PER_PX: f64 = 9525.0;
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Deck {
+    #[serde(default = "default_slide_width")]
+    pub slide_width: f64,
+    #[serde(default = "default_slide_height")]
+    pub slide_height: f64,
     pub slides: Vec<Slide>,
+}
+
+pub fn default_slide_width() -> f64 {
+    SLIDE_W
+}
+
+pub fn default_slide_height() -> f64 {
+    SLIDE_H
+}
+
+impl Default for Deck {
+    fn default() -> Self {
+        Deck {
+            slide_width: SLIDE_W,
+            slide_height: SLIDE_H,
+            slides: Vec::new(),
+        }
+    }
 }
 
 /// One slide: its own background color plus the shapes drawn on it. The

--- a/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
+++ b/product/akbun-makepresentation/workspace/src-tauri/crates/deck/src/pptx.rs
@@ -62,7 +62,10 @@ pub fn write<W: Write + Seek>(deck: &Deck, out: W) -> Result<(), String> {
     let n = deck.slides.len().max(1);
     add("[Content_Types].xml", content_types(n).as_bytes())?;
     add("_rels/.rels", ROOT_RELS.as_bytes())?;
-    add("ppt/presentation.xml", presentation(n).as_bytes())?;
+    add(
+        "ppt/presentation.xml",
+        presentation(n, deck.slide_width, deck.slide_height).as_bytes(),
+    )?;
     add("ppt/_rels/presentation.xml.rels", presentation_rels(n).as_bytes())?;
     add("ppt/slideMasters/slideMaster1.xml", MASTER.as_bytes())?;
     add(
@@ -80,7 +83,7 @@ pub fn write<W: Write + Seek>(deck: &Deck, out: W) -> Result<(), String> {
     let mut media = MediaStore::default();
     for i in 0..n {
         let slide = deck.slides.get(i).unwrap_or(&empty);
-        let (xml, rels) = slide_xml(slide, &mut media);
+        let (xml, rels) = slide_xml(slide, &mut media, deck.slide_width, deck.slide_height);
         add(&format!("ppt/slides/slide{}.xml", i + 1), xml.as_bytes())?;
         add(
             &format!("ppt/slides/_rels/slide{}.xml.rels", i + 1),
@@ -194,7 +197,7 @@ const ROOT_RELS: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"y
 <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"ppt/presentation.xml\"/>\
 </Relationships>";
 
-fn presentation(slides: usize) -> String {
+fn presentation(slides: usize, width: f64, height: f64) -> String {
     let mut ids = String::new();
     for i in 0..slides {
         ids.push_str(&format!(
@@ -208,9 +211,11 @@ fn presentation(slides: usize) -> String {
 <p:presentation{NS}>\
 <p:sldMasterIdLst><p:sldMasterId id=\"2147483648\" r:id=\"rId1\"/></p:sldMasterIdLst>\
 <p:sldIdLst>{ids}</p:sldIdLst>\
-<p:sldSz cx=\"12192000\" cy=\"6858000\"/>\
+<p:sldSz cx=\"{}\" cy=\"{}\"/>\
 <p:notesSz cx=\"6858000\" cy=\"9144000\"/>\
-</p:presentation>"
+</p:presentation>",
+        emu(width),
+        emu(height)
     )
 }
 
@@ -296,7 +301,12 @@ const THEME: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"
 </a:themeElements>\
 </a:theme>";
 
-fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
+fn slide_xml(
+    slide: &Slide,
+    media: &mut MediaStore,
+    slide_width: f64,
+    slide_height: f64,
+) -> (String, String) {
     let mut shapes = String::new();
     let mut rels = String::from(SLIDE_REL_LAYOUT);
     // rId1 is the layout; image relationships follow it.
@@ -309,7 +319,12 @@ fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
                 shapes.push_str("</p:grpSp>");
             }
             if !shape.group_id.is_empty() {
-                shapes.push_str(&group_xml(next_id, &shape.group_id));
+                shapes.push_str(&group_xml(
+                    next_id,
+                    &shape.group_id,
+                    slide_width,
+                    slide_height,
+                ));
                 next_id += 1;
             }
             open_group = shape.group_id.clone();
@@ -347,15 +362,15 @@ fn slide_xml(slide: &Slide, media: &mut MediaStore) -> (String, String) {
     (xml, rels)
 }
 
-fn group_xml(id: u64, name: &str) -> String {
+fn group_xml(id: u64, name: &str, slide_width: f64, slide_height: f64) -> String {
     format!(
         "<p:grpSp><p:nvGrpSpPr><p:cNvPr id=\"{id}\" name=\"{}\"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr>\
 <p:grpSpPr><a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"{}\" cy=\"{}\"/><a:chOff x=\"0\" y=\"0\"/><a:chExt cx=\"{}\" cy=\"{}\"/></a:xfrm></p:grpSpPr>",
         xml_escape(name),
-        emu(SLIDE_W),
-        emu(SLIDE_H),
-        emu(SLIDE_W),
-        emu(SLIDE_H),
+        emu(slide_width),
+        emu(slide_height),
+        emu(slide_width),
+        emu(slide_height),
     )
 }
 
@@ -634,7 +649,8 @@ pub fn read<R: Read + Seek>(input: R) -> Result<Deck, String> {
         return Err("no slides found in file".into());
     }
 
-    // The declared page size, for fitting foreign canvases onto 1280x720.
+    // The page and shapes use the same pixel-to-EMU scale, so imported decks
+    // keep their original dimensions without remapping shape coordinates.
     let sld_sz = part(&mut archive, "ppt/presentation.xml").and_then(|xml| parse_sld_sz(&xml));
     let (page_w, page_h) = sld_sz
         .map(|(cx, cy)| (cx / EMU_PER_PX, cy / EMU_PER_PX))
@@ -642,7 +658,11 @@ pub fn read<R: Read + Seek>(input: R) -> Result<Deck, String> {
 
     let mut media_cache: HashMap<String, String> = HashMap::new();
 
-    let mut deck = Deck::default();
+    let mut deck = Deck {
+        slide_width: page_w,
+        slide_height: page_h,
+        ..Deck::default()
+    };
     for (_, name) in names {
         let xml = part(&mut archive, &name).ok_or(format!("cannot read {name}"))?;
         let rels = rels_for_part(&mut archive, &name);
@@ -765,19 +785,6 @@ pub fn read<R: Read + Seek>(input: R) -> Result<Deck, String> {
         deck.slides.push(Slide { shapes, background });
     }
 
-    // Other editors use other canvases: 4:3, Google Slides' smaller 16:9,
-    // portrait one-offs. Fit whatever size the file declares onto this
-    // editor's 1280x720 while keeping the aspect ratio.
-    if let Some((cx, cy)) = sld_sz {
-        let scale = (SLIDE_W * EMU_PER_PX / cx).min(SLIDE_H * EMU_PER_PX / cy);
-        if (scale - 1.0).abs() > 0.001 {
-            for slide in &mut deck.slides {
-                for shape in &mut slide.shapes {
-                    scale_shape(shape, scale);
-                }
-            }
-        }
-    }
     Ok(deck)
 }
 
@@ -798,20 +805,6 @@ fn parse_sld_sz(xml: &str) -> Option<(f64, f64)> {
         }
     }
     None
-}
-
-fn scale_shape(shape: &mut Shape, scale: f64) {
-    let s = |v: f64| (v * scale * 100.0).round() / 100.0;
-    shape.x = s(shape.x);
-    shape.y = s(shape.y);
-    shape.w = s(shape.w);
-    shape.h = s(shape.h);
-    for p in &mut shape.points {
-        p[0] = s(p[0]);
-        p[1] = s(p[1]);
-    }
-    shape.font_size = s(shape.font_size).max(1.0);
-    shape.stroke_width = s(shape.stroke_width);
 }
 
 /// One zip entry as text, or None when missing or unreadable.
@@ -1948,6 +1941,7 @@ mod tests {
                     ..Slide::default()
                 },
             ],
+            ..Deck::default()
         }
     }
 
@@ -2003,6 +1997,19 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn round_trip_preserves_custom_slide_size() {
+        let mut deck = sample_deck();
+        deck.slide_width = 720.0;
+        deck.slide_height = 1280.0;
+        let mut buffer = Cursor::new(Vec::new());
+        write(&deck, &mut buffer).unwrap();
+        buffer.set_position(0);
+        let back = read(buffer).unwrap();
+        assert_eq!(back.slide_width, 720.0);
+        assert_eq!(back.slide_height, 1280.0);
     }
 
     /// A minimal package shaped the way PowerPoint writes one: theme colors
@@ -2241,34 +2248,15 @@ mod tests {
     }
 
     #[test]
-    fn foreign_slide_sizes_fit_the_canvas() {
-        // A portrait 4:3 flipped on its side: 6858000 x 12192000 EMU.
+    fn foreign_slide_sizes_keep_their_declared_canvas() {
         let sz = parse_sld_sz(
             "<p:presentation xmlns:p=\"x\"><p:sldSz cx=\"6858000\" cy=\"12192000\"/>\
 <p:notesSz cx=\"1\" cy=\"1\"/></p:presentation>",
         )
         .unwrap();
         assert_eq!(sz, (6858000.0, 12192000.0));
-        let scale = (SLIDE_W * EMU_PER_PX / sz.0).min(SLIDE_H * EMU_PER_PX / sz.1);
-        // Height is the binding side: 720 / 1280 of the declared height.
-        assert!((scale - 0.5625).abs() < 1e-9);
-
-        let mut shape = Shape {
-            kind: "pen".into(),
-            x: 100.0,
-            y: 200.0,
-            w: 400.0,
-            h: 80.0,
-            points: vec![[100.0, 200.0]],
-            font_size: 24.0,
-            stroke_width: 2.0,
-            ..Shape::default()
-        };
-        scale_shape(&mut shape, scale);
-        assert_eq!(shape.x, 56.25);
-        assert_eq!(shape.w, 225.0);
-        assert_eq!(shape.points[0], [56.25, 112.5]);
-        assert_eq!(shape.font_size, 13.5);
+        assert_eq!(sz.0 / EMU_PER_PX, 720.0);
+        assert_eq!(sz.1 / EMU_PER_PX, 1280.0);
     }
 
     #[test]

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -6,6 +6,16 @@
 
 const SLIDE_W = 1280;
 const SLIDE_H = 720;
+const PX_PER_INCH = 96;
+const CM_PER_INCH = 2.54;
+const MIN_SLIDE_SIZE = 64;
+const MAX_SLIDE_SIZE = 10000;
+const SLIDE_SIZE_PRESETS = Object.freeze({
+  '16:9': Object.freeze({ width: 1280, height: 720 }),
+  '4:3': Object.freeze({ width: 960, height: 720 }),
+  '3:4': Object.freeze({ width: 720, height: 960 }),
+  '9:16': Object.freeze({ width: 720, height: 1280 }),
+});
 
 // Paper white. A slide keeps its own background so changing it touches that
 // one field and nothing else on the slide.
@@ -59,11 +69,57 @@ const MAX_CLIPBOARD_SHAPES = 100;
 const MAX_GEOMETRY = 1_000_000;
 
 function createDeck() {
-  return { slides: [createSlide()] };
+  return { slideWidth: SLIDE_W, slideHeight: SLIDE_H, slides: [createSlide()] };
 }
 
 function createSlide() {
   return { shapes: [], background: DEFAULT_BACKGROUND };
+}
+
+function slideSize(deck) {
+  const width = Number(deck && deck.slideWidth);
+  const height = Number(deck && deck.slideHeight);
+  return {
+    width: Number.isFinite(width) && width >= MIN_SLIDE_SIZE && width <= MAX_SLIDE_SIZE
+      ? width
+      : SLIDE_W,
+    height: Number.isFinite(height) && height >= MIN_SLIDE_SIZE && height <= MAX_SLIDE_SIZE
+      ? height
+      : SLIDE_H,
+  };
+}
+
+function setSlideSize(deck, width, height) {
+  const nextWidth = Number(width);
+  const nextHeight = Number(height);
+  if (
+    !deck ||
+    !Number.isFinite(nextWidth) ||
+    !Number.isFinite(nextHeight) ||
+    nextWidth < MIN_SLIDE_SIZE ||
+    nextHeight < MIN_SLIDE_SIZE ||
+    nextWidth > MAX_SLIDE_SIZE ||
+    nextHeight > MAX_SLIDE_SIZE
+  ) return false;
+  deck.slideWidth = Math.round(nextWidth * 100) / 100;
+  deck.slideHeight = Math.round(nextHeight * 100) / 100;
+  return true;
+}
+
+function slideSizePreset(ratio) {
+  const preset = SLIDE_SIZE_PRESETS[ratio];
+  return preset ? { ...preset } : null;
+}
+
+function pixelsToCentimeters(value) {
+  return Math.round((Number(value) * CM_PER_INCH / PX_PER_INCH) * 1000) / 1000;
+}
+
+function centimetersToPixels(value) {
+  const pixels = Number(value) * PX_PER_INCH / CM_PER_INCH;
+  const nearestInteger = Math.round(pixels);
+  if (Math.abs(pixels - nearestInteger) < 0.05) return nearestInteger;
+  return Math.round(pixels * 100) / 100;
 }
 
 // A deck saved before slides carried a background, or a slide read from a
@@ -678,8 +734,8 @@ function duplicateSlide(deck, index) {
 
 // The page number as an ordinary text shape rather than a special case, so it
 // draws, rasterizes and exports to pptx through the paths that already exist.
-function slideNumberShape(number) {
-  const shape = createShape('text', SLIDE_W - 110, SLIDE_H - 52, {
+function slideNumberShape(number, width = SLIDE_W, height = SLIDE_H) {
+  const shape = createShape('text', width - 110, height - 52, {
     fontSize: 18,
     textColor: '#868e96',
   });
@@ -996,6 +1052,8 @@ function arrowSvg(shape) {
 // A whole slide as standalone SVG markup, used for thumbnails, the
 // presentation view, and rasterizing pages for the pdf export.
 function renderSlideSvg(slide, options) {
+  const width = Number(options && options.width) || SLIDE_W;
+  const height = Number(options && options.height) || SLIDE_H;
   let shapes = slide.shapes
     .map((shape, i) =>
       renderShapeSvg(shape, {
@@ -1004,11 +1062,11 @@ function renderSlideSvg(slide, options) {
     )
     .join('');
   if (options && options.number) {
-    shapes += renderShapeSvg(slideNumberShape(options.number));
+    shapes += renderShapeSvg(slideNumberShape(options.number, width, height));
   }
   return (
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SLIDE_W} ${SLIDE_H}">` +
-    `<rect width="${SLIDE_W}" height="${SLIDE_H}" fill="${slideBackground(slide)}"/>${shapes}</svg>`
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}">` +
+    `<rect width="${width}" height="${height}" fill="${slideBackground(slide)}"/>${shapes}</svg>`
   );
 }
 
@@ -1086,6 +1144,7 @@ function filterFonts(fonts, query) {
 const exported = {
   SLIDE_W,
   SLIDE_H,
+  SLIDE_SIZE_PRESETS,
   DEFAULT_STYLE,
   DEFAULT_BACKGROUND,
   ARROW_ENDS,
@@ -1099,6 +1158,11 @@ const exported = {
   filterFonts,
   createDeck,
   createSlide,
+  slideSize,
+  setSlideSize,
+  slideSizePreset,
+  pixelsToCentimeters,
+  centimetersToPixels,
   slideBackground,
   createShape,
   defaultPresetShapes,

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -38,10 +38,18 @@
       </div>
     </div>
     <div class="menu">
+      <button class="menu-title" data-menu="slides" aria-haspopup="true" aria-expanded="false">Slides</button>
+      <div class="menu-panel" data-menu-panel="slides" hidden>
+        <button data-command="present">Presentation</button>
+        <button data-command="numbers">Slide numbers</button>
+        <hr />
+        <button data-command="slide-size">Slide size…</button>
+      </div>
+    </div>
+    <div class="menu">
       <button class="menu-title" data-menu="view" aria-haspopup="true" aria-expanded="false">View</button>
       <div class="menu-panel" data-menu-panel="view" hidden>
         <button data-command="guidelines">Guidelines</button>
-        <button data-command="numbers">Slide numbers</button>
         <hr />
         <button data-command="zoom-in">Zoom in<span class="accel">⌘+</span></button>
         <button data-command="zoom-out">Zoom out<span class="accel">⌘-</span></button>
@@ -272,6 +280,41 @@
       <div id="custom-presets" class="preset-grid"></div>
     </section>
   </div>
+
+  <dialog id="slide-size-dialog" aria-labelledby="slide-size-title">
+    <form id="slide-size-form" method="dialog">
+      <header>
+        <h1 id="slide-size-title">Slide size</h1>
+      </header>
+      <div class="slide-size-content">
+        <fieldset>
+          <legend>Ratio</legend>
+          <div class="ratio-options">
+            <button type="button" data-slide-ratio="16:9">16:9</button>
+            <button type="button" data-slide-ratio="4:3">4:3</button>
+            <button type="button" data-slide-ratio="3:4">3:4</button>
+            <button type="button" data-slide-ratio="9:16">9:16</button>
+          </div>
+        </fieldset>
+        <div class="slide-size-fields">
+          <label for="slide-size-unit">Unit</label>
+          <select id="slide-size-unit">
+            <option value="px">Pixels (px)</option>
+            <option value="cm">Centimeters (cm)</option>
+          </select>
+          <label for="slide-size-width">Width</label>
+          <input id="slide-size-width" type="number" min="64" max="10000" step="1" required />
+          <label for="slide-size-height">Height</label>
+          <input id="slide-size-height" type="number" min="64" max="10000" step="1" required />
+        </div>
+        <p id="slide-size-status" class="settings-status" aria-live="polite"></p>
+      </div>
+      <footer>
+        <button id="btn-slide-size-cancel" type="button">Cancel</button>
+        <button type="submit" class="primary">Apply</button>
+      </footer>
+    </form>
+  </dialog>
 
   <dialog id="settings-dialog" aria-labelledby="settings-title">
     <div class="settings-shell">

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -303,9 +303,9 @@
             <option value="cm">Centimeters (cm)</option>
           </select>
           <label for="slide-size-width">Width</label>
-          <input id="slide-size-width" type="number" min="64" max="10000" step="1" required />
+          <input id="slide-size-width" type="number" min="64" max="10000" step="0.01" required />
           <label for="slide-size-height">Height</label>
-          <input id="slide-size-height" type="number" min="64" max="10000" step="1" required />
+          <input id="slide-size-height" type="number" min="64" max="10000" step="0.01" required />
         </div>
         <p id="slide-size-status" class="settings-status" aria-live="polite"></p>
       </div>

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -1166,7 +1166,7 @@ function setSlideSizeUnit(unit, size) {
   for (const input of [$('slide-size-width'), $('slide-size-height')]) {
     input.min = unit === 'cm' ? '1.693' : '64';
     input.max = unit === 'cm' ? '264.583' : '10000';
-    input.step = unit === 'cm' ? '0.001' : '1';
+    input.step = unit === 'cm' ? '0.001' : '0.01';
   }
   setSlideSizeFields(size, unit);
 }
@@ -1202,7 +1202,9 @@ $('slide-size-form').addEventListener('submit', (event) => {
   const size = slideSizeFromFields();
   const before = deckSize();
   if (!size || !L.setSlideSize(state.deck, size.width, size.height)) {
-    $('slide-size-status').textContent = 'Enter a size from 64 to 10,000 pixels.';
+    $('slide-size-status').textContent = slideSizeUnit === 'cm'
+      ? 'Enter width and height from 1.693 to 264.583 cm.'
+      : 'Enter width and height from 64 to 10,000 px.';
     return;
   }
   if (before.width !== state.deck.slideWidth || before.height !== state.deck.slideHeight) {

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -32,6 +32,7 @@ const textEditor = $('text-editor');
 const present = $('present');
 const contextMenu = $('context-menu');
 const presetMenu = $('preset-menu');
+const slideSizeDialog = $('slide-size-dialog');
 const settingsDialog = $('settings-dialog');
 const fontPicker = $('font-picker');
 const fontMenu = $('font-menu');
@@ -43,12 +44,18 @@ let customPresets = [];
 let settingsPresetDraft = [];
 
 const slide = () => state.deck.slides[state.current];
+const deckSize = () => L.slideSize(state.deck);
 const selectedShape = () =>
   state.selected >= 0 ? slide().shapes[state.selected] : null;
 const selectedShapes = () =>
   state.selection
     .filter((index) => index >= 0 && index < slide().shapes.length)
     .map((index) => slide().shapes[index]);
+
+function fitTextBoxForSlide(shape, text) {
+  const available = deckSize().width - Math.max(0, Number(shape.x) || 0);
+  return L.fitTextBox(shape, text, available);
+}
 
 function selectOnly(index) {
   state.selected = index;
@@ -183,22 +190,33 @@ function marqueeSvg() {
 // outside the g[data-i] groups that make shapes selectable.
 function slideNumberSvg(index) {
   if (!state.showNumbers) return '';
-  return L.renderShapeSvg(L.slideNumberShape(index + 1));
+  const { width, height } = deckSize();
+  return L.renderShapeSvg(L.slideNumberShape(index + 1, width, height));
 }
 
 function guidelinesSvg() {
   if (!state.showGuidelines) return '';
+  const { width, height } = deckSize();
+  const marginX = width * 0.05;
+  const titleY = height * 0.067;
+  const titleHeight = height * 0.156;
+  const contentY = height * 0.267;
+  const contentHeight = height * 0.644;
   return (
     '<g class="guidelines" aria-hidden="true">' +
-    '<rect x="64" y="48" width="1152" height="112"/>' +
-    '<text x="76" y="72">TITLE</text>' +
-    '<rect x="64" y="192" width="1152" height="464"/>' +
-    '<text x="76" y="216">CONTENT</text>' +
+    `<rect x="${marginX}" y="${titleY}" width="${width - marginX * 2}" height="${titleHeight}"/>` +
+    `<text x="${marginX + 12}" y="${titleY + 24}">TITLE</text>` +
+    `<rect x="${marginX}" y="${contentY}" width="${width - marginX * 2}" height="${contentHeight}"/>` +
+    `<text x="${marginX + 12}" y="${contentY + 24}">CONTENT</text>` +
     '</g>'
   );
 }
 
 function renderCanvas() {
+  const { width, height } = deckSize();
+  canvas.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  stageInner.style.setProperty('--slide-ratio', String(width / height));
+  stageInner.style.setProperty('--slide-aspect', `${width} / ${height}`);
   // The slide's own color, not the app theme: what the editor shows here is
   // what the pdf and the projector show.
   canvas.style.background = L.slideBackground(slide());
@@ -259,6 +277,7 @@ function cropOverlaySvg() {
 
 function renderThumbs() {
   const thumbs = $('thumbs');
+  const { width, height } = deckSize();
   // The panel takes focus so Backspace can mean "delete this slide" there and
   // keep meaning "delete this object" on the canvas.
   const focused = document.activeElement && thumbs.contains(document.activeElement);
@@ -266,7 +285,7 @@ function renderThumbs() {
     .map(
       (s, i) =>
         `<div class="thumb${i === state.current ? ' active' : ''}${state.slideSelection.includes(i) ? ' selected' : ''}" data-slide="${i}" draggable="true" tabindex="${i === state.current ? '0' : '-1'}">` +
-        `${L.renderSlideSvg(s, { number: state.showNumbers ? i + 1 : 0 })}` +
+        `${L.renderSlideSvg(s, { width, height, number: state.showNumbers ? i + 1 : 0 })}` +
         `<span class="num">${i + 1}</span></div>`
     )
     .join('');
@@ -435,9 +454,10 @@ function isSecondPress(index) {
 
 function toPoint(event) {
   const rect = canvas.getBoundingClientRect();
+  const { width, height } = deckSize();
   return {
-    x: (event.clientX - rect.left) * (L.SLIDE_W / rect.width),
-    y: (event.clientY - rect.top) * (L.SLIDE_H / rect.height),
+    x: (event.clientX - rect.left) * (width / rect.width),
+    y: (event.clientY - rect.top) * (height / rect.height),
   };
 }
 
@@ -685,7 +705,7 @@ function canEditText(shape) {
 
 function styleTextEditor(shape) {
   if (!shape) return;
-  const scale = canvas.getBoundingClientRect().width / L.SLIDE_W;
+  const scale = canvas.getBoundingClientRect().width / deckSize().width;
   // The same inset the glyphs are drawn at, so text does not jump sideways
   // when editing starts inside a rect or an ellipse.
   const box = L.textBox(shape);
@@ -723,7 +743,7 @@ function startTextEdit(index, seed) {
   renderCanvas();
 
   textEditor.value = seed ? shape.text + seed : shape.text;
-  if (seed && shape.kind === 'text') L.fitTextBox(shape, textEditor.value);
+  if (seed && shape.kind === 'text') fitTextBoxForSlide(shape, textEditor.value);
   styleTextEditor(shape);
   textEditor.hidden = false;
   // Deferred so it wins over whatever focus change the triggering click
@@ -769,7 +789,7 @@ function commitTextEdit() {
     shape.text = text;
   } else if (changed) {
     shape.text = text;
-    L.fitTextBox(shape, text);
+    fitTextBoxForSlide(shape, text);
   } else if (before && shape.kind === 'text') {
     shape.w = before.w;
     shape.h = before.h;
@@ -782,7 +802,7 @@ textEditor.addEventListener('blur', commitTextEdit);
 textEditor.addEventListener('input', () => {
   const shape = slide().shapes[state.editingIndex];
   if (!shape || shape.kind !== 'text') return;
-  L.fitTextBox(shape, textEditor.value);
+  fitTextBoxForSlide(shape, textEditor.value);
   styleTextEditor(shape);
   renderCanvas();
 });
@@ -810,7 +830,7 @@ textEditor.addEventListener('keydown', (event) => {
 const TOOL_KEYS = { v: 'select', r: 'rect', o: 'ellipse', l: 'line', a: 'arrow', p: 'pen', t: 'text' };
 
 document.addEventListener('keydown', (event) => {
-  if (settingsDialog.open) return;
+  if (settingsDialog.open || slideSizeDialog.open) return;
   if (!presetMenu.hidden && event.key === 'Escape') {
     hidePresetMenu();
     event.preventDefault();
@@ -904,6 +924,11 @@ document.addEventListener('keydown', (event) => {
     renderProps();
     return;
   }
+  if (slidesHaveFocus() && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+    selectAdjacentSlide(event.key === 'ArrowUp' ? -1 : 1);
+    event.preventDefault();
+    return;
+  }
   if (event.key.startsWith('Arrow')) {
     const shapes = selectedShapes();
     if (shapes.length === 0) return;
@@ -989,7 +1014,7 @@ const PRESET_MARGIN_Y = 48;
 function cornerPresetShapes(shapes) {
   const copies = L.cloneShapes(shapes);
   const bounds = shapeBounds(copies);
-  const dx = L.SLIDE_W - PRESET_MARGIN_X - bounds.w - bounds.x;
+  const dx = deckSize().width - PRESET_MARGIN_X - bounds.w - bounds.x;
   const dy = PRESET_MARGIN_Y - bounds.y;
   for (const shape of copies) L.moveShape(shape, dx, dy);
   return copies;
@@ -1098,6 +1123,93 @@ presetMenu.addEventListener('click', (event) => {
   if (!preset) return;
   insertShapes(cornerPresetShapes(preset.shapes), 0);
   hidePresetMenu();
+  canvas.focus({ preventScroll: true });
+});
+
+let slideSizeUnit = 'px';
+
+function slideSizeValue(value, unit) {
+  if (unit === 'cm') return String(L.pixelsToCentimeters(value));
+  return String(Math.round(value * 100) / 100);
+}
+
+function setSlideSizeFields(size, unit) {
+  $('slide-size-width').value = slideSizeValue(size.width, unit);
+  $('slide-size-height').value = slideSizeValue(size.height, unit);
+  syncSlideRatioButtons(size);
+}
+
+function slideSizeFromFields(unit = slideSizeUnit) {
+  const width = Number($('slide-size-width').value);
+  const height = Number($('slide-size-height').value);
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
+  return unit === 'cm'
+    ? {
+        width: L.centimetersToPixels(width),
+        height: L.centimetersToPixels(height),
+      }
+    : { width, height };
+}
+
+function syncSlideRatioButtons(size) {
+  const ratio = size && size.height ? size.width / size.height : 0;
+  for (const button of slideSizeDialog.querySelectorAll('[data-slide-ratio]')) {
+    const preset = L.slideSizePreset(button.dataset.slideRatio);
+    const selected = preset && Math.abs(ratio - preset.width / preset.height) < 0.0001;
+    button.setAttribute('aria-pressed', String(!!selected));
+  }
+}
+
+function setSlideSizeUnit(unit, size) {
+  slideSizeUnit = unit;
+  $('slide-size-unit').value = unit;
+  for (const input of [$('slide-size-width'), $('slide-size-height')]) {
+    input.min = unit === 'cm' ? '1.693' : '64';
+    input.max = unit === 'cm' ? '264.583' : '10000';
+    input.step = unit === 'cm' ? '0.001' : '1';
+  }
+  setSlideSizeFields(size, unit);
+}
+
+function openSlideSizeDialog() {
+  hideMenus();
+  hidePresetMenu();
+  $('slide-size-status').textContent = '';
+  setSlideSizeUnit(slideSizeUnit, deckSize());
+  slideSizeDialog.showModal();
+  slideSizeDialog.querySelector('[data-slide-ratio][aria-pressed="true"]')?.focus();
+}
+
+slideSizeDialog.querySelector('.ratio-options').addEventListener('click', (event) => {
+  const button = event.target.closest('[data-slide-ratio]');
+  if (!button) return;
+  const preset = L.slideSizePreset(button.dataset.slideRatio);
+  if (preset) setSlideSizeFields(preset, slideSizeUnit);
+});
+
+$('slide-size-unit').addEventListener('change', (event) => {
+  const size = slideSizeFromFields(slideSizeUnit) || deckSize();
+  setSlideSizeUnit(event.target.value, size);
+});
+
+for (const input of [$('slide-size-width'), $('slide-size-height')]) {
+  input.addEventListener('input', () => syncSlideRatioButtons(slideSizeFromFields()));
+}
+
+$('btn-slide-size-cancel').addEventListener('click', () => slideSizeDialog.close('cancel'));
+$('slide-size-form').addEventListener('submit', (event) => {
+  event.preventDefault();
+  const size = slideSizeFromFields();
+  const before = deckSize();
+  if (!size || !L.setSlideSize(state.deck, size.width, size.height)) {
+    $('slide-size-status').textContent = 'Enter a size from 64 to 10,000 pixels.';
+    return;
+  }
+  if (before.width !== state.deck.slideWidth || before.height !== state.deck.slideHeight) {
+    markDirty();
+    renderAll();
+  }
+  slideSizeDialog.close('apply');
   canvas.focus({ preventScroll: true });
 });
 
@@ -1214,19 +1326,24 @@ function readImageSize(src) {
 function pastedTextShape(text) {
   const shape = L.createShape('text', 80, 80, state.defaults);
   shape.text = text.replace(/\r\n/g, '\n');
-  L.fitTextBox(shape, shape.text);
+  fitTextBoxForSlide(shape, shape.text);
   return shape;
 }
 
 async function pastedImageShape(file, index) {
   const src = await readFileDataUrl(file);
   const size = await readImageSize(src);
-  const scale = Math.min(1, (L.SLIDE_W * 0.8) / size.width, (L.SLIDE_H * 0.8) / size.height);
+  const slideDimensions = deckSize();
+  const scale = Math.min(
+    1,
+    (slideDimensions.width * 0.8) / size.width,
+    (slideDimensions.height * 0.8) / size.height
+  );
   const shape = L.createShape('image', 0, 0, state.defaults);
   shape.w = Math.max(1, size.width * scale);
   shape.h = Math.max(1, size.height * scale);
-  shape.x = (L.SLIDE_W - shape.w) / 2 + index * PASTE_OFFSET;
-  shape.y = (L.SLIDE_H - shape.h) / 2 + index * PASTE_OFFSET;
+  shape.x = (slideDimensions.width - shape.w) / 2 + index * PASTE_OFFSET;
+  shape.y = (slideDimensions.height - shape.h) / 2 + index * PASTE_OFFSET;
   shape.src = src;
   return shape;
 }
@@ -1557,7 +1674,7 @@ function applyProp(patch) {
         shape.kind === 'text' &&
         ['fontSize', 'fontFamily', 'bold', 'italic'].some((name) => Object.hasOwn(patch, name))
       ) {
-        L.fitTextBox(shape, shape.text);
+        fitTextBoxForSlide(shape, shape.text);
       }
     }
     markDirty();
@@ -1696,6 +1813,17 @@ $('prop-vertical-align').addEventListener('click', (event) => {
 const TEXT_STYLE_KEYS = { b: 'bold', i: 'italic', u: 'underline' };
 
 // --- slide panel ------------------------------------------------------------------------
+
+function selectAdjacentSlide(direction) {
+  const next = Math.max(0, Math.min(state.current + direction, state.deck.slides.length - 1));
+  if (next !== state.current) {
+    state.current = next;
+    setSlideSelection([next]);
+    clearSelection();
+    renderAll();
+  }
+  $('thumbs').querySelector(`[data-slide="${state.current}"]`)?.focus();
+}
 
 $('thumbs').addEventListener('click', (event) => {
   const thumb = event.target.closest('[data-slide]');
@@ -1908,7 +2036,8 @@ function suggestName(extension) {
 function deckForSave() {
   if (!state.showNumbers) return state.deck;
   const copy = structuredClone(state.deck);
-  copy.slides.forEach((s, i) => s.shapes.push(L.slideNumberShape(i + 1)));
+  const { width, height } = deckSize();
+  copy.slides.forEach((s, i) => s.shapes.push(L.slideNumberShape(i + 1, width, height)));
   return copy;
 }
 
@@ -1928,24 +2057,33 @@ async function saveFile(alwaysAsk) {
   }
 }
 
-// Rasterize one slide at 1920x1080, which is enough for PDF pages and PNG
-// exports at this slide size.
+function slideRasterSize() {
+  const { width, height } = deckSize();
+  const scale = Math.min(1.5, 4096 / width, 4096 / height);
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale)),
+  };
+}
+
 function rasterizeSlideCanvas(s, number) {
   return new Promise((resolve, reject) => {
-    const svg = L.renderSlideSvg(s, { number });
+    const slideDimensions = deckSize();
+    const rasterSize = slideRasterSize();
+    const svg = L.renderSlideSvg(s, { ...slideDimensions, number });
     const url = URL.createObjectURL(new Blob([svg], { type: 'image/svg+xml' }));
     const image = new Image();
     image.onload = () => {
       const raster = document.createElement('canvas');
-      raster.width = 1920;
-      raster.height = 1080;
+      raster.width = rasterSize.width;
+      raster.height = rasterSize.height;
       const context = raster.getContext('2d');
       if (!context) {
         URL.revokeObjectURL(url);
         reject(new Error('cannot create slide canvas'));
         return;
       }
-      context.drawImage(image, 0, 0, 1920, 1080);
+      context.drawImage(image, 0, 0, raster.width, raster.height);
       URL.revokeObjectURL(url);
       resolve(raster);
     };
@@ -1959,7 +2097,11 @@ function rasterizeSlideCanvas(s, number) {
 
 async function rasterizeSlideForPdf(s, number) {
   const raster = await rasterizeSlideCanvas(s, number);
-  return { dataUrl: raster.toDataURL('image/jpeg', 0.92), width: 1920, height: 1080 };
+  return {
+    dataUrl: raster.toDataURL('image/jpeg', 0.92),
+    width: raster.width,
+    height: raster.height,
+  };
 }
 
 async function exportPdf() {
@@ -2000,7 +2142,10 @@ async function exportPng() {
 // --- presentation mode ------------------------------------------------------------------------
 
 function renderPresent() {
+  const { width, height } = deckSize();
   present.innerHTML = L.renderSlideSvg(state.deck.slides[state.presentIndex], {
+    width,
+    height,
     number: state.showNumbers ? state.presentIndex + 1 : 0,
   });
 }
@@ -2078,9 +2223,11 @@ const MENU_COMMANDS = {
   delete: deleteSelectedShape,
   group: groupSelection,
   ungroup: ungroupSelection,
+  present: enterPresent,
   settings: openSettings,
   guidelines: toggleGuidelines,
   numbers: toggleNumbers,
+  'slide-size': openSlideSizeDialog,
   'zoom-in': () => setZoom(L.zoomIn(state.zoom)),
   'zoom-out': () => setZoom(L.zoomOut(state.zoom)),
   'zoom-fit': () => setZoom(L.ZOOM_FIT),

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -323,7 +323,7 @@ main {
   position: relative;
   margin: auto;
   flex: none;
-  width: calc(min(100%, (100vh - 176px) * 16 / 9) * var(--zoom, 1));
+  width: calc(min(100%, (100vh - 176px) * var(--slide-ratio, 1.7777778)) * var(--zoom, 1));
 }
 
 /* --- status bar --- */
@@ -367,7 +367,7 @@ main {
 #canvas {
   display: block;
   width: 100%;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: var(--slide-aspect, 16 / 9);
   background: #ffffff;
   box-shadow: 0 0 0 1px var(--border), 0 2px 12px rgba(0, 0, 0, 0.25);
   user-select: none;
@@ -826,6 +826,87 @@ input[type='color'] {
   white-space: nowrap;
 }
 
+/* --- modal dialogs --- */
+
+#slide-size-dialog {
+  width: min(460px, calc(100vw - 32px));
+  padding: 0;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+}
+
+#slide-size-dialog::backdrop,
+#settings-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.42);
+}
+
+#slide-size-form > header,
+#slide-size-form > footer {
+  padding: 14px 18px;
+}
+
+#slide-size-form > header {
+  border-bottom: 1px solid var(--border);
+}
+
+#slide-size-form h1 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.slide-size-content {
+  padding: 18px;
+}
+
+.slide-size-content fieldset {
+  margin: 0 0 18px;
+  padding: 0;
+  border: 0;
+}
+
+.slide-size-content legend {
+  margin-bottom: 8px;
+  color: var(--muted);
+}
+
+.ratio-options {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.ratio-options button[aria-pressed='true'] {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.slide-size-fields {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  align-items: center;
+  gap: 10px;
+}
+
+.slide-size-fields input,
+.slide-size-fields select {
+  width: 100%;
+}
+
+#slide-size-status {
+  min-height: 1.2em;
+  margin: 10px 0 0 100px;
+}
+
+#slide-size-form > footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+}
+
 /* --- settings dialog --- */
 
 #settings-dialog {
@@ -837,10 +918,6 @@ input[type='color'] {
   border-radius: 10px;
   background: var(--panel);
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
-}
-
-#settings-dialog::backdrop {
-  background: rgba(0, 0, 0, 0.42);
 }
 
 .settings-shell {

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -8,6 +8,28 @@ test('createDeck starts with one empty slide', () => {
   const deck = L.createDeck();
   assert.strictEqual(deck.slides.length, 1);
   assert.deepStrictEqual(deck.slides[0].shapes, []);
+  assert.deepStrictEqual(L.slideSize(deck), { width: 1280, height: 720 });
+});
+
+test('slide size supports presets, custom pixels, and centimeters', () => {
+  const deck = L.createDeck();
+  assert.deepStrictEqual(L.slideSizePreset('4:3'), { width: 960, height: 720 });
+  assert.deepStrictEqual(L.slideSizePreset('9:16'), { width: 720, height: 1280 });
+  assert.strictEqual(L.slideSizePreset('custom'), null);
+  assert.strictEqual(L.pixelsToCentimeters(960), 25.4);
+  assert.strictEqual(L.centimetersToPixels(25.4), 960);
+  assert.strictEqual(L.centimetersToPixels(33.867), 1280);
+  assert.ok(L.setSlideSize(deck, 1000, 1000));
+  assert.deepStrictEqual(L.slideSize(deck), { width: 1000, height: 1000 });
+  assert.ok(!L.setSlideSize(deck, 0, 1000));
+  assert.deepStrictEqual(L.slideSize({ slides: [] }), { width: 1280, height: 720 });
+});
+
+test('renderSlideSvg uses the requested slide dimensions', () => {
+  const svg = L.renderSlideSvg(L.createSlide(), { width: 720, height: 1280, number: 2 });
+  assert.ok(svg.includes('viewBox="0 0 720 1280"'));
+  assert.ok(svg.includes('<rect width="720" height="1280"'));
+  assert.ok(svg.includes('>2<'));
 });
 
 test('new shapes use a red stroke and text keeps a dark text color', () => {


### PR DESCRIPTION
# 구현

Slides 메뉴, 모달 슬라이드 크기 조절, 방향키 슬라이드 선택 이동 추가
- JavaScript 82개, Rust 11개 테스트와 Tauri cargo check 및 내장 브라우저 검증 통과

# 어려웠던 점

1280×720 고정 가정을 편집 화면과 PPTX 입출력 및 이미지 내보내기 전체에서 제거
- 덱의 픽셀 크기를 단일 기준으로 두고 cm와 EMU를 경계에서 변환

# 리스크

슬라이드 크기 변경 시 기존 도형을 자동 축소하지 않아 새 경계 밖 도형이 잘릴 수 있음
- 슬라이드 경계 변경과 콘텐츠 변형을 분리하기 위한 의도된 동작

Issue #938
Issue #939
Issue #940