### PR TITLE
Web search tool 실행 위치 비교 핸즈온 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@
 91. LLM 서빙 시스템 설계 Chapter 3 핸즈온 (26.8.15) - [링크](./computer_science/ai/study-llmserving/ch3/)
 92. 멀티턴 대화 핸즈온 (LLM API는 왜 잊는가, OpenAI/Claude 비교) (26.8.16) - [링크](./computer_science/ai/multi-turn-conversation/)
 93. Amazon Bedrock 모델 호출(Runtime, Mantle, Playground) (26.8.16) - [링크](./aws/bedrock/model-inference/)
+94. Web search tool 실행 위치 비교(Client, LiteLLM, Bedrock, vLLM) (26.8.17) - [링크](./computer_science/ai/web-search-tool/)
 
 ## 직접 만든 제품
 

--- a/computer_science/ai/web-search-tool/.dockerignore
+++ b/computer_science/ai/web-search-tool/.dockerignore
@@ -1,0 +1,8 @@
+.env
+.git
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__
+studysheet-*.html
+tests

--- a/computer_science/ai/web-search-tool/.env.example
+++ b/computer_science/ai/web-search-tool/.env.example
@@ -1,0 +1,17 @@
+LITELLM_MASTER_KEY=sk-local-web-search
+LITELLM_BASE_URL=http://litellm:4000/v1
+LITELLM_IMAGE=ghcr.io/berriai/litellm:main-latest
+UI_USERNAME=admin
+UI_PASSWORD=replace-with-ui-password
+POSTGRES_USER=litellm
+POSTGRES_PASSWORD=replace-with-database-password
+POSTGRES_DB=litellm
+VLLM_API_BASE=http://vllm:8000/v1
+VLLM_API_KEY=replace-with-generated-value
+VLLM_MODEL=Qwen/Qwen2.5-1.5B-Instruct
+VLLM_IMAGE=vllm/vllm-openai-cpu:latest
+VLLM_CPU_KVCACHE_SPACE=2
+VLLM_CPU_NUM_OF_RESERVED_CPU=1
+SEARXNG_URL=http://searxng:8080
+AWS_REGION=us-east-1
+AWS_PROFILE=default

--- a/computer_science/ai/web-search-tool/.gitignore
+++ b/computer_science/ai/web-search-tool/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv/
+__pycache__/
+.pytest_cache/
+.ruff_cache/

--- a/computer_science/ai/web-search-tool/Dockerfile
+++ b/computer_science/ai/web-search-tool/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+
+WORKDIR /workspace
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY . .
+
+ENV PATH="/workspace/.venv/bin:${PATH}"

--- a/computer_science/ai/web-search-tool/Makefile
+++ b/computer_science/ai/web-search-tool/Makefile
@@ -1,0 +1,23 @@
+.PHONY: up up-vllm up-aws-login down provider-bedrock test check
+
+up:
+	docker compose --progress quiet up -d searxng litellm
+
+up-vllm:
+	docker compose --progress quiet up -d vllm
+
+up-aws-login:
+	docker compose -f compose.yaml -f compose.aws-login.yaml --progress quiet up -d --build --force-recreate vllm litellm
+
+down:
+	docker compose --profile cpu --profile client --profile bedrock down -v
+
+provider-bedrock:
+	docker compose -f compose.yaml -f compose.aws-login.yaml --profile bedrock run --rm bedrock-provider-search
+
+test:
+	uv run pytest
+
+check:
+	uv run ruff check .
+	uv run ruff format --check .

--- a/computer_science/ai/web-search-tool/README.md
+++ b/computer_science/ai/web-search-tool/README.md
@@ -1,0 +1,74 @@
+# Web search tool 실행 위치 비교 핸즈온
+
+`client → LiteLLM → AI provider` 경로에서 web search 실행 책임을 어디에 둘지 비교한다. Client·LiteLLM뿐 아니라 Bedrock 또는 vLLM이 검색과 최종 답변 조립까지 담당하는 흐름을 확인한다.
+
+`tool call`은 검색 실행이 아니다. 모델은 함수 이름과 인자를 만들고, client·gateway·provider의 server-side runtime 중 하나가 실제 검색을 실행해야 한다.
+
+## 학습지
+
+[studysheet-web-search-tool-v1.html](studysheet-web-search-tool-v1.html)에서 요청 흐름, 책임 경계, 선택 기준을 먼저 확인한다.
+
+## 시나리오 비교
+
+| 시나리오 | 모델 경로 | 검색 실행 | 장점 | 비용·트레이드오프 |
+| --- | --- | --- | --- | --- |
+| Client 소유 | client → LiteLLM → Qwen 또는 Bedrock | client → SearXNG | 같은 client 로직으로 provider 교체, gateway가 트래픽 관리에 집중 | client마다 loop·timeout·citation 검증 중복 |
+| LiteLLM 소유 | client → LiteLLM → vLLM | LiteLLM interceptor → SearXNG | thin client, 검색 정책과 key 중앙화 | gateway가 agent runtime이 됨, 장애 범위·지연·디버깅 복잡도 증가 |
+| Bedrock 소유 | client → LiteLLM → Nova 2 Lite | Nova Web Grounding | Client가 최종 응답만 받음, 검색 인프라 불필요 | 지원 모델·region·IAM 권한에 종속 |
+| vLLM 소유 | client → LiteLLM → vLLM/Qwen | vLLM Tool Server → SearXNG MCP | 로컬 검색 backend를 유지하면서 Client는 thin하게 구성 | non-Harmony MCP가 실험적이고 serving 구성이 복잡함 |
+
+기본 선택은 **client 소유**다. LiteLLM은 routing·auth·quota·logging 같은 트래픽 책임만 맡긴다. 여러 client가 같은 검색 정책과 자격증명을 공유해야 할 때만 LiteLLM interception을 선택한다.
+
+## 문서
+
+문서는 실행 순서대로 한 디렉터리에 모았다.
+
+1. [개념과 책임 경계](docs/1-concept.md)
+2. [공통 환경 준비](docs/2-setup.md)
+3. [Web search 실행 주체가 없는 기준선](docs/3-no-tool-runtime-hands-on.md)
+4. [Client가 web search 실행](docs/4-client-hands-on.md)
+5. [LiteLLM이 web search 실행](docs/5-litellm-hands-on.md)
+6. [Bedrock이 web search 실행](docs/6-bedrock-hands-on.md)
+7. [vLLM이 web search 실행](docs/7-vllm-hands-on.md)
+
+## 코드 디렉터리
+
+| 디렉터리 | 내용 |
+| --- | --- |
+| [client/](client/) | OpenAI SDK로 LiteLLM을 호출하고 tool loop 실행 |
+| [litellm/](litellm/) | web search interception으로 gateway가 loop 실행 |
+| [ai-provider/](ai-provider/) | Bedrock Web Grounding과 vLLM server-side tool 실행 |
+
+## vLLM을 두 번 확인하는 이유
+
+두 시나리오는 같은 `Qwen/Qwen2.5-1.5B-Instruct`와 같은 SearXNG를 쓴다. 바뀌는 것은 검색 실행 위치뿐이다.
+
+1. [Client hands-on](docs/4-client-hands-on.md): vLLM이 `web_search` 호출을 생성하고 client가 실행
+2. [LiteLLM hands-on](docs/5-litellm-hands-on.md): vLLM이 `litellm_web_search` 호출을 생성하고 LiteLLM이 실행
+
+## 로컬 구성
+
+- LiteLLM: `ghcr.io/berriai/litellm:main-latest`
+- Search: self-hosted SearXNG JSON API
+- Local model: vLLM CPU + Qwen2.5 1.5B Instruct, macOS Docker Desktop
+- Bedrock model: Client/LiteLLM 실행은 Nova Micro, provider 실행은 `us.amazon.nova-2-lite-v1:0`
+
+`main-latest`와 `latest`는 실습 시점의 최신 동작을 확인하기 위한 선택이다. 운영에서는 검증한 digest로 고정해야 한다.
+
+## 검증 상태
+
+- Python unit test와 Ruff 검사 통과
+- Docker Compose config 렌더링 확인
+- HTML 학습지 내비게이션과 좁은 화면 확인
+- Qwen과 Bedrock을 LiteLLM 뒤의 같은 Client Tool loop로 실행 확인
+- Nova Web Grounding과 vLLM MCP server-side tool 경로 실행 확인
+
+## 참고자료
+
+- [LiteLLM Web Search Integration](https://docs.litellm.ai/docs/integrations/websearch_interception)
+- [LiteLLM Search API](https://docs.litellm.ai/docs/search)
+- [vLLM Tool Calling](https://docs.vllm.ai/en/stable/features/tool_calling/)
+- [Amazon Bedrock tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html)
+- [Amazon Nova 2 Web Grounding](https://docs.aws.amazon.com/nova/latest/nova2-userguide/web-grounding.html)
+- [Amazon Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
+- [Amazon Bedrock AgentCore Web Search](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-target-connector-web-search-tool.html)

--- a/computer_science/ai/web-search-tool/ai-provider/README.md
+++ b/computer_science/ai/web-search-tool/ai-provider/README.md
@@ -1,0 +1,1 @@
+Bedrock Nova Web Grounding과 vLLM Tool Server가 web search를 직접 실행하는 흐름을 확인하는 코드다.

--- a/computer_science/ai/web-search-tool/ai-provider/bedrock/app.py
+++ b/computer_science/ai/web-search-tool/ai-provider/bedrock/app.py
@@ -1,0 +1,45 @@
+"""Call Bedrock Nova Web Grounding through LiteLLM."""
+
+import os
+
+from openai import OpenAI
+
+
+def request_search(client: OpenAI, question: str):
+  return client.chat.completions.create(
+    model="bedrock-provider-search",
+    messages=[{"role": "user", "content": question}],
+    web_search_options={},
+  )
+
+
+def citation_urls(message) -> list[str]:
+  fields = message.provider_specific_fields or {}
+  citations = fields.get("citationsContent", [])
+  return [
+    citation["location"]["web"]["url"]
+    for content in citations
+    for citation in content.get("citations", [])
+    if citation.get("location", {}).get("web", {}).get("url")
+  ]
+
+
+def main() -> None:
+  client = OpenAI(
+    base_url=os.getenv("LITELLM_BASE_URL", "http://localhost:4000/v1"),
+    api_key=os.getenv("LITELLM_MASTER_KEY", "sk-local-web-search"),
+  )
+  response = request_search(
+    client,
+    os.getenv("QUESTION", "오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요."),
+  )
+  message = response.choices[0].message
+  print(message.content)
+  urls = citation_urls(message)
+  if urls:
+    print("\nSources:")
+    print("\n".join(f"- {url}" for url in urls))
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/web-search-tool/ai-provider/vllm/Dockerfile
+++ b/computer_science/ai/web-search-tool/ai-provider/vllm/Dockerfile
@@ -1,0 +1,4 @@
+ARG VLLM_BASE_IMAGE=vllm/vllm-openai-cpu:latest
+FROM ${VLLM_BASE_IMAGE}
+
+RUN /opt/venv/bin/python -m pip install --no-cache-dir "mcp>=1.29,<2"

--- a/computer_science/ai/web-search-tool/ai-provider/vllm/app.py
+++ b/computer_science/ai/web-search-tool/ai-provider/vllm/app.py
@@ -1,0 +1,47 @@
+"""Call vLLM server-side web search through LiteLLM."""
+
+import os
+
+from openai import OpenAI
+
+
+def request_search(client: OpenAI, question: str):
+  return client.responses.create(
+    model="vllm-provider-search",
+    input=question,
+    instructions=(
+      "Call web_search_preview exactly once before answering. "
+      "After the tool result arrives, do not call a tool again; answer with source URLs."
+    ),
+    tools=[
+      {"type": "web_search_preview"},
+      {
+        "type": "function",
+        "name": "web_search_preview",
+        "description": "Search the public web for current information.",
+        "parameters": {
+          "type": "object",
+          "properties": {"query": {"type": "string"}},
+          "required": ["query"],
+        },
+      },
+    ],
+    tool_choice="auto",
+    temperature=0,
+  )
+
+
+def main() -> None:
+  client = OpenAI(
+    base_url=os.getenv("LITELLM_BASE_URL", "http://localhost:4000/v1"),
+    api_key=os.getenv("LITELLM_MASTER_KEY", "sk-local-web-search"),
+  )
+  response = request_search(
+    client,
+    os.getenv("QUESTION", "오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요."),
+  )
+  print(response.output_text)
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/web-search-tool/ai-provider/vllm/mcp_server.py
+++ b/computer_science/ai/web-search-tool/ai-provider/vllm/mcp_server.py
@@ -1,0 +1,39 @@
+"""Expose SearXNG as vLLM's server-side browser tool."""
+
+import os
+
+import httpx
+from fastmcp import FastMCP
+
+mcp = FastMCP(
+  "browser",
+  instructions="Search the public web and return titles, URLs, and snippets.",
+)
+
+
+@mcp.tool
+async def search(query: str) -> dict:
+  """Search the public web for current information."""
+  print(f"search query={query!r}", flush=True)
+  async with httpx.AsyncClient(timeout=20) as client:
+    response = await client.get(
+      f"{os.getenv('SEARXNG_URL', 'http://searxng:8080').rstrip('/')}/search",
+      params={"q": query, "format": "json"},
+    )
+    response.raise_for_status()
+  results = response.json().get("results", [])[:5]
+  return {
+    "query": query,
+    "results": [
+      {
+        "title": result.get("title", ""),
+        "url": result.get("url", ""),
+        "snippet": result.get("content", ""),
+      }
+      for result in results
+    ],
+  }
+
+
+if __name__ == "__main__":
+  mcp.run(transport="sse", host="0.0.0.0", port=8888, show_banner=False)

--- a/computer_science/ai/web-search-tool/client/README.md
+++ b/computer_science/ai/web-search-tool/client/README.md
@@ -1,0 +1,1 @@
+OpenAI 호환 Client가 LiteLLM을 통해 Qwen과 Bedrock을 호출하고 web search Tool loop를 직접 실행하는 코드다.

--- a/computer_science/ai/web-search-tool/client/app.py
+++ b/computer_science/ai/web-search-tool/client/app.py
@@ -1,0 +1,106 @@
+"""Run a client-owned web-search tool loop through LiteLLM."""
+
+import argparse
+import json
+import os
+
+from openai import OpenAI
+
+from web_search import search_web
+
+MODEL_GROUPS = {
+  "qwen": "local-tool-model",
+  "bedrock": "bedrock-nova-micro",
+}
+MAX_TOOL_ROUNDS = 3
+
+WEB_SEARCH_TOOL = {
+  "type": "function",
+  "function": {
+    "name": "web_search",
+    "description": "Search the public web for current information and source URLs.",
+    "strict": True,
+    "parameters": {
+      "type": "object",
+      "properties": {"query": {"type": "string"}},
+      "required": ["query"],
+      "additionalProperties": False,
+    },
+  },
+}
+
+
+def create_client() -> OpenAI:
+  """Create an OpenAI-compatible client pointed at LiteLLM."""
+  return OpenAI(
+    base_url=os.getenv("LITELLM_BASE_URL", "http://localhost:4000/v1"),
+    api_key=os.getenv("LITELLM_MASTER_KEY", "sk-local-web-search"),
+  )
+
+
+def parse_model_argument() -> str:
+  """Map a user-facing model name to a LiteLLM model group."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--model", choices=MODEL_GROUPS, default="qwen")
+  arguments = parser.parse_args()
+  return MODEL_GROUPS[arguments.model]
+
+
+def request_search(client: OpenAI, model: str, messages):
+  """Ask the model to emit one structured web-search request."""
+  return client.chat.completions.create(
+    model=model,
+    messages=messages,
+    tools=[WEB_SEARCH_TOOL],
+    tool_choice={"type": "function", "function": {"name": "web_search"}},
+  )
+
+
+def request_answer(client: OpenAI, model: str, messages):
+  """Continue the conversation after client-executed tool results."""
+  return client.chat.completions.create(model=model, messages=messages, tools=[WEB_SEARCH_TOOL])
+
+
+def append_tool_results(messages, assistant_message, search_url: str) -> None:
+  """Execute every requested web search and append its result messages."""
+  messages.append(assistant_message.model_dump(exclude_none=True))
+  for tool_call in assistant_message.tool_calls:
+    if tool_call.function.name != "web_search":
+      raise ValueError(f"Unsupported tool: {tool_call.function.name}")
+    query = json.loads(tool_call.function.arguments)["query"]
+    results = search_web(query, search_url)
+    messages.append(
+      {
+        "role": "tool",
+        "tool_call_id": tool_call.id,
+        "content": json.dumps(results, ensure_ascii=False),
+      }
+    )
+
+
+def main() -> None:
+  """Execute the client-owned search scenario."""
+  client = create_client()
+  model = parse_model_argument()
+  question = os.getenv(
+    "QUESTION", "오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요."
+  )
+  search_url = os.getenv("SEARXNG_URL", "http://localhost:8080")
+  messages = [{"role": "user", "content": question}]
+  response = request_search(client, model, messages)
+
+  for tool_round in range(MAX_TOOL_ROUNDS + 1):
+    assistant_message = response.choices[0].message
+    if not assistant_message.tool_calls:
+      print(assistant_message.content)
+      return
+    if tool_round == MAX_TOOL_ROUNDS:
+      break
+    append_tool_results(messages, assistant_message, search_url)
+    response = request_answer(client, model, messages)
+
+  raise RuntimeError(f"Tool loop exceeded {MAX_TOOL_ROUNDS} rounds")
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/web-search-tool/compose.aws-login.yaml
+++ b/computer_science/ai/web-search-tool/compose.aws-login.yaml
@@ -1,0 +1,8 @@
+services:
+  litellm:
+    environment:
+      AWS_PROFILE: ${AWS_PROFILE:-default}
+      AWS_SDK_LOAD_CONFIG: "1"
+    volumes:
+      - ${HOME}/.aws/config:/root/.aws/config:ro
+      - ${HOME}/.aws/login/cache:/root/.aws/login/cache

--- a/computer_science/ai/web-search-tool/compose.yaml
+++ b/computer_science/ai/web-search-tool/compose.yaml
@@ -1,0 +1,178 @@
+services:
+  searxng:
+    image: searxng/searxng:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+    environment:
+      SEARXNG_BASE_URL: http://localhost:8080/
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/config"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-litellm}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-litellm-local-db-password}
+      POSTGRES_DB: ${POSTGRES_DB:-litellm}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  litellm:
+    build:
+      context: .
+      dockerfile: litellm/Dockerfile
+      args:
+        LITELLM_BASE_IMAGE: ${LITELLM_IMAGE:-ghcr.io/berriai/litellm:main-latest}
+    image: web-search-tool-litellm:local
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./litellm/config.yaml:/app/config.yaml:ro
+    environment:
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-local-web-search}
+      UI_USERNAME: ${UI_USERNAME:-admin}
+      UI_PASSWORD: ${UI_PASSWORD:-sk-local-web-search}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-litellm}:${POSTGRES_PASSWORD:-litellm-local-db-password}@postgres:5432/${POSTGRES_DB:-litellm}
+      VLLM_API_BASE: ${VLLM_API_BASE:-http://vllm:8000/v1}
+      VLLM_API_KEY: ${VLLM_API_KEY:-local-vllm-key}
+      VLLM_MODEL: ${VLLM_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}
+      SEARXNG_URL: http://searxng:8080
+      AWS_REGION: ${AWS_REGION:-us-east-1}
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness', timeout=3)
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 20s
+    depends_on:
+      postgres:
+        condition: service_healthy
+      searxng:
+        condition: service_healthy
+
+  client-search:
+    profiles: ["client"]
+    build: .
+    entrypoint: ["python", "-m", "client.app"]
+    command: ["--model", "qwen"]
+    environment:
+      LITELLM_BASE_URL: http://litellm:4000/v1
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-local-web-search}
+      SEARXNG_URL: http://searxng:8080
+      QUESTION: ${QUESTION:-오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요.}
+    depends_on:
+      litellm:
+        condition: service_healthy
+
+  gateway-search:
+    profiles: ["client"]
+    build: .
+    entrypoint: ["python", "litellm/app.py"]
+    command: ["--model", "qwen"]
+    environment:
+      LITELLM_BASE_URL: http://litellm:4000/v1
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-local-web-search}
+      QUESTION: ${QUESTION:-오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요.}
+    depends_on:
+      litellm:
+        condition: service_healthy
+
+  bedrock-provider-search:
+    profiles: ["bedrock"]
+    build: .
+    command: ["python", "ai-provider/bedrock/app.py"]
+    environment:
+      LITELLM_BASE_URL: http://litellm:4000/v1
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-local-web-search}
+      QUESTION: ${QUESTION:-오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요.}
+    depends_on:
+      litellm:
+        condition: service_healthy
+
+  vllm-provider-search:
+    profiles: ["client"]
+    build: .
+    command: ["python", "ai-provider/vllm/app.py"]
+    environment:
+      LITELLM_BASE_URL: http://litellm:4000/v1
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-local-web-search}
+      QUESTION: ${QUESTION:-오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요.}
+    depends_on:
+      litellm:
+        condition: service_healthy
+
+  searxng-mcp:
+    profiles: ["cpu"]
+    build: .
+    command: ["python", "ai-provider/vllm/mcp_server.py"]
+    environment:
+      SEARXNG_URL: http://searxng:8080
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import socket; connection = socket.create_connection(('localhost', 8888), 3); connection.close()
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    depends_on:
+      searxng:
+        condition: service_healthy
+
+  vllm:
+    profiles: ["cpu"]
+    build:
+      context: .
+      dockerfile: ai-provider/vllm/Dockerfile
+      args:
+        VLLM_BASE_IMAGE: ${VLLM_IMAGE:-vllm/vllm-openai-cpu:latest}
+    image: web-search-tool-vllm:local
+    environment:
+      VLLM_API_KEY: ${VLLM_API_KEY:-local-vllm-key}
+      VLLM_CPU_KVCACHE_SPACE: ${VLLM_CPU_KVCACHE_SPACE:-2}
+      VLLM_CPU_NUM_OF_RESERVED_CPU: ${VLLM_CPU_NUM_OF_RESERVED_CPU:-1}
+      VLLM_ENABLE_RESPONSES_API_STORE: "1"
+      VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT: "1"
+    command:
+      - ${VLLM_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - hermes
+      - --dtype
+      - float16
+      - --max-model-len
+      - "4096"
+      - --tool-server
+      - searxng-mcp:8888
+    ports:
+      - "8000:8000"
+    shm_size: 4gb
+    cap_add:
+      - SYS_NICE
+    security_opt:
+      - seccomp=unconfined
+    volumes:
+      - huggingface-cache:/root/.cache/huggingface
+    depends_on:
+      searxng-mcp:
+        condition: service_healthy
+
+volumes:
+  huggingface-cache:
+  postgres-data:

--- a/computer_science/ai/web-search-tool/docs/1-concept.md
+++ b/computer_science/ai/web-search-tool/docs/1-concept.md
@@ -1,0 +1,148 @@
+# Web search tool 실행 책임
+
+`tool call`은 검색 실행이 아니다. 모델은 함수 이름과 인자를 만들고, client·gateway·provider adapter 중 하나가 실제 검색을 실행한다.
+
+## 실습 구성요소
+
+### SearXNG
+
+- 실제 web 검색을 수행하는 self-hosted search backend다.
+- Client 또는 LiteLLM이 HTTP JSON API로 호출한다.
+- 여러 검색 engine의 결과를 공통 형식으로 제공한다.
+- AI 모델이나 tool 실행 여부를 결정하는 agent가 아니다.
+- 모델에는 검색 결과의 title·URL·snippet만 전달한다.
+
+### AI 모델
+
+- vLLM: `Qwen/Qwen2.5-1.5B-Instruct`
+- Bedrock: `amazon.nova-micro-v1:0`
+
+두 vLLM 시나리오는 같은 Qwen 모델을 사용한다. 검색 실행 위치만 Client와 LiteLLM으로 달라진다.
+
+## Client가 실행
+
+Client는 OpenAI Chat Completions 요청에서 구조화된 함수 호출을 받고 SearXNG를 실행한 뒤, tool 결과를 담아 두 번째 요청을 보낸다.
+
+- LiteLLM은 인증·라우팅·quota·usage 기록에 집중한다.
+- 검색 장애가 gateway 전체 장애로 확산되지 않는다.
+- Client마다 tool round·timeout·검색 정책을 구현해야 한다.
+- 결과 절단·prompt injection 방어·citation 검증도 client 책임이다.
+
+기본 선택은 client 실행이다. 여러 client가 동일한 정책을 공유해야 할 때만 실행 위치를 gateway로 옮긴다.
+
+### 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Client
+  participant LiteLLM
+  participant vLLM as "vLLM (Qwen2.5)"
+  participant SearXNG
+
+  User->>Client: 질문
+  Client->>LiteLLM: Chat Completions + web_search 정의
+  LiteLLM->>vLLM: 첫 번째 completion
+  vLLM-->>LiteLLM: tool_calls(query)
+  LiteLLM-->>Client: tool_calls(query)
+  Client->>SearXNG: GET /search?format=json
+  SearXNG-->>Client: title, URL, snippet
+  Client->>LiteLLM: tool 결과를 포함한 두 번째 요청
+  LiteLLM->>vLLM: 두 번째 completion
+  vLLM-->>LiteLLM: 최종 답변
+  LiteLLM-->>Client: 최종 답변
+  Client-->>User: 답변과 출처
+```
+
+## LiteLLM이 실행
+
+Web search interception은 LiteLLM을 request router에서 작은 agent runtime으로 확장한다. LiteLLM이 `litellm_web_search`를 감지하고 검색과 후속 completion을 실행한다.
+
+- Client는 OpenAI 호환 요청 한 번만 보낸다.
+- 검색 자격증명과 정책을 중앙화할 수 있다.
+- 검색 latency·retry·실패 처리가 gateway 책임이 된다.
+- 검색 장애가 정상적인 모델 요청에도 영향을 줄 수 있다.
+
+LiteLLM의 `/v1/search/{search_tool_name}`는 검색 API만 정규화한다. Interception은 모델 판단, 검색, 후속 completion까지 포함한다.
+
+SearXNG는 LiteLLM의 `max_results`를 따르지 않는다. Gateway가 실행할 때는 검색 결과 크기를 별도로 제한해야 한다.
+
+### 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Client as "Thin client"
+  participant LiteLLM as "LiteLLM interceptor"
+  participant vLLM as "vLLM (Qwen2.5)"
+  participant SearXNG
+
+  User->>Client: 질문
+  Client->>LiteLLM: Chat Completions 한 번
+  LiteLLM->>vLLM: 첫 번째 completion
+  vLLM-->>LiteLLM: litellm_web_search(query)
+  LiteLLM->>SearXNG: GET /search?format=json
+  SearXNG-->>LiteLLM: title, URL, snippet
+  LiteLLM->>vLLM: 검색 결과를 포함한 두 번째 completion
+  vLLM-->>LiteLLM: 최종 답변
+  LiteLLM-->>Client: 최종 답변 하나
+  Client-->>User: 답변과 출처
+```
+
+## AI provider가 tool call 생성
+
+vLLM과 Bedrock Converse는 구조화된 tool call을 생성한다. 모델 프로세스가 임의의 web request를 직접 수행한다는 의미는 아니다.
+
+### vLLM
+
+- 모델 출력을 OpenAI `tool_calls` 형식으로 변환한다.
+- Named tool choice는 schema 형태를 강제한다.
+- Automatic choice는 `--enable-auto-tool-choice`와 모델별 parser가 필요하다.
+- Qwen2.5 실습은 Hermes parser를 사용한다.
+- 이 실습의 Chat Completions custom tool은 정의·실행·결과 추가·최종 요청이 caller 책임이다.
+- vLLM은 Responses API와 `--tool-server`를 조합하면 serving runtime에서 등록된 tool을 실행할 수도 있다.
+- Tool server는 기본으로 활성화되지 않으며 이 실습에서도 사용하지 않는다.
+
+### Bedrock Converse
+
+- Application이 tool definition을 보낸다.
+- 모델은 `toolUse`를 반환한다.
+- Application이 검색 후 `toolResult`를 보낸다.
+- Server-side tool 실행은 일부 Responses API 모델과 AgentCore Gateway 또는 Lambda가 필요하다.
+
+Amazon Nova Micro는 AWS 모델이므로 Anthropic first-time use form이나 third-party Marketplace 구독 없이 Converse tool use를 확인하기 적합하다.
+
+이 실습에서 AI provider가 검색을 직접 실행하지 않는다. Application adapter가 Bedrock의 `toolUse`를 받아 SearXNG를 호출한다.
+
+#### 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant App as "Application adapter"
+  participant Bedrock as "Bedrock Converse (Nova Micro)"
+  participant SearXNG
+
+  User->>App: 질문
+  App->>Bedrock: Converse + toolConfig
+  Bedrock-->>App: toolUse(query)
+  App->>SearXNG: GET /search?format=json
+  SearXNG-->>App: title, URL, snippet
+  App->>Bedrock: toolResult를 포함한 Converse
+  Bedrock-->>App: 최종 답변
+  App-->>User: 답변과 출처
+```
+
+## 참고자료
+
+- [LiteLLM Web Search Integration](https://docs.litellm.ai/docs/integrations/websearch_interception)
+- [LiteLLM Search API](https://docs.litellm.ai/docs/search)
+- [LiteLLM SearXNG provider](https://docs.litellm.ai/docs/search/searxng)
+- [vLLM tool calling](https://docs.vllm.ai/en/stable/features/tool_calling/)
+- [vLLM tool server와 MCP 보안](https://docs.vllm.ai/en/latest/usage/security/#tool-server-and-mcp-security)
+- [Bedrock tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html)
+- [Bedrock server-side tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-server-side.html)
+- [Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)

--- a/computer_science/ai/web-search-tool/docs/2-setup.md
+++ b/computer_science/ai/web-search-tool/docs/2-setup.md
@@ -1,0 +1,355 @@
+# 실습 환경 준비
+
+실습 명령은 `web-search-tool` 디렉터리에서 실행한다. 모든 container를 동시에 시작하지 않고 시나리오에 필요한 service만 선택한다.
+
+이 문서의 detached 실행 명령은 `--progress quiet`로 Docker Compose progress UI를 표시하지 않는다. Progress의 `Starting` 표시는 실제 container 상태와 다르게 남을 수 있으므로 `docker compose ps`와 service log 또는 API로 준비 상태를 확인한다.
+
+## 1. Docker Compose container와 역할
+
+| Container | 실행 형태 | 역할 | 기본 port |
+| --- | --- | --- | --- |
+| `searxng` | 상시 service | 실제 web 검색을 실행하고 JSON 결과 제공 | `8080` |
+| `searxng-mcp` | `cpu` profile의 상시 service | SearXNG를 vLLM Tool Server용 MCP browser로 제공 | `8888` |
+| `vllm` | `cpu` profile의 상시 service | CPU Qwen 추론과 선택적인 server-side tool loop 실행 | `8000` |
+| `postgres` | 상시 service | LiteLLM Admin UI 사용자와 gateway 관리 데이터 저장 | 없음 |
+| `litellm` | 상시 service | 인증·model routing·usage 기록, 선택적으로 web search interception 실행 | `4000` |
+| `client-search` | `client` profile의 일회성 job | Client-owned tool loop 실행 | 없음 |
+| `gateway-search` | `client` profile의 일회성 job | 검색 코드가 없는 thin client 실행 | 없음 |
+| `bedrock-provider-search` | `bedrock` profile의 일회성 job | LiteLLM을 거쳐 Bedrock Web Grounding 최종 응답 확인 | 없음 |
+| `vllm-provider-search` | `client` profile의 일회성 job | LiteLLM을 거쳐 vLLM server-side search 최종 응답 확인 | 없음 |
+
+`Amazon Bedrock`과 Nova Web Grounding은 Docker Compose container가 아니다. LiteLLM이 AWS HTTPS endpoint를 호출한다.
+
+## 2. 호출 관계
+
+```mermaid
+flowchart LR
+  subgraph Compose["Docker Compose"]
+    ClientSearch["client-search<br/>Client tool loop"]
+    GatewaySearch["gateway-search<br/>Thin client"]
+    BedrockJob["bedrock-provider-search<br/>Thin client"]
+    vLLMJob["vllm-provider-search<br/>Thin client"]
+    LiteLLM["litellm<br/>LLM gateway"]
+    PostgreSQL["postgres<br/>Admin UI data"]
+    vLLM["vllm<br/>Qwen2.5 inference"]
+    MCP["searxng-mcp<br/>MCP browser"]
+    SearXNG["searxng<br/>Web search JSON API"]
+  end
+
+  Bedrock["Amazon Bedrock<br/>Nova Micro / Nova 2 Lite"]
+  Grounding["Nova Web Grounding"]
+
+  ClientSearch -->|"OpenAI Chat Completions"| LiteLLM
+  ClientSearch -->|"HTTP GET /search"| SearXNG
+  GatewaySearch -->|"OpenAI Chat Completions"| LiteLLM
+  LiteLLM -->|"Bearer VLLM_API_KEY"| vLLM
+  LiteLLM -->|"Bedrock model group<br/>AWS SigV4"| Bedrock
+  LiteLLM -->|"DATABASE_URL"| PostgreSQL
+  LiteLLM -->|"HTTP GET /search<br/>interception 시나리오"| SearXNG
+  BedrockJob -->|"Chat Completions"| LiteLLM
+  vLLMJob -->|"Responses API"| LiteLLM
+  vLLM -->|"server-side tool"| MCP
+  MCP -->|"HTTP GET /search"| SearXNG
+  Bedrock -->|"provider-side search"| Grounding
+```
+
+### 2.1 Client 실행 시나리오
+
+1. `client-search`가 LiteLLM의 `/v1/chat/completions`를 호출한다.
+2. LiteLLM이 model group에 따라 vLLM/Qwen 또는 Bedrock/Nova Micro를 호출한다.
+3. 선택한 AI model이 `web_search` tool call을 반환한다.
+4. `client-search`가 SearXNG의 `/search?format=json`을 호출한다.
+5. 검색 결과를 같은 model 경로로 전달하고 최종 답변까지 Tool loop를 반복한다.
+
+### 2.2 LiteLLM 실행 시나리오
+
+1. `gateway-search`가 LiteLLM에 OpenAI 호환 요청 한 번을 보낸다.
+2. LiteLLM이 vLLM의 `litellm_web_search` tool call을 감지한다.
+3. LiteLLM interceptor가 SearXNG를 호출한다.
+4. LiteLLM이 검색 결과를 넣어 vLLM을 다시 호출한다.
+5. `gateway-search`는 최종 응답 하나만 받는다.
+
+### 2.3 Bedrock이 검색을 실행하는 시나리오
+
+1. `bedrock-provider-search`가 LiteLLM에 `web_search_options` 요청을 한 번 보낸다.
+2. LiteLLM adapter가 요청을 Nova 2 Lite의 `nova_grounding` system tool로 변환한다.
+3. Bedrock이 web search와 재추론을 실행한다.
+4. Client는 provider trace를 실행하지 않고 최종 답변과 citation을 사용한다.
+
+### 2.4 vLLM이 검색을 실행하는 시나리오
+
+1. `vllm-provider-search`가 LiteLLM Responses API에 요청을 한 번 보낸다.
+2. LiteLLM이 요청을 `vllm-provider-search` model group으로 routing한다.
+3. vLLM Tool Server가 `searxng-mcp`를 호출하고 검색 결과를 Qwen에 다시 전달한다.
+4. Client는 vLLM 내부 tool loop에 참여하지 않고 최종 답변을 사용한다.
+
+## 3. 환경별 지원 범위
+
+| 환경 | SearXNG | LiteLLM | vLLM container | Bedrock |
+| --- | --- | --- | --- | --- |
+| macOS Intel | 지원 | 지원 | 지원, CPU | 지원 |
+| macOS Apple Silicon | 지원 | 지원 | 지원, CPU | 지원 |
+| Linux | 지원 | 지원 | 지원, CPU | 지원 |
+
+SearXNG 공식 image는 `linux/amd64`와 `linux/arm64`를 제공한다. macOS에서는 Docker Desktop의 Linux VM 안에서 실행된다.
+
+이 실습의 기본 환경은 GPU가 없는 macOS와 Docker Desktop이다. `vllm/vllm-openai-cpu:latest` multi-architecture image가 Mac CPU에 맞는 Linux image를 자동으로 선택한다.
+
+- Apple Silicon: `linux/arm64`
+- Intel Mac: `linux/amd64`
+
+Docker container는 macOS native vLLM이 아니라 Docker Desktop Linux VM에서 CPU inference를 실행한다. CPU 응답은 GPU보다 느리므로 정확도와 tool-call 흐름 확인에만 사용한다.
+
+### 3.1 jq 설치
+
+실습의 JSON 응답은 `jq`로 필요한 필드를 확인한다. macOS에 `jq`가 없다면 Homebrew로 설치한다.
+
+```bash
+brew install jq
+jq --version
+```
+
+## 4. SearXNG 실행
+
+Docker Desktop 또는 Docker Engine을 실행한 뒤 SearXNG만 시작한다.
+
+```bash
+docker compose --progress quiet up -d searxng
+```
+
+설정과 JSON 검색을 확인한다.
+
+```bash
+curl -sS http://localhost:8080/config \
+  | jq .
+
+curl -sS -G http://localhost:8080/search \
+  --data-urlencode "q=오늘 날짜 서울 날씨" \
+  --data-urlencode "format=json" \
+  | jq '{
+      query,
+      results: [.results[:3][] | {title, url, content}]
+    }'
+```
+
+`searxng/settings.yml`은 로컬 실습을 위해 JSON 응답을 허용하고 limiter를 끈다. 외부에 공개하는 설정으로 사용하지 않는다.
+
+## 5. vLLM 실행
+
+LiteLLM보다 먼저 macOS Docker Desktop에서 CPU vLLM을 시작하고 model load와 API 인증을 확인한다.
+
+### 5.1 배경지식
+
+- vLLM은 모델 자체가 아니라 model inference server다.
+- `Qwen/Qwen2.5-1.5B-Instruct`를 load한다.
+- 이 실습은 CUDA나 Metal 가속을 사용하지 않는다.
+- Docker Desktop Linux VM 안에서 CPU image를 실행한다.
+- LiteLLM은 vLLM의 OpenAI 호환 `/v1/chat/completions`를 호출한다.
+- `--enable-auto-tool-choice`가 자동 tool 선택을 허용한다.
+- `--tool-call-parser hermes`가 Qwen 출력을 OpenAI `tool_calls`로 변환한다.
+- `--tool-server searxng-mcp:8888`이 vLLM 내부 tool loop를 MCP browser에 연결한다.
+- `VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT=1`이 non-Harmony Qwen의 MCP tool calling을 활성화한다.
+- `ai-provider/vllm/Dockerfile`은 현재 vLLM Tool Server와 호환되는 MCP 1.x를 고정한다.
+
+### 5.2 API key 생성
+
+vLLM이 API key를 발급하는 endpoint는 없다. 운영자가 임의의 secret을 생성하고 vLLM server와 LiteLLM에 같은 값을 설정한다.
+
+```bash
+openssl rand -hex 32
+```
+
+출력값을 현재 shell 환경 변수로 설정한다. 이 값을 뒤의 공통 환경 파일에도 동일하게 저장한다.
+
+```bash
+export VLLM_API_KEY="paste-generated-key-here"
+```
+
+API key는 vLLM 시작 시 읽힌다. 실행 중 값을 변경했다면 container를 다시 생성한다.
+
+### 5.3 vLLM container 시작
+
+Docker Desktop의 CPU와 memory를 각각 4 core, 8GB 이상 할당하는 것을 권장한다. vLLM을 시작하면 의존 service인 SearXNG와 MCP browser도 함께 시작된다.
+
+```bash
+docker compose --progress quiet up -d vllm
+```
+
+또는 Make target을 사용한다.
+
+```bash
+make up-vllm
+```
+
+Qwen2.5 1.5B 모델을 처음 실행하면 Hugging Face model download 시간이 필요하다.
+
+Compose progress UI 대신 실제 container 상태를 확인한다.
+
+```bash
+docker compose ps vllm searxng-mcp
+```
+
+`STATUS`가 `Up`이어도 model download와 CPU warm-up이 진행 중일 수 있다. Log를 따라가다가 `Application startup complete`를 확인한 뒤 `Ctrl+C`로 log 보기만 종료한다. Container는 계속 실행된다.
+
+```bash
+docker compose logs -f vllm
+```
+
+실행 image와 CPU memory 설정은 `.env.example`의 다음 값으로 조정할 수 있다.
+
+```dotenv
+VLLM_IMAGE=vllm/vllm-openai-cpu:latest
+VLLM_CPU_KVCACHE_SPACE=2
+VLLM_CPU_NUM_OF_RESERVED_CPU=1
+```
+
+### 5.4 vLLM 인증 확인
+
+API key 없이 요청하면 `401 Unauthorized`가 반환되어야 한다.
+
+```bash
+curl -sS http://localhost:8000/v1/models \
+  | jq .
+```
+
+현재 shell에 설정한 key로 다시 요청한다.
+
+```bash
+curl -sS http://localhost:8000/v1/models \
+  -H "Authorization: Bearer ${VLLM_API_KEY}" \
+  | jq '{models: [.data[].id]}'
+```
+
+Model 목록에 `Qwen/Qwen2.5-1.5B-Instruct`가 있으면 준비가 끝난다. vLLM의 API key는 일부 OpenAI 호환 endpoint만 보호하므로 운영에서는 network 접근 제어를 함께 사용한다.
+
+## 6. 공통 환경 파일
+
+vLLM 실행과 인증 확인이 끝나면 LiteLLM이 사용할 환경 파일을 만든다. `.env`는 Git에서 제외된다.
+
+```bash
+cp .env.example .env
+```
+
+API key가 필요한 host `curl`에서도 같은 값을 사용하도록 `.env`를 현재 shell에 반영한다.
+
+```bash
+set -a
+source .env
+set +a
+```
+
+로컬 vLLM은 Compose network의 service 이름과 5.2에서 생성한 같은 API key를 설정한다.
+
+```dotenv
+VLLM_API_BASE=http://vllm:8000/v1
+VLLM_API_KEY=<5.2에서 생성한-key>
+```
+
+원격 vLLM으로 바꾸려면 LiteLLM container에서 접근 가능한 주소와 원격 server의 API key를 설정한다.
+
+```dotenv
+VLLM_API_BASE=http://vllm-host.example:8000/v1
+VLLM_API_KEY=remote-vllm-api-key
+```
+
+Compose는 `VLLM_API_KEY`를 vLLM의 인증 검증과 LiteLLM upstream 요청의 Bearer token에 공통으로 사용한다. 두 값이 다르면 LiteLLM의 vLLM 요청이 `401 Unauthorized`로 실패한다.
+
+LiteLLM API master key, Admin UI 계정, PostgreSQL 계정을 설정한다. Admin UI 비밀번호는 API master key와 분리한다.
+
+```dotenv
+LITELLM_MASTER_KEY=<API-master-key>
+UI_USERNAME=admin
+UI_PASSWORD=<UI-password>
+POSTGRES_USER=litellm
+POSTGRES_PASSWORD=<database-password>
+POSTGRES_DB=litellm
+```
+
+## 7. 로컬 Bedrock 인증
+
+LiteLLM을 시작하기 전에 AWS CLI session을 준비한다. 로컬에서는 장기 access key 대신 `aws login` session을 사용한다. AWS CLI가 만든 임시 자격증명과 refresh token은 `~/.aws/login/cache`에 저장된다.
+
+Named profile로 로그인한다.
+
+```bash
+aws login --profile default
+aws sts get-caller-identity --profile default
+```
+
+Session이 만료되면 `aws login --profile default`를 다시 실행한다. Login cache를 container에 연결하므로 재로그인 후 LiteLLM을 재생성할 필요는 없다.
+
+`.env`에 같은 profile과 region을 설정한다.
+
+```dotenv
+AWS_REGION=us-east-1
+AWS_PROFILE=default
+```
+
+로컬 전용 `compose.aws-login.yaml`은 다음 파일을 LiteLLM container에 전달한다.
+
+- `~/.aws/config`: read-only profile 설정
+- `~/.aws/login/cache`: 임시 자격증명 자동 갱신을 위한 read-write cache
+
+Boto3에서 login credentials provider를 사용하려면 AWS CRT가 필요하다. `litellm/Dockerfile`과 실습 application image는 `boto3[crt]`를 설치한다.
+
+## 8. LiteLLM 실행
+
+SearXNG, vLLM endpoint, AWS login session을 먼저 준비하고 LiteLLM을 시작한다. Compose가 PostgreSQL을 먼저 시작하고 health check가 성공한 뒤 LiteLLM을 시작한다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --progress quiet up -d --build vllm litellm
+```
+
+`.env`의 UI 계정이나 database 설정을 변경한 경우 실행 중인 container의 환경 변수는 바뀌지 않는다. LiteLLM을 재생성해 새 값을 적용한다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --progress quiet up -d --build --force-recreate vllm litellm
+```
+
+또는 같은 명령을 Make target으로 실행한다.
+
+```bash
+make up-aws-login
+```
+
+vLLM API key는 vLLM의 검증 값과 LiteLLM의 upstream Bearer token에 함께 사용된다. `.env`에서 변경하면 `restart`가 아니라 두 container를 모두 `--force-recreate`해야 한다.
+
+LiteLLM은 `litellm/config.yaml`의 `os.environ/VLLM_API_KEY`를 읽어 vLLM 요청에 사용한다.
+
+상태와 log를 확인한다.
+
+```bash
+docker compose ps
+docker compose logs --since=2m litellm
+```
+
+`http://localhost:4000/ui/`에서 `.env`의 `UI_USERNAME`과 `UI_PASSWORD`로 로그인한다. `LITELLM_MASTER_KEY`는 OpenAI 호환 API 인증에 사용한다.
+
+LiteLLM `main-latest`는 최신 web search interception 확인을 위한 선택이다. 운영에서는 검증한 digest로 고정한다.
+
+## 9. AWS workload 인증
+
+AWS workload에서는 `compose.aws-login.yaml`을 사용하지 않는다. Access key 환경 변수도 설정하지 않는다.
+
+- EC2: instance profile
+- ECS: task role
+- EKS: Pod Identity 또는 IRSA
+- Lambda: execution role
+
+Boto3 기본 자격증명 체인이 workload role의 임시 자격증명을 자동으로 선택한다. 동일한 application 코드를 유지하고 배포 환경에서 role만 연결한다.
+
+Converse 호출에는 최소 `bedrock:InvokeModel` 권한이 필요하다. Nova Web Grounding에는 `arn:aws:bedrock::*:system-tool/amazon.nova_grounding` 대상의 `bedrock:InvokeTool` 권한도 필요하다. Streaming 호출에는 `bedrock:InvokeModelWithResponseStream`도 필요하다.
+
+## 10. 종료
+
+```bash
+docker compose --profile cpu --profile client --profile bedrock down -v
+```
+
+`-v`는 vLLM model cache와 PostgreSQL의 LiteLLM Admin UI 데이터를 모두 제거한다. 다음 실행에서는 model을 다시 download하고 database migration을 다시 수행한다.

--- a/computer_science/ai/web-search-tool/docs/3-no-tool-runtime-hands-on.md
+++ b/computer_science/ai/web-search-tool/docs/3-no-tool-runtime-hands-on.md
@@ -1,0 +1,210 @@
+# Web search 실행 주체가 없는 기준선
+
+[실습 환경](2-setup.md)을 준비한다. vLLM과 Bedrock에 `web_search` 함수 정의만 전달하고, 반환된 tool call을 실행하지 않으면 어떤 결과가 나오는지 확인한다.
+
+## 시나리오 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 확인 목적 | Tool call과 tool 실행이 서로 다른 단계임을 확인 |
+| 호출 방법 | vLLM은 `curl`, Bedrock은 AWS CLI |
+| vLLM 경로 | `curl → LiteLLM → vLLM` 한 번 |
+| Bedrock 경로 | `AWS CLI → Bedrock Converse` 한 번 |
+| 검색 경로 | 없음, 현재 설정에 server-side tool executor가 없음 |
+| 예상 결과 | vLLM은 `tool_calls`, Bedrock은 `toolUse`만 반환 |
+
+## 15초 이론
+
+AI 모델은 사용할 tool과 인자를 결정한다. 실제 실행은 Client·gateway뿐 아니라 AI provider의 관리형 runtime이나 tool server가 연결된 serving engine도 담당할 수 있다. 이 실습의 vLLM Chat Completions와 Bedrock Converse는 client-side custom tool mode이므로 caller가 실행하지 않으면 각각 `tool_calls`와 `toolUse`에서 끝난다.
+
+## Tool 실행 위치 구분
+
+| 실행 위치 | 동작 예 | 현재 실습 |
+| --- | --- | --- |
+| Client | Application이 `tool_calls`를 받아 SearXNG 실행 | 4번에서 확인 |
+| Gateway | LiteLLM interceptor가 SearXNG 실행 | 5번에서 확인 |
+| AI provider runtime | Bedrock Responses가 Lambda 또는 AgentCore tool 실행 | 사용하지 않음 |
+| Serving engine runtime | vLLM Responses API가 `--tool-server`로 연결한 tool 실행 | 비활성화 |
+
+Provider 또는 serving engine이 실행하더라도 foundation model process가 임의의 network 요청을 직접 보내는 것은 아니다. 신뢰된 server-side runtime이 모델의 요청을 받아 등록된 tool을 실행한다.
+
+## vLLM 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Caller as "curl caller"
+  participant LiteLLM
+  participant vLLM as "vLLM (Qwen2.5)"
+  participant SearXNG
+
+  User->>Caller: 최신 정보 질문
+  Caller->>LiteLLM: Chat Completions + web_search 정의
+  LiteLLM->>vLLM: 첫 번째 completion
+  vLLM-->>LiteLLM: tool_calls(query)
+  LiteLLM-->>Caller: tool_calls(query)
+  Note over Caller,SearXNG: 현재 설정에는 server-side executor가 없어 검색 호출 없음
+  Caller-->>User: 최종 답변 없이 종료
+```
+
+## Bedrock 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Caller as "AWS CLI caller"
+  participant Bedrock as "Bedrock Converse (Nova Micro)"
+  participant SearXNG
+
+  User->>Caller: 최신 정보 질문
+  Caller->>Bedrock: Converse + toolConfig
+  Bedrock-->>Caller: stopReason=tool_use + toolUse(query)
+  Note over Caller,SearXNG: toolResult 후속 요청과 검색 실행 없음
+  Caller-->>User: 최종 답변 없이 종료
+```
+
+## vLLM 실행
+
+`web_search`를 강제로 선택한 요청을 한 번 보낸다.
+
+```bash
+curl -sS --fail-with-body http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer ${LITELLM_MASTER_KEY:-sk-local-web-search}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "local-tool-model",
+    "messages": [
+      {"role": "user", "content": "오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요."}
+    ],
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "web_search",
+          "description": "Search the public web.",
+          "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"]
+          }
+        }
+      }
+    ],
+    "tool_choice": {
+      "type": "function",
+      "function": {"name": "web_search"}
+    }
+  }' \
+  | jq '{
+      finish_reason: .choices[0].finish_reason,
+      content: .choices[0].message.content,
+      tool_calls: .choices[0].message.tool_calls
+    }'
+```
+
+응답의 `choices[0].message.tool_calls`에는 검색어가 있지만 최종 자연어 답변은 없다.
+
+예상 응답의 핵심 형태는 다음과 같다.
+
+```json
+{
+  "finish_reason": "tool_calls",
+  "content": "",
+  "tool_calls": [
+    {
+      "function": {
+        "name": "web_search",
+        "arguments": "{\"query\": \"today's month and day in Seoul, Korea\"}"
+      }
+    }
+  ]
+}
+```
+
+- `arguments.query`: 날씨 검색 결과가 아니라 모델이 검색 도구에 넘기려는 검색어다.
+- `finish_reason=tool_calls`: 모델이 자연어 답변 대신 Tool 실행을 요청하고 멈췄다는 뜻이다.
+- `content=""`: 날짜·날씨에 대한 최종 답변이 아직 없다는 뜻이다.
+- SearXNG 실행과 두 번째 모델 호출이 없으므로 이 결과가 3번 실습의 성공 조건이다.
+
+## Bedrock 실행
+
+[로컬 Bedrock 인증](2-setup.md#7-로컬-bedrock-인증)을 완료한 뒤 Nova Micro에 Converse 요청을 한 번 보낸다.
+
+먼저 같은 profile의 host 자격증명이 유효한지 확인한다.
+
+```bash
+aws sts get-caller-identity \
+  --profile "${AWS_PROFILE:-default}" \
+  | jq '{Account, Arn}'
+```
+
+STS 확인이 성공한 뒤에만 다음 Bedrock 요청을 실행한다.
+
+```bash
+aws bedrock-runtime converse \
+  --profile "${AWS_PROFILE:-default}" \
+  --region "${AWS_REGION:-us-east-1}" \
+  --model-id "${BEDROCK_MODEL_ID:-amazon.nova-micro-v1:0}" \
+  --messages '[
+    {
+      "role": "user",
+      "content": [
+        {"text": "오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요."}
+      ]
+    }
+  ]' \
+  --tool-config '{
+    "tools": [
+      {
+        "toolSpec": {
+          "name": "web_search",
+          "description": "Search the public web.",
+          "inputSchema": {
+            "json": {
+              "type": "object",
+              "properties": {"query": {"type": "string"}},
+              "required": ["query"]
+            }
+          }
+        }
+      }
+    ],
+    "toolChoice": {
+      "tool": {"name": "web_search"}
+    }
+  }' \
+  --inference-config '{"maxTokens": 512, "temperature": 0}' \
+  | jq '{
+      stopReason,
+      toolUse: [.output.message.content[] | select(.toolUse) | .toolUse]
+    }'
+```
+
+응답의 `stopReason`은 `tool_use`이고 `output.message.content[].toolUse`에는 `toolUseId`, 함수명, 검색어가 있다. Tool을 실행하거나 `toolResult`를 보내지 않았으므로 최종 자연어 답변은 없다.
+
+## 검색 미실행 확인
+
+두 요청을 실행한 뒤 SearXNG log에서 `/search` 요청이 발생하지 않았는지 확인한다.
+
+```bash
+docker compose logs --since=1m searxng
+```
+
+## 성공 조건
+
+- 응답에 `web_search`와 `query`가 있다.
+- vLLM 응답의 최종 `message.content`가 비어 있다.
+- Bedrock 응답의 `stopReason`이 `tool_use`다.
+- Bedrock에 `toolResult`를 포함한 두 번째 요청이 없다.
+- SearXNG에 `/search` 요청이 없다.
+
+이 결과는 장애가 아니라 의도한 기준선이다. [다음 실습](4-client-hands-on.md)에서는 Client가 누락된 실행 단계를 담당한다.
+
+## 참고자료
+
+- [Amazon Bedrock server-side tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-server-side.html)
+- [Amazon Bedrock client-side tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use-client-side.html)
+- [AWS CLI Converse 명령](https://docs.aws.amazon.com/cli/latest/reference/bedrock-runtime/converse.html)
+- [vLLM tool server와 MCP 보안](https://docs.vllm.ai/en/latest/usage/security/#tool-server-and-mcp-security)

--- a/computer_science/ai/web-search-tool/docs/4-client-hands-on.md
+++ b/computer_science/ai/web-search-tool/docs/4-client-hands-on.md
@@ -1,0 +1,130 @@
+# Client가 같은 로직으로 Qwen과 Bedrock의 web search 실행
+
+[실습 환경](2-setup.md)을 준비한다. OpenAI Python SDK로 LiteLLM을 호출하고 Client application이 SearXNG를 실행한다. `--model` 인자만 바꿔 Qwen과 Bedrock을 같은 Tool loop로 호출한다.
+
+## 시나리오 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 확인 목적 | LiteLLM 뒤의 AI model을 바꿔도 Client Tool loop가 같음을 확인 |
+| 실행 job | `client-search` |
+| Qwen 경로 | `client-search → LiteLLM → vLLM/Qwen`을 Tool loop 동안 호출 |
+| Bedrock 경로 | `client-search → LiteLLM → Bedrock/Nova Micro`를 Tool loop 동안 호출 |
+| 검색 경로 | `client-search → SearXNG` |
+| 변경되는 값 | `--model qwen` 또는 `--model bedrock` |
+| 유지되는 로직 | Tool schema, 검색 실행, Tool 결과 message, 최종 답변 요청 |
+
+## 15초 이론
+
+Client-owned tool loop는 모델의 요청을 application이 직접 실행하는 방식이다. Application은 OpenAI 호환 형식만 사용하고 LiteLLM이 `local-tool-model`은 Qwen으로, `bedrock-nova-micro`는 Bedrock으로 routing한다. Provider가 날짜와 날씨를 한 번 또는 여러 번의 검색으로 나눠도 같은 loop가 최종 답변까지 처리한다.
+
+Client는 두 model에 같은 `tool_choice`를 보낸다. Bedrock model route의 `drop_params`가 adapter에서 지원하지 않는 OpenAI parameter만 제거한다. 이 provider 차이는 Client 분기가 아니라 gateway 변환 설정으로 처리한다.
+
+두 model route는 LiteLLM 시작 전에 한 번 설정한다. 실행 중에는 Client 코드, LiteLLM 설정, container 구성을 변경하지 않는다. 각 요청의 `model` 값만 바뀐다.
+
+| 실행 인자 | LiteLLM model group | 실제 AI model |
+| --- | --- | --- |
+| `qwen` | `local-tool-model` | `Qwen/Qwen2.5-1.5B-Instruct` |
+| `bedrock` | `bedrock-nova-micro` | `amazon.nova-micro-v1:0` |
+
+## 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Client as "Client application"
+  participant LiteLLM
+  participant Model as "Qwen 또는 Bedrock Nova"
+  participant SearXNG
+
+  User->>Client: --model qwen 또는 bedrock
+  Client->>LiteLLM: Chat Completions + web_search 정의
+  LiteLLM->>Model: model group에 따른 첫 번째 completion
+  loop model이 tool_calls를 반환하는 동안
+    Model-->>LiteLLM: tool_calls(query)
+    LiteLLM-->>Client: tool_calls(query)
+    Client->>SearXNG: GET /search?format=json
+    SearXNG-->>Client: title, URL, snippet
+    Client->>LiteLLM: assistant tool_call + tool 결과
+    LiteLLM->>Model: 같은 model group으로 다음 completion
+  end
+  Model-->>LiteLLM: 최종 답변
+  LiteLLM-->>Client: 최종 답변
+  Client-->>User: 답변과 출처
+```
+
+## Application 조립
+
+Application은 다음 네 단계를 하나의 tool loop로 조립한다.
+
+```text
+model_group = --model 인자를 LiteLLM model group으로 변환
+
+web_search_schema = 함수 이름, 설명, query JSON schema 정의
+
+response = model에게 질문과 web_search_schema 전달
+
+최대 3회 반복:
+  response에 tool_calls가 없으면 최종 답변 출력 후 종료
+  각 tool_call의 함수 이름, call ID, query 추출
+  SearXNG에 query 전달
+  assistant tool_call과 같은 call ID의 tool result를 conversation에 추가
+  conversation과 같은 web_search_schema를 model에 전달
+```
+
+핵심은 첫 응답을 버리지 않는 것이다. Assistant의 `tool_calls`와 Client가 만든 `tool` message를 함께 보내야 모델이 어떤 호출의 결과인지 연결할 수 있다.
+
+실제 코드의 역할은 다음과 같다.
+
+| 단계 | 코드 |
+| --- | --- |
+| Model 인자 변환 | `parse_model_argument()` |
+| 함수 schema 정의 | `WEB_SEARCH_TOOL` |
+| 첫 모델 요청 | `request_search()` |
+| 함수 인자 해석·검색·결과 조립 | `append_tool_results()` |
+| 다음 모델 요청 | `request_answer()` |
+| 전체 순서 제어 | `main()` |
+
+## 실행
+
+AWS login mount가 적용된 동일한 LiteLLM instance를 사용해 두 model을 차례로 호출한다. Qwen도 이 구성에서 그대로 사용할 수 있다.
+
+Qwen을 선택해 Client Tool loop를 실행한다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --profile client run --rm client-search --model qwen
+```
+
+같은 Client와 LiteLLM에서 model 인자만 Bedrock으로 바꾼다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --profile client run --rm client-search --model bedrock
+```
+
+다른 terminal에서 LiteLLM log를 확인한다.
+
+```bash
+docker compose logs --since=2m litellm
+```
+
+## 성공 조건
+
+- Qwen과 Bedrock 실행 모두 답변과 source URL을 출력한다.
+- 두 실행 모두 같은 `client/app.py`와 `web_search.py`를 사용한다.
+- 각 실행의 LiteLLM log에 첫 Tool 요청, Tool 결과 전달, 최종 답변 요청이 있다.
+- Qwen은 `local-tool-model`, Bedrock은 `bedrock-nova-micro`로 routing된다.
+- LiteLLM search endpoint log에는 SearXNG 호출이 없다.
+
+## 실패 해석
+
+- vLLM 연결 실패: `VLLM_API_BASE`를 LiteLLM container에서 접근할 수 없다.
+- Bedrock 연결 실패: [로컬 Bedrock 인증](2-setup.md#7-로컬-bedrock-인증)을 확인한다.
+- 빈 `tool_calls`: 모델이 forced function schema를 따르지 않았다.
+- SearXNG `403`: `searxng/settings.yml`에서 JSON 형식이 비활성화되었다.

--- a/computer_science/ai/web-search-tool/docs/5-litellm-hands-on.md
+++ b/computer_science/ai/web-search-tool/docs/5-litellm-hands-on.md
@@ -1,0 +1,166 @@
+# LiteLLM이 Qwen과 Bedrock의 web search 실행
+
+[실습 환경](2-setup.md)을 준비한다. Thin Client는 LiteLLM을 한 번 호출하고 LiteLLM이 model 호출, SearXNG 검색, 후속 model 호출을 실행한다. `--model` 인자만 바꿔 Qwen과 Bedrock에서 같은 interception을 확인한다.
+
+## 시나리오 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 확인 목적 | LiteLLM이 AI provider와 무관하게 Tool runtime 역할을 수행하는지 확인 |
+| 실행 job | `gateway-search` |
+| Qwen 경로 | `Thin Client → LiteLLM → vLLM/Qwen` |
+| Bedrock 경로 | `Thin Client → LiteLLM → Bedrock/Nova Micro` |
+| 검색 경로 | `LiteLLM interceptor → SearXNG` |
+| 변경되는 값 | `--model qwen` 또는 `--model bedrock` |
+| 핵심 관찰 | Thin Client는 중간 Tool call과 검색 결과를 처리하지 않음 |
+
+## 15초 이론
+
+`websearch_interception`은 모든 질문을 자동 검색하지 않는다. Model이 `litellm_web_search` Tool call을 반환했을 때만 LiteLLM이 이를 가로채 SearXNG를 실행한다. 따라서 Client는 사용 가능한 Tool 정의를 요청에 포함해야 하지만 Tool call을 해석하거나 실행할 필요는 없다.
+
+`litellm_web_search`는 interception callback이 알아보는 예약된 함수명이다. 일반 `web_search`와 구분해 Application이 실행할 Tool을 LiteLLM이 실수로 가로채지 않도록 실행 책임을 명시한다.
+
+이 실습은 `tool_choice`로 `litellm_web_search` 선택을 강제한다. `tool_choice`를 생략하면 검색 필요 여부를 model이 결정한다.
+
+## LiteLLM 필수 설정
+
+```yaml
+search_tools:
+  - search_tool_name: local-search
+    litellm_params:
+      search_provider: searxng
+      api_base: os.environ/SEARXNG_URL
+
+litellm_settings:
+  callbacks: ["websearch_interception"]
+  websearch_interception_params:
+    enabled_providers: ["openai", "bedrock"]
+    search_tool_name: local-search
+```
+
+- `search_tools`: LiteLLM이 실행할 검색 backend를 등록한다.
+- `callbacks`: model 응답의 Tool call을 검사하는 interceptor를 활성화한다.
+- `enabled_providers`: interception을 허용할 AI provider를 제한한다.
+- `search_tool_name`: 여러 검색 backend 중 `local-search`를 선택한다.
+- `SEARXNG_URL`: Compose network의 `http://searxng:8080`을 사용한다.
+
+## `drop_params` 이해
+
+Provider가 지원하지 않는 OpenAI parameter를 받으면 LiteLLM은 기본적으로 오류를 반환한다. `drop_params: true`는 오류 대신 지원하지 않는 parameter를 제거하고 요청을 계속한다.
+
+```text
+Client 요청: tools + tool_choice
+
+Qwen route:    tools + tool_choice 전달
+Bedrock route: tools 전달, 지원하지 않는 tool_choice 제거
+```
+
+현재 설정은 영향을 줄이기 위해 Bedrock model route에만 적용한다.
+
+```yaml
+- model_name: bedrock-nova-micro
+  litellm_params:
+    model: bedrock/amazon.nova-micro-v1:0
+    drop_params: true
+```
+
+장점:
+
+- Client에 provider별 parameter 분기가 필요 없다.
+- 하나의 OpenAI 호환 요청을 여러 provider에 재사용할 수 있다.
+
+트레이드오프:
+
+- 강제 Tool 선택이 자동 선택으로 바뀌는 등 요청 의미가 약해질 수 있다.
+- `response_format`, `seed` 같은 parameter가 제거되면 출력 형식이나 재현성이 달라질 수 있다.
+- 오류가 사라지는 대신 parameter 제거 사실을 놓치기 쉽다.
+
+운영에서는 전역 설정보다 model별 `drop_params`를 사용하고, 중요한 parameter가 실제 적용됐는지 test와 trace로 확인한다. 제거할 항목을 이미 알고 있다면 `additional_drop_params: ["tool_choice"]`처럼 대상을 한정하는 편이 더 엄격하다.
+
+## 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Client as "Thin Client"
+  participant LiteLLM as "LiteLLM interceptor"
+  participant Model as "Qwen 또는 Bedrock Nova"
+  participant SearXNG
+
+  User->>Client: --model qwen 또는 bedrock
+  Client->>LiteLLM: Chat Completions + litellm_web_search
+  LiteLLM->>Model: model group에 따른 첫 completion
+  Model-->>LiteLLM: litellm_web_search(query)
+  LiteLLM->>SearXNG: GET /search?format=json
+  SearXNG-->>LiteLLM: title, URL, snippet
+  LiteLLM->>Model: 검색 결과를 포함한 후속 completion
+  Model-->>LiteLLM: 최종 답변
+  LiteLLM-->>Client: 최종 답변 하나
+  Client-->>User: 답변과 출처
+```
+
+## Thin Client 요청
+
+Client는 예약된 함수명과 입력 schema를 선언한다.
+
+```python
+{
+  "type": "function",
+  "function": {
+    "name": "litellm_web_search",
+    "parameters": {
+      "type": "object",
+      "properties": {"query": {"type": "string"}},
+      "required": ["query"],
+    },
+  },
+}
+```
+
+Client에는 SearXNG 호출, Tool 결과 message, 반복 Tool loop 코드가 없다.
+
+## Qwen 실행
+
+AWS login mount가 적용된 동일한 LiteLLM instance를 두 model에서 사용한다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --profile client run --rm gateway-search --model qwen
+```
+
+## Bedrock 실행
+
+Client와 LiteLLM 설정을 바꾸지 않고 model 인자만 변경한다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --profile client run --rm gateway-search --model bedrock
+```
+
+## 확인
+
+```bash
+docker compose logs --since=5m litellm
+```
+
+## 성공 조건
+
+- Qwen과 Bedrock 모두 Thin Client 요청 한 번으로 최종 답변을 반환한다.
+- 두 실행 모두 같은 `litellm/app.py`를 사용한다.
+- LiteLLM log에 `litellm_web_search` interception과 SearXNG 실행이 기록된다.
+- Thin Client에는 SearXNG URL과 검색 실행 코드가 없다.
+
+## Client 실행 시나리오와 비교
+
+- [4번](4-client-hands-on.md): `web_search`를 Client가 실행한다.
+- [5번](5-litellm-hands-on.md): `litellm_web_search`를 LiteLLM이 실행한다.
+
+## 참고자료
+
+- [LiteLLM Web Search Interception](https://docs.litellm.ai/docs/integrations/websearch_interception)
+- [LiteLLM Drop Unsupported Params](https://docs.litellm.ai/docs/completion/drop_params)

--- a/computer_science/ai/web-search-tool/docs/6-bedrock-hands-on.md
+++ b/computer_science/ai/web-search-tool/docs/6-bedrock-hands-on.md
@@ -1,0 +1,98 @@
+# Bedrock이 web search 실행
+
+[실습 환경](2-setup.md)에서 LiteLLM과 로컬 AWS login session을 준비한다. Client는 LiteLLM을 한 번 호출하고, Amazon Nova 2 Lite가 Web Grounding으로 검색과 답변 조립을 완료한다.
+
+## 시나리오 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 확인 목적 | AI provider가 web search와 최종 답변 조립까지 담당하는 흐름 확인 |
+| 실행 job | `bedrock-provider-search` |
+| 호출 경로 | `Client → LiteLLM → Bedrock Nova 2 Lite` |
+| 검색 실행 | Amazon Nova Web Grounding |
+| Client가 받는 값 | 추가 tool loop 없이 사용할 수 있는 최종 답변과 citation metadata |
+| 사용하지 않는 구성 | Client tool loop, LiteLLM interception, SearXNG, vLLM |
+
+## 15초 이론
+
+일반적인 Bedrock Converse `toolConfig`는 모델이 `toolUse`만 반환하므로 호출자가 tool을 실행해야 한다. Nova 2 Lite의 Web Grounding은 예외다. LiteLLM이 OpenAI 형식의 `web_search_options`를 Bedrock `nova_grounding` system tool로 변환하면 Bedrock이 검색, 출처 수집, 재추론을 수행하고 최종 답변을 반환한다.
+
+## 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Client as "Thin client"
+  participant LiteLLM
+  participant Nova as "Bedrock Nova 2 Lite"
+  participant Grounding as "Nova Web Grounding"
+
+  User->>Client: 오늘 날짜와 서울 날씨 질문
+  Client->>LiteLLM: Chat Completions + web_search_options
+  LiteLLM->>Nova: Converse + nova_grounding systemTool
+  Nova->>Grounding: 최신 정보 검색
+  Grounding-->>Nova: 검색 결과와 출처
+  Nova->>Nova: 검색 결과로 최종 답변 생성
+  Nova-->>LiteLLM: 최종 답변, 인용, grounding trace
+  LiteLLM-->>Client: OpenAI 호환 최종 응답
+  Client-->>User: 답변 출력
+```
+
+## 코드와 설정
+
+Client는 tool schema와 tool loop를 구현하지 않는다.
+
+```python
+response = client.chat.completions.create(
+  model="bedrock-provider-search",
+  messages=[{"role": "user", "content": question}],
+  web_search_options={},
+)
+```
+
+LiteLLM model group은 Nova 2 Lite를 가리킨다.
+
+```yaml
+- model_name: bedrock-provider-search
+  litellm_params:
+    model: bedrock/us.amazon.nova-2-lite-v1:0
+    aws_region_name: os.environ/AWS_REGION
+```
+
+`websearch_interception`이 아니라 LiteLLM의 Bedrock adapter가 `web_search_options`를 Nova의 `nova_grounding` system tool로 변환한다. 검색 실행 주체는 LiteLLM이 아니라 Bedrock다. OpenAI 호환 응답에는 `nova_grounding` tool trace가 남을 수 있지만 Client가 실행하거나 재호출할 대상은 아니다.
+
+## 실행
+
+AWS login session을 LiteLLM container에 연결한 상태로 실행한다.
+
+```bash
+docker compose \
+  -f compose.yaml \
+  -f compose.aws-login.yaml \
+  --profile bedrock run --rm bedrock-provider-search
+```
+
+또는 Make target을 사용한다.
+
+```bash
+make provider-bedrock
+```
+
+## 성공 조건
+
+- Client가 LiteLLM에 요청을 한 번만 보낸다.
+- Client와 LiteLLM이 SearXNG를 호출하지 않는다.
+- 별도 tool 요청을 처리하지 않고 출처가 포함된 최종 답변을 출력한다.
+- Bedrock 호출 role에 `bedrock:InvokeModel`과 `bedrock:InvokeTool` 권한이 있다.
+
+## 제약
+
+- Web Grounding은 Nova 2 Lite와 지원되는 미국 region 또는 US cross-region inference profile을 사용한다.
+- 일반적인 Converse tool use와 Web Grounding을 같은 동작으로 해석하면 안 된다.
+- Provider 종속 기능이므로 다른 model로 바꾸면 `web_search_options` 지원 여부를 다시 확인한다.
+
+## 참고자료
+
+- [Amazon Nova 2 Web Grounding](https://docs.aws.amazon.com/nova/latest/nova2-userguide/web-grounding.html)
+- [Amazon Bedrock tool use](https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html)

--- a/computer_science/ai/web-search-tool/docs/7-vllm-hands-on.md
+++ b/computer_science/ai/web-search-tool/docs/7-vllm-hands-on.md
@@ -1,0 +1,131 @@
+# vLLM이 web search 실행
+
+[실습 환경](2-setup.md)에 따라 SearXNG MCP server, vLLM, LiteLLM을 준비한다. Client는 LiteLLM을 한 번 호출하고, vLLM이 Qwen 추론·검색 실행·재추론을 완료한다. Client application은 최종 `output_text`만 출력한다.
+
+## 시나리오 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 확인 목적 | 로컬 AI serving engine이 web search와 최종 답변 조립까지 담당하는 흐름 확인 |
+| 실행 job | `vllm-provider-search` |
+| 호출 경로 | `Client → LiteLLM → vLLM/Qwen` |
+| 검색 경로 | `vLLM Tool Server → SearXNG MCP → SearXNG` |
+| Client가 사용하는 값 | Responses 결과의 최종 `output_text` |
+| LiteLLM 역할 | 인증과 model routing만 담당 |
+
+## 15초 이론
+
+vLLM Responses API의 `--tool-server`는 server-side tool runtime이다. Qwen이 검색 호출을 만들면 vLLM이 MCP browser tool을 실행하고, 결과를 Qwen에 다시 넣어 최종 답변까지 만든다. Client와 LiteLLM은 이 반복 실행에 참여하지 않는다.
+
+## 예상 흐름
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User
+  participant Client as "Thin client"
+  participant LiteLLM
+  participant vLLM as "vLLM Responses API"
+  participant Qwen as "Qwen2.5 1.5B"
+  participant MCP as "SearXNG MCP browser"
+  participant SearXNG
+
+  User->>Client: 오늘 날짜와 서울 날씨 질문
+  Client->>LiteLLM: Responses API + server tool 선언
+  LiteLLM->>vLLM: 요청 전달
+  vLLM->>Qwen: 질문과 search schema로 추론
+  Qwen-->>vLLM: web_search_preview(query)
+  vLLM->>MCP: browser.search(query)
+  MCP->>SearXNG: GET /search?format=json
+  SearXNG-->>MCP: 제목, URL, snippet
+  MCP-->>vLLM: tool 결과
+  vLLM->>Qwen: 검색 결과로 재추론
+  Qwen-->>vLLM: 출처를 포함한 최종 답변
+  vLLM-->>LiteLLM: 최종 Responses 응답
+  LiteLLM-->>Client: 최종 응답
+  Client-->>User: 답변 출력
+```
+
+## 코드와 설정
+
+현재 vLLM의 non-Harmony model MCP 지원은 실험적이다. Qwen2.5에는 다음 두 선언을 함께 전달한다.
+
+```python
+tools = [
+  {"type": "web_search_preview"},
+  {
+    "type": "function",
+    "name": "web_search_preview",
+    "description": "Search the public web for current information.",
+    "parameters": {
+      "type": "object",
+      "properties": {"query": {"type": "string"}},
+      "required": ["query"],
+    },
+  },
+]
+```
+
+- 첫 선언: vLLM의 server-side browser 실행을 활성화한다.
+- 둘째 선언: Qwen prompt에 호출 가능한 함수 schema를 제공한다.
+- 같은 이름: Qwen의 함수 호출을 vLLM built-in browser 실행으로 연결한다.
+- `tool_choice="auto"`: 검색 결과를 받은 다음 추론에서 반복 호출을 멈추고 최종 답변을 만들 수 있게 한다.
+- `instructions`: 검색을 정확히 한 번 실행하고 결과를 받은 뒤 답변하도록 경량 model의 행동을 제한한다.
+
+vLLM은 다음 옵션으로 MCP tool server를 연결한다.
+
+```yaml
+command:
+  - Qwen/Qwen2.5-1.5B-Instruct
+  - --enable-auto-tool-choice
+  - --tool-call-parser
+  - hermes
+  - --tool-server
+  - searxng-mcp:8888
+```
+
+LiteLLM의 `vllm-provider-search` group은 `hosted_vllm` provider를 사용한다. 현재 interception 대상인 `openai`, `bedrock`에 포함되지 않으므로 LiteLLM이 검색을 가로채지 않는다.
+
+## 실행
+
+vLLM과 MCP search server를 시작한다.
+
+```bash
+docker compose --profile cpu --progress quiet up -d --build vllm
+docker compose ps vllm searxng-mcp
+```
+
+Client job을 실행한다.
+
+```bash
+docker compose --profile client run --rm vllm-provider-search
+```
+
+vLLM이 MCP tool을 실행했는지 log로 확인한다.
+
+```bash
+docker compose logs --since=5m vllm searxng-mcp
+```
+
+## 성공 조건
+
+- vLLM log에 `MCPToolServer initialized with tools: ['browser']`가 있다.
+- `searxng-mcp` log에 Client 요청 시점의 `search query=`가 있다.
+- Client는 LiteLLM에 요청을 한 번만 보낸다.
+- Client는 server-side tool trace를 실행하지 않고 최종 `output_text`를 출력한다.
+- LiteLLM interceptor가 SearXNG를 호출하지 않는다.
+
+## 제약
+
+- Qwen2.5 1.5B는 경량 model이라 검색 query와 출처 조립 품질이 낮을 수 있다.
+- SearXNG upstream이 CAPTCHA나 `403`을 반환하면 tool loop는 성공해도 검색 결과가 비어 답변 품질이 낮아진다.
+- non-Harmony MCP tool calling은 실험적이므로 vLLM upgrade 시 두 tool 선언의 필요 여부를 다시 검증한다.
+- `vllm/vllm-openai-cpu:latest`는 재현성이 낮다. 운영에서는 검증한 version과 image digest를 고정한다.
+- vLLM Tool Server의 MCP client와 MCP dependency major version이 맞아야 한다. 이 예제 image는 호환되는 MCP 1.x를 고정한다.
+
+## 참고자료
+
+- [vLLM OpenAI-compatible server](https://docs.vllm.ai/en/latest/serving/online_serving/)
+- [vLLM serve CLI: tool server](https://docs.vllm.ai/en/latest/cli/serve/)
+- [vLLM server security](https://docs.vllm.ai/en/latest/usage/security/)
+- [vLLM MCP tool example](https://github.com/vllm-project/vllm/blob/main/examples/tool_calling/openai_responses_client_with_mcp_tools.py)

--- a/computer_science/ai/web-search-tool/litellm/Dockerfile
+++ b/computer_science/ai/web-search-tool/litellm/Dockerfile
@@ -1,0 +1,5 @@
+ARG LITELLM_BASE_IMAGE=ghcr.io/berriai/litellm:main-latest
+FROM ${LITELLM_BASE_IMAGE}
+
+RUN /app/.venv/bin/python -m ensurepip \
+  && /app/.venv/bin/python -m pip install --no-cache-dir "boto3[crt]"

--- a/computer_science/ai/web-search-tool/litellm/README.md
+++ b/computer_science/ai/web-search-tool/litellm/README.md
@@ -1,0 +1,1 @@
+LiteLLM을 AI gateway로 실행해 model routing과 선택적인 web search interception을 확인하는 코드다.

--- a/computer_science/ai/web-search-tool/litellm/app.py
+++ b/computer_science/ai/web-search-tool/litellm/app.py
@@ -1,0 +1,60 @@
+"""Run a LiteLLM-owned web-search interception request."""
+
+import argparse
+import os
+
+from openai import OpenAI
+
+MODEL_GROUPS = {
+  "qwen": "local-tool-model",
+  "bedrock": "bedrock-nova-micro",
+}
+
+LITELLM_WEB_SEARCH_TOOL = {
+  "type": "function",
+  "function": {
+    "name": "litellm_web_search",
+    "description": "Search the public web for current information and source URLs.",
+    "strict": True,
+    "parameters": {
+      "type": "object",
+      "properties": {"query": {"type": "string"}},
+      "required": ["query"],
+      "additionalProperties": False,
+    },
+  },
+}
+
+
+def parse_model_argument() -> str:
+  """Map a user-facing model name to a LiteLLM model group."""
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--model", choices=MODEL_GROUPS, default="qwen")
+  arguments = parser.parse_args()
+  return MODEL_GROUPS[arguments.model]
+
+
+def main() -> None:
+  """Send one request and let LiteLLM execute the complete tool loop."""
+  client = OpenAI(
+    base_url=os.getenv("LITELLM_BASE_URL", "http://localhost:4000/v1"),
+    api_key=os.getenv("LITELLM_MASTER_KEY", "sk-local-web-search"),
+  )
+  response = client.chat.completions.create(
+    model=parse_model_argument(),
+    messages=[
+      {
+        "role": "user",
+        "content": os.getenv(
+          "QUESTION", "오늘은 몇 월 며칠이고 서울 날씨는 어때요? 출처 URL과 함께 답하세요."
+        ),
+      }
+    ],
+    tools=[LITELLM_WEB_SEARCH_TOOL],
+    tool_choice={"type": "function", "function": {"name": "litellm_web_search"}},
+  )
+  print(response.choices[0].message.content)
+
+
+if __name__ == "__main__":
+  main()

--- a/computer_science/ai/web-search-tool/litellm/config.yaml
+++ b/computer_science/ai/web-search-tool/litellm/config.yaml
@@ -1,0 +1,35 @@
+model_list:
+  - model_name: local-tool-model
+    litellm_params:
+      model: openai/Qwen/Qwen2.5-1.5B-Instruct
+      api_base: os.environ/VLLM_API_BASE
+      api_key: os.environ/VLLM_API_KEY
+  - model_name: bedrock-nova-micro
+    litellm_params:
+      model: bedrock/amazon.nova-micro-v1:0
+      aws_region_name: os.environ/AWS_REGION
+      drop_params: true
+  - model_name: bedrock-provider-search
+    litellm_params:
+      model: bedrock/us.amazon.nova-2-lite-v1:0
+      aws_region_name: os.environ/AWS_REGION
+  - model_name: vllm-provider-search
+    litellm_params:
+      model: hosted_vllm/Qwen/Qwen2.5-1.5B-Instruct
+      api_base: os.environ/VLLM_API_BASE
+      api_key: os.environ/VLLM_API_KEY
+
+search_tools:
+  - search_tool_name: local-search
+    litellm_params:
+      search_provider: searxng
+      api_base: os.environ/SEARXNG_URL
+
+litellm_settings:
+  callbacks: ["websearch_interception"]
+  websearch_interception_params:
+    enabled_providers: ["openai", "bedrock"]
+    search_tool_name: local-search
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY

--- a/computer_science/ai/web-search-tool/pyproject.toml
+++ b/computer_science/ai/web-search-tool/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "web-search-tool-handson"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+  "boto3[crt]>=1.41",
+  "fastmcp>=3",
+  "httpx>=0.28",
+  "openai>=1.100",
+]
+
+[dependency-groups]
+dev = [
+  "pytest>=8.4",
+  "ruff>=0.12",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+
+[tool.ruff]
+indent-width = 2
+line-length = 100
+
+[tool.ruff.format]
+indent-style = "space"

--- a/computer_science/ai/web-search-tool/searxng/README.md
+++ b/computer_science/ai/web-search-tool/searxng/README.md
@@ -1,0 +1,1 @@
+SearXNG를 로컬 web search backend로 실행해 JSON 검색 결과를 제공하는 설정이다.

--- a/computer_science/ai/web-search-tool/searxng/settings.yml
+++ b/computer_science/ai/web-search-tool/searxng/settings.yml
@@ -1,0 +1,11 @@
+use_default_settings: true
+
+server:
+  secret_key: local-web-search-handson
+  limiter: false
+
+search:
+  safe_search: 0
+  formats:
+    - html
+    - json

--- a/computer_science/ai/web-search-tool/studysheet-web-search-tool-v1.html
+++ b/computer_science/ai/web-search-tool/studysheet-web-search-tool-v1.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>web_search는 누가 실행하는가</title>
+<style>
+:root{
+  --dark:#212022;--ink:#000;--point:#FFC000;--hl:#FFE066;--prob:#F00;
+  --wl:#FFF2CC;--rs:#E2EFDA;--grp:#F2F2F2;--code-bg:#1E1E1E;--code-ink:#D4D4D4
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{font-size:clamp(17px,min(2vw,3.4vh),40px)}
+body{background:#F2F2F2;color:var(--ink);font-family:"NanumBarunGothic","Apple SD Gothic Neo",sans-serif;line-height:1.7}
+#book{width:min(97vw,calc((100vh - 104px) * 16 / 9));margin:0 auto;padding:12px 0 86px}
+.page{display:none;animation:fade .25s ease;background:#fff;border:1px solid #E2E2E2;border-radius:10px;aspect-ratio:16/9;overflow-y:auto;padding:5% 7%}
+.page.on{display:block}
+@keyframes fade{from{opacity:0;transform:translateY(6px)}to{opacity:1;transform:none}}
+.page.cover{padding:5% 9%}
+.page.cover.on{display:flex;flex-direction:column;justify-content:center}
+.bar{border-left:8px solid var(--point);padding-left:22px}
+.cover h1{font-size:2.15rem;line-height:1.35;margin-bottom:10px}
+.sub{color:#555;margin-bottom:28px}
+.sec{font-size:.92rem;font-weight:800;letter-spacing:.02em}
+h2{font-size:1.55rem;line-height:1.35;margin:6px 0 18px}
+h3{font-size:1rem;margin:10px 0 4px}
+p{margin:9px 0}
+mark{background:var(--hl);color:var(--ink);padding:0 2px}
+.prob{color:var(--prob);font-weight:800}
+.dim{color:#666;font-size:.88rem}
+ul.bullets{list-style:none;margin:10px 0}
+ul.bullets>li{margin:7px 0}
+ul.bullets>li::before{content:"■";font-size:.65em;margin-right:9px;vertical-align:.15em}
+ul.bullets ul{list-style:none;margin:3px 0 3px 22px}
+ul.bullets ul>li::before{content:"-";margin-right:8px}
+.diagram{display:flex;align-items:center;justify-content:center;gap:10px;flex-wrap:wrap;padding:18px 6px;margin:10px 0}
+.dbox{border:1.2px solid var(--ink);border-radius:6px;padding:10px 15px;background:#fff;font-weight:650;font-size:.9rem;text-align:center}
+.dbox small{display:block;color:#555;font-weight:400;font-size:.72rem}
+.dbox.wl{background:var(--wl)}.dbox.rs{background:var(--rs)}.dbox.hot{background:var(--point);font-weight:800}.dbox.dim{opacity:.3}
+.darrow{font-size:1.1rem;font-weight:900}.darrow.bad{color:var(--prob)}
+.caption{text-align:center;font-size:.8rem;color:#555}
+.compare{width:100%;border-collapse:collapse;margin:12px 0;font-size:.78rem}
+.compare th,.compare td{border-bottom:1px solid #CCC;padding:8px;text-align:left;vertical-align:top}
+.compare th{background:var(--grp)}
+pre.code{background:var(--code-bg);color:var(--code-ink);border-radius:8px;padding:14px 16px;overflow-x:auto;font-size:.76rem;line-height:1.55;margin:10px 0;font-family:Consolas,monospace}
+.codedesc{font-size:.88rem;color:#444;margin-top:12px;font-weight:700}
+.tradeoff{display:flex;gap:26px;flex-wrap:wrap;margin:12px 0}
+.tradeoff>div{flex:1;min-width:240px}.tradeoff h3{border-bottom:2px solid var(--ink);padding-bottom:4px}
+.tradeoff .con h3{border-color:var(--prob);color:var(--prob)}
+.tradeoff ul{list-style:none}.tradeoff li{margin:6px 0}
+.tradeoff .pro li::before{content:"■";font-size:.65em;margin-right:8px}.tradeoff .con li::before{content:"✕";color:var(--prob);font-weight:900;margin-right:8px}
+.quiz{margin:14px 0}.quiz .q{font-weight:700}.quiz .opts{list-style:none;margin:8px 0}
+.quiz .opts li{border:1.3px solid var(--ink);border-radius:8px;padding:7px 12px;margin:7px 0;font-size:.9rem;cursor:pointer}
+.quiz.done .opts li{cursor:default}.quiz .opts li.correct{background:var(--point);font-weight:700}.quiz .opts li.wrong{border-color:var(--prob);color:var(--prob)}
+.quiz .fb{display:none;border-left:3px solid var(--point);padding-left:12px}.quiz.done .fb{display:block}.quiz .fb.no{border-color:var(--prob)}
+.foot{font-size:.76rem;color:#555;margin-top:18px}.foot a{color:#555}
+#nav{position:fixed;left:0;right:0;bottom:0;background:rgba(255,255,255,.96);border-top:1px solid #E2E2E2;backdrop-filter:blur(4px)}
+#nav .in{width:min(97vw,calc((100vh - 104px) * 16 / 9));margin:0 auto;display:flex;align-items:center;gap:12px;padding:11px 18px}
+#nav button{border:0;background:var(--dark);color:#fff;border-radius:999px;padding:8px 18px;font-weight:700;cursor:pointer}
+#nav button:disabled{opacity:.25;cursor:default}
+#dots{flex:1;display:flex;justify-content:center;gap:6px;flex-wrap:wrap}
+#dots button{width:9px;height:9px;padding:0;border-radius:50%;background:#DDD}#dots button.on{background:var(--point);transform:scale(1.25)}
+#counter{font-weight:800;color:#777;font-size:14px;min-width:58px;text-align:right}
+body.fs #book{width:min(97vw,calc((100vh - 24px) * 16 / 9));padding:12px 0}
+body.fs #nav{left:50%;right:auto;bottom:16px;width:auto;border:1px solid #DDD;border-radius:999px;box-shadow:0 8px 26px rgba(0,0,0,.18);transform:translate(-50%,calc(100% + 26px));opacity:0;pointer-events:none;transition:.22s}
+body.fs #nav .in{width:auto;padding:8px 14px}body.fs #dots{flex:0 0 auto}body.fs.dock-on #nav{transform:translate(-50%,0);opacity:1;pointer-events:auto}
+#dockhint{position:fixed;left:50%;bottom:18px;transform:translateX(-50%);background:rgba(33,32,34,.92);color:#fff;border-radius:999px;padding:7px 16px;font-size:13px;font-weight:700;opacity:0;pointer-events:none;transition:opacity .4s}#dockhint.on{opacity:1}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;transition-duration:.01ms!important}}
+@media print{body{background:#fff}#book{width:auto;padding:0}.page{display:block!important;aspect-ratio:auto;border:0;overflow:visible;page-break-after:always}#nav{display:none}}
+@media(max-width:640px){html{font-size:17px}#book,#nav .in{width:auto;max-width:100%}#book{padding:10px 8px 86px}.page,.page.cover{aspect-ratio:auto;min-height:70vh;padding:26px 20px}.tradeoff{gap:12px}.compare{font-size:.62rem;line-height:1.35}.compare th,.compare td{padding:5px 3px}#dots{display:none}#nav .in{gap:8px;padding:10px 12px}#nav button{padding:8px 13px}body.fs #book{width:auto}}
+</style>
+</head>
+<body>
+<main id="book">
+<section class="page cover">
+  <div class="bar">
+    <p class="sec">CLIENT → LITELLM → AI PROVIDER</p>
+    <h1>web_search는<br>누가 실행하는가</h1>
+    <p class="sub">tool call과 tool execution을 분리하고, 책임 경계를 직접 바꿔 봅니다.</p>
+  </div>
+  <p><span class="prob">오해:</span> 모델에 tool을 주면 모델이 인터넷에 접속합니다.</p>
+  <p><mark>완주:</mark> 같은 vLLM에서 client 소유와 LiteLLM 소유를 비교합니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">먼저 예측</p>
+  <h2>이 JSON 다음에 누가 움직여야 할까요?</h2>
+  <pre class="code">{
+  "name": "web_search",
+  "arguments": "{\"query\":\"오늘 날짜 서울 날씨\"}"
+}</pre>
+  <p>이 출력은 검색 결과가 아닙니다. 모델이 만든 <mark>실행 요청</mark>입니다.</p>
+  <div class="quiz">
+    <p class="q">검색 서버에 실제 HTTP 요청을 보내는 주체는?</p>
+    <ul class="opts">
+      <li>항상 모델 프로세스</li>
+      <li data-answer>설계가 지정한 client·gateway·provider runtime</li>
+      <li>OpenAI SDK가 자동 결정</li>
+    </ul>
+    <p class="fb"><b class="verdict"></b> tool call의 구조화와 tool의 실행은 서로 다른 책임입니다.</p>
+  </div>
+</section>
+
+<section class="page">
+  <p class="sec">핵심 원리</p>
+  <h2>한 번의 답변에는 최소 두 번의 모델 호출이 있습니다</h2>
+  <div class="diagram">
+    <div class="dbox wl">① 질문</div><div class="darrow">→</div>
+    <div class="dbox hot">② tool call</div><div class="darrow">→</div>
+    <div class="dbox rs">③ 검색 실행</div><div class="darrow">→</div>
+    <div class="dbox wl">④ tool result</div><div class="darrow">→</div>
+    <div class="dbox hot">⑤ 최종 답변</div>
+  </div>
+  <p class="caption">[ 모델 호출: ①→②, ④→⑤ · 도구 호출: ②→③→④ ]</p>
+  <p>책임 위치를 바꿔도 이 상태 전이는 사라지지 않습니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 A</p>
+  <h2>client가 loop를 소유하면 gateway는 트래픽만 봅니다</h2>
+  <div class="diagram">
+    <div class="dbox hot">Client<small>tool loop + search HTTP</small></div>
+    <div class="darrow">⇄</div><div class="dbox wl">LiteLLM<small>route · auth · log</small></div>
+    <div class="darrow">⇄</div><div class="dbox rs">vLLM<small>tool_calls 생성</small></div>
+  </div>
+  <ul class="bullets">
+    <li>검색 query, timeout, 최대 round를 애플리케이션이 통제</li>
+    <li>LiteLLM 장애 범위에 search provider를 넣지 않음</li>
+    <li>client가 많으면 같은 loop가 반복됨</li>
+  </ul>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 A · 핸즈온</p>
+  <h2>OpenAI SDK가 LiteLLM을 통과해 vLLM을 부릅니다</h2>
+  <p class="codedesc">macOS Docker Desktop에서 CPU vLLM과 로컬 서비스를 올린 뒤 client-owned loop를 실행합니다.</p>
+  <pre class="code">docker compose --progress quiet up -d searxng
+docker compose --progress quiet up -d vllm
+docker compose --progress quiet up -d litellm
+docker compose --profile client run --rm client-search</pre>
+  <p class="codedesc">기대 결과</p>
+  <pre class="code">오늘 날짜와 서울 날씨 설명 ...
+Sources: https://www.weather.go.kr/...</pre>
+  <p><b>성공 판정.</b> LiteLLM에는 두 model call이 보이고, 검색 HTTP 코드는 `client/app.py`에 있습니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 B</p>
+  <h2>LiteLLM interception은 gateway를 agent runtime으로 바꿉니다</h2>
+  <div class="diagram">
+    <div class="dbox dim">Client<small>한 번만 호출</small></div>
+    <div class="darrow">→</div><div class="dbox hot">LiteLLM<small>tool loop + SearXNG</small></div>
+    <div class="darrow">⇄</div><div class="dbox rs">vLLM<small>tool_calls + answer</small></div>
+  </div>
+  <p>client는 최종 응답만 받습니다. 검색 key와 정책은 중앙화되지만, 검색 장애가 gateway 장애가 됩니다.</p>
+  <p><mark>한 API call</mark>은 한 번의 upstream model call을 뜻하지 않습니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 B · 핸즈온</p>
+  <h2>같은 vLLM, 다른 실행 주체</h2>
+  <p class="codedesc">thin client는 `litellm_web_search`만 선언합니다.</p>
+  <pre class="code">docker compose --profile client run --rm gateway-search
+docker compose logs --since=2m litellm</pre>
+  <p class="codedesc">로그에서 찾을 흐름</p>
+  <pre class="code">vLLM → litellm_web_search(query)
+LiteLLM → SearXNG
+LiteLLM → vLLM(tool result)
+LiteLLM → client(final answer)</pre>
+  <p><b>성공 판정.</b> client 코드에 SearXNG 호출이 없고 LiteLLM 로그에 interception이 있습니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 C</p>
+  <h2>Nova Web Grounding은 Bedrock 안에서 검색을 끝냅니다</h2>
+  <div class="diagram">
+    <div class="dbox dim">Client<small>한 번만 호출</small></div>
+    <div class="darrow">→</div><div class="dbox wl">LiteLLM<small>형식 변환 + routing</small></div>
+    <div class="darrow">→</div><div class="dbox rs">Nova 2 Lite<small>검색 + 최종 답변</small></div>
+  </div>
+  <p>LiteLLM이 `web_search_options`를 `nova_grounding` system tool로 변환합니다. Bedrock이 검색과 재추론을 실행합니다.</p>
+  <p>응답에 grounding trace가 남아도 Client가 실행하거나 재호출할 대상은 아닙니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 C · 핸즈온</p>
+  <h2>Client는 최종 답변과 citation만 사용합니다</h2>
+  <p class="codedesc">로컬 AWS login session을 LiteLLM에 연결해 실행합니다.</p>
+  <pre class="code">make provider-bedrock</pre>
+  <p class="codedesc">관찰할 흐름</p>
+  <pre class="code">Client → LiteLLM(web_search_options)
+LiteLLM → Nova 2 Lite(nova_grounding)
+Nova 2 Lite → Client(final answer + citations)</pre>
+  <p><b>성공 판정.</b> Client와 LiteLLM이 SearXNG를 호출하지 않고 최종 답변을 받습니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">시나리오 D</p>
+  <h2>vLLM Tool Server도 검색 loop를 소유할 수 있습니다</h2>
+  <div class="diagram">
+    <div class="dbox dim">Client</div><div class="darrow">→</div>
+    <div class="dbox wl">LiteLLM</div><div class="darrow">→</div>
+    <div class="dbox hot">vLLM + Qwen</div><div class="darrow">⇄</div>
+    <div class="dbox rs">SearXNG MCP</div>
+  </div>
+  <ul class="bullets">
+    <li>vLLM Responses API와 `--tool-server`가 MCP browser를 실행</li>
+    <li>Qwen이 검색 결과를 받아 재추론하고 최종 답변 생성</li>
+    <li>LiteLLM은 interception 없이 인증과 routing만 담당</li>
+  </ul>
+  <pre class="code">docker compose --profile client run --rm vllm-provider-search
+docker compose logs --since=5m vllm searxng-mcp</pre>
+  <p class="prob">Qwen2.5 non-Harmony MCP는 실험적이며 SearXNG upstream 상태가 답변 품질에 영향을 줍니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">비교</p>
+  <h2>같은 loop를 어디에 둘 것인가</h2>
+  <table class="compare">
+    <thead><tr><th>기준</th><th>Client</th><th>LiteLLM</th><th>AI provider/runtime</th></tr></thead>
+    <tbody>
+      <tr><td>이식성</td><td>높음</td><td>중간</td><td>낮음</td></tr>
+      <tr><td>정책 중앙화</td><td>낮음</td><td>높음</td><td>높음</td></tr>
+      <tr><td>gateway 단순성</td><td>높음</td><td>낮음</td><td>해당 없음</td></tr>
+      <tr><td>debug 경계</td><td>명시적</td><td>중간 응답 숨김</td><td>provider telemetry 의존</td></tr>
+      <tr><td>지원 범위</td><td>모든 tool-capable 모델</td><td>interceptor 호환 provider</td><td>지원 API·모델만</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section class="page">
+  <p class="sec">판단</p>
+  <h2>LiteLLM은 트래픽만 관리해야 할까요?</h2>
+  <div class="tradeoff">
+    <div class="pro"><h3>기본값: 그렇습니다</h3><ul>
+      <li>route·auth·quota·logging에 집중</li>
+      <li>서로 다른 client 정책을 강제하지 않음</li>
+      <li>검색 장애의 blast radius 제한</li>
+    </ul></div>
+    <div class="con"><h3>예외: 중앙 실행</h3><ul>
+      <li>많은 client가 같은 search key 사용</li>
+      <li>domain 정책을 한 곳에서 강제</li>
+      <li>중복 loop보다 중앙 복잡도가 저렴</li>
+    </ul></div>
+  </div>
+  <p>gateway 소유는 기능 추가가 아니라 <mark>책임 이전</mark>으로 결정합니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">운영 체크</p>
+  <h2>실행 위치보다 먼저 고정할 안전장치</h2>
+  <ul class="bullets">
+    <li>최대 tool round와 전체 deadline</li>
+    <li>검색 query·domain allowlist와 egress policy</li>
+    <li>검색 결과의 prompt injection 취급</li>
+    <li>본문 인용 URL 보존과 사용자 출력 검증</li>
+    <li>model call과 search call의 공통 trace ID</li>
+    <li>검색 결과 크기 제한과 민감 query logging 정책</li>
+  </ul>
+  <p>어느 레이어든 이 목록을 소유하지 않으면, 책임은 분산된 것이 아니라 비어 있는 것입니다.</p>
+</section>
+
+<section class="page">
+  <p class="sec">Teach-back</p>
+  <h2>한 문장으로 경계를 설명해 보세요</h2>
+  <p>다음 빈칸을 자기 말로 채우면 핵심을 이해한 것입니다.</p>
+  <p style="font-size:1.15rem;margin:24px 0;border-bottom:2px solid #000;padding-bottom:12px">
+    모델의 tool call은 <mark>________</mark>이고, 실제 web search는 <mark>________</mark>가 실행합니다.
+  </p>
+  <div class="quiz">
+    <p class="q">LiteLLM을 traffic-only로 유지하면서 provider 종속성을 최소화하려면 search loop는 어디에 있어야 할까요?</p>
+    <ul class="opts"><li data-answer>client</li><li>vLLM 내부</li><li>항상 AgentCore</li></ul>
+    <p class="fb"><b class="verdict"></b> gateway는 model request를 전달하고 client가 tool result를 다시 보냅니다.</p>
+  </div>
+</section>
+
+<section class="page">
+  <p class="sec">완주</p>
+  <h2>두 로그를 비교하면 설계가 보입니다</h2>
+  <ul class="bullets">
+    <li>Client 시나리오: tool 상태가 client 로그에 남음</li>
+    <li>LiteLLM 시나리오: interception과 두 upstream call이 gateway 로그에 남음</li>
+    <li>Bedrock 시나리오: Nova Grounding trace와 citation이 provider 응답에 남음</li>
+    <li>vLLM 시나리오: MCP search query가 serving runtime 로그에 남음</li>
+  </ul>
+  <p><mark>추천 시작점:</mark> client-owned loop + traffic-only LiteLLM.</p>
+  <p class="foot">github 링크: <a href="https://github.com/choisungwook/portfolio/tree/master/computer_science/ai/web-search-tool">portfolio/web-search-tool</a></p>
+  <p class="foot">출처: <a href="https://docs.litellm.ai/docs/integrations/websearch_interception">LiteLLM</a> · <a href="https://docs.vllm.ai/en/latest/serving/online_serving/">vLLM</a> · <a href="https://docs.aws.amazon.com/bedrock/latest/userguide/tool-use.html">Bedrock</a> · <a href="https://docs.aws.amazon.com/nova/latest/nova2-userguide/web-grounding.html">Nova Web Grounding</a></p>
+</section>
+</main>
+
+<nav id="nav"><div class="in">
+  <button id="prev">← 이전</button><div id="dots"></div><span id="counter"></span>
+  <button id="next">다음 →</button><button id="fs">전체 화면</button>
+</div></nav>
+
+<script>
+(function(){
+  var pages=[].slice.call(document.querySelectorAll('.page')),i=0;
+  var prev=document.getElementById('prev'),next=document.getElementById('next');
+  var dots=document.getElementById('dots'),counter=document.getElementById('counter');
+  pages.forEach(function(_,j){var d=document.createElement('button');d.setAttribute('aria-label',(j+1)+'페이지로 이동');d.onclick=function(){i=j;show();};dots.appendChild(d);});
+  function show(){pages.forEach(function(p,j){p.classList.toggle('on',j===i);});[].forEach.call(dots.children,function(d,j){d.classList.toggle('on',j===i);});counter.textContent=(i+1)+' / '+pages.length;prev.disabled=i===0;next.disabled=i===pages.length-1;window.scrollTo(0,0);}
+  prev.onclick=function(){if(i>0){i--;show();}};next.onclick=function(){if(i<pages.length-1){i++;show();}};
+  document.addEventListener('keydown',function(e){if(e.key==='ArrowLeft')prev.onclick();if(e.key==='ArrowRight')next.onclick();});show();
+})();
+(function(){
+  var fs=document.getElementById('fs'),nav=document.getElementById('nav'),el=document.documentElement,over=false,hintTimer;
+  if(!el.requestFullscreen||!document.fullscreenEnabled){fs.style.display='none';return;}
+  var hint=document.createElement('div');hint.id='dockhint';hint.textContent='마우스를 아래로 내리면 메뉴 표시 · Esc로 창 모드';document.body.appendChild(hint);
+  function dock(on){document.body.classList.toggle('dock-on',on);if(on)hint.classList.remove('on');}
+  function track(e){if(!over)dock(e.clientY>=window.innerHeight-72);}
+  nav.addEventListener('pointerenter',function(){over=true;dock(true);});nav.addEventListener('pointerleave',function(){over=false;dock(false);});
+  fs.onclick=function(){var p=document.fullscreenElement?document.exitFullscreen():el.requestFullscreen();if(p&&p.catch)p.catch(function(){});};
+  document.addEventListener('fullscreenchange',function(){var on=!!document.fullscreenElement;fs.textContent=on?'창 모드':'전체 화면';document.body.classList.toggle('fs',on);document[on?'addEventListener':'removeEventListener']('pointermove',track);clearTimeout(hintTimer);hint.classList.toggle('on',on);if(on)hintTimer=setTimeout(function(){hint.classList.remove('on');},2600);});
+})();
+document.querySelectorAll('.quiz').forEach(function(qz){
+  var opts=[].slice.call(qz.querySelectorAll('.opts li'));
+  opts.forEach(function(o){o.setAttribute('role','button');o.tabIndex=0;o.onkeydown=function(e){if(e.key==='Enter'||e.key===' '){e.preventDefault();o.onclick();}};o.onclick=function(){if(qz.classList.contains('done'))return;qz.classList.add('done');var ok=o.hasAttribute('data-answer');opts.forEach(function(x){if(x.hasAttribute('data-answer'))x.classList.add('correct');});var fb=qz.querySelector('.fb');if(!ok){o.classList.add('wrong');fb.classList.add('no');}fb.querySelector('.verdict').textContent=ok?'정답.':'오답. 정답은 노란 보기.';};});
+});
+</script>
+</body>
+</html>

--- a/computer_science/ai/web-search-tool/tests/test_bedrock.py
+++ b/computer_science/ai/web-search-tool/tests/test_bedrock.py
@@ -1,0 +1,35 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+
+def load_bedrock_app():
+  path = Path(__file__).parents[1] / "ai-provider" / "bedrock" / "app.py"
+  spec = importlib.util.spec_from_file_location("bedrock_app", path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_request_search_uses_bedrock_provider_search() -> None:
+  app = load_bedrock_app()
+  client = Mock()
+
+  app.request_search(client, "오늘 날씨")
+
+  client.chat.completions.create.assert_called_once_with(
+    model="bedrock-provider-search",
+    messages=[{"role": "user", "content": "오늘 날씨"}],
+    web_search_options={},
+  )
+
+
+def test_citation_urls_reads_provider_metadata() -> None:
+  app = load_bedrock_app()
+  message = Mock(
+    provider_specific_fields={
+      "citationsContent": [{"citations": [{"location": {"web": {"url": "https://example.com"}}}]}]
+    }
+  )
+
+  assert app.citation_urls(message) == ["https://example.com"]

--- a/computer_science/ai/web-search-tool/tests/test_client.py
+++ b/computer_science/ai/web-search-tool/tests/test_client.py
@@ -1,0 +1,8 @@
+from client.app import MODEL_GROUPS
+
+
+def test_model_arguments_map_to_litellm_model_groups() -> None:
+  assert MODEL_GROUPS == {
+    "qwen": "local-tool-model",
+    "bedrock": "bedrock-nova-micro",
+  }

--- a/computer_science/ai/web-search-tool/tests/test_vllm_provider.py
+++ b/computer_science/ai/web-search-tool/tests/test_vllm_provider.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+
+def load_vllm_app():
+  path = Path(__file__).parents[1] / "ai-provider" / "vllm" / "app.py"
+  spec = importlib.util.spec_from_file_location("vllm_app", path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def test_request_search_enables_vllm_server_tool() -> None:
+  app = load_vllm_app()
+  client = Mock()
+
+  app.request_search(client, "오늘 날씨")
+
+  call = client.responses.create.call_args.kwargs
+  assert call["model"] == "vllm-provider-search"
+  assert call["input"] == "오늘 날씨"
+  assert "exactly once" in call["instructions"]
+  assert call["tools"][0] == {"type": "web_search_preview"}
+  assert call["tools"][1]["name"] == "web_search_preview"
+  assert call["tool_choice"] == "auto"
+  assert call["temperature"] == 0

--- a/computer_science/ai/web-search-tool/tests/test_web_search.py
+++ b/computer_science/ai/web-search-tool/tests/test_web_search.py
@@ -1,0 +1,18 @@
+from web_search import normalize_results
+
+
+def test_normalize_results_limits_and_renames_content() -> None:
+  payload = {
+    "results": [
+      {"title": "A", "url": "https://a.example", "content": "alpha"},
+      {"title": "B", "url": "https://b.example", "content": "beta"},
+    ]
+  }
+
+  assert normalize_results(payload, max_results=1) == [
+    {"title": "A", "url": "https://a.example", "snippet": "alpha"}
+  ]
+
+
+def test_normalize_results_handles_missing_fields() -> None:
+  assert normalize_results({"results": [{}]}) == [{"title": "", "url": "", "snippet": ""}]

--- a/computer_science/ai/web-search-tool/web_search.py
+++ b/computer_science/ai/web-search-tool/web_search.py
@@ -1,0 +1,30 @@
+"""Search the web through a SearXNG JSON endpoint."""
+
+from typing import Any
+
+import httpx
+
+
+def normalize_results(payload: dict[str, Any], max_results: int = 5) -> list[dict[str, str]]:
+  """Return compact title, URL, and snippet dictionaries from SearXNG output."""
+  results = []
+  for item in payload.get("results", [])[:max_results]:
+    results.append(
+      {
+        "title": str(item.get("title", "")),
+        "url": str(item.get("url", "")),
+        "snippet": str(item.get("content", "")),
+      }
+    )
+  return results
+
+
+def search_web(query: str, base_url: str, max_results: int = 5) -> list[dict[str, str]]:
+  """Query SearXNG and return compact results for an LLM tool response."""
+  response = httpx.get(
+    f"{base_url.rstrip('/')}/search",
+    params={"q": query, "format": "json"},
+    timeout=30,
+  )
+  response.raise_for_status()
+  return normalize_results(response.json(), max_results)


### PR DESCRIPTION
# 구현

Client·LiteLLM·Bedrock·vLLM별 web search 실행 위치 비교 핸즈온 추가
- 6개 unit test, Ruff, Docker Compose config 렌더링, Bedrock Web Grounding·vLLM MCP 경로 실행 확인

# 어려웠던 점

vLLM non-Harmony 모델의 server-side MCP tool loop 종료 조건 조정
- 강제 tool choice에서 재검색 반복 발생, auto와 1회 검색 지시로 최종 응답 종료

# 리스크

Qwen2.5 non-Harmony MCP 지원과 SearXNG upstream 가용성 의존
- vLLM 실험 기능 변경 또는 검색 engine CAPTCHA 발생 시 답변 품질 저하

Issue #974