### PR TITLE
fix: Codex sandbox 프로필 이름을 portfolio로 변경

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,10 +1,10 @@
-default_permissions = "workspace"
+default_permissions = "portfolio"
 
-[permissions.workspace]
-description = "Project workspace permissions."
+[permissions.portfolio]
+description = "Portfolio project permissions."
 extends = ":workspace"
 
-[permissions.workspace.filesystem.":workspace_roots"]
+[permissions.portfolio.filesystem.":workspace_roots"]
 "**/*.avif" = "deny"
 "**/*.AVIF" = "deny"
 "**/*.bmp" = "deny"
@@ -28,5 +28,5 @@ extends = ":workspace"
 "**/*.webp" = "deny"
 "**/*.WEBP" = "deny"
 
-[permissions.workspace.network]
+[permissions.portfolio.network]
 enabled = true


### PR DESCRIPTION
# 구현

sandbox 프로필 이름을 portfolio로 변경
- 기본 선택값과 파일시스템·네트워크 섹션 이름 동기화

Issue #958