### PR TITLE
fix: akbun-makepresentation 선택 객체 마우스 이동 복구

### DIFF
--- a/product/akbun-makepresentation/knowledge/decisions/2026-08-drag-wins-over-double-click-edit.md
+++ b/product/akbun-makepresentation/knowledge/decisions/2026-08-drag-wins-over-double-click-edit.md
@@ -1,0 +1,20 @@
+---
+type: Decision
+title: 드래그는 더블클릭 편집보다 우선
+description: 두 번째 누름이 이동되면 객체 드래그로 처리하고 이동이 없을 때만 편집 진입.
+tags: [desktop, editor, pointer, drag]
+timestamp: 2026-08-16T09:15:00Z
+---
+
+## 결정
+
+- 두 번째 pointerdown은 편집 후보로만 저장.
+- pointermove가 발생하면 객체 이동 우선.
+- 이동 없는 pointerup에서만 텍스트 또는 코드 편집 진입.
+- 선택된 빈 도형 내부는 다른 도형을 가리지 않을 때 이동 영역으로 사용.
+
+## 이유
+
+- pointerdown 즉시 편집하면 선택 직후 드래그도 더블클릭으로 오인.
+- 채움 없는 사각형과 원은 내부에 SVG hit target이 없어 선택 후에도 테두리에서만 이동 가능.
+- 실제 도형 hit를 먼저 사용하면 선택 도형 내부의 다른 객체 선택 유지.

--- a/product/akbun-makepresentation/knowledge/decisions/index.md
+++ b/product/akbun-makepresentation/knowledge/decisions/index.md
@@ -2,6 +2,7 @@
 
 akbun-makepresentation 작업 중 내린 의사결정과 이유.
 
+* [드래그는 더블클릭 편집보다 우선](2026-08-drag-wins-over-double-click-edit.md)
 * [삭제 단축키의 대상은 편집 영역 포커스로 결정](2026-08-delete-key-follows-editor-focus.md)
 * [Shift 리사이즈는 비율과 선의 축을 유지](2026-08-shift-resize-keeps-line-axis.md)
 * [전체 선택 단축키는 패널 포커스를 따름](2026-08-select-all-follows-pane-focus.md)

--- a/product/akbun-makepresentation/knowledge/log.md
+++ b/product/akbun-makepresentation/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-16
 
+* **Creation**: [드래그는 더블클릭 편집보다 우선](decisions/2026-08-drag-wins-over-double-click-edit.md) 결정 기록.
 * **Creation**: [코드 블록은 편집 모델과 PPTX 표현을 분리](decisions/2026-08-code-blocks-keep-source-metadata.md) 결정 기록.
 * **Creation**: [AI 인증은 Codex를 재사용하고 대화는 앱이 소유](decisions/2026-08-ai-sessions-are-app-owned.md) 결정 기록.
 * **Update**: [사용자 프리셋은 로컬 설정으로 저장](decisions/2026-08-custom-presets-are-local-settings.md)의 저장 위치를 settings.json으로 변경하고 가이드라인 설정 포함.

--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src/editor.js
+++ b/product/akbun-makepresentation/workspace/src/editor.js
@@ -387,6 +387,28 @@ function shapeBBox(shape) {
   return { x, y, w: Math.abs(shape.w), h: Math.abs(shape.h) };
 }
 
+function shapeSelectionContainsPoint(shape, x, y) {
+  const box = shapeBBox(shape);
+  if (!(box.w > 0) || !(box.h > 0)) return false;
+  const cx = box.x + box.w / 2;
+  const cy = box.y + box.h / 2;
+  const angle = -(Number(shape.rotation) || 0) * Math.PI / 180;
+  const dx = x - cx;
+  const dy = y - cy;
+  const localX = cx + dx * Math.cos(angle) - dy * Math.sin(angle);
+  const localY = cy + dx * Math.sin(angle) + dy * Math.cos(angle);
+
+  if (shape.kind === 'ellipse') {
+    const nx = (localX - cx) / (box.w / 2);
+    const ny = (localY - cy) / (box.h / 2);
+    return nx * nx + ny * ny <= 1;
+  }
+  return (
+    localX >= box.x && localX <= box.x + box.w &&
+    localY >= box.y && localY <= box.y + box.h
+  );
+}
+
 function defaultPresetShapes(id) {
   const red = '#e03131';
   if (id === 'red-filled-rectangle' || id === 'red-outline-rectangle') {
@@ -1366,6 +1388,7 @@ const exported = {
   dragShape,
   isDegenerate,
   shapeBBox,
+  shapeSelectionContainsPoint,
   normalizeRect,
   shapeIndicesInRect,
   toggleSelection,

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -479,11 +479,7 @@ function selectedShapeIndexAtPoint(point) {
   for (const index of [...state.selection].reverse()) {
     const shape = slide().shapes[index];
     if (!canEditText(shape)) continue;
-    const box = L.shapeBBox(shape);
-    if (
-      point.x >= box.x && point.x <= box.x + box.w &&
-      point.y >= box.y && point.y <= box.y + box.h
-    ) return index;
+    if (L.shapeSelectionContainsPoint(shape, point.x, point.y)) return index;
   }
   return -1;
 }

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -475,6 +475,19 @@ function toPoint(event) {
   };
 }
 
+function selectedShapeIndexAtPoint(point) {
+  for (const index of [...state.selection].reverse()) {
+    const shape = slide().shapes[index];
+    if (!canEditText(shape)) continue;
+    const box = L.shapeBBox(shape);
+    if (
+      point.x >= box.x && point.x <= box.x + box.w &&
+      point.y >= box.y && point.y <= box.y + box.h
+    ) return index;
+  }
+  return -1;
+}
+
 canvas.addEventListener('pointerdown', (event) => {
   if (event.button !== 0) return;
   const handleEl = event.target.closest('[data-handle]');
@@ -545,32 +558,15 @@ canvas.addEventListener('pointerdown', (event) => {
     return;
   }
 
-  const index = hitShape ? slide().shapes.indexOf(hitShape) : -1;
+  const index = hitShape ? slide().shapes.indexOf(hitShape) : selectedShapeIndexAtPoint(p);
   const additive = event.shiftKey && !(event.metaKey || event.ctrlKey);
   if (index >= 0) {
 
-    // Opening a text box for editing is decided here rather than from a
-    // dblclick event, because the browser never reports one: pointerup
-    // redraws the canvas, so mouseup lands on a freshly built element and
-    // not the one that took mousedown, and a click needs both.
-    //
-    // preventDefault keeps the focus the overlay is about to take. Without
-    // it the press moves focus back to the page, and from there Backspace
-    // deletes the box being typed into instead of a character.
-    if (isSecondPress(index) && slide().shapes[index].kind === 'code') {
-      selectOnly(index);
-      renderCanvas();
-      renderProps();
-      openCodeDialog(index, false);
-      return;
-    }
-    if (isSecondPress(index) && canEditText(slide().shapes[index])) {
-      event.preventDefault();
-      selectOnly(index);
-      renderCanvas();
-      renderProps();
-      startTextEdit(index);
-      return;
+    const secondPress = isSecondPress(index);
+    let editOnClick = '';
+    if (secondPress && !(event.shiftKey || event.metaKey || event.ctrlKey)) {
+      if (slide().shapes[index].kind === 'code') editOnClick = 'code';
+      else if (canEditText(slide().shapes[index])) editOnClick = 'text';
     }
 
     // Shift changes this object's membership, but only on a press that never
@@ -605,6 +601,8 @@ canvas.addEventListener('pointerdown', (event) => {
       moved: false,
       duplicated,
       originalSelection,
+      editOnClick,
+      editIndex: index,
       // Only an already-selected object can be dropped by a Shift-click. One
       // that was just added by the same press has to stay.
       toggleIndex: additive && wasSelected ? index : -1,
@@ -699,6 +697,13 @@ canvas.addEventListener('pointerup', () => {
         ...L.shapeIndicesInRect(slide().shapes, rect),
       ]);
     }
+  } else if (drag.mode === 'move' && !drag.moved && drag.editOnClick) {
+    selectOnly(drag.editIndex);
+    renderCanvas();
+    renderProps();
+    if (drag.editOnClick === 'code') openCodeDialog(drag.editIndex, false);
+    else startTextEdit(drag.editIndex);
+    return;
   } else if (drag.mode === 'move' && !drag.moved && drag.toggleIndex >= 0) {
     // A Shift-press that never moved: the click half of Shift-click.
     selectMany(L.toggleSelection(state.selection, drag.toggleIndex, slide().shapes.length));

--- a/product/akbun-makepresentation/workspace/test/editor.test.js
+++ b/product/akbun-makepresentation/workspace/test/editor.test.js
@@ -145,6 +145,21 @@ test('shapeBBox normalizes negative line extents', () => {
   assert.deepStrictEqual(L.shapeBBox(shape), { x: 40, y: 100, w: 60, h: 60 });
 });
 
+test('shapeSelectionContainsPoint follows rotated rectangles', () => {
+  const shape = L.createShape('rect', 0, 0, {});
+  L.dragShape(shape, 0, 0, 100, 20);
+  shape.rotation = 90;
+  assert.ok(L.shapeSelectionContainsPoint(shape, 50, 40));
+  assert.ok(!L.shapeSelectionContainsPoint(shape, 90, 10));
+});
+
+test('shapeSelectionContainsPoint excludes ellipse corners', () => {
+  const shape = L.createShape('ellipse', 0, 0, {});
+  L.dragShape(shape, 0, 0, 100, 50);
+  assert.ok(L.shapeSelectionContainsPoint(shape, 50, 25));
+  assert.ok(!L.shapeSelectionContainsPoint(shape, 0, 0));
+});
+
 test('normalizeRect accepts a drag in any direction', () => {
   assert.deepStrictEqual(L.normalizeRect(100, 80, 20, 10), {
     x: 20,


### PR DESCRIPTION
# 구현

선택 객체의 마우스 드래그와 더블클릭 편집 판정 분리
- 텍스트·사각형·원 드래그 확인, Node 테스트 93개 통과

# 어려웠던 점

두 번째 pointerdown을 즉시 편집으로 처리해 빠른 드래그까지 차단
- 편집 진입을 이동 없는 pointerup으로 지연하고 실제 도형 hit 부재 시 선택 영역 보완

# 리스크

선택된 빈 도형 내부가 추가 이동 영역으로 동작
- 실제 도형 hit를 우선해 내부의 다른 객체 선택 유지

Issue #956
