### PR TITLE
fix: AI 슬라이드 생성 오류와 시스템 프롬프트 설정

### DIFF
--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",

--- a/product/akbun-makepresentation/workspace/src/ai-panel.js
+++ b/product/akbun-makepresentation/workspace/src/ai-panel.js
@@ -35,12 +35,6 @@
     'In SLIDE MODE, return only the JSON required by the supplied output schema.',
   ].join(' ');
 
-  const BASE_INSTRUCTIONS = [
-    'You are the AI assistant inside akbun-makepresentation.',
-    'Help with presentation text, generated images, and structured slide edits.',
-    'Follow the developer instructions and return only the requested result.',
-  ].join(' ');
-
   function setConnection(next) {
     connection = { ...connection, ...next };
     renderConnection();
@@ -595,7 +589,7 @@
       sandbox: 'workspace-write',
       personality: 'friendly',
       serviceName: 'akbun_makepresentation',
-      baseInstructions: BASE_INSTRUCTIONS,
+      baseInstructions: A.baseInstructions(callbacks.systemPrompts?.()),
       developerInstructions: DEVELOPER_INSTRUCTIONS,
       ephemeral: true,
       config,

--- a/product/akbun-makepresentation/workspace/src/ai.js
+++ b/product/akbun-makepresentation/workspace/src/ai.js
@@ -145,6 +145,7 @@
       'Use zero-based shape indices from the supplied slide.',
       'Do not add image shapes. Existing image shapes may be repositioned with update operations.',
       'For update operations, set every unchanged field in changes to null.',
+      'For add operations, set fields unused by the shape kind to null. Pen shapes still require points.',
       'Set background to null unless the slide background should change.',
       '',
       `Request: ${prompt}`,
@@ -208,6 +209,11 @@
       .filter(([name]) => CHANGE_FIELDS.has(name))
       .map(([name, schema]) => [name, nullable(schema)])
   );
+  const requiredAddFields = new Set(['kind', 'x', 'y', 'w', 'h']);
+  const addShapeProperties = Object.fromEntries(
+    Object.entries(shapeProperties)
+      .map(([name, schema]) => [name, requiredAddFields.has(name) ? schema : nullable(schema)])
+  );
 
   const SLIDE_OUTPUT_SCHEMA = Object.freeze(strictObject({
     summary: { type: 'string', maxLength: 500 },
@@ -228,7 +234,7 @@
           }),
           strictObject({
             op: { type: 'string', enum: ['add'] },
-            shape: strictObject(shapeProperties),
+            shape: strictObject(addShapeProperties),
           }),
         ],
       },

--- a/product/akbun-makepresentation/workspace/src/ai.js
+++ b/product/akbun-makepresentation/workspace/src/ai.js
@@ -144,6 +144,8 @@
       'Return only the JSON object required by the output schema.',
       'Use zero-based shape indices from the supplied slide.',
       'Do not add image shapes. Existing image shapes may be repositioned with update operations.',
+      'For update operations, set every unchanged field in changes to null.',
+      'Set background to null unless the slide background should change.',
       '',
       `Request: ${prompt}`,
       `Slide size: ${JSON.stringify(size)}`,
@@ -151,7 +153,28 @@
     ].join('\n');
   }
 
+  function baseInstructions(systemPrompts) {
+    const prompts = systemPrompts && typeof systemPrompts === 'object' ? systemPrompts : {};
+    return [
+      'You are the AI assistant inside akbun-makepresentation.',
+      'Help with presentation text, generated images, and structured slide edits.',
+      'Follow the developer instructions and return only the requested result.',
+      '',
+      'App-configured system prompts follow. Apply the prompt matching the request mode.',
+      `<TEXT_MODE_SYSTEM_PROMPT>${safeText(prompts.text, 20_000)}</TEXT_MODE_SYSTEM_PROMPT>`,
+      `<IMAGE_MODE_SYSTEM_PROMPT>${safeText(prompts.image, 20_000)}</IMAGE_MODE_SYSTEM_PROMPT>`,
+      `<SLIDE_MODE_SYSTEM_PROMPT>${safeText(prompts.slide, 20_000)}</SLIDE_MODE_SYSTEM_PROMPT>`,
+    ].join('\n');
+  }
+
   const colorSchema = { type: 'string', pattern: '^(none|#[0-9a-fA-F]{6})$' };
+  const nullable = (schema) => ({ anyOf: [schema, { type: 'null' }] });
+  const strictObject = (properties) => ({
+    type: 'object',
+    additionalProperties: false,
+    required: Object.keys(properties),
+    properties,
+  });
   const shapeProperties = {
     kind: { type: 'string', enum: ['rect', 'ellipse', 'line', 'arrow', 'pen', 'text'] },
     x: { type: 'number' },
@@ -180,40 +203,37 @@
     arrowStart: { type: 'string', enum: L.ARROW_ENDS },
     arrowEnd: { type: 'string', enum: L.ARROW_ENDS },
   };
+  const nullableChangeProperties = Object.fromEntries(
+    Object.entries(shapeProperties)
+      .filter(([name]) => CHANGE_FIELDS.has(name))
+      .map(([name, schema]) => [name, nullable(schema)])
+  );
 
-  const SLIDE_OUTPUT_SCHEMA = Object.freeze({
-    type: 'object',
-    additionalProperties: false,
-    required: ['summary', 'operations'],
-    properties: {
-      summary: { type: 'string', maxLength: 500 },
-      background: colorSchema,
-      operations: {
-        type: 'array',
-        maxItems: 100,
-        items: {
-          type: 'object',
-          additionalProperties: false,
-          required: ['op'],
-          properties: {
-            op: { type: 'string', enum: ['update', 'remove', 'add'] },
+  const SLIDE_OUTPUT_SCHEMA = Object.freeze(strictObject({
+    summary: { type: 'string', maxLength: 500 },
+    background: nullable(colorSchema),
+    operations: {
+      type: 'array',
+      maxItems: 100,
+      items: {
+        anyOf: [
+          strictObject({
+            op: { type: 'string', enum: ['update'] },
             index: { type: 'integer', minimum: 0 },
-            changes: {
-              type: 'object',
-              additionalProperties: false,
-              properties: shapeProperties,
-            },
-            shape: {
-              type: 'object',
-              additionalProperties: false,
-              required: ['kind', 'x', 'y', 'w', 'h'],
-              properties: shapeProperties,
-            },
-          },
-        },
+            changes: strictObject(nullableChangeProperties),
+          }),
+          strictObject({
+            op: { type: 'string', enum: ['remove'] },
+            index: { type: 'integer', minimum: 0 },
+          }),
+          strictObject({
+            op: { type: 'string', enum: ['add'] },
+            shape: strictObject(shapeProperties),
+          }),
+        ],
       },
     },
-  });
+  }));
 
   function jsonObject(text) {
     const source = String(text || '').trim();
@@ -230,7 +250,7 @@
   function cleanChanges(value) {
     const source = value && typeof value === 'object' ? value : {};
     return Object.fromEntries(
-      Object.entries(source).filter(([name]) => CHANGE_FIELDS.has(name))
+      Object.entries(source).filter(([name, field]) => CHANGE_FIELDS.has(name) && field !== null)
     );
   }
 
@@ -303,6 +323,7 @@
     cryptoId,
     slideSnapshot,
     slidePrompt,
+    baseInstructions,
     parseSlidePatch,
     applySlidePatch,
   };

--- a/product/akbun-makepresentation/workspace/src/index.html
+++ b/product/akbun-makepresentation/workspace/src/index.html
@@ -532,6 +532,15 @@
             </div>
           </div>
           <button id="btn-ai-refresh" type="button">Refresh status</button>
+          <p>System prompts apply to new AI conversations.</p>
+          <div class="settings-ai-prompts">
+            <label for="settings-ai-text-prompt">Text system prompt</label>
+            <textarea id="settings-ai-text-prompt" rows="4" maxlength="20000"></textarea>
+            <label for="settings-ai-image-prompt">Image system prompt</label>
+            <textarea id="settings-ai-image-prompt" rows="4" maxlength="20000"></textarea>
+            <label for="settings-ai-slide-prompt">Slide system prompt</label>
+            <textarea id="settings-ai-slide-prompt" rows="4" maxlength="20000"></textarea>
+          </div>
         </section>
         <!-- Checking for a version is something you do now and then, not while
              drawing, so it sits here rather than next to the tools. -->

--- a/product/akbun-makepresentation/workspace/src/renderer.js
+++ b/product/akbun-makepresentation/workspace/src/renderer.js
@@ -140,6 +140,7 @@ async function initialize() {
     applySlidePatch: applyAiSlidePatch,
     insertImage: insertAiImage,
     deckSize,
+    systemPrompts: () => appSettings.aiSystemPrompts,
   });
 }
 

--- a/product/akbun-makepresentation/workspace/src/renderer/settings.js
+++ b/product/akbun-makepresentation/workspace/src/renderer/settings.js
@@ -59,6 +59,20 @@ function renderGeneralSettings() {
   $('general-settings-status').textContent = '';
 }
 
+function renderAiSettings() {
+  for (const mode of ['text', 'image', 'slide']) {
+    $(`settings-ai-${mode}-prompt`).value = appSettings.aiSystemPrompts[mode];
+  }
+}
+
+function aiSystemPromptsFromFields() {
+  return {
+    text: $('settings-ai-text-prompt').value,
+    image: $('settings-ai-image-prompt').value,
+    slide: $('settings-ai-slide-prompt').value,
+  };
+}
+
 function borderSettingsFromFields(prefix) {
   const width = Number($(`settings-${prefix}-border-width`).value);
   if (!Number.isFinite(width) || width < 1 || width > 30) return null;
@@ -87,6 +101,7 @@ function openSettings() {
   $('preset-settings-status').textContent = '';
   setSettingsPage('general');
   renderGeneralSettings();
+  renderAiSettings();
   renderSettingsPresets();
   settingsDialog.showModal();
   settingsDialog.querySelector('[data-settings-page="general"]')?.focus();
@@ -123,6 +138,7 @@ $('btn-settings-ok').addEventListener('click', async () => {
       ...appSettings,
       snapping: { enabled: $('settings-snapping').checked },
       editorDefaults,
+      aiSystemPrompts: aiSystemPromptsFromFields(),
       customPresets: settingsPresetDraft,
     });
     customPresets = structuredClone(appSettings.customPresets);

--- a/product/akbun-makepresentation/workspace/src/settings.js
+++ b/product/akbun-makepresentation/workspace/src/settings.js
@@ -5,8 +5,14 @@
     ? require('./editor.js')
     : globalThis.slidesLib;
 
-  const SETTINGS_VERSION = 3;
+  const SETTINGS_VERSION = 4;
   const DEFAULT_FONT_FAMILY = 'Noto Sans KR';
+  const MAX_SYSTEM_PROMPT_LENGTH = 20_000;
+  const DEFAULT_AI_SYSTEM_PROMPTS = Object.freeze({
+    text: 'You are a presentation writing assistant. Produce concise, audience-ready wording with a clear hierarchy. Preserve the user\'s language and return only the requested text.',
+    image: 'You are a presentation visual designer. Generate one clean, presentation-ready image that communicates the requested idea. Avoid embedded text unless the user explicitly asks for it.',
+    slide: 'You are a presentation slide editor. Improve the selected slide\'s clarity, hierarchy, spacing, alignment, and visual consistency while preserving its core meaning. Prefer focused edits over unnecessary additions.',
+  });
   const DEFAULT_SHAPE_BORDER = Object.freeze({
     color: '#e03131',
     width: 2,
@@ -36,6 +42,7 @@
         shapeBorder: { ...DEFAULT_SHAPE_BORDER },
         imageBorder: { ...DEFAULT_IMAGE_BORDER },
       },
+      aiSystemPrompts: { ...DEFAULT_AI_SYSTEM_PROMPTS },
       customPresets: [],
     };
   }
@@ -106,6 +113,21 @@
     return { enabled: source.enabled !== false };
   }
 
+  function normalizeSystemPrompt(value, fallback) {
+    const prompt = typeof value === 'string' ? value.trim() : '';
+    return prompt ? prompt.slice(0, MAX_SYSTEM_PROMPT_LENGTH) : fallback;
+  }
+
+  function normalizeAiSystemPrompts(value) {
+    const source = value && typeof value === 'object' ? value : {};
+    return Object.fromEntries(
+      Object.entries(DEFAULT_AI_SYSTEM_PROMPTS).map(([mode, fallback]) => [
+        mode,
+        normalizeSystemPrompt(source[mode], fallback),
+      ])
+    );
+  }
+
   function normalizeAppSettings(value) {
     const source = value && typeof value === 'object' ? value : {};
     return {
@@ -113,6 +135,7 @@
       snapping: normalizeSnapping(source.snapping),
       guidelines: normalizeGuidelines(source.guidelines),
       editorDefaults: normalizeEditorDefaults(source.editorDefaults),
+      aiSystemPrompts: normalizeAiSystemPrompts(source.aiSystemPrompts),
       customPresets: normalizeCustomPresets(source.customPresets),
     };
   }
@@ -171,11 +194,14 @@
     DEFAULT_FONT_FAMILY,
     DEFAULT_SHAPE_BORDER,
     DEFAULT_IMAGE_BORDER,
+    DEFAULT_AI_SYSTEM_PROMPTS,
+    MAX_SYSTEM_PROMPT_LENGTH,
     defaultAppSettings,
     normalizeGuidelines,
     normalizeBorder,
     normalizeEditorDefaults,
     normalizeSnapping,
+    normalizeAiSystemPrompts,
     normalizeCustomPresets,
     normalizeAppSettings,
     settingsEqual,

--- a/product/akbun-makepresentation/workspace/src/style.css
+++ b/product/akbun-makepresentation/workspace/src/style.css
@@ -949,6 +949,22 @@ main {
   margin: 4px 0 0;
 }
 
+.settings-ai-prompts {
+  display: grid;
+  gap: 7px;
+  margin-top: 16px;
+}
+
+.settings-ai-prompts label {
+  font-weight: 600;
+}
+
+.settings-ai-prompts textarea {
+  width: 100%;
+  min-height: 88px;
+  resize: vertical;
+}
+
 #props-hint {
   margin: 0;
   color: var(--muted);

--- a/product/akbun-makepresentation/workspace/test/ai.test.js
+++ b/product/akbun-makepresentation/workspace/test/ai.test.js
@@ -5,6 +5,22 @@ const assert = require('node:assert/strict');
 const L = require('../src/editor.js');
 const A = require('../src/ai.js');
 
+function assertStrictObjects(schema, path = 'schema') {
+  if (!schema || typeof schema !== 'object') return;
+  if (schema.type === 'object') {
+    const properties = Object.keys(schema.properties || {}).sort();
+    assert.equal(schema.additionalProperties, false, `${path} allows extra properties`);
+    assert.deepEqual([...(schema.required || [])].sort(), properties, `${path} has optional fields`);
+  }
+  for (const [name, child] of Object.entries(schema)) {
+    if (Array.isArray(child)) {
+      child.forEach((item, index) => assertStrictObjects(item, `${path}.${name}[${index}]`));
+    } else if (child && typeof child === 'object') {
+      assertStrictObjects(child, `${path}.${name}`);
+    }
+  }
+}
+
 test('session starts with the first user message and a compact title', () => {
   const session = A.createSession('session-1', '  Make   this title intentionally longer than forty eight characters please  ', 'slide');
   assert.equal(session.id, 'session-1');
@@ -37,6 +53,27 @@ test('text capacity reserves room for the stopped and readonly state', () => {
   assert.equal(A.canAppendText(available, 'answer'), true);
   assert.equal(A.canAppendText(available + 1, 'answer'), false);
   assert.equal(A.encodedJsonTextBytes('a\n"💡'), 9);
+});
+
+test('slide output schema makes every object field required', () => {
+  assertStrictObjects(A.SLIDE_OUTPUT_SCHEMA);
+});
+
+test('slide prompt explains nullable strict fields', () => {
+  const prompt = A.slidePrompt('Polish this slide.', L.createSlide(), { width: 1280, height: 720 }, 4);
+  assert.match(prompt, /unchanged field in changes to null/);
+  assert.match(prompt, /background to null unless/);
+});
+
+test('AI base instructions carry each configured system prompt', () => {
+  const instructions = A.baseInstructions({
+    text: 'Text rules',
+    image: 'Image rules',
+    slide: 'Slide rules',
+  });
+  assert.match(instructions, /<TEXT_MODE_SYSTEM_PROMPT>Text rules<\/TEXT_MODE_SYSTEM_PROMPT>/);
+  assert.match(instructions, /<IMAGE_MODE_SYSTEM_PROMPT>Image rules<\/IMAGE_MODE_SYSTEM_PROMPT>/);
+  assert.match(instructions, /<SLIDE_MODE_SYSTEM_PROMPT>Slide rules<\/SLIDE_MODE_SYSTEM_PROMPT>/);
 });
 
 test('slide patch changes a clone and preserves the source slide', () => {
@@ -87,4 +124,32 @@ test('slide patch rejects invalid indices and image additions', () => {
       shape: { kind: 'image', x: 0, y: 0, w: 10, h: 10 },
     }],
   }), 1), null);
+});
+
+test('null update fields mean unchanged in strict structured output', () => {
+  const source = L.createSlide();
+  const arrow = L.createShape('arrow', 10, 20, {});
+  arrow.w = 200;
+  arrow.h = 100;
+  arrow.arrowEnd = 'diamond';
+  source.shapes.push(arrow);
+
+  const changeSchema = A.SLIDE_OUTPUT_SCHEMA.properties.operations.items.anyOf[0]
+    .properties.changes;
+  const changes = Object.fromEntries(changeSchema.required.map((name) => [name, null]));
+  changes.x = 40;
+  const patch = A.parseSlidePatch(JSON.stringify({
+    summary: 'Moved the arrow.',
+    background: null,
+    operations: [{
+      op: 'update',
+      index: 0,
+      changes,
+    }],
+  }), 1);
+  const changed = A.applySlidePatch(source, patch);
+
+  assert.equal(changed.shapes[0].x, 40);
+  assert.equal(changed.shapes[0].arrowEnd, 'diamond');
+  assert.equal(changed.background, source.background);
 });

--- a/product/akbun-makepresentation/workspace/test/ai.test.js
+++ b/product/akbun-makepresentation/workspace/test/ai.test.js
@@ -62,7 +62,19 @@ test('slide output schema makes every object field required', () => {
 test('slide prompt explains nullable strict fields', () => {
   const prompt = A.slidePrompt('Polish this slide.', L.createSlide(), { width: 1280, height: 720 }, 4);
   assert.match(prompt, /unchanged field in changes to null/);
+  assert.match(prompt, /fields unused by the shape kind to null/);
   assert.match(prompt, /background to null unless/);
+});
+
+test('add shape schema keeps core geometry required and allows unused fields to be null', () => {
+  const shapeSchema = A.SLIDE_OUTPUT_SCHEMA.properties.operations.items.anyOf[2]
+    .properties.shape;
+  for (const name of ['kind', 'x', 'y', 'w', 'h']) {
+    assert.equal(shapeSchema.properties[name].anyOf, undefined);
+  }
+  for (const name of ['points', 'stroke', 'text', 'bold', 'arrowEnd']) {
+    assert.deepEqual(shapeSchema.properties[name].anyOf.at(-1), { type: 'null' });
+  }
 });
 
 test('AI base instructions carry each configured system prompt', () => {

--- a/product/akbun-makepresentation/workspace/test/settings.test.js
+++ b/product/akbun-makepresentation/workspace/test/settings.test.js
@@ -13,6 +13,7 @@ test('settings use the smaller guideline margins by default', () => {
     imageBorder: { color: '#000000', width: 2, dash: 'solid' },
   });
   assert.deepStrictEqual(settings.snapping, { enabled: true });
+  assert.deepStrictEqual(settings.aiSystemPrompts, S.DEFAULT_AI_SYSTEM_PROMPTS);
   assert.deepStrictEqual(settings.guidelines, {
     visible: false,
     unit: 'px',
@@ -47,6 +48,11 @@ test('settings normalize guidelines and custom presets', () => {
       shapeBorder: { color: '#ABCDEF', width: 3.5, dash: 'dot' },
       imageBorder: { color: 'bad', width: 0, dash: 'bad' },
     },
+    aiSystemPrompts: {
+      text: '  Custom text prompt  ',
+      image: '',
+      slide: 'Custom slide prompt',
+    },
     customPresets: [
       { id: 'rectangle', name: 'Rectangle', shapes: [shape] },
       { id: 'rectangle', name: 'Duplicate', shapes: [shape] },
@@ -68,6 +74,11 @@ test('settings normalize guidelines and custom presets', () => {
     shapeBorder: { color: '#abcdef', width: 3.5, dash: 'dot' },
     imageBorder: { color: '#000000', width: 2, dash: 'solid' },
   });
+  assert.deepStrictEqual(settings.aiSystemPrompts, {
+    text: 'Custom text prompt',
+    image: S.DEFAULT_AI_SYSTEM_PROMPTS.image,
+    slide: 'Custom slide prompt',
+  });
 });
 
 test('guideline margins must leave drawable slide space', () => {
@@ -87,18 +98,20 @@ test('guideline margins must leave drawable slide space', () => {
 
 test('settings comparison ignores object key order', () => {
   const left = {
-    version: 3,
+    version: S.SETTINGS_VERSION,
     snapping: { enabled: true },
     guidelines: { visible: false, unit: 'px', top: 36, bottom: 48, left: 48, right: 48 },
     editorDefaults: S.normalizeEditorDefaults(),
+    aiSystemPrompts: S.normalizeAiSystemPrompts(),
     customPresets: [],
   };
   const right = {
     customPresets: [],
     guidelines: { right: 48, left: 48, bottom: 48, top: 36, unit: 'px', visible: false },
     editorDefaults: S.normalizeEditorDefaults(),
+    aiSystemPrompts: S.normalizeAiSystemPrompts(),
     snapping: { enabled: true },
-    version: 3,
+    version: S.SETTINGS_VERSION,
   };
   assert.ok(S.settingsEqual(left, right));
   right.guidelines.top = 40;


### PR DESCRIPTION
# 구현

AI 슬라이드 strict schema 수정과 모드별 시스템 프롬프트 설정 추가
- JavaScript 107건, Rust 17건 통과와 AI.pptx 슬라이드 4 기반 생성 성공

# 어려웠던 점

중첩 변경 객체마다 strict schema의 전체 키 필수 조건 충족 필요
- 작업 유형별 anyOf 분리와 선택 값의 null 허용으로 스키마와 적용 로직 일치

# 리스크

사용자 시스템 프롬프트 내용에 따른 AI 결과 품질 편차
- 보안·개발자 지침은 고정하고 모드별 사용자 지침만 설정 대상으로 제한

Issue #968
Issue #969