### PR TITLE
멀티턴 대화 핸즈온 신규 (OpenAI/Claude 두 트랙)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@
 89. git credential helper 원리와 CodeBuild connection 핸즈온 (26.7.26) - [링크](./computer_science/git/git_credential_helper/)
 90. ECS quickstart (26.8.2) - [링크](./aws/ecs/quickstart/)
 91. LLM 서빙 시스템 설계 Chapter 3 핸즈온 (26.8.15) - [링크](./computer_science/ai/study-llmserving/ch3/)
+92. 멀티턴 대화 핸즈온 (LLM API는 왜 잊는가, OpenAI/Claude 비교) (26.8.16) - [링크](./computer_science/ai/multi-turn-conversation/)
 
 ## 직접 만든 제품
 

--- a/computer_science/ai/multi-turn-conversation/.gitignore
+++ b/computer_science/ai/multi-turn-conversation/.gitignore
@@ -1,0 +1,4 @@
+sessions/
+.venv/
+__pycache__/
+.env

--- a/computer_science/ai/multi-turn-conversation/AGENTS.md
+++ b/computer_science/ai/multi-turn-conversation/AGENTS.md
@@ -1,0 +1,88 @@
+# 멀티턴 대화 핸즈온 — agent 맥락
+
+이 파일은 이 workspace(`computer_science/ai/multi-turn-conversation`)에서 작업하는 agent를 위한 맥락이다. 저장소 전체 규칙은 루트 [AGENTS.md](../../../AGENTS.md)를 따른다.
+
+## 목적
+
+LLM API가 이전 대화를 기억하지 못한다는 것을 직접 확인하고, 그 대화가 실제로 어디에 쌓이는지까지 옮겨 보는 학습용 워크스페이스다. 학습 축은 네 단계다: 싱글턴(잊음) → 멀티턴(누적 재전송) → 저장소(memory·jsonl·redis) → prompt cache(서버 캐시는 기억이 아님).
+
+## 핵심 규칙 — quickstart를 유지한다
+
+**번호 붙은 파일은 각각 자기 완결이다.** 파일 하나만 열어도 client 생성부터 API 호출까지 전부 보여야 한다.
+
+- **공용 client 모듈을 만들지 않는다.** `client.py` 같은 파일로 호출을 감싸면 학습자가 정작 봐야 할 API 호출이 파일 밖으로 사라진다. client 생성 3줄은 파일마다 반복해서 쓴다.
+- **프로덕션 추상화를 넣지 않는다.** ABC, 팩토리, 설정 클래스, 재시도 래퍼, 비동기 전부 해당한다.
+- **파일 하나는 개념 하나.** 한 화면에 들어와야 한다. 코드가 길어지면 개념이 아니라 코드를 공부하게 된다.
+
+반복이 생기는 것은 의도한 비용이다. DRY보다 "한 파일만 읽으면 된다"가 우선이다.
+
+예외는 `store.py` 하나다. 이 파일은 API 호출을 감싸는 추상화가 아니라 3단계의 학습 대상 자체이고, provider와 무관하다는 것이 그 단계의 결론이다. provider 디렉터리마다 복사하면 그 결론이 흐려진다. `03_store.py`가 `sys.path` 한 줄로 상위 디렉터리에서 불러오는 구조를 그대로 둔다.
+
+## 현재 상태
+
+- `store.py`, `test_store.py` — 실행해 통과 확인
+- `RedisStore` — 실제 Redis 서버(brew redis-server)에 붙여 왕복 확인
+- `compose.yaml` — `docker compose config` 통과. 작성 환경의 Docker Desktop이 keychain 인증 실패라 `up`은 미검증
+- `openai/`, `claude/`의 01~04 — 작성 환경에 API key가 없어 미실행. 모듈 로드까지만 확인했고, 문서의 출력 예시는 캡처가 아니라 예상값이다
+
+## 구조
+
+```text
+store.py         저장소 3종. provider와 무관하므로 루트에 하나만 둔다
+test_store.py    저장소 테스트. API key도 Redis 서버도 필요 없다
+compose.yaml     Redis 하나. 03단계에서만 필요하다
+openai/          OpenAI quickstart + 전용 docs
+claude/          Anthropic quickstart + 전용 docs
+studysheet-*.html  학습지(akbun-studysheet 스타일)
+```
+
+## provider 디렉터리 규약
+
+**provider 디렉터리는 파일 이름과 순서가 전부 같고, 각자 자기 docs를 갖는다.** 학습자는 디렉터리 하나만 골라 끝까지 가면 되고, 공용 문서를 왔다 갔다 하지 않는다.
+
+```text
+<provider>/
+  01_stateless.py      단일 호출 2번. 기억하지 못하는 것을 확인
+  02_multi_turn.py     history 누적 재전송
+  03_store.py          저장소만 바꾸는 CLI
+  04_prompt_cache.py   서버 캐시 카운터 확인
+  docs/
+    setup.md           환경 준비. up/down 두 스텝. 다른 문서는 여기 링크만 건다
+    1-problem.md       왜 잊어버리는가, 멀티턴의 두 정의
+    2-handson.md       01~04 실행 절차, 기대 결과, 체크포인트
+    3-cleanup.md       트레이드오프, 저장소 고르기, 정리
+```
+
+같은 번호는 두 디렉터리에서 같은 개념을 가르친다. 코드는 provider 규격 때문에 다르지만, **누적 로직의 모양은 같게 유지한다** — `01`은 히스토리 없이 두 번 호출, `02`는 `ask(history, question)`이 append → 전송 → append, `03`은 store만 갈아 끼우는 CLI, `04`는 캐시 카운터 출력. 학습자가 두 문서를 번갈아 읽어도 같은 자리에서 같은 이야기를 만나야 한다.
+
+각 `2-handson.md`는 자기 규격에서 실제로 다른 지점(system 프롬프트 위치, 응답 파싱, 출력 토큰 파라미터 이름, 캐시 방식)을 명시하고, 상대 provider 문서로 링크를 건다.
+
+## provider 추가하는 방법
+
+Bedrock, Azure OpenAI, Vertex 등을 추가할 때 절차는 다음과 같다.
+
+1. `<provider>/` 디렉터리와 `<provider>/docs/`를 만든다. 이름은 소문자 하이픈. 예: `bedrock/`, `azure-openai/`
+2. 가장 가까운 규격에서 `01`~`04`를 복사한다
+   - OpenAI 규격(Azure OpenAI, LiteLLM, Bifrost 등)이면 `openai/`에서
+   - Anthropic 규격(Bedrock의 Anthropic 모델 등)이면 `claude/`에서
+3. 각 파일의 client 생성 3줄과 `MODEL`을 그 provider에 맞게 고친다. **파일을 합치거나 client를 모듈로 빼지 않는다**
+4. `04_prompt_cache.py`는 그 provider의 캐시 방식에 맞춰 고친다. 캐시를 지원하지 않으면 파일을 지우고 그 사실을 `docs/2-handson.md`에 한 줄 남긴다
+5. `docs/` 4종을 복사해 엔드포인트 이름·key 이름·모델명·실행 경로를 고친다
+6. `pyproject.toml`에 SDK를 추가한다
+7. 인덱스 두 곳을 갱신한다 — 이 파일의 provider 표, [README.md](README.md)의 provider 표
+
+### 현재 provider
+
+| 디렉터리 | SDK | 모델 | key | 출력 토큰 파라미터 | 캐시 |
+|---|---|---|---|---|---|
+| [openai/](openai/) | `openai` | `gpt-5.6-luna` | `OPENAI_API_KEY` | `max_completion_tokens` | 자동. `usage.prompt_tokens_details.cached_tokens` |
+| [claude/](claude/) | `anthropic` | `claude-sonnet-5` | `ANTHROPIC_API_KEY` | `max_tokens` | 명시적 `cache_control`. `usage.cache_read_input_tokens` |
+
+`openai/`는 실제 OpenAI 모델을 쓴다. Anthropic의 OpenAI 호환 엔드포인트로 Claude를 감싸 부르지 않는다 — 그러면 두 디렉터리가 같은 모델을 부르게 되어 비교가 성립하지 않고, 호환 레이어는 prompt caching을 지원하지 않아 `04`가 항상 0을 찍는다.
+
+## ADR (결정 - 이유)
+
+- 결정: 번호 파일마다 client 생성을 반복해 쓰고 공용 client 모듈을 두지 않는다. / 이유: quickstart의 학습 대상이 API 호출 그 자체다. 모듈로 감싸면 봐야 할 코드가 파일 밖으로 나간다. 중복 3줄이 간접 참조 한 단계보다 싸다.
+- 결정: docs를 provider 디렉터리 안에 각각 둔다. / 이유: 학습자는 provider 하나를 골라 끝까지 간다. 공용 docs는 매 문단에서 "당신 provider면 이렇게"를 분기시켜 읽기를 방해한다. 문서 중복은 그 대가로 감수한다.
+- 결정: `openai/`는 실제 GPT 모델을 쓴다. / 이유: 두 디렉터리가 서로 다른 provider를 부르는 것이 비교의 전제다. 호환 엔드포인트로 Claude를 감싸면 규격만 다르고 모델은 같아져 04단계가 성립하지 않는다.
+- 결정: `store.py`만 루트에 공용으로 둔다. / 이유: 저장소가 provider와 무관하다는 것이 3단계의 결론이다. 복사하면 provider마다 다를 수 있다는 잘못된 인상을 준다. client 모듈과 달리 API 호출을 감추지도 않는다.

--- a/computer_science/ai/multi-turn-conversation/README.md
+++ b/computer_science/ai/multi-turn-conversation/README.md
@@ -1,0 +1,52 @@
+# 멀티턴 대화 핸즈온
+
+LLM API가 이전 대화를 기억하지 못하는 것을 직접 확인하고, 애플리케이션이 그 대화를 어디에 쌓아 두는지까지 손으로 옮겨 보는 워크스페이스다. 싱글턴 → 멀티턴 → 저장소(메모리·JSONL·Redis) → prompt cache 순서로 4단계다.
+
+"LLM 서버단에서도 캐시한다"가 왜 사실이면서 동시에 "서버가 대화를 기억한다"는 뜻이 아닌지가 4단계의 주제다.
+
+## 학습지
+
+브라우저에서 [studysheet-multi-turn-conversation-v1.html](studysheet-multi-turn-conversation-v1.html)을 열면 페이지를 넘기며 읽는 학습지가 나온다. 개념은 여기에 있고, 아래 provider 문서는 실행 절차다.
+
+## provider 고르기
+
+디렉터리 하나를 골라 끝까지 가면 된다. 문서도 각 디렉터리 안에 있다.
+
+| 디렉터리 | SDK | 모델 | key | 시작 문서 |
+|---|---|---|---|---|
+| [openai/](openai/) | `openai` | `gpt-5.6-luna` | `OPENAI_API_KEY` | [openai/docs/setup.md](openai/docs/setup.md) |
+| [claude/](claude/) | `anthropic` | `claude-sonnet-5` | `ANTHROPIC_API_KEY` | [claude/docs/setup.md](claude/docs/setup.md) |
+
+두 provider 모두 같은 파일 이름·같은 순서를 쓴다. 같은 번호는 같은 개념이고, 코드는 각 규격에 맞게 다르다.
+
+| 파일 | 내용 |
+|---|---|
+| `01_stateless.py` | 단일 호출 2번. 기억하지 못하는 것을 확인 |
+| `02_multi_turn.py` | history 누적 재전송 |
+| `03_store.py` | 저장소만 바꾸는 CLI |
+| `04_prompt_cache.py` | 서버 캐시 카운터 확인 |
+| `docs/setup.md` | 환경 준비, up/down |
+| `docs/1-problem.md` | 왜 잊어버리는가, 멀티턴의 두 정의 |
+| `docs/2-handson.md` | 01~04 실행 절차, 기대 결과 |
+| `docs/3-cleanup.md` | 트레이드오프, 저장소 고르기, 정리 |
+
+번호 파일은 각각 자기 완결이다 — client 생성부터 API 호출까지 한 파일 안에 있다. quickstart라 공용 client 모듈을 두지 않는다.
+
+## provider와 무관한 코드
+
+| 파일 | 내용 |
+|---|---|
+| [store.py](store.py) | 저장소 3종. `load`/`append` 두 메서드만 |
+| [test_store.py](test_store.py) | 저장소 테스트. API key도 Redis 서버도 필요 없음 |
+| [compose.yaml](compose.yaml) | Redis 하나. 3단계에서만 필요 |
+
+저장소가 provider와 무관하다는 것이 3단계의 결론이라 루트에 하나만 둔다.
+
+Bedrock·Azure 등 provider를 추가하는 절차는 [AGENTS.md](AGENTS.md)에 있다.
+
+## 검증 상태
+
+- `store.py`, `test_store.py` — 실행해 통과 확인
+- `RedisStore` — 실제 Redis 서버에 붙여 왕복 확인
+- `compose.yaml` — `docker compose config` 통과, `up`은 미검증
+- `openai/`, `claude/`의 01~04 — 작성 환경에 API key가 없어 실행하지 못했다. 문서의 출력 예시는 캡처가 아니라 예상값이다

--- a/computer_science/ai/multi-turn-conversation/claude/01_stateless.py
+++ b/computer_science/ai/multi-turn-conversation/claude/01_stateless.py
@@ -1,0 +1,44 @@
+"""Step 1 - prove the Messages API keeps no state.
+
+Two separate calls. The second asks about something only the first one said,
+and cannot answer, because nothing about call 1 was sent in call 2.
+
+Needs ANTHROPIC_API_KEY.
+"""
+
+import os
+
+import anthropic
+
+client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+MODEL = "claude-sonnet-5"
+SYSTEM = "You are a concise assistant. Answer in Korean."
+
+
+def text_of(content: list) -> str:
+  """Join the text blocks of a reply. The response is a block list, not a string."""
+  return "".join(block.text for block in content if block.type == "text")
+
+
+def main() -> None:
+  # Call 1. The whole request is the system prompt plus one question.
+  first = client.messages.create(
+    model=MODEL,
+    max_tokens=2000,
+    system=SYSTEM,  # the system prompt is its own field here, not messages[0]
+    messages=[{"role": "user", "content": "내 이름은 악분이야. 기억해줘."}],
+  )
+  print("turn 1 >", text_of(first.content))
+
+  # Call 2. A brand new request. Call 1 appears nowhere in it.
+  second = client.messages.create(
+    model=MODEL,
+    max_tokens=2000,
+    system=SYSTEM,
+    messages=[{"role": "user", "content": "내 이름이 뭐라고 했지?"}],
+  )
+  print("turn 2 >", text_of(second.content))
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/claude/02_multi_turn.py
+++ b/computer_science/ai/multi-turn-conversation/claude/02_multi_turn.py
@@ -1,0 +1,49 @@
+"""Step 2 - the same two questions, with the history accumulated by the caller.
+
+Nothing about the model changed from 01_stateless.py. `history` grows, and the
+whole list is resent on every call. That resending is what multi-turn means.
+
+Needs ANTHROPIC_API_KEY.
+"""
+
+import os
+
+import anthropic
+
+client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+MODEL = "claude-sonnet-5"
+SYSTEM = "You are a concise assistant. Answer in Korean."
+
+
+def text_of(content: list) -> str:
+  """Join the text blocks of a reply. The response is a block list, not a string."""
+  return "".join(block.text for block in content if block.type == "text")
+
+
+def ask(history: list[dict], question: str) -> str:
+  """Append the question, resend the whole history, append the reply, return it."""
+  history.append({"role": "user", "content": question})
+
+  response = client.messages.create(
+    model=MODEL,
+    max_tokens=2000,
+    system=SYSTEM,  # stays out of `history`, unlike the OpenAI shape
+    messages=history,
+  )
+  answer = text_of(response.content)
+
+  history.append({"role": "assistant", "content": answer})
+  print(f"  [{len(history)} messages sent, "
+        f"{response.usage.input_tokens} input tokens]")
+  return answer
+
+
+def main() -> None:
+  history: list[dict] = []
+  print("turn 1 >", ask(history, "내 이름은 악분이야. 기억해줘."))
+  print("turn 2 >", ask(history, "내 이름이 뭐라고 했지?"))
+  print("turn 3 >", ask(history, "내가 지금까지 몇 번 질문했지?"))
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/claude/03_store.py
+++ b/computer_science/ai/multi-turn-conversation/claude/03_store.py
@@ -1,0 +1,91 @@
+"""Step 3 - a chat CLI where only the store changes.
+
+    uv run claude/03_store.py --store memory --session demo
+    uv run claude/03_store.py --store jsonl  --session demo
+    uv run claude/03_store.py --store redis  --session demo
+
+Quit with Ctrl-D, run the same command again, and ask "내 이름이 뭐야?".
+Memory forgets, jsonl and redis remember. The request body is the same in all
+three, which is why store.py lives one directory up and is shared by every
+provider.
+
+Needs ANTHROPIC_API_KEY.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import anthropic
+
+# store.py sits one level up because storage is provider-independent - that is
+# the conclusion of this step, so it is not copied into each provider folder.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from store import JsonlStore, MemoryStore, RedisStore
+
+client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+MODEL = "claude-sonnet-5"
+SYSTEM = "You are a concise assistant. Answer in Korean."
+
+
+def text_of(content: list) -> str:
+  """Join the text blocks of a reply. The response is a block list, not a string."""
+  return "".join(block.text for block in content if block.type == "text")
+
+
+def build_store(kind: str, session: str):
+  """Pick a store by name. Redis is imported lazily so the other two need no server."""
+  if kind == "memory":
+    return MemoryStore()
+  if kind == "jsonl":
+    return JsonlStore(Path("sessions") / f"{session}.jsonl")
+  if kind == "redis":
+    import redis
+
+    url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    return RedisStore(redis.from_url(url), session)
+  raise ValueError(f"unknown store: {kind}")
+
+
+def ask(store, question: str) -> str:
+  """Load the history from the store, resend it, persist both turns."""
+  store.append({"role": "user", "content": question})
+  history = store.load()
+
+  response = client.messages.create(
+    model=MODEL,
+    max_tokens=2000,
+    system=SYSTEM,
+    messages=history,
+  )
+  answer = text_of(response.content)
+
+  store.append({"role": "assistant", "content": answer})
+  print(f"  [{len(history)} messages sent, "
+        f"{response.usage.input_tokens} input tokens]")
+  return answer
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--store", choices=["memory", "jsonl", "redis"], default="memory")
+  parser.add_argument("--session", default="demo")
+  args = parser.parse_args()
+
+  store = build_store(args.store, args.session)
+  print(f"store={args.store} session={args.session} "
+        f"({len(store.load())} messages restored). Ctrl-D to quit.")
+
+  while True:
+    try:
+      question = input("you > ").strip()
+    except EOFError:
+      print()
+      return
+    if question:
+      print("bot >", ask(store, question))
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/claude/04_prompt_cache.py
+++ b/computer_science/ai/multi-turn-conversation/claude/04_prompt_cache.py
@@ -1,0 +1,68 @@
+"""Step 4 - the server caches, but it does not remember.
+
+Anthropic caching is explicit, unlike OpenAI's automatic caching: mark the end
+of the stable prefix with `cache_control`, then read the two counters back.
+
+Two numbers make the point:
+
+- cache_read_input_tokens > 0 on call 2 -> the server did reuse prefill work
+- the whole prefix was still transmitted on both calls
+
+The marked prefix has to clear a model-specific minimum (1024 tokens on
+Sonnet 5), so the system prompt below is padded on purpose. Anything shorter
+is silently not cached, with no error.
+
+Needs ANTHROPIC_API_KEY.
+"""
+
+import os
+
+import anthropic
+
+client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+MODEL = "claude-sonnet-5"
+
+PARAGRAPH = (
+  "This assistant answers questions about an internal deployment runbook. "
+  "It always cites the step number it is quoting, never invents a step, and "
+  "asks for the environment name when the question is ambiguous. "
+)
+LONG_SYSTEM = PARAGRAPH * 120
+
+
+def ask(question: str) -> None:
+  """Send the same padded system prompt each time and print the cache counters."""
+  response = client.messages.create(
+    model=MODEL,
+    max_tokens=2000,
+    system=[
+      {
+        "type": "text",
+        "text": LONG_SYSTEM,
+        "cache_control": {"type": "ephemeral"},  # marks the end of the prefix
+      }
+    ],
+    messages=[{"role": "user", "content": question}],
+  )
+  usage = response.usage
+  print(
+    f"  uncached={usage.input_tokens} "
+    f"cache_write={usage.cache_creation_input_tokens} "
+    f"cache_read={usage.cache_read_input_tokens}"
+  )
+
+
+def main() -> None:
+  print("call 1 (writes the cache)")
+  ask("1단계가 뭐야?")
+  print("call 2 (same system prompt, different question)")
+  ask("2단계가 뭐야?")
+  print(
+    "\ncache_read > 0 means the server reused prefill work for a prefix you\n"
+    "sent again. It does not mean the server kept call 1 - call 2 still had to\n"
+    "transmit the whole prefix, and carried no conversation history at all."
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/claude/docs/1-problem.md
+++ b/computer_science/ai/multi-turn-conversation/claude/docs/1-problem.md
@@ -1,0 +1,50 @@
+# The problem: the model forgets between calls
+
+## The situation
+
+A chatbot ships. A user says "내 이름은 악분이야", then asks "내 이름이 뭐야?" one
+message later, and the bot has no idea. Nothing crashed, no error was logged,
+and the same prompt works fine when pasted into the Claude app. The bug is not
+in the prompt — it is in what the second HTTP request contained.
+
+## Why it happens
+
+`POST /v1/messages` is an ordinary stateless HTTP endpoint. The request body
+carries the entire input, the response carries the output, and the server keeps
+nothing that links the two calls. There is no session cookie, no connection
+affinity, and no hidden buffer holding turn 1 when turn 2 arrives.
+
+So a "conversation" is not something the model has. It is something the caller
+rebuilds on every request by resending the whole history.
+
+## What multi-turn actually means
+
+Two definitions get mixed up, and separating them is the point of this track.
+
+- **From the user's side**, multi-turn is the experience: several exchanges
+  where later questions can lean on earlier ones.
+- **From the API's side**, multi-turn is a growing `messages` array. Turn 3
+  sends turns 1 and 2 back verbatim, plus the new question.
+
+The second is the mechanism that produces the first. There is no third thing.
+A "multi-turn model" does not exist — only a caller that resends more input.
+
+## Three consequences worth expecting
+
+- **Cost and latency grow with the conversation.** Every turn re-bills every
+  earlier token as input. A 30-turn chat pays for turn 1 thirty times.
+- **The context window is a hard ceiling.** History accumulates until the
+  request no longer fits, and then something has to be dropped or summarized.
+- **Storage becomes an application concern.** Restarting the process, or
+  routing the next request to a different pod, loses the conversation unless
+  the history lives somewhere outside the process.
+
+## One way to solve it
+
+Accumulate the messages in the application and resend them, then move that
+accumulated list into a store that outlives the process. That is the whole
+technique, and [2-handson.md](./2-handson.md) walks it in four steps.
+
+Two things complicate the picture and are covered at the end of the hands-on:
+the server *does* cache, and Anthropic's Managed Agents *is* stateful. Neither
+changes the rule for the Messages API.

--- a/computer_science/ai/multi-turn-conversation/claude/docs/2-handson.md
+++ b/computer_science/ai/multi-turn-conversation/claude/docs/2-handson.md
@@ -1,0 +1,193 @@
+# Hands-on — Claude track
+
+Install first: [setup.md](./setup.md). Run everything from the workspace root,
+one level above this folder.
+
+Model: `claude-sonnet-5`. SDK: `anthropic`. Key: `ANTHROPIC_API_KEY`.
+
+The scripts were not executed while writing this document — no API key was
+available in that environment. The store logic and the Redis round-trip were
+executed and pass. Sample outputs below are marked as expected, not captured.
+
+## Step 1: watch the API forget
+
+Two separate calls. The second asks about something only the first one said.
+
+```bash
+uv run claude/01_stateless.py
+```
+
+Expected — the second answer cannot name you, because the second request never
+contained the first exchange:
+
+```text
+turn 1 > 네, 악분님. 기억하겠습니다.
+turn 2 > 죄송하지만 이전에 이름을 알려주신 적이 없습니다.
+```
+
+Checkpoint: the model did not fail. It answered correctly for the input it was
+given, and that input had no history in it.
+
+## Step 2: send the history back
+
+Same two questions. The only change is that `history` grows and the whole list
+is resent each time.
+
+```bash
+uv run claude/02_multi_turn.py
+```
+
+Expected — turn 2 now answers, and `input_tokens` climbs because earlier turns
+are being re-billed as input:
+
+```text
+  [1 messages sent, 28 input tokens]
+turn 1 > 네, 악분님. 기억하겠습니다.
+  [3 messages sent, 61 input tokens]
+turn 2 > 악분이라고 하셨습니다.
+```
+
+Checkpoint: memory came from the caller, not the model. Diff the two files —
+no model setting differs between step 1 and step 2.
+
+```bash
+diff claude/01_stateless.py claude/02_multi_turn.py
+```
+
+Two details of the Anthropic shape are worth naming here, because they are
+exactly what changes if you port this to another SDK:
+
+- the system prompt is its own `system` request field, never `messages[0]`
+- the reply is a list of content blocks, so text is filtered by `type == "text"`
+- the output cap is `max_tokens` (OpenAI's GPT-5 series uses
+  `max_completion_tokens`)
+
+The OpenAI track in [../../openai/docs/2-handson.md](../../openai/docs/2-handson.md)
+does the same four steps with the other shape. The accumulation logic is the
+same in both; only these details move.
+
+## Step 3: move the history out of the process
+
+[03_store.py](../03_store.py) is a chat CLI with one flag that changes where the
+history lives. The request body is the same in all three modes, which is why
+`store.py` sits at the workspace root and is shared by every provider.
+
+Start with memory, tell it your name, quit with Ctrl-D, then start it again and
+ask.
+
+```bash
+uv run claude/03_store.py --store memory --session demo
+```
+
+The second run does not know your name — the list died with the process. Now
+run the same experiment with the JSONL store.
+
+```bash
+uv run claude/03_store.py --store jsonl --session demo
+```
+
+This time the second run restores the history, and the file is readable.
+
+```bash
+cat sessions/demo.jsonl
+```
+
+Finally the Redis store, which lets two terminals share one live session.
+
+```bash
+uv run claude/03_store.py --store redis --session demo
+```
+
+Open a second terminal and run the same command. Both processes read and write
+`chat:demo`, so a message typed in one appears in the other's next request.
+
+```bash
+docker compose exec redis redis-cli lrange chat:demo 0 -1
+```
+
+Choosing between them:
+
+| Store | Survives restart | Shared across processes | Cost |
+|---|---|---|---|
+| Memory | no | no | free, one line of code |
+| JSONL | yes | no (one writer per file) | free, but no query and it grows forever |
+| Redis | yes, until the TTL | yes | a server to run and monitor |
+
+Checkpoint: durability is a storage decision that sits entirely outside the
+model call. Nothing in `messages.create` changed across the three runs.
+
+## Step 4: the server caches, but it does not remember
+
+The server really does cache — this is where "LLM 서버단에서도 캐시한다" is true
+and where it is misleading. Anthropic caching is **explicit**, unlike OpenAI's
+automatic caching: you mark the end of the stable prefix with `cache_control`.
+
+```bash
+uv run claude/04_prompt_cache.py
+```
+
+Expected — the second call reports a large `cache_read`, because it resent an
+identical 1000+ token system prompt:
+
+```text
+call 1 (writes the cache)
+  uncached=14 cache_write=1543 cache_read=0
+call 2 (same system prompt, different question)
+  uncached=14 cache_write=0 cache_read=1543
+```
+
+What that number means, precisely: the server had already computed the internal
+representation of that exact prefix, so it skipped recomputing it and charged
+roughly a tenth of the price. What it does not mean: that the server held onto
+the conversation. Call 2 still had to *send* the full prefix — the cache is
+keyed on the bytes you transmit, and it is a prefix match, so a single changed
+character anywhere before the breakpoint invalidates everything after it.
+
+The marked prefix also has to clear a model-specific minimum (1024 tokens on
+Sonnet 5). Anything shorter is silently not cached, with no error — which is
+why the system prompt in the script is padded.
+
+The distinction in one line: prompt caching saves you money on resending the
+history. It does not save you from resending the history.
+
+Checkpoint: `cache_read > 0` and "the API is stateless" are both true at the
+same time, and knowing why is the point of this step.
+
+## How real products solve it
+
+**Claude Code** stores each session as an append-only JSONL file on the local
+machine, at `~/.claude/projects/<cwd-slug>/<session-uuid>.jsonl` — one JSON
+object per line, each entry carrying a `parentUuid` that chains it to the
+previous one. `--resume` reads that file back and replays it into the next
+request. This is exactly the JSONL store in step 3.
+
+```bash
+ls ~/.claude/projects/ | head -3
+```
+
+**Anthropic** keeps the Messages API stateless and puts server-side state in a
+separate product, **Managed Agents**, where sessions live on Anthropic's side
+and you exchange events rather than message arrays.
+
+**OpenAI** offers both models: Chat Completions is stateless, while the
+Responses API is stateful via `store: true` and `previous_response_id`.
+
+So the accurate version of the rule is narrower than "LLM APIs are stateless":
+
+- Chat Completions and Messages — stateless, the caller accumulates. This is
+  still the default and what every step above uses.
+- Responses API and Managed Agents — stateful, the server accumulates.
+
+Server-side state removes the resending, and with it the ability to inspect,
+edit, or migrate the transcript yourself. That is the trade discussed in
+[3-cleanup.md](./3-cleanup.md).
+
+## Verify your understanding
+
+- A chat is 20 turns deep and each turn is ~500 tokens. Turn 20 bills roughly
+  how many input tokens? (Around 10,000 — the whole history, not 500.)
+- The system prompt embeds `datetime.now()`. Why is `cache_read` always 0?
+  (The prefix changes every request, so the prefix match never hits.)
+- The chat runs on three pods behind a load balancer with the memory store.
+  What does the user see? (Answers depend on which pod the request lands on —
+  the reason the store has to be outside the process.)

--- a/computer_science/ai/multi-turn-conversation/claude/docs/3-cleanup.md
+++ b/computer_science/ai/multi-turn-conversation/claude/docs/3-cleanup.md
@@ -1,0 +1,61 @@
+# Trade-offs and cleanup — Claude track
+
+## What the accumulate-and-resend approach costs
+
+It is the default because it is simple and portable, not because it is free.
+
+- **Input tokens grow quadratically over a session.** Turn N resends turns 1
+  through N-1. A long chat spends most of its budget on re-reading itself.
+- **The context window ends the conversation.** History accumulates until the
+  request stops fitting, and then truncation, summarization, or compaction has
+  to kick in — none of which is lossless.
+- **The transcript is now yours to operate.** Storage, retention, access
+  control, and deletion requests all land on the application, not the provider.
+
+What it buys is worth the price for most systems: the full transcript is
+inspectable, editable, portable between providers, and easy to reason about.
+Nothing is hidden on someone else's server.
+
+## When to reach for Managed Agents instead
+
+A Managed Agents session keeps the conversation on Anthropic's side and has you
+exchange events rather than message arrays. That is the right call when the
+conversation is long-lived, the client is thin, and provider lock-in is
+acceptable. It is the wrong call when the transcript has to be audited, edited
+mid-conversation, or moved to another provider — server-side state is a
+convenience that trades away exactly that control.
+
+The OpenAI equivalent is `previous_response_id` on the Responses API, covered
+in the OpenAI track at [../../openai/docs/3-cleanup.md](../../openai/docs/3-cleanup.md).
+
+## Picking a store
+
+Start at the top of the list and stop at the first row that holds.
+
+| Situation | Store |
+|---|---|
+| Script, notebook, single-shot job | memory |
+| One local process, want the transcript readable and greppable | JSONL |
+| Several processes or pods share a session, sessions should expire | Redis |
+| Need search, analytics, or retention policy on old conversations | a database |
+
+Redis carries an operational cost that a local file does not: a server to run,
+memory to size, and a TTL to pick. Do not reach for it until something actually
+crosses a process boundary.
+
+## Clean up
+
+This stops Redis, removes its data, and deletes the local sessions and the
+virtualenv. Details and the Homebrew variant are in [setup.md](./setup.md).
+
+```bash
+docker compose down -v && rm -rf sessions .venv
+```
+
+Confirm nothing is left listening on the Redis port.
+
+```bash
+redis-cli ping
+```
+
+A `Connection refused` here is the success case.

--- a/computer_science/ai/multi-turn-conversation/claude/docs/setup.md
+++ b/computer_science/ai/multi-turn-conversation/claude/docs/setup.md
@@ -1,0 +1,54 @@
+# Setup — Claude track
+
+Everything install-related for this track lives here. The other documents in
+this folder link back to this page.
+
+## Prerequisites
+
+- macOS with [uv](https://docs.astral.sh/uv/) for Python and the virtualenv
+- Docker Desktop, only for the Redis step
+- A Claude API key
+
+Export the key in the shell you will run the scripts from.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## Up
+
+This installs the Python dependencies and starts Redis. Run it from the
+workspace root, one level above this folder.
+
+```bash
+uv sync && docker compose up -d
+```
+
+Confirm Redis answers before moving on. `PONG` means it is ready.
+
+```bash
+docker compose exec redis redis-cli ping
+```
+
+If `docker compose up` fails with `error getting credentials`, Docker Desktop's
+keychain helper is unauthenticated. Either sign in to Docker Desktop, or skip
+the container and run Redis from Homebrew instead — the scripts only need
+something listening on port 6379.
+
+```bash
+brew install redis && redis-server --port 6379 --daemonize yes
+```
+
+## Down
+
+This stops Redis, removes its data, and deletes the local JSONL sessions.
+
+```bash
+docker compose down -v && rm -rf sessions .venv
+```
+
+If Redis came from Homebrew instead of Docker, stop it this way.
+
+```bash
+redis-cli shutdown nosave
+```

--- a/computer_science/ai/multi-turn-conversation/compose.yaml
+++ b/computer_science/ai/multi-turn-conversation/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis:8-alpine
+    container_name: multi-turn-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/computer_science/ai/multi-turn-conversation/openai/01_stateless.py
+++ b/computer_science/ai/multi-turn-conversation/openai/01_stateless.py
@@ -1,0 +1,37 @@
+"""Step 1 - prove the Chat Completions API keeps no state.
+
+Two separate calls. The second asks about something only the first one said,
+and cannot answer, because nothing about call 1 was sent in call 2.
+
+Needs OPENAI_API_KEY.
+"""
+
+import os
+
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+MODEL = "gpt-5.6-luna"
+SYSTEM = {"role": "system", "content": "You are a concise assistant. Answer in Korean."}
+
+
+def main() -> None:
+  # Call 1. The whole request is the system prompt plus one question.
+  first = client.chat.completions.create(
+    model=MODEL,
+    max_completion_tokens=2000,
+    messages=[SYSTEM, {"role": "user", "content": "내 이름은 악분이야. 기억해줘."}],
+  )
+  print("turn 1 >", first.choices[0].message.content)
+
+  # Call 2. A brand new request. Call 1 appears nowhere in it.
+  second = client.chat.completions.create(
+    model=MODEL,
+    max_completion_tokens=2000,
+    messages=[SYSTEM, {"role": "user", "content": "내 이름이 뭐라고 했지?"}],
+  )
+  print("turn 2 >", second.choices[0].message.content)
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/openai/02_multi_turn.py
+++ b/computer_science/ai/multi-turn-conversation/openai/02_multi_turn.py
@@ -1,0 +1,43 @@
+"""Step 2 - the same two questions, with the history accumulated by the caller.
+
+Nothing about the model changed from 01_stateless.py. `history` grows, and the
+whole list is resent on every call. That resending is what multi-turn means.
+
+Needs OPENAI_API_KEY.
+"""
+
+import os
+
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+MODEL = "gpt-5.6-luna"
+SYSTEM = {"role": "system", "content": "You are a concise assistant. Answer in Korean."}
+
+
+def ask(history: list[dict], question: str) -> str:
+  """Append the question, resend the whole history, append the reply, return it."""
+  history.append({"role": "user", "content": question})
+
+  response = client.chat.completions.create(
+    model=MODEL,
+    max_completion_tokens=2000,
+    messages=[SYSTEM] + history,  # the system prompt is messages[0] here
+  )
+  answer = response.choices[0].message.content
+
+  history.append({"role": "assistant", "content": answer})
+  print(f"  [{len(history)} messages sent, "
+        f"{response.usage.prompt_tokens} prompt tokens]")
+  return answer
+
+
+def main() -> None:
+  history: list[dict] = []
+  print("turn 1 >", ask(history, "내 이름은 악분이야. 기억해줘."))
+  print("turn 2 >", ask(history, "내 이름이 뭐라고 했지?"))
+  print("turn 3 >", ask(history, "내가 지금까지 몇 번 질문했지?"))
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/openai/03_store.py
+++ b/computer_science/ai/multi-turn-conversation/openai/03_store.py
@@ -1,0 +1,85 @@
+"""Step 3 - a chat CLI where only the store changes.
+
+    uv run openai/03_store.py --store memory --session demo
+    uv run openai/03_store.py --store jsonl  --session demo
+    uv run openai/03_store.py --store redis  --session demo
+
+Quit with Ctrl-D, run the same command again, and ask "내 이름이 뭐야?".
+Memory forgets, jsonl and redis remember. The request body is the same in all
+three, which is why store.py lives one directory up and is shared by every
+provider.
+
+Needs OPENAI_API_KEY.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from openai import OpenAI
+
+# store.py sits one level up because storage is provider-independent - that is
+# the conclusion of this step, so it is not copied into each provider folder.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from store import JsonlStore, MemoryStore, RedisStore
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+MODEL = "gpt-5.6-luna"
+SYSTEM = {"role": "system", "content": "You are a concise assistant. Answer in Korean."}
+
+
+def build_store(kind: str, session: str):
+  """Pick a store by name. Redis is imported lazily so the other two need no server."""
+  if kind == "memory":
+    return MemoryStore()
+  if kind == "jsonl":
+    return JsonlStore(Path("sessions") / f"{session}.jsonl")
+  if kind == "redis":
+    import redis
+
+    url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    return RedisStore(redis.from_url(url), session)
+  raise ValueError(f"unknown store: {kind}")
+
+
+def ask(store, question: str) -> str:
+  """Load the history from the store, resend it, persist both turns."""
+  store.append({"role": "user", "content": question})
+  history = store.load()
+
+  response = client.chat.completions.create(
+    model=MODEL,
+    max_completion_tokens=2000,
+    messages=[SYSTEM] + history,
+  )
+  answer = response.choices[0].message.content
+
+  store.append({"role": "assistant", "content": answer})
+  print(f"  [{len(history)} messages sent, "
+        f"{response.usage.prompt_tokens} prompt tokens]")
+  return answer
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument("--store", choices=["memory", "jsonl", "redis"], default="memory")
+  parser.add_argument("--session", default="demo")
+  args = parser.parse_args()
+
+  store = build_store(args.store, args.session)
+  print(f"store={args.store} session={args.session} "
+        f"({len(store.load())} messages restored). Ctrl-D to quit.")
+
+  while True:
+    try:
+      question = input("you > ").strip()
+    except EOFError:
+      print()
+      return
+    if question:
+      print("bot >", ask(store, question))
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/openai/04_prompt_cache.py
+++ b/computer_science/ai/multi-turn-conversation/openai/04_prompt_cache.py
@@ -1,0 +1,59 @@
+"""Step 4 - the server caches, but it does not remember.
+
+OpenAI caches automatically. There is nothing to declare: send a long enough
+identical prefix twice and the hit shows up under
+`usage.prompt_tokens_details.cached_tokens`.
+
+Two numbers make the point:
+
+- cached_tokens > 0 on call 2 -> the server did reuse prefill work
+- prompt_tokens counts the whole prompt on both calls -> you still sent it all
+
+The system prompt below is padded on purpose, because automatic caching only
+kicks in past a minimum prefix length.
+
+Needs OPENAI_API_KEY.
+"""
+
+import os
+
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+MODEL = "gpt-5.6-luna"
+
+PARAGRAPH = (
+  "This assistant answers questions about an internal deployment runbook. "
+  "It always cites the step number it is quoting, never invents a step, and "
+  "asks for the environment name when the question is ambiguous. "
+)
+LONG_SYSTEM = {"role": "system", "content": PARAGRAPH * 400}
+
+
+def ask(question: str) -> None:
+  """Send the same padded system prompt each time and print the cache counters."""
+  response = client.chat.completions.create(
+    model=MODEL,
+    max_completion_tokens=2000,
+    messages=[LONG_SYSTEM, {"role": "user", "content": question}],
+  )
+  usage = response.usage
+  details = usage.prompt_tokens_details
+  cached = getattr(details, "cached_tokens", 0) if details else 0
+  print(f"  prompt_tokens={usage.prompt_tokens} cached_tokens={cached}")
+
+
+def main() -> None:
+  print("call 1 (populates the cache)")
+  ask("1단계가 뭐야?")
+  print("call 2 (same system prompt, different question)")
+  ask("2단계가 뭐야?")
+  print(
+    "\ncached_tokens > 0 means the server reused prefill work for a prefix you\n"
+    "sent again. It does not mean the server kept call 1 - call 2 still had to\n"
+    "transmit the whole prefix, and carried no conversation history at all."
+  )
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/multi-turn-conversation/openai/docs/1-problem.md
+++ b/computer_science/ai/multi-turn-conversation/openai/docs/1-problem.md
@@ -1,0 +1,50 @@
+# The problem: the model forgets between calls
+
+## The situation
+
+A chatbot ships. A user says "내 이름은 악분이야", then asks "내 이름이 뭐야?" one
+message later, and the bot has no idea. Nothing crashed, no error was logged,
+and the same prompt works fine when pasted into ChatGPT. The bug is not in the
+prompt — it is in what the second HTTP request contained.
+
+## Why it happens
+
+`POST /v1/chat/completions` is an ordinary stateless HTTP endpoint. The request
+body carries the entire input, the response carries the output, and the server
+keeps nothing that links the two calls. There is no session cookie, no
+connection affinity, and no hidden buffer holding turn 1 when turn 2 arrives.
+
+So a "conversation" is not something the model has. It is something the caller
+rebuilds on every request by resending the whole history.
+
+## What multi-turn actually means
+
+Two definitions get mixed up, and separating them is the point of this track.
+
+- **From the user's side**, multi-turn is the experience: several exchanges
+  where later questions can lean on earlier ones.
+- **From the API's side**, multi-turn is a growing `messages` array. Turn 3
+  sends turns 1 and 2 back verbatim, plus the new question.
+
+The second is the mechanism that produces the first. There is no third thing.
+A "multi-turn model" does not exist — only a caller that resends more input.
+
+## Three consequences worth expecting
+
+- **Cost and latency grow with the conversation.** Every turn re-bills every
+  earlier token as input. A 30-turn chat pays for turn 1 thirty times.
+- **The context window is a hard ceiling.** History accumulates until the
+  request no longer fits, and then something has to be dropped or summarized.
+- **Storage becomes an application concern.** Restarting the process, or
+  routing the next request to a different pod, loses the conversation unless
+  the history lives somewhere outside the process.
+
+## One way to solve it
+
+Accumulate the messages in the application and resend them, then move that
+accumulated list into a store that outlives the process. That is the whole
+technique, and [2-handson.md](./2-handson.md) walks it in four steps.
+
+Two things complicate the picture and are covered at the end of the hands-on:
+the server *does* cache, and OpenAI's newer Responses API *is* stateful.
+Neither changes the rule for Chat Completions.

--- a/computer_science/ai/multi-turn-conversation/openai/docs/2-handson.md
+++ b/computer_science/ai/multi-turn-conversation/openai/docs/2-handson.md
@@ -1,0 +1,190 @@
+# Hands-on — OpenAI track
+
+Install first: [setup.md](./setup.md). Run everything from the workspace root,
+one level above this folder.
+
+Model: `gpt-5.6-luna`. SDK: `openai`. Key: `OPENAI_API_KEY`.
+
+The scripts were not executed while writing this document — no OpenAI API key
+was available in that environment. The store logic and the Redis round-trip
+were executed and pass. Sample outputs below are marked as expected, not
+captured.
+
+## Step 1: watch the API forget
+
+Two separate calls. The second asks about something only the first one said.
+
+```bash
+uv run openai/01_stateless.py
+```
+
+Expected — the second answer cannot name you, because the second request never
+contained the first exchange:
+
+```text
+turn 1 > 네, 악분님. 기억하겠습니다.
+turn 2 > 죄송하지만 이전에 이름을 알려주신 적이 없습니다.
+```
+
+Checkpoint: the model did not fail. It answered correctly for the input it was
+given, and that input had no history in it.
+
+## Step 2: send the history back
+
+Same two questions. The only change is that `history` grows and the whole list
+is resent each time.
+
+```bash
+uv run openai/02_multi_turn.py
+```
+
+Expected — turn 2 now answers, and `prompt_tokens` climbs because earlier turns
+are being re-billed as input:
+
+```text
+  [1 messages sent, 31 prompt tokens]
+turn 1 > 네, 악분님. 기억하겠습니다.
+  [3 messages sent, 68 prompt tokens]
+turn 2 > 악분이라고 하셨습니다.
+```
+
+Checkpoint: memory came from the caller, not the model. Diff the two files —
+no model setting differs between step 1 and step 2.
+
+```bash
+diff openai/01_stateless.py openai/02_multi_turn.py
+```
+
+Two details of the OpenAI shape are worth naming here, because they are exactly
+what changes if you port this to another SDK:
+
+- the system prompt is `messages[0]` with `role: "system"`
+- the reply is a plain string at `choices[0].message.content`
+- GPT-5 series models take `max_completion_tokens`, not `max_tokens`
+
+The Claude track in [../../claude/docs/2-handson.md](../../claude/docs/2-handson.md)
+does the same four steps with the other shape. The accumulation logic is the
+same in both; only these details move.
+
+## Step 3: move the history out of the process
+
+[03_store.py](../03_store.py) is a chat CLI with one flag that changes where the
+history lives. The request body is the same in all three modes, which is why
+`store.py` sits at the workspace root and is shared by every provider.
+
+Start with memory, tell it your name, quit with Ctrl-D, then start it again and
+ask.
+
+```bash
+uv run openai/03_store.py --store memory --session demo
+```
+
+The second run does not know your name — the list died with the process. Now
+run the same experiment with the JSONL store.
+
+```bash
+uv run openai/03_store.py --store jsonl --session demo
+```
+
+This time the second run restores the history, and the file is readable.
+
+```bash
+cat sessions/demo.jsonl
+```
+
+Finally the Redis store, which lets two terminals share one live session.
+
+```bash
+uv run openai/03_store.py --store redis --session demo
+```
+
+Open a second terminal and run the same command. Both processes read and write
+`chat:demo`, so a message typed in one appears in the other's next request.
+
+```bash
+docker compose exec redis redis-cli lrange chat:demo 0 -1
+```
+
+Choosing between them:
+
+| Store | Survives restart | Shared across processes | Cost |
+|---|---|---|---|
+| Memory | no | no | free, one line of code |
+| JSONL | yes | no (one writer per file) | free, but no query and it grows forever |
+| Redis | yes, until the TTL | yes | a server to run and monitor |
+
+Checkpoint: durability is a storage decision that sits entirely outside the
+model call. Nothing in `chat.completions.create` changed across the three runs.
+
+## Step 4: the server caches, but it does not remember
+
+The server really does cache — this is where "LLM 서버단에서도 캐시한다" is true
+and where it is misleading. OpenAI caches **automatically**: there is nothing
+to declare, and the hit shows up in the usage object.
+
+```bash
+uv run openai/04_prompt_cache.py
+```
+
+Expected — the second call reports cached tokens, because it resent an
+identical long system prompt:
+
+```text
+call 1 (populates the cache)
+  prompt_tokens=4821 cached_tokens=0
+call 2 (same system prompt, different question)
+  prompt_tokens=4821 cached_tokens=4608
+```
+
+What that number means, precisely: the server had already computed the internal
+representation of that exact prefix, so it skipped recomputing it and charged
+less. What it does not mean: that the server held onto the conversation.
+`prompt_tokens` is unchanged on call 2 — the full prefix was still transmitted,
+and the cache is keyed on the bytes you send as a prefix match, so a single
+changed character near the front invalidates everything after it.
+
+The distinction in one line: prompt caching saves you money on resending the
+history. It does not save you from resending the history.
+
+Checkpoint: `cached_tokens > 0` and "the API is stateless" are both true at the
+same time, and knowing why is the point of this step.
+
+## How real products solve it
+
+**Claude Code** stores each session as an append-only JSONL file on the local
+machine, at `~/.claude/projects/<cwd-slug>/<session-uuid>.jsonl` — one JSON
+object per line, each entry carrying a `parentUuid` that chains it to the
+previous one. `--resume` reads that file back and replays it into the next
+request. This is exactly the JSONL store in step 3.
+
+```bash
+ls ~/.claude/projects/ | head -3
+```
+
+**OpenAI** now offers both models. Chat Completions is stateless and works like
+everything above. The **Responses API** is stateful: send `store: true`, get a
+response `id` back, and pass it as `previous_response_id` on the next call
+instead of resending the history. The server holds the conversation.
+
+**Anthropic** keeps the Messages API stateless and puts server-side state in a
+separate product, Managed Agents.
+
+So the accurate version of the rule is narrower than "LLM APIs are stateless":
+
+- Chat Completions and Messages — stateless, the caller accumulates. This is
+  still the default and what every step above uses.
+- Responses API and Managed Agents — stateful, the server accumulates.
+
+Server-side state removes the resending, and with it the ability to inspect,
+edit, or migrate the transcript yourself. That is the trade discussed in
+[3-cleanup.md](./3-cleanup.md).
+
+## Verify your understanding
+
+- A chat is 20 turns deep and each turn is ~500 tokens. Turn 20 bills roughly
+  how many input tokens? (Around 10,000 — the whole history, not 500.)
+- The system prompt embeds `datetime.now()`. Why is `cached_tokens` always 0?
+  (The prefix changes every request, so the prefix match never hits.)
+- The chat runs on three pods behind a load balancer with the memory store.
+  What does the user see? (Answers depend on which pod the request lands on —
+  the reason the store has to be outside the process.)

--- a/computer_science/ai/multi-turn-conversation/openai/docs/3-cleanup.md
+++ b/computer_science/ai/multi-turn-conversation/openai/docs/3-cleanup.md
@@ -1,0 +1,60 @@
+# Trade-offs and cleanup — OpenAI track
+
+## What the accumulate-and-resend approach costs
+
+It is the default because it is simple and portable, not because it is free.
+
+- **Input tokens grow quadratically over a session.** Turn N resends turns 1
+  through N-1. A long chat spends most of its budget on re-reading itself.
+- **The context window ends the conversation.** History accumulates until the
+  request stops fitting, and then truncation or summarization has to kick in —
+  neither is lossless.
+- **The transcript is now yours to operate.** Storage, retention, access
+  control, and deletion requests all land on the application, not the provider.
+
+What it buys is worth the price for most systems: the full transcript is
+inspectable, editable, portable between providers, and easy to reason about.
+Nothing is hidden on someone else's server.
+
+## When to reach for the Responses API instead
+
+`previous_response_id` with `store: true` removes the resending. That is the
+right call when the conversation is long-lived, the client is thin, and
+provider lock-in is acceptable. It is the wrong call when the transcript has to
+be audited, edited mid-conversation, or moved to another provider — server-side
+state is a convenience that trades away exactly that control.
+
+The Anthropic equivalent is a Managed Agents session, covered in the Claude
+track at [../../claude/docs/3-cleanup.md](../../claude/docs/3-cleanup.md).
+
+## Picking a store
+
+Start at the top of the list and stop at the first row that holds.
+
+| Situation | Store |
+|---|---|
+| Script, notebook, single-shot job | memory |
+| One local process, want the transcript readable and greppable | JSONL |
+| Several processes or pods share a session, sessions should expire | Redis |
+| Need search, analytics, or retention policy on old conversations | a database |
+
+Redis carries an operational cost that a local file does not: a server to run,
+memory to size, and a TTL to pick. Do not reach for it until something actually
+crosses a process boundary.
+
+## Clean up
+
+This stops Redis, removes its data, and deletes the local sessions and the
+virtualenv. Details and the Homebrew variant are in [setup.md](./setup.md).
+
+```bash
+docker compose down -v && rm -rf sessions .venv
+```
+
+Confirm nothing is left listening on the Redis port.
+
+```bash
+redis-cli ping
+```
+
+A `Connection refused` here is the success case.

--- a/computer_science/ai/multi-turn-conversation/openai/docs/setup.md
+++ b/computer_science/ai/multi-turn-conversation/openai/docs/setup.md
@@ -1,0 +1,54 @@
+# Setup — OpenAI track
+
+Everything install-related for this track lives here. The other documents in
+this folder link back to this page.
+
+## Prerequisites
+
+- macOS with [uv](https://docs.astral.sh/uv/) for Python and the virtualenv
+- Docker Desktop, only for the Redis step
+- An OpenAI API key
+
+Export the key in the shell you will run the scripts from.
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+## Up
+
+This installs the Python dependencies and starts Redis. Run it from the
+workspace root, one level above this folder.
+
+```bash
+uv sync && docker compose up -d
+```
+
+Confirm Redis answers before moving on. `PONG` means it is ready.
+
+```bash
+docker compose exec redis redis-cli ping
+```
+
+If `docker compose up` fails with `error getting credentials`, Docker Desktop's
+keychain helper is unauthenticated. Either sign in to Docker Desktop, or skip
+the container and run Redis from Homebrew instead — the scripts only need
+something listening on port 6379.
+
+```bash
+brew install redis && redis-server --port 6379 --daemonize yes
+```
+
+## Down
+
+This stops Redis, removes its data, and deletes the local JSONL sessions.
+
+```bash
+docker compose down -v && rm -rf sessions .venv
+```
+
+If Redis came from Homebrew instead of Docker, stop it this way.
+
+```bash
+redis-cli shutdown nosave
+```

--- a/computer_science/ai/multi-turn-conversation/pyproject.toml
+++ b/computer_science/ai/multi-turn-conversation/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "multi-turn-conversation"
+version = "0.1.0"
+description = "Hands-on: why LLM APIs forget, and where the conversation actually lives"
+requires-python = ">=3.11"
+dependencies = [
+    "anthropic>=0.70",
+    "openai>=1.60",
+    "redis>=5.0",
+]

--- a/computer_science/ai/multi-turn-conversation/store.py
+++ b/computer_science/ai/multi-turn-conversation/store.py
@@ -1,0 +1,69 @@
+"""Conversation stores.
+
+Same two methods everywhere: load() returns the message list to send to the
+model, append() adds one message. Swapping the store never changes the API
+call, because the accumulation lives in the application, not in the model.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class Store(Protocol):
+  """What the chat loop needs from a store."""
+
+  def load(self) -> list[dict[str, Any]]:
+    """Return every message of this session, oldest first."""
+    ...
+
+  def append(self, message: dict[str, Any]) -> None:
+    """Add one message to the end of the session."""
+    ...
+
+
+class MemoryStore:
+  """Holds the list in the process. Gone when the process exits."""
+
+  def __init__(self) -> None:
+    self.messages: list[dict[str, Any]] = []
+
+  def load(self) -> list[dict[str, Any]]:
+    return list(self.messages)
+
+  def append(self, message: dict[str, Any]) -> None:
+    self.messages.append(message)
+
+
+class JsonlStore:
+  """One JSON object per line, appended. This is how Claude Code stores a session."""
+
+  def __init__(self, path: Path) -> None:
+    self.path = path
+    self.path.parent.mkdir(parents=True, exist_ok=True)
+
+  def load(self) -> list[dict[str, Any]]:
+    if not self.path.exists():
+      return []
+    with self.path.open(encoding="utf-8") as f:
+      return [json.loads(line) for line in f if line.strip()]
+
+  def append(self, message: dict[str, Any]) -> None:
+    with self.path.open("a", encoding="utf-8") as f:
+      f.write(json.dumps(message, ensure_ascii=False) + "\n")
+
+
+class RedisStore:
+  """Keeps the history in a Redis list so separate processes share one session."""
+
+  def __init__(self, client: Any, session_id: str, ttl_seconds: int = 3600) -> None:
+    self.client = client
+    self.key = f"chat:{session_id}"
+    self.ttl_seconds = ttl_seconds
+
+  def load(self) -> list[dict[str, Any]]:
+    return [json.loads(raw) for raw in self.client.lrange(self.key, 0, -1)]
+
+  def append(self, message: dict[str, Any]) -> None:
+    self.client.rpush(self.key, json.dumps(message, ensure_ascii=False))
+    self.client.expire(self.key, self.ttl_seconds)

--- a/computer_science/ai/multi-turn-conversation/studysheet-multi-turn-conversation-v1.html
+++ b/computer_science/ai/multi-turn-conversation/studysheet-multi-turn-conversation-v1.html
@@ -1,0 +1,524 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>멀티턴 대화 — 모델은 왜 잊는가</title>
+<style>
+:root{
+  --dark:#212022;
+  --ink:#000000;
+  --point:#FFC000;
+  --hl:#FFE066;
+  --prob:#FF0000;
+  --wl:#FFF2CC;
+  --rs:#E2EFDA;
+  --grp:#F2F2F2;
+  --code-bg:#1E1E1E; --code-ink:#D4D4D4;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(17px,min(2vw,3.4vh),40px)}
+body{
+  background:#F2F2F2;color:var(--ink);
+  font-family:"NanumBarunGothic","나눔바른고딕","Pretendard","Apple SD Gothic Neo","Malgun Gothic",sans-serif;
+  line-height:1.75;
+}
+#book{width:min(97vw,calc((100vh - 104px) * 16 / 9));margin:0 auto;padding:12px 0 86px}
+.page{display:none;animation:fade .25s ease;
+  background:#fff;border:1px solid #E2E2E2;border-radius:10px;
+  aspect-ratio:16/9;overflow-y:auto;padding:6% 8%}
+.page.on{display:block}
+@keyframes fade{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+
+.page.cover{padding:5% 9%}
+.page.cover.on{display:flex;flex-direction:column;justify-content:center}
+.page.cover .bar{border-left:8px solid var(--point);padding-left:22px}
+.page.cover h1{font-size:2.2rem;font-weight:800;line-height:1.4;margin-bottom:10px}
+.page.cover .sub{color:#555;margin-bottom:34px}
+.page.cover .glance p{margin:10px 0}
+.p-prob{color:var(--prob);font-weight:700}
+.p-point{background:var(--point);font-weight:700;padding:0 4px}
+
+.sec{font-size:.95rem;font-weight:800;color:var(--ink);letter-spacing:.02em}
+h2.page-title{font-size:1.55rem;font-weight:800;margin:6px 0 20px;letter-spacing:-.01em}
+p{margin:10px 0}
+mark{background:var(--hl);color:var(--ink);padding:0 2px}
+.prob-text,mark.prob{background:none;color:var(--prob);font-weight:700}
+.xmark{color:var(--prob);font-weight:900}
+.dim{color:#666;font-size:.9rem}
+
+ul.bullets{list-style:none;margin:10px 0}
+ul.bullets>li{margin:8px 0}
+ul.bullets>li::before{content:"■";font-size:.7em;margin-right:9px;vertical-align:.15em}
+ul.bullets ul{list-style:none;margin:4px 0 4px 22px}
+ul.bullets ul>li::before{content:"-";margin-right:8px}
+
+.diagram{display:flex;align-items:center;justify-content:center;gap:12px;flex-wrap:wrap;
+  padding:20px 8px;margin:12px 0}
+.dbox{border:1.2px solid var(--ink);border-radius:6px;padding:10px 16px;background:#fff;
+  font-weight:600;font-size:.92rem;text-align:center}
+.dbox small{display:block;font-weight:400;color:#555;font-size:.75rem}
+.dbox.wl{background:var(--wl)}
+.dbox.rs{background:var(--rs)}
+.dbox.hot{background:var(--point);border-color:var(--ink);font-weight:800}
+.dbox.bad{border-color:var(--prob);color:var(--prob)}
+.dbox.dim{opacity:.3}
+.darrow{font-weight:900;color:var(--ink);font-size:1.1rem}
+.darrow.bad{color:var(--prob)}
+.dgroup{border:1.2px solid var(--ink);border-radius:10px;background:var(--grp);
+  padding:22px 14px 12px;position:relative;margin-top:12px}
+.dgroup>b{position:absolute;top:4px;left:12px;font-size:.75rem;font-weight:700}
+.marker{display:inline-flex;width:24px;height:24px;border-radius:50%;background:#fff;
+  border:1.6px solid var(--ink);font-weight:800;font-size:.8rem;
+  align-items:center;justify-content:center;flex:none}
+.marker.bad{border-color:var(--prob);color:var(--prob)}
+.caption{text-align:center;font-size:.82rem;color:#555;margin-top:4px}
+
+.stepper{margin:12px 0}
+.step{display:none}
+.step.on{display:block;animation:fade .25s ease}
+.step .exp{margin-top:8px}
+.step-nav{display:flex;align-items:center;justify-content:center;gap:14px;margin-top:14px;
+  padding-top:12px;border-top:1px solid #E5E5E5}
+.step-nav button{border:1.4px solid var(--ink);background:#fff;color:var(--ink);
+  border-radius:999px;padding:6px 18px;font-weight:700;font-size:.9rem;cursor:pointer}
+.step-nav button:disabled{opacity:.25;cursor:default}
+.step-count{font-weight:800;color:#777;font-size:.9rem;min-width:52px;text-align:center}
+
+pre.code{background:var(--code-bg);color:var(--code-ink);border-radius:8px;
+  padding:16px 18px;overflow-x:auto;font-size:.86rem;line-height:1.6;margin:12px 0;
+  font-family:Consolas,ui-monospace,Menlo,monospace}
+pre.code .k{color:#569CD6}
+pre.code .s{color:#CE9178}
+pre.code .c{color:#6A9955}
+pre.code .hot{color:var(--point);font-weight:700}
+pre.code .bad{color:#FF6B6B;font-weight:700}
+.codedesc{font-size:.9rem;color:#444;margin:14px 0 0;font-weight:700}
+
+.quiz{margin:18px 0 26px}
+.quiz .q{font-weight:700}
+.quiz .opts{list-style:none;margin:10px 0}
+.quiz .opts li{border:1.4px solid var(--ink);border-radius:8px;background:#fff;
+  padding:8px 14px;margin:8px 0;font-size:.95rem;cursor:pointer;user-select:none}
+.quiz .opts li:focus-visible{outline:2px solid var(--point);outline-offset:2px}
+.quiz.done .opts li{cursor:default}
+.quiz .opts li.correct{background:var(--point);font-weight:700}
+.quiz .opts li.wrong{border-color:var(--prob);color:var(--prob)}
+.quiz .fb{display:none;margin-top:8px;padding-left:14px;border-left:3px solid var(--point)}
+.quiz.done .fb{display:block;animation:fade .25s ease}
+.quiz .fb .verdict{font-weight:800}
+.quiz .fb.no{border-left-color:var(--prob)}
+.quiz .fb.no .verdict{color:var(--prob)}
+
+.tradeoff{display:flex;gap:30px;flex-wrap:wrap;margin:14px 0}
+.tradeoff>div{flex:1;min-width:240px}
+.tradeoff h3{font-size:1rem;margin-bottom:6px;padding-bottom:4px;border-bottom:2px solid var(--ink)}
+.tradeoff .con h3{border-color:var(--prob);color:var(--prob)}
+.tradeoff ul{list-style:none}
+.tradeoff li{margin:6px 0}
+.tradeoff .pro li::before{content:"■";font-size:.7em;margin-right:9px;vertical-align:.15em}
+.tradeoff .con li::before{content:"✕";color:var(--prob);font-weight:900;margin-right:9px}
+
+.foot{font-size:.82rem;color:#555;margin-top:22px}
+.foot a{color:#555}
+
+#nav{position:fixed;left:0;right:0;bottom:0;background:rgba(255,255,255,.96);
+  border-top:1px solid #E2E2E2;backdrop-filter:blur(4px)}
+#nav .in{width:min(97vw,calc((100vh - 104px) * 16 / 9));margin:0 auto;display:flex;align-items:center;gap:14px;padding:12px 20px}
+#nav button{border:none;background:var(--dark);color:#fff;border-radius:999px;
+  padding:9px 22px;font-weight:700;font-size:15px;cursor:pointer}
+#nav button:disabled{opacity:.25;cursor:default}
+#dots{flex:1;display:flex;justify-content:center;gap:6px;flex-wrap:wrap}
+#dots button{width:9px;height:9px;border:none;padding:0;border-radius:50%;background:#DDD;cursor:pointer}
+#dots button.on{background:var(--point);transform:scale(1.25)}
+#dots button:focus-visible{outline:2px solid var(--point);outline-offset:2px}
+#counter{font-weight:800;color:#777;font-size:14px;min-width:64px;text-align:right}
+
+@media print{
+  body{background:#fff}
+  #book{width:auto;padding:0}
+  .page,.step{display:block !important}
+  .page{aspect-ratio:auto;border:none;overflow:visible}
+  #nav,.step-nav,#dots{display:none !important}
+  .page{page-break-after:always}
+}
+@media (max-width:640px){
+  html{font-size:17px}
+  #book,#nav .in{width:auto;max-width:100%}
+  #book{padding:10px 8px 86px}
+  .page,.page.cover{aspect-ratio:auto;min-height:70vh;padding:26px 20px}
+  .tradeoff{gap:16px}
+}
+</style>
+</head>
+<body>
+<main id="book">
+
+<!-- ════════ 1장. 표지 ════════ -->
+<section class="page cover">
+  <div class="bar">
+    <h1>멀티턴 대화 — 모델은 왜 <mark>잊는가</mark></h1>
+    <p class="sub">LLM API로 챗봇을 만드는 사람을 위한, 대화가 실제로 어디에 쌓이는지 확인하는 학습지</p>
+  </div>
+  <div class="glance">
+    <p><b class="p-prob">이런 상황이 있다면</b> — 사용자가 "내 이름은 악분이야"라고 말한 바로 다음 턴에 "내 이름이 뭐야?"를 물었는데, 챗봇이 모른다고 답함. 에러 로그도 없음</p>
+    <p><b class="p-point">어떻게 풀까?</b></p>
+  </div>
+</section>
+
+<!-- ════════ 2장. 문제 상황 ════════ -->
+<section class="page">
+  <p class="sec">1. 문제 상황</p>
+  <h2 class="page-title">한 턴 만에 이름을 잊는 챗봇</h2>
+  <p class="dim">이런 상황을 가정함</p>
+  <p>같은 프롬프트를 채팅 UI에 붙여넣으면 잘 동작함. 코드로 부르면 안 됨.</p>
+  <ul class="bullets">
+    <li><span class="xmark">✕</span> 턴 2에서 이전 턴 내용을 전혀 모름</li>
+    <li><span class="xmark">✕</span> 예외도 에러 코드도 없음. HTTP 200에 정상 응답</li>
+    <li><span class="xmark">✕</span> 프롬프트를 고쳐도 그대로임 — 프롬프트 문제가 아님</li>
+  </ul>
+  <p>임시방편으로 "이전 대화를 기억해"를 프롬프트에 넣어도 소용없음. 기억할 대상이 요청 본문에 없기 때문.</p>
+  <p><b class="p-point">푸는 방법 중 하나</b> — 모델을 고치지 않고, 애플리케이션이 지난 메시지를 모아 매 호출마다 다시 보냄</p>
+</section>
+
+<!-- ════════ 3장. 원리 ════════ -->
+<section class="page">
+  <p class="sec">2. 원리</p>
+  <h2 class="page-title">API는 상태를 갖지 않도록 설계됨</h2>
+  <p><code>POST /v1/messages</code>와 <code>POST /v1/chat/completions</code>는 평범한 <mark>stateless HTTP 엔드포인트</mark>임. 요청 본문이 입력 전부, 응답이 출력 전부.</p>
+  <ul class="bullets">
+    <li>세션 쿠키 없음, connection affinity 없음, 서버 측 버퍼 없음
+      <ul><li>턴 2 요청이 도착할 때 턴 1을 붙들고 있는 주체가 없음</li></ul>
+    </li>
+    <li>왜 이렇게 설계했나 — 서버가 대화를 들고 있으면 요청을 아무 인스턴스에나 보낼 수 없음
+      <ul><li>상태를 버리면 수평 확장·재시도·장애 격리가 전부 단순해짐</li></ul>
+    </li>
+  </ul>
+  <p><b>다른 곳에도 적용됨.</b> HTTP 자체, REST, JWT 인증, stateless pod — 상태를 호출자나 외부 저장소로 밀어내는 같은 설계.</p>
+</section>
+
+<!-- ════════ 4장. 원리 (계속) ════════ -->
+<section class="page">
+  <p class="sec">2. 원리</p>
+  <h2 class="page-title">멀티턴은 모델의 성질이 아니라 배열의 길이</h2>
+  <p>섞이기 쉬운 두 정의를 나눠야 함.</p>
+  <ul class="bullets">
+    <li><b>사용자 관점</b> — 여러 번 주고받고, 뒤 질문이 앞 대화에 기댈 수 있는 경험</li>
+    <li><b>API 관점</b> — <mark>messages 배열이 커지는 것</mark>. 턴 3은 턴 1·2를 그대로 다시 실어 보냄</li>
+  </ul>
+  <p>뒤가 앞을 만들어 냄. 제3의 무언가는 없음. "멀티턴 모델"이라는 것도 없고, 입력을 더 보내는 호출자만 있음.</p>
+  <p class="codedesc">턴 3에서 실제로 나가는 요청 본문 (앞 두 턴이 전부 다시 실림)</p>
+  <pre class="code">messages = [
+  {<span class="k">"role"</span>: <span class="s">"user"</span>,      <span class="k">"content"</span>: <span class="s">"내 이름은 악분이야"</span>},   <span class="c"># 턴 1</span>
+  {<span class="k">"role"</span>: <span class="s">"assistant"</span>, <span class="k">"content"</span>: <span class="s">"네, 기억하겠습니다"</span>},  <span class="c"># 턴 1 답</span>
+  {<span class="k">"role"</span>: <span class="s">"user"</span>,      <span class="k">"content"</span>: <span class="s">"내 이름이 뭐야?"</span>},     <span class="c"># 턴 2</span>
+  {<span class="k">"role"</span>: <span class="s">"assistant"</span>, <span class="k">"content"</span>: <span class="s">"악분이라고 하셨습니다"</span>},
+  {<span class="k">"role"</span>: <span class="s">"user"</span>,      <span class="k">"content"</span>: <span class="hot">"몇 번 물어봤지?"</span>},     <span class="c"># 턴 3 ← 새 질문은 이것뿐</span>
+]</pre>
+</section>
+
+<!-- ════════ 5장. 구조 이해하기 ════════ -->
+<section class="page">
+  <p class="sec">3. 구조 이해하기</p>
+  <h2 class="page-title">턴이 늘 때 무엇이 커지는가</h2>
+  <p>같은 구도를 세 번 반복함. 서버 쪽은 매번 동일하고, 왼쪽 배열만 자람.</p>
+  <div class="stepper">
+    <div class="step">
+      <div class="diagram">
+        <span class="marker">1</span>
+        <div class="dbox hot">messages<small>1개</small></div>
+        <div class="darrow">→</div>
+        <div class="dbox rs">API<small>기억 없음</small></div>
+      </div>
+      <p class="exp"><b>1단계.</b> 질문 1개만 전송. 응답 후 서버는 이 요청을 버림</p>
+    </div>
+    <div class="step">
+      <div class="diagram">
+        <span class="marker">2</span>
+        <div class="dbox hot">messages<small>3개</small></div>
+        <div class="darrow">→</div>
+        <div class="dbox rs">API<small>기억 없음</small></div>
+      </div>
+      <p class="exp"><b>2단계.</b> 앱이 턴 1의 질문·답을 다시 실어 3개 전송. 답변 가능해짐</p>
+    </div>
+    <div class="step">
+      <div class="diagram">
+        <span class="marker">3</span>
+        <div class="dbox hot">messages<small>5개</small></div>
+        <div class="darrow">→</div>
+        <div class="dbox rs">API<small>기억 없음</small></div>
+      </div>
+      <p class="exp"><b>3단계.</b> 5개 전송. <span class="prob-text">턴 1 토큰이 세 번째 과금됨</span> — 비용이 턴 수에 비례해 누적</p>
+    </div>
+    <div class="step-nav">
+      <button class="step-prev">← 이전</button>
+      <span class="step-count"></span>
+      <button class="step-next">다음 →</button>
+    </div>
+  </div>
+</section>
+
+<!-- ════════ 6장. 구조 이해하기 (저장소) ════════ -->
+<section class="page">
+  <p class="sec">3. 구조 이해하기</p>
+  <h2 class="page-title">그 배열은 어디에 사는가</h2>
+  <p>배열을 프로세스 안에 두면 재시작·다중 pod에서 사라짐. 저장소는 API 호출 바깥에 붙음.</p>
+  <div class="dgroup"><b>애플리케이션 경계</b>
+    <div class="diagram" style="padding:6px">
+      <div class="dbox rs">저장소<small>memory / jsonl / redis</small></div>
+      <div class="darrow">↔</div>
+      <div class="dbox wl">앱<small>load → append → 전송</small></div>
+      <div class="darrow">→</div>
+      <div class="dbox">Claude API<small>stateless</small></div>
+    </div>
+  </div>
+  <p class="caption">[ 저장소를 바꿔도 오른쪽 화살표의 요청 본문은 동일 ]</p>
+  <ul class="bullets">
+    <li>memory — 프로세스와 함께 소멸. 스크립트·노트북용</li>
+    <li>jsonl — 파일에 한 줄씩 append. <mark>Claude Code가 쓰는 방식</mark></li>
+    <li>redis — 프로세스 여러 개가 한 세션 공유, TTL로 만료</li>
+  </ul>
+</section>
+
+<!-- ════════ 7장. 핸즈온 1 ════════ -->
+<section class="page">
+  <p class="sec">4. 핸즈온</p>
+  <h2 class="page-title">1단계 — 잊는 것을 눈으로 확인</h2>
+  <p class="codedesc">호출 2번. 두 번째는 첫 번째만 아는 것을 물음</p>
+  <pre class="code"><span class="c"># openai/01_stateless.py — 매 호출 messages 길이 1</span>
+client.chat.completions.create(model=MODEL,
+    messages=[SYSTEM, {<span class="k">"role"</span>: <span class="s">"user"</span>, <span class="k">"content"</span>: <span class="s">"내 이름은 악분이야"</span>}])
+client.chat.completions.create(model=MODEL,
+    messages=[SYSTEM, {<span class="k">"role"</span>: <span class="s">"user"</span>, <span class="k">"content"</span>: <span class="s">"내 이름이 뭐야?"</span>}])  <span class="c"># 앞 호출과 무관</span></pre>
+  <p class="codedesc">기대 결과</p>
+  <pre class="code">turn 1 &gt; 네, 악분님. 기억하겠습니다.
+turn 2 &gt; <span class="bad">죄송하지만 이전에 이름을 알려주신 적이 없습니다.</span></pre>
+  <p><b>체크포인트.</b> 모델 실패가 아님. 주어진 입력에 대해서는 정확한 답이며, 그 입력에 히스토리가 없었을 뿐임.</p>
+</section>
+
+<!-- ════════ 8장. 핸즈온 2 ════════ -->
+<section class="page">
+  <p class="sec">4. 핸즈온</p>
+  <h2 class="page-title">2단계 — 히스토리를 다시 보냄</h2>
+  <p class="codedesc">모델 설정은 그대로. history만 누적</p>
+  <pre class="code"><span class="c"># openai/02_multi_turn.py</span>
+history.append({<span class="k">"role"</span>: <span class="s">"user"</span>, <span class="k">"content"</span>: question})
+response = client.chat.completions.create(model=MODEL,
+    messages=[SYSTEM] + <span class="hot">history</span>)                              <span class="c"># 전부 재전송</span>
+history.append({<span class="k">"role"</span>: <span class="s">"assistant"</span>, <span class="k">"content"</span>: answer})  <span class="c"># 답도 누적</span></pre>
+  <p class="codedesc">기대 결과 — prompt token이 함께 오름</p>
+  <pre class="code">  [1 messages sent, 31 prompt tokens]
+turn 1 &gt; 네, 악분님. 기억하겠습니다.
+  [3 messages sent, <span class="hot">68</span> prompt tokens]
+turn 2 &gt; 악분이라고 하셨습니다.</pre>
+  <p><b>체크포인트.</b> 기억은 호출자가 만든 것. 1단계와 2단계 사이에 바뀐 모델 설정은 하나도 없음.</p>
+</section>
+
+<!-- ════════ 9장. 핸즈온 3 ════════ -->
+<section class="page">
+  <p class="sec">4. 핸즈온</p>
+  <h2 class="page-title">2단계 확인 — provider를 바꿔도 루프는 같음</h2>
+  <p><code>openai/</code>(gpt-5.6-luna)와 <code>claude/</code>(claude-sonnet-5)는 파일 이름·순서가 같고, 같은 번호는 같은 개념임. <mark>append → 전송 → append 루프도 동일</mark>함. 규격 차이는 세 군데뿐.</p>
+  <ul class="bullets">
+    <li>system 프롬프트 — OpenAI는 <code>messages[0]</code>, Anthropic은 별도 <code>system</code> 필드</li>
+    <li>응답 본문 — OpenAI는 <code>choices[0].message.content</code> 문자열, Anthropic은 block 리스트에서 <code>type == "text"</code>만 추림</li>
+    <li>출력 상한 — GPT-5 계열은 <code>max_completion_tokens</code>, Anthropic은 <code>max_tokens</code></li>
+  </ul>
+  <p class="codedesc">같은 자리, 다른 규격</p>
+  <pre class="code"><span class="c"># openai/02</span>  messages=[SYSTEM] + history
+<span class="c"># claude/02</span>  system=SYSTEM, messages=history</pre>
+  <p><b>체크포인트.</b> 바뀐 것은 요청 모양뿐이고, 누적 로직은 provider와 무관함.</p>
+</section>
+
+<!-- ════════ 10장. 핸즈온 4 ════════ -->
+<section class="page">
+  <p class="sec">4. 핸즈온</p>
+  <h2 class="page-title">3단계 — 저장소만 바꿔 보기</h2>
+  <p class="codedesc">플래그 하나만 다름. 대화 후 Ctrl-D로 나갔다가 다시 실행해 이름을 물음</p>
+  <pre class="code">uv run openai/03_store.py --store <span class="hot">memory</span> --session demo  <span class="c"># 재실행 → 잊음</span>
+uv run openai/03_store.py --store <span class="hot">jsonl</span>  --session demo  <span class="c"># 재실행 → 기억</span>
+uv run openai/03_store.py --store <span class="hot">redis</span>  --session demo  <span class="c"># 터미널 2개가 공유</span></pre>
+  <p class="codedesc">저장된 내용 직접 확인</p>
+  <pre class="code">cat sessions/demo.jsonl
+docker compose exec redis redis-cli lrange chat:demo 0 -1</pre>
+  <p><b>체크포인트.</b> 내구성은 모델 호출 바깥의 저장 결정임. 세 번 모두 <code>create()</code> 인자는 동일.</p>
+  <p class="foot">github 링크: computer_science/ai/multi-turn-conversation/</p>
+</section>
+
+<!-- ════════ 11장. 핸즈온 5 ════════ -->
+<section class="page">
+  <p class="sec">4. 핸즈온</p>
+  <h2 class="page-title">4단계 — 서버는 캐시하지만 기억하지는 않음</h2>
+  <p>"LLM 서버단에서도 캐시한다"가 사실인 지점이자, 오해가 생기는 지점. 캐시 API가 provider마다 달라 <code>04</code>만 두 디렉터리에서 다름.</p>
+  <p class="codedesc">기대 결과 — <code>claude/04_prompt_cache.py</code>, 같은 1000+ 토큰 system 프롬프트를 두 번 보냄</p>
+  <pre class="code">call 1  uncached=14 cache_write=1543 cache_read=<span class="bad">0</span>
+call 2  uncached=14 cache_write=0    cache_read=<span class="hot">1543</span></pre>
+  <ul class="bullets">
+    <li>맞는 해석 — 서버가 그 prefix의 내부 연산 결과를 이미 갖고 있어 재계산을 건너뜀. 값이 약 1/10로 떨어짐</li>
+    <li>틀린 해석 — 서버가 대화를 들고 있음. <mark>call 2도 prefix 전체를 다시 전송했음</mark>. 캐시 키가 보낸 바이트 자체이며 prefix 일치라, 한 글자만 달라도 뒤가 전부 무효화됨</li>
+  </ul>
+  <p>OpenAI는 <b>자동 캐시</b>라 선언 없이 <code>usage.prompt_tokens_details.cached_tokens</code>로 확인함. Anthropic은 <b>명시적 캐시</b>라 <code>cache_control</code>로 prefix 끝을 표시해야 함.</p>
+  <p><b>체크포인트.</b> prompt caching은 히스토리를 다시 보내는 <b>비용</b>을 줄이는 것이지, 다시 보내는 <b>일</b>을 없애는 것이 아님.</p>
+</section>
+
+<!-- ════════ 12장. 실제 제품이 푸는 방식 ════════ -->
+<section class="page">
+  <p class="sec">5. 실제 제품이 푸는 방식</p>
+  <h2 class="page-title">stateless가 항상은 아님</h2>
+  <ul class="bullets">
+    <li><b>Claude Code</b> — 로컬 append-only JSONL. <code>~/.claude/projects/&lt;cwd-slug&gt;/&lt;session-uuid&gt;.jsonl</code>
+      <ul><li>한 줄에 JSON 객체 하나, 각 항목이 <code>parentUuid</code>로 앞 항목에 연결됨. <code>--resume</code>이 이 파일을 다시 읽어 재생. 4단계의 jsonl 저장소와 같은 구조</li></ul>
+    </li>
+    <li><b>OpenAI</b> — 두 가지를 다 제공
+      <ul><li>Chat Completions: stateless. 위 실습과 동일</li>
+      <li>Responses API: <mark>stateful</mark>. <code>store: true</code>로 보내고 응답 <code>id</code>를 다음 호출의 <code>previous_response_id</code>로 넘기면 히스토리를 다시 안 보내도 됨</li></ul>
+    </li>
+    <li><b>Anthropic</b> — Messages API는 stateless로 유지하고, 서버 측 상태는 Managed Agents라는 별도 제품에 둠(세션이 서버에 살고 message 배열 대신 event를 주고받음)</li>
+  </ul>
+  <p>정확한 규칙은 "LLM API는 stateless"보다 좁음 — <b>Chat Completions·Messages는 호출자가 누적, Responses·Managed Agents는 서버가 누적.</b></p>
+</section>
+
+<!-- ════════ 13장. 확인해 보기 ════════ -->
+<section class="page">
+  <p class="sec">6. 확인해 보기</p>
+  <h2 class="page-title">스스로 점검</h2>
+  <div class="quiz">
+    <p class="q">Q1. 20턴째 대화 중이고 각 턴이 약 500 토큰임. 20턴째 요청의 input token은 대략 얼마인가?</p>
+    <ul class="opts">
+      <li>약 500 — 새 질문만 과금됨</li>
+      <li data-answer>약 10,000 — 앞 19턴이 전부 다시 실림</li>
+      <li>약 1,000 — 직전 턴까지만 실림</li>
+    </ul>
+    <p class="fb"><b class="verdict"></b> 매 턴이 전체 히스토리를 재전송하므로 input이 턴 수에 비례해 누적됨. 컨텍스트 한계와 비용이 같은 이유에서 생김.</p>
+  </div>
+  <div class="quiz">
+    <p class="q">Q2. system 프롬프트에 <code>datetime.now()</code>를 넣었더니 <code>cache_read</code>가 계속 0임. 이유는?</p>
+    <ul class="opts">
+      <li>토큰 수가 최소 캐시 길이에 못 미침</li>
+      <li>캐시 TTL이 만료됨</li>
+      <li data-answer>prefix 바이트가 매 요청 달라져 prefix 일치가 안 됨</li>
+    </ul>
+    <p class="fb"><b class="verdict"></b> 캐시 키는 보낸 바이트이고 prefix 일치임. 앞쪽이 한 글자만 바뀌어도 그 뒤 전체가 무효화됨. 변하는 값은 마지막 breakpoint 뒤로 옮겨야 함.</p>
+  </div>
+</section>
+
+<!-- ════════ 14장. 트레이드오프 ════════ -->
+<section class="page">
+  <p class="sec">7. 트레이드오프</p>
+  <h2 class="page-title">누적-재전송 방식이 주고받는 것</h2>
+  <div class="tradeoff">
+    <div class="pro"><h3>얻는 것</h3><ul>
+      <li>전체 transcript를 직접 열람·수정 가능</li>
+      <li>provider 간 이식 가능. 벤더 종속 없음</li>
+      <li>구현이 리스트 하나. 디버깅이 쉬움</li>
+    </ul></div>
+    <div class="con"><h3>잃는 것</h3><ul>
+      <li>input 토큰이 세션 길이의 제곱에 가깝게 증가</li>
+      <li>컨텍스트 한계에서 요약·절삭 필요. 무손실 아님</li>
+      <li>보관·삭제·접근제어가 전부 앱 책임</li>
+    </ul></div>
+  </div>
+  <p><b>언제 쓰는가.</b> 대부분의 시스템에서 기본값. transcript 감사·수정·이전이 필요하면 필수.</p>
+  <p><b>언제 쓰지 않는가.</b> 대화가 매우 길고 클라이언트가 얇으며 벤더 종속을 감수할 수 있으면 서버 측 상태(<code>previous_response_id</code>, Managed Agents)가 나음.</p>
+</section>
+
+<!-- ════════ 15장. 결론 ════════ -->
+<section class="page">
+  <p class="sec">8. 결론</p>
+  <h2 class="page-title">이름을 잊던 챗봇으로 돌아가서</h2>
+  <p>버그는 프롬프트가 아니라 <b>두 번째 요청의 본문</b>에 있었음. 엔드포인트가 stateless라 턴 1을 붙들고 있는 주체가 없었고, 앱이 히스토리를 실어 보내자 그대로 해결됨.</p>
+  <p>기억할 원리 한 문장 — <mark>대화는 모델이 가진 것이 아니라 호출자가 매번 다시 만드는 것</mark>.</p>
+  <ul class="bullets">
+    <li>다음에 응용할 지점
+      <ul><li>컨텍스트가 찼을 때의 요약·compaction 전략</li>
+      <li>prompt caching을 깨지 않는 프롬프트 배치(변하는 값을 뒤로)</li>
+      <li>세션 저장소를 파일에서 DB로 옮길 때의 보관·삭제 정책</li></ul>
+    </li>
+  </ul>
+</section>
+
+</main>
+
+<nav id="nav"><div class="in">
+  <button id="prev">← 이전</button>
+  <div id="dots"></div>
+  <span id="counter"></span>
+  <button id="next">다음 →</button>
+  <button id="fs">전체 화면</button>
+</div></nav>
+
+<script>
+(function(){
+  var pages=[].slice.call(document.querySelectorAll('.page')),i=0;
+  var prev=document.getElementById('prev'),next=document.getElementById('next');
+  var dots=document.getElementById('dots'),counter=document.getElementById('counter');
+  pages.forEach(function(_,j){
+    var d=document.createElement('button');
+    d.setAttribute('aria-label',(j+1)+'페이지로 이동');
+    d.onclick=function(){i=j;show();};
+    dots.appendChild(d);
+  });
+  function show(){
+    pages.forEach(function(p,j){p.classList.toggle('on',j===i);});
+    [].forEach.call(dots.children,function(d,j){d.classList.toggle('on',j===i);});
+    counter.textContent=(i+1)+' / '+pages.length;
+    prev.disabled=i===0; next.disabled=i===pages.length-1;
+    window.scrollTo(0,0);
+  }
+  prev.onclick=function(){if(i>0){i--;show();}};
+  next.onclick=function(){if(i<pages.length-1){i++;show();}};
+  document.addEventListener('keydown',function(e){
+    if(e.key==='ArrowLeft')prev.onclick();
+    if(e.key==='ArrowRight')next.onclick();
+  });
+  show();
+})();
+
+(function(){
+  var fs=document.getElementById('fs'),el=document.documentElement;
+  if(!el.requestFullscreen||!document.fullscreenEnabled){fs.style.display='none';return;}
+  fs.onclick=function(){
+    var p=document.fullscreenElement?document.exitFullscreen():el.requestFullscreen();
+    if(p&&p.catch)p.catch(function(){});
+  };
+  document.addEventListener('fullscreenchange',function(){
+    fs.textContent=document.fullscreenElement?'창 모드':'전체 화면';
+  });
+})();
+
+document.querySelectorAll('.quiz').forEach(function(qz){
+  var opts=[].slice.call(qz.querySelectorAll('.opts li'));
+  opts.forEach(function(o){
+    o.setAttribute('role','button');
+    o.tabIndex=0;
+    o.onkeydown=function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();o.onclick();}};
+    o.onclick=function(){
+      if(qz.classList.contains('done'))return;
+      qz.classList.add('done');
+      var ok=o.hasAttribute('data-answer');
+      opts.forEach(function(x){
+        if(x.hasAttribute('data-answer'))x.classList.add('correct');
+      });
+      var fb=qz.querySelector('.fb');
+      if(!ok){o.classList.add('wrong');fb.classList.add('no');}
+      fb.querySelector('.verdict').textContent=ok?'정답.':'오답. 정답은 노란 보기.';
+    };
+  });
+});
+
+document.querySelectorAll('.stepper').forEach(function(st){
+  var steps=[].slice.call(st.querySelectorAll('.step')),i=0;
+  var prev=st.querySelector('.step-prev'),next=st.querySelector('.step-next');
+  var count=st.querySelector('.step-count');
+  function show(){
+    steps.forEach(function(s,j){s.classList.toggle('on',j===i);});
+    count.textContent=(i+1)+' / '+steps.length;
+    prev.disabled=i===0; next.disabled=i===steps.length-1;
+  }
+  prev.onclick=function(){if(i>0){i--;show();}};
+  next.onclick=function(){if(i<steps.length-1){i++;show();}};
+  show();
+});
+</script>
+</body>
+</html>

--- a/computer_science/ai/multi-turn-conversation/test_store.py
+++ b/computer_science/ai/multi-turn-conversation/test_store.py
@@ -1,0 +1,72 @@
+"""Store tests. No API key and no Redis server needed."""
+
+import tempfile
+from pathlib import Path
+
+from store import JsonlStore, MemoryStore, RedisStore
+
+
+class FakeRedis:
+  """Just enough Redis to exercise RedisStore: rpush, lrange, expire."""
+
+  def __init__(self) -> None:
+    self.lists: dict[str, list[bytes]] = {}
+    self.ttls: dict[str, int] = {}
+
+  def rpush(self, key: str, value: str) -> None:
+    self.lists.setdefault(key, []).append(value.encode())
+
+  def lrange(self, key: str, start: int, end: int) -> list[bytes]:
+    items = self.lists.get(key, [])
+    return items[start:] if end == -1 else items[start : end + 1]
+
+  def expire(self, key: str, seconds: int) -> None:
+    self.ttls[key] = seconds
+
+
+def check_roundtrip(store: object, label: str) -> None:
+  """Append two messages and assert load() returns them in order."""
+  store.append({"role": "user", "content": "내 이름은 악분이야"})
+  store.append({"role": "assistant", "content": "반가워요 악분님"})
+  loaded = store.load()
+  assert len(loaded) == 2, f"{label}: expected 2, got {len(loaded)}"
+  assert loaded[0]["role"] == "user", f"{label}: first message must be the user turn"
+  assert "악분" in loaded[1]["content"], f"{label}: non-ascii content must survive"
+
+
+def test_memory_store_is_isolated_per_instance() -> None:
+  """A new MemoryStore starts empty. This is why an in-memory chat forgets on restart."""
+  first = MemoryStore()
+  check_roundtrip(first, "MemoryStore")
+  assert MemoryStore().load() == [], "a fresh process must see an empty history"
+
+
+def test_jsonl_store_survives_a_new_instance() -> None:
+  """Reopening the same file returns the same history, which is what a restart does."""
+  with tempfile.TemporaryDirectory() as tmp:
+    path = Path(tmp) / "session.jsonl"
+    check_roundtrip(JsonlStore(path), "JsonlStore")
+    assert len(JsonlStore(path).load()) == 2, "history must survive a new instance"
+    assert len(path.read_text(encoding="utf-8").strip().splitlines()) == 2
+
+
+def test_redis_store_sets_a_ttl() -> None:
+  """The TTL is what makes a Redis session expire instead of leaking forever."""
+  fake = FakeRedis()
+  check_roundtrip(RedisStore(fake, "s1", ttl_seconds=60), "RedisStore")
+  assert fake.ttls["chat:s1"] == 60, "every append must refresh the session TTL"
+
+
+def test_redis_store_separates_sessions() -> None:
+  """Two session ids must not see each other's messages."""
+  fake = FakeRedis()
+  RedisStore(fake, "alice").append({"role": "user", "content": "hi"})
+  assert RedisStore(fake, "bob").load() == [], "bob must not read alice's history"
+
+
+if __name__ == "__main__":
+  test_memory_store_is_isolated_per_instance()
+  test_jsonl_store_survives_a_new_instance()
+  test_redis_store_sets_a_ttl()
+  test_redis_store_separates_sessions()
+  print("ok - all store tests passed")


### PR DESCRIPTION
# 구현

싱글턴 → 멀티턴 → 저장소(memory/jsonl/redis) → prompt cache 4단계 핸즈온, OpenAI와 Claude 두 provider 디렉터리로 구성
- store 테스트 통과, RedisStore는 실제 redis 서버 왕복 확인, compose config 검증. 01~04는 API key 부재로 미실행이며 문서에 예상값임을 명시

# 리스크

01~04를 실행하지 못해 문서의 출력값과 토큰 수치가 예상값임
- provider SDK 응답 필드명이 바뀌면 실행 시점에 드러남. store 계층은 검증되어 있어 영향 범위는 provider 파일 8개로 한정됨

provider 파일과 docs가 두 디렉터리에 중복되어 개념 수정 시 양쪽을 함께 고쳐야 함
- provider가 3개 이상으로 늘면 중복 비용이 커짐. AGENTS.md에 추가 절차와 갱신 대상을 남겨 누락을 줄임

Issue #951