### PR TITLE
akbun-makevideo: Inspector와 Source Monitor 추가

### DIFF
--- a/product/akbun-makevideo/README.md
+++ b/product/akbun-makevideo/README.md
@@ -8,6 +8,8 @@ Desktop video editor: a multi track timeline, a live preview, and a render to FH
 - Projects are folders under a workspace directory (`~/Documents/akbun-makevideo` by default, settable), with an Open list instead of a file dialog
 - Assets panel: drop files from Finder or import them, with kind, length and size read by ffprobe. **Importing references the file where it is — media is never copied into the project**
 - Program monitor: the render's own compositor draws straight onto a surface in the window, and the audio clock decides when each frame is shown. Playing and stopped are the same picture, so what is on screen is what will be in the file
+- Source monitor: preview an asset independently, mark frame-aligned in and out points, then insert, overwrite or append video, audio or both
+- Inspector: edit a selected layer's position, size, rotation and opacity, plus text, shape, subtitle or clip-specific properties
 - The older preview — stacked media elements, with the composited frame swapped in when the playhead stops — is still there as a setting and as the automatic fallback when the monitor cannot start
 - Timeline: up to four video and four audio tracks, linked picture and sound from video assets, drag to move, drag an edge to trim
 - Frame rates including the broadcast ones — 23.976, 29.97 and 59.94 are held as the exact ratios they are, so a camera file stays in step with itself. The clock reads in timecode and the arrow keys step a frame at a time

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.32.2",
+      "version": "0.33.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -135,6 +135,40 @@ pub enum Command {
         link_group: Option<String>,
     },
     #[serde(rename_all = "camelCase")]
+    InsertSource {
+        asset_id: String,
+        #[serde(default)]
+        video_track_id: Option<String>,
+        #[serde(default)]
+        audio_track_id: Option<String>,
+        start: i64,
+        in_point: i64,
+        out_point: i64,
+        #[serde(default)]
+        ripple_all_tracks: bool,
+    },
+    #[serde(rename_all = "camelCase")]
+    OverwriteSource {
+        asset_id: String,
+        #[serde(default)]
+        video_track_id: Option<String>,
+        #[serde(default)]
+        audio_track_id: Option<String>,
+        start: i64,
+        in_point: i64,
+        out_point: i64,
+    },
+    #[serde(rename_all = "camelCase")]
+    AppendSource {
+        asset_id: String,
+        #[serde(default)]
+        video_track_id: Option<String>,
+        #[serde(default)]
+        audio_track_id: Option<String>,
+        in_point: i64,
+        out_point: i64,
+    },
+    #[serde(rename_all = "camelCase")]
     MoveClip {
         clip_id: String,
         track_id: String,
@@ -397,6 +431,9 @@ impl Command {
             Command::SetTrackFlags { .. } => "Track settings",
             Command::SetSubtitleStyle { .. } => "Subtitle style",
             Command::AddClip { .. } => "Add clip",
+            Command::InsertSource { .. } => "Insert source",
+            Command::OverwriteSource { .. } => "Overwrite source",
+            Command::AppendSource { .. } => "Append source",
             Command::MoveClip { .. } => "Move clip",
             Command::TrimClip { .. } => "Trim clip",
             Command::SplitAt { .. } => "Split",
@@ -457,6 +494,57 @@ impl Command {
                 id,
                 link_group,
             } => add_clip(project, ids, track_id, asset_id, start, id, link_group),
+            Command::InsertSource {
+                asset_id,
+                video_track_id,
+                audio_track_id,
+                start,
+                in_point,
+                out_point,
+                ripple_all_tracks,
+            } => insert_source(
+                project,
+                ids,
+                asset_id,
+                video_track_id,
+                audio_track_id,
+                start,
+                in_point,
+                out_point,
+                ripple_all_tracks,
+            ),
+            Command::OverwriteSource {
+                asset_id,
+                video_track_id,
+                audio_track_id,
+                start,
+                in_point,
+                out_point,
+            } => overwrite_source(
+                project,
+                ids,
+                asset_id,
+                video_track_id,
+                audio_track_id,
+                start,
+                in_point,
+                out_point,
+            ),
+            Command::AppendSource {
+                asset_id,
+                video_track_id,
+                audio_track_id,
+                in_point,
+                out_point,
+            } => append_source(
+                project,
+                ids,
+                asset_id,
+                video_track_id,
+                audio_track_id,
+                in_point,
+                out_point,
+            ),
             Command::MoveClip {
                 clip_id,
                 track_id,
@@ -807,6 +895,472 @@ fn add_clip(
         },
         inverse: Command::DropClips { clip_ids: vec![id] },
     })
+}
+
+fn insert_source(
+    project: &mut Project,
+    ids: &mut Ids,
+    asset_id: String,
+    video_track_id: Option<String>,
+    audio_track_id: Option<String>,
+    start: i64,
+    in_point: i64,
+    out_point: i64,
+    ripple_all_tracks: bool,
+) -> Result<Applied, String> {
+    let before = project.clone();
+    let result = (|| {
+        let targets = source_targets(project, &asset_id, video_track_id, audio_track_id)?;
+        validate_source_range(project, &asset_id, in_point, out_point)?;
+        let duration = out_point - in_point;
+        let mut shifted: HashSet<String> = if ripple_all_tracks {
+            project.tracks.iter().map(|track| track.id.clone()).collect()
+        } else {
+            targets.iter().cloned().collect()
+        };
+        expand_linked_tracks(project, start, &mut shifted);
+        split_for_insert(project, ids, start, &shifted);
+        for track in &mut project.tracks {
+            if !shifted.contains(&track.id) {
+                continue;
+            }
+            for clip in &mut track.clips {
+                if clip.start >= start {
+                    clip.start += duration;
+                }
+            }
+            for item in &mut track.visual_items {
+                if item.start >= start {
+                    item.start += duration;
+                }
+            }
+            track.sort();
+        }
+        add_source_clips(
+            project,
+            ids,
+            &asset_id,
+            &targets,
+            start,
+            in_point,
+            out_point,
+        )?;
+        project.validate()?;
+        Ok(timeline_applied(&before, project))
+    })();
+    if result.is_err() {
+        *project = before;
+    }
+    result
+}
+
+fn overwrite_source(
+    project: &mut Project,
+    ids: &mut Ids,
+    asset_id: String,
+    video_track_id: Option<String>,
+    audio_track_id: Option<String>,
+    start: i64,
+    in_point: i64,
+    out_point: i64,
+) -> Result<Applied, String> {
+    let before = project.clone();
+    let result = (|| {
+        let targets = source_targets(project, &asset_id, video_track_id, audio_track_id)?;
+        validate_source_range(project, &asset_id, in_point, out_point)?;
+        let end = start
+            .checked_add(out_point - in_point)
+            .ok_or("that source range is too long")?;
+        carve_overwrite(project, ids, &targets, start, end);
+        add_source_clips(
+            project,
+            ids,
+            &asset_id,
+            &targets,
+            start,
+            in_point,
+            out_point,
+        )?;
+        project.validate()?;
+        Ok(timeline_applied(&before, project))
+    })();
+    if result.is_err() {
+        *project = before;
+    }
+    result
+}
+
+fn append_source(
+    project: &mut Project,
+    ids: &mut Ids,
+    asset_id: String,
+    video_track_id: Option<String>,
+    audio_track_id: Option<String>,
+    in_point: i64,
+    out_point: i64,
+) -> Result<Applied, String> {
+    let before = project.clone();
+    let result = (|| {
+        let targets = source_targets(project, &asset_id, video_track_id, audio_track_id)?;
+        validate_source_range(project, &asset_id, in_point, out_point)?;
+        let start = project
+            .tracks
+            .iter()
+            .flat_map(|track| {
+                let clips = track.clips.iter().map(Clip::end_frame);
+                let items = track.visual_items.iter().map(VisualItem::end_frame);
+                clips.chain(items)
+            })
+            .max()
+            .unwrap_or(0);
+        add_source_clips(
+            project,
+            ids,
+            &asset_id,
+            &targets,
+            start,
+            in_point,
+            out_point,
+        )?;
+        project.validate()?;
+        Ok(timeline_applied(&before, project))
+    })();
+    if result.is_err() {
+        *project = before;
+    }
+    result
+}
+
+fn source_targets(
+    project: &Project,
+    asset_id: &str,
+    video_track_id: Option<String>,
+    audio_track_id: Option<String>,
+) -> Result<Vec<String>, String> {
+    let asset = project
+        .asset(asset_id)
+        .ok_or("that source asset is not in this project")?;
+    let mut targets = Vec::new();
+    for (track_id, kind) in [
+        (video_track_id, TrackKind::Video),
+        (audio_track_id, TrackKind::Audio),
+    ] {
+        let Some(track_id) = track_id else {
+            continue;
+        };
+        let track = project
+            .track(&track_id)
+            .ok_or("that source target track is not on the timeline")?;
+        if track.kind != kind || !track.accepts(asset) {
+            return Err(format!("{} cannot receive that source", track.name));
+        }
+        targets.push(track_id);
+    }
+    if targets.is_empty() {
+        return Err("choose video, audio, or both before placing the source".into());
+    }
+    Ok(targets)
+}
+
+fn validate_source_range(
+    project: &Project,
+    asset_id: &str,
+    in_point: i64,
+    out_point: i64,
+) -> Result<(), String> {
+    if in_point < 0 || out_point <= in_point {
+        return Err("the source out point must be after its in point".into());
+    }
+    let asset = project
+        .asset(asset_id)
+        .ok_or("that source asset is not in this project")?;
+    if let Some(limit) = asset.source_limit_frames(project.rate()) {
+        if out_point > limit {
+            return Err("the source range reaches past the end of the file".into());
+        }
+    }
+    Ok(())
+}
+
+fn add_source_clips(
+    project: &mut Project,
+    ids: &mut Ids,
+    asset_id: &str,
+    targets: &[String],
+    start: i64,
+    in_point: i64,
+    out_point: i64,
+) -> Result<(), String> {
+    if start < 0 {
+        return Err("a source cannot start before the timeline does".into());
+    }
+    let duration = out_point - in_point;
+    for track_id in targets {
+        let track = project.track(track_id).expect("source target was checked");
+        if track.free_start(start, duration, None) != start {
+            return Err(format!("{} has no room for that source range", track.name));
+        }
+    }
+    let group = (targets.len() == 2).then(|| ids.make('g'));
+    for track_id in targets {
+        let clip = Clip {
+            id: ids.make('c'),
+            asset_id: asset_id.into(),
+            link_group: group.clone(),
+            lut_path: None,
+            start,
+            in_point,
+            out_point,
+            volume: 1.0,
+            opacity: 1.0,
+        };
+        let track = project
+            .track_mut(track_id)
+            .expect("source target was checked");
+        track.clips.push(clip);
+        track.sort();
+    }
+    Ok(())
+}
+
+fn expand_linked_tracks(project: &Project, from: i64, tracks: &mut HashSet<String>) {
+    loop {
+        let groups: HashSet<String> = project
+            .tracks
+            .iter()
+            .filter(|track| tracks.contains(&track.id))
+            .flat_map(|track| &track.clips)
+            .filter(|clip| clip.end_frame() > from)
+            .filter_map(|clip| clip.link_group.clone())
+            .collect();
+        let before = tracks.len();
+        for track in &project.tracks {
+            if track
+                .clips
+                .iter()
+                .any(|clip| clip.link_group.as_ref().is_some_and(|group| groups.contains(group)))
+            {
+                tracks.insert(track.id.clone());
+            }
+        }
+        if tracks.len() == before {
+            break;
+        }
+    }
+}
+
+fn split_for_insert(
+    project: &mut Project,
+    ids: &mut Ids,
+    at: i64,
+    tracks: &HashSet<String>,
+) {
+    let mut units = Vec::new();
+    let mut seen = HashSet::new();
+    for track in &project.tracks {
+        if !tracks.contains(&track.id) {
+            continue;
+        }
+        for clip in &track.clips {
+            if clip.start < at && at < clip.end_frame() {
+                let key = clip.link_group.as_deref().unwrap_or(&clip.id).to_string();
+                if seen.insert(key) {
+                    units.push(clip.id.clone());
+                }
+            }
+        }
+    }
+    for clip_id in units {
+        let placements = project.linked_placements(&clip_id);
+        let right_group = (placements.len() == 2).then(|| ids.make('g'));
+        let remove: HashSet<String> = placements
+            .iter()
+            .map(|entry| entry.clip.id.clone())
+            .collect();
+        for track in &mut project.tracks {
+            track.clips.retain(|clip| !remove.contains(&clip.id));
+        }
+        for entry in placements {
+            let mut left = entry.clip.clone();
+            let mut right = entry.clip;
+            let offset = at - left.start;
+            left.out_point = left.in_point + offset;
+            right.id = ids.make('c');
+            right.link_group = right_group.clone();
+            right.start = at;
+            right.in_point += offset;
+            let track = project
+                .track_mut(&entry.track_id)
+                .expect("clip placement has a track");
+            track.clips.extend([left, right]);
+            track.sort();
+        }
+    }
+}
+
+fn carve_overwrite(
+    project: &mut Project,
+    ids: &mut Ids,
+    targets: &[String],
+    start: i64,
+    end: i64,
+) {
+    let target_set: HashSet<&str> = targets.iter().map(String::as_str).collect();
+    let mut units = Vec::new();
+    let mut seen = HashSet::new();
+    for track in &project.tracks {
+        if !target_set.contains(track.id.as_str()) {
+            continue;
+        }
+        for clip in &track.clips {
+            if clip.start >= end || clip.end_frame() <= start {
+                continue;
+            }
+            let key = clip.link_group.as_deref().unwrap_or(&clip.id).to_string();
+            if seen.insert(key) {
+                units.push(clip.id.clone());
+            }
+        }
+    }
+    for clip_id in units {
+        let placements = project.linked_placements(&clip_id);
+        let remove: HashSet<String> = placements
+            .iter()
+            .map(|entry| entry.clip.id.clone())
+            .collect();
+        for track in &mut project.tracks {
+            track.clips.retain(|clip| !remove.contains(&clip.id));
+        }
+        let needs_right = placements
+            .first()
+            .is_some_and(|entry| entry.clip.start < start && entry.clip.end_frame() > end);
+        let right_group = (placements.len() == 2 && needs_right).then(|| ids.make('g'));
+        for entry in placements {
+            let clip = entry.clip;
+            let mut pieces = Vec::new();
+            if clip.start < start {
+                let mut left = clip.clone();
+                left.out_point = left.in_point + (start - left.start);
+                pieces.push(left);
+            }
+            if clip.end_frame() > end {
+                let mut right = clip.clone();
+                if clip.start < start {
+                    right.id = ids.make('c');
+                    right.link_group = right_group.clone();
+                }
+                right.in_point += end - right.start;
+                right.start = end;
+                pieces.push(right);
+            }
+            let track = project
+                .track_mut(&entry.track_id)
+                .expect("clip placement has a track");
+            track.clips.extend(pieces);
+            track.sort();
+        }
+    }
+}
+
+fn timeline_applied(before: &Project, after: &Project) -> Applied {
+    let before_clips = clip_entries(before);
+    let after_clips = clip_entries(after);
+    let before_items = visual_item_entries(before);
+    let after_items = visual_item_entries(after);
+    Applied {
+        resolved: timeline_replace(&before_clips, &after_clips, &before_items, &after_items),
+        inverse: timeline_replace(&after_clips, &before_clips, &after_items, &before_items),
+    }
+}
+
+fn clip_entries(project: &Project) -> Vec<ClipAt> {
+    project
+        .tracks
+        .iter()
+        .flat_map(|track| {
+            track.clips.iter().cloned().map(|clip| ClipAt {
+                track_id: track.id.clone(),
+                clip,
+            })
+        })
+        .collect()
+}
+
+fn visual_item_entries(project: &Project) -> Vec<VisualItemAt> {
+    project
+        .tracks
+        .iter()
+        .flat_map(|track| {
+            track
+                .visual_items
+                .iter()
+                .cloned()
+                .map(|item| VisualItemAt {
+                    track_id: track.id.clone(),
+                    item,
+                })
+        })
+        .collect()
+}
+
+fn timeline_replace(
+    old_clips: &[ClipAt],
+    new_clips: &[ClipAt],
+    old_items: &[VisualItemAt],
+    new_items: &[VisualItemAt],
+) -> Command {
+    let old_clip_map: HashMap<&str, &ClipAt> = old_clips
+        .iter()
+        .map(|entry| (entry.clip.id.as_str(), entry))
+        .collect();
+    let new_clip_map: HashMap<&str, &ClipAt> = new_clips
+        .iter()
+        .map(|entry| (entry.clip.id.as_str(), entry))
+        .collect();
+    let old_item_map: HashMap<&str, &VisualItemAt> = old_items
+        .iter()
+        .map(|entry| (entry.item.id.as_str(), entry))
+        .collect();
+    let new_item_map: HashMap<&str, &VisualItemAt> = new_items
+        .iter()
+        .map(|entry| (entry.item.id.as_str(), entry))
+        .collect();
+    let drop_clips = old_clips
+        .iter()
+        .filter(|entry| new_clip_map.get(entry.clip.id.as_str()).copied() != Some(*entry))
+        .map(|entry| entry.clip.id.clone())
+        .collect();
+    let restore_clips = new_clips
+        .iter()
+        .filter(|entry| old_clip_map.get(entry.clip.id.as_str()).copied() != Some(*entry))
+        .cloned()
+        .collect();
+    let drop_items = old_items
+        .iter()
+        .filter(|entry| new_item_map.get(entry.item.id.as_str()).copied() != Some(*entry))
+        .map(|entry| entry.item.id.clone())
+        .collect();
+    let restore_items = new_items
+        .iter()
+        .filter(|entry| old_item_map.get(entry.item.id.as_str()).copied() != Some(*entry))
+        .cloned()
+        .collect();
+    Command::Transaction {
+        commands: vec![
+            Command::DropClips {
+                clip_ids: drop_clips,
+            },
+            Command::RestoreClips {
+                entries: restore_clips,
+            },
+            Command::DropVisualItems {
+                item_ids: drop_items,
+            },
+            Command::RestoreVisualItems {
+                entries: restore_items,
+            },
+        ],
+    }
 }
 
 fn move_clip(

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -1223,7 +1223,31 @@ fn carve_overwrite(
         }
     }
     for clip_id in units {
-        let placements = project.linked_placements(&clip_id);
+        let mut linked = project.linked_placements(&clip_id);
+        if linked
+            .iter()
+            .any(|entry| !target_set.contains(entry.track_id.as_str()))
+        {
+            let link_group = linked
+                .first()
+                .and_then(|entry| entry.clip.link_group.clone());
+            if let Some(link_group) = link_group {
+                for track in &mut project.tracks {
+                    for clip in &mut track.clips {
+                        if clip.link_group.as_deref() == Some(&link_group) {
+                            clip.link_group = None;
+                        }
+                    }
+                }
+                for entry in &mut linked {
+                    entry.clip.link_group = None;
+                }
+            }
+        }
+        let placements: Vec<_> = linked
+            .into_iter()
+            .filter(|entry| target_set.contains(entry.track_id.as_str()))
+            .collect();
         let remove: HashSet<String> = placements
             .iter()
             .map(|entry| entry.clip.id.clone())

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -1376,6 +1376,28 @@ mod tests {
     }
 
     #[test]
+    fn source_video_only_overwrite_preserves_linked_audio() {
+        let mut document = document();
+        add_linked(&mut document, 0);
+        let mut expected_audio = document.project().tracks[1].clips.clone();
+        expected_audio[0].link_group = None;
+
+        document
+            .apply(Command::OverwriteSource {
+                asset_id: "v".into(),
+                video_track_id: Some(video_track(&document)),
+                audio_track_id: None,
+                start: 90,
+                in_point: 30,
+                out_point: 90,
+            })
+            .unwrap();
+
+        assert_eq!(clips(&document).len(), 3);
+        assert_eq!(document.project().tracks[1].clips, expected_audio);
+    }
+
+    #[test]
     fn source_video_and_audio_are_linked_and_append_uses_the_sequence_end() {
         let mut document = document();
         add(&mut document, 0);

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -1307,6 +1307,97 @@ mod tests {
     }
 
     #[test]
+    fn source_insert_splits_at_a_frame_boundary_and_is_one_undo_step() {
+        let mut document = document();
+        add(&mut document, 0);
+        let original = clips(&document)[0].clone();
+
+        document
+            .apply(Command::InsertSource {
+                asset_id: "v".into(),
+                video_track_id: Some(video_track(&document)),
+                audio_track_id: None,
+                start: 150,
+                in_point: 30,
+                out_point: 90,
+                ripple_all_tracks: false,
+            })
+            .unwrap();
+
+        let placed = clips(&document);
+        assert_eq!(placed.len(), 3);
+        assert_eq!(
+            placed
+                .iter()
+                .map(|clip| (clip.start, clip.in_point, clip.out_point))
+                .collect::<Vec<_>>(),
+            vec![(0, 0, 150), (150, 30, 90), (210, 150, 300)]
+        );
+        let ids: Vec<String> = placed.iter().map(|clip| clip.id.clone()).collect();
+
+        document.undo().unwrap();
+        assert_eq!(clips(&document), vec![original]);
+        document.redo().unwrap();
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| clip.id.clone())
+                .collect::<Vec<_>>(),
+            ids
+        );
+    }
+
+    #[test]
+    fn source_overwrite_carves_the_range_and_undo_restores_the_clip() {
+        let mut document = document();
+        add(&mut document, 0);
+        let original = clips(&document)[0].clone();
+
+        document
+            .apply(Command::OverwriteSource {
+                asset_id: "v".into(),
+                video_track_id: Some(video_track(&document)),
+                audio_track_id: None,
+                start: 90,
+                in_point: 30,
+                out_point: 90,
+            })
+            .unwrap();
+
+        assert_eq!(
+            clips(&document)
+                .iter()
+                .map(|clip| (clip.start, clip.in_point, clip.out_point))
+                .collect::<Vec<_>>(),
+            vec![(0, 0, 90), (90, 30, 90), (150, 150, 300)]
+        );
+        document.undo().unwrap();
+        assert_eq!(clips(&document), vec![original]);
+    }
+
+    #[test]
+    fn source_video_and_audio_are_linked_and_append_uses_the_sequence_end() {
+        let mut document = document();
+        add(&mut document, 0);
+        document
+            .apply(Command::AppendSource {
+                asset_id: "v".into(),
+                video_track_id: Some(video_track(&document)),
+                audio_track_id: Some(audio_track(&document)),
+                in_point: 60,
+                out_point: 120,
+            })
+            .unwrap();
+
+        let video = document.project().tracks[0].clips.last().unwrap();
+        let audio = document.project().tracks[1].clips.last().unwrap();
+        assert_eq!((video.start, video.in_point, video.out_point), (300, 60, 120));
+        assert_eq!((audio.start, audio.in_point, audio.out_point), (300, 60, 120));
+        assert!(video.link_group.is_some());
+        assert_eq!(video.link_group, audio.link_group);
+    }
+
+    #[test]
     fn markers_are_saved_edited_and_undone() {
         let mut document = document();
         document

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -123,36 +123,70 @@
         <p id="asset-empty">Drop video, audio or image files here, or use Import.</p>
       </aside>
 
-      <section id="preview-panel">
-        <header class="panel-head">
-          <h2>Preview</h2>
-          <button id="btn-debug" class="small" type="button">Debug</button>
-        </header>
-        <div id="stage-wrap">
-          <div id="stage">
-            <div id="stage-inner"><canvas id="stage-exact"></canvas></div>
-            <canvas id="stage-visuals" aria-label="Text and shape layers"></canvas>
-            <canvas id="stage-overlay" aria-label="Program Monitor selection overlay"></canvas>
+      <div id="monitor-workspace">
+        <section id="source-panel">
+          <header class="panel-head">
+            <h2>Source Monitor</h2>
+          </header>
+          <div id="source-stage-wrap" class="monitor-stage-wrap">
+            <div id="source-stage" class="monitor-stage">
+              <div id="source-stage-inner" class="monitor-stage-inner"></div>
+            </div>
+            <p id="source-hint">Select an asset to preview it before placing it.</p>
           </div>
-          <span id="stage-mode" hidden></span>
-          <p id="stage-hint">Drop media on the timeline below to see it here.</p>
-        </div>
-        <div id="transport">
-          <button id="btn-play" title="Play or pause (Space)">▶</button>
-          <span id="clock" class="mono">0:00:00.00</span>
-          <span class="dim mono">/</span>
-          <span id="duration" class="mono dim">0:00:00.00</span>
-          <span class="menubar-gap"></span>
-          <label class="inline">
-            Preview quality
-            <select id="preview-quality">
-              <option value="full">Full</option>
-              <option value="half">Half</option>
-              <option value="quarter">Quarter</option>
-            </select>
-          </label>
-        </div>
-      </section>
+          <div id="source-transport" class="monitor-transport">
+            <button id="source-play" title="Play or pause the source">▶</button>
+            <span id="source-clock" class="mono">0:00:00:00</span>
+            <span class="dim mono">/</span>
+            <span id="source-duration" class="mono dim">0:00:00:00</span>
+            <button id="source-mark-in" title="Set the source in point">In</button>
+            <button id="source-mark-out" title="Set the source out point">Out</button>
+          </div>
+          <div id="source-actions">
+            <input id="source-seek" type="range" min="0" max="1" step="1" value="0" aria-label="Source position" />
+            <span id="source-range" class="mono dim">0:00:00:00 – 0:00:00:00</span>
+            <label class="check"><input id="source-video" type="checkbox" checked /> Video</label>
+            <label class="check"><input id="source-audio" type="checkbox" checked /> Audio</label>
+            <label class="inline">Insert ripple
+              <select id="source-ripple"><option value="track">Target tracks</option><option value="all">All tracks</option></select>
+            </label>
+            <button id="source-insert">Insert</button>
+            <button id="source-overwrite">Overwrite</button>
+            <button id="source-append">Append</button>
+          </div>
+        </section>
+
+        <section id="preview-panel">
+          <header class="panel-head">
+            <h2>Program Monitor</h2>
+            <button id="btn-debug" class="small" type="button">Debug</button>
+          </header>
+          <div id="stage-wrap">
+            <div id="stage">
+              <div id="stage-inner"><canvas id="stage-exact"></canvas></div>
+              <canvas id="stage-visuals" aria-label="Text and shape layers"></canvas>
+              <canvas id="stage-overlay" aria-label="Program Monitor selection overlay"></canvas>
+            </div>
+            <span id="stage-mode" hidden></span>
+            <p id="stage-hint">Drop media on the timeline below to see it here.</p>
+          </div>
+          <div id="transport">
+            <button id="btn-play" title="Play or pause (Space)">▶</button>
+            <span id="clock" class="mono">0:00:00.00</span>
+            <span class="dim mono">/</span>
+            <span id="duration" class="mono dim">0:00:00.00</span>
+            <span class="menubar-gap"></span>
+            <label class="inline">
+              Preview quality
+              <select id="preview-quality">
+                <option value="full">Full</option>
+                <option value="half">Half</option>
+                <option value="quarter">Quarter</option>
+              </select>
+            </label>
+          </div>
+        </section>
+      </div>
 
       <aside id="inspector-panel">
         <header class="panel-head">
@@ -160,6 +194,13 @@
         </header>
         <div id="inspector-body">
           <p id="inspector-empty" class="dim small-text">Select a clip or a layer to edit its properties.</p>
+          <div id="transform-panel" hidden>
+            <h3>Transform</h3>
+            <div class="field-pair"><label>X <input id="transform-x" type="number" step="1" /></label><label>Y <input id="transform-y" type="number" step="1" /></label></div>
+            <div class="field-pair"><label>Width <input id="transform-width" type="number" min="1" step="1" /></label><label>Height <input id="transform-height" type="number" min="1" step="1" /></label></div>
+            <label class="row">Rotation <input id="transform-rotation" type="number" step="0.1" /></label>
+            <label class="row">Opacity <input id="transform-opacity" type="range" min="0" max="1" step="0.01" /><input id="transform-opacity-value" class="compact-number" type="number" min="0" max="1" step="0.01" /></label>
+          </div>
           <div id="clip-panel" hidden>
             <h3>Clip</h3>
             <p id="clip-summary" class="dim small-text"></p>
@@ -486,6 +527,7 @@
   <script src="time.js"></script>
   <script src="geometry.js"></script>
   <script src="timeline.js"></script>
+  <script src="source.js"></script>
   <script src="shortcuts.js"></script>
   <script src="quality.js"></script>
   <script src="preview.js"></script>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -21,6 +21,7 @@ const T = globalThis.timeLib;
 const K = globalThis.shortcutLib;
 const X = globalThis.transformLib;
 const G = globalThis.guideLib;
+const S = globalThis.sourceLib;
 
 // Pointer distance from a clip edge that starts a trim instead of a move.
 const HANDLE_PX = 8;
@@ -73,6 +74,23 @@ const dom = {
   assetsPanel: el('assets-panel'),
   btnImport: el('btn-import'),
   btnDebug: el('btn-debug'),
+  sourceStageWrap: el('source-stage-wrap'),
+  sourceStage: el('source-stage'),
+  sourceStageInner: el('source-stage-inner'),
+  sourceHint: el('source-hint'),
+  sourcePlay: el('source-play'),
+  sourceClock: el('source-clock'),
+  sourceDuration: el('source-duration'),
+  sourceMarkIn: el('source-mark-in'),
+  sourceMarkOut: el('source-mark-out'),
+  sourceSeek: el('source-seek'),
+  sourceRange: el('source-range'),
+  sourceVideo: el('source-video'),
+  sourceAudio: el('source-audio'),
+  sourceRipple: el('source-ripple'),
+  sourceInsert: el('source-insert'),
+  sourceOverwrite: el('source-overwrite'),
+  sourceAppend: el('source-append'),
   debugPanel: el('debug-panel'),
   debugMetrics: el('debug-metrics'),
   debugLog: el('debug-log'),
@@ -113,6 +131,14 @@ const dom = {
   ruler: el('ruler'),
   markerList: el('marker-list'),
   inspectorEmpty: el('inspector-empty'),
+  transformPanel: el('transform-panel'),
+  transformX: el('transform-x'),
+  transformY: el('transform-y'),
+  transformWidth: el('transform-width'),
+  transformHeight: el('transform-height'),
+  transformRotation: el('transform-rotation'),
+  transformOpacity: el('transform-opacity'),
+  transformOpacityValue: el('transform-opacity-value'),
   clipPanel: el('clip-panel'),
   clipSummary: el('clip-summary'),
   clipOpacityRow: el('clip-opacity-row'),
@@ -186,6 +212,7 @@ const state = {
   selectedClipId: null,
   selectedVisualItemId: null,
   selectedAssetId: null,
+  sourceSelection: null,
   targetTrackId: null,
   pxPerSecond: 30,
   rendering: false,
@@ -198,6 +225,7 @@ const state = {
 
 let preview = null;
 let mediaPreview = null;
+let sourcePreview = null;
 let qualityMonitor = null;
 let visualDrag = null;
 let editorOverlayActive = false;
@@ -559,6 +587,80 @@ function renderAssets() {
   dom.assetEmpty.hidden = state.project.assets.length > 0;
 }
 
+function selectedSourceAsset() {
+  return state.selectedAssetId ? L.findAsset(state.project, state.selectedAssetId) : null;
+}
+
+function sourceTime(frame) {
+  return L.formatTimecode(Math.max(0, Math.round(frame || 0)), rate());
+}
+
+function renderSourceMonitor() {
+  const asset = selectedSourceAsset();
+  if (state.selectedAssetId && !asset) {
+    state.selectedAssetId = null;
+    state.sourceSelection = null;
+    if (sourcePreview) sourcePreview.showAsset(null);
+  }
+  const selection = asset && (state.sourceSelection || S.selectionFor(asset, rate()));
+  const limit = asset ? S.sourceLimitFrames(asset, rate()) : 0;
+  if (selection) state.sourceSelection = selection;
+  dom.sourceHint.hidden = Boolean(asset);
+  dom.sourceClock.textContent = sourceTime(sourcePreview ? sourcePreview.position() : 0);
+  dom.sourceDuration.textContent = sourceTime(limit);
+  dom.sourceSeek.max = String(Math.max(1, limit));
+  dom.sourceSeek.value = String(Math.min(limit, Math.round(sourcePreview ? sourcePreview.position() : 0)));
+  dom.sourceSeek.disabled = !asset || asset.kind === 'image';
+  dom.sourceRange.textContent = selection
+    ? `${sourceTime(selection.inPoint)} – ${sourceTime(selection.outPoint)}`
+    : `${sourceTime(0)} – ${sourceTime(0)}`;
+  const canVideo = Boolean(asset) && (asset.kind === 'video' || asset.kind === 'image');
+  const canAudio = Boolean(asset) &&
+    (asset.kind === 'audio' || (asset.kind === 'video' && asset.hasAudio));
+  dom.sourceVideo.disabled = !canVideo;
+  dom.sourceAudio.disabled = !canAudio;
+  if (!canVideo) dom.sourceVideo.checked = false;
+  if (!canAudio) dom.sourceAudio.checked = false;
+  dom.sourcePlay.disabled = !asset || asset.kind === 'image';
+  dom.sourceMarkIn.disabled = !asset || asset.kind === 'image';
+  dom.sourceMarkOut.disabled = !asset || asset.kind === 'image';
+  const command = asset && S.commandFor('insert', state.project, asset, selection, {
+    video: dom.sourceVideo.checked,
+    audio: dom.sourceAudio.checked,
+    targetTrackId: state.targetTrackId,
+    start: preview ? preview.position() : 0,
+  });
+  for (const button of [dom.sourceInsert, dom.sourceOverwrite, dom.sourceAppend]) {
+    button.disabled = !command;
+  }
+}
+
+function setSourceMark(which) {
+  const asset = selectedSourceAsset();
+  if (!asset || !state.sourceSelection || !sourcePreview) return;
+  const at = Math.round(sourcePreview.position());
+  state.sourceSelection = which === 'in'
+    ? S.markIn(state.sourceSelection, at)
+    : S.markOut(state.sourceSelection, at, S.sourceLimitFrames(asset, rate()));
+  renderSourceMonitor();
+}
+
+async function placeSource(mode) {
+  const asset = selectedSourceAsset();
+  if (!asset || !state.sourceSelection) return;
+  const command = S.commandFor(mode, state.project, asset, state.sourceSelection, {
+    video: dom.sourceVideo.checked,
+    audio: dom.sourceAudio.checked,
+    targetTrackId: state.targetTrackId,
+    start: preview.position(),
+    rippleAllTracks: dom.sourceRipple.value === 'all',
+  });
+  if (!command) return;
+  const made = await edit(command);
+  if (!made || !made.length) return;
+  selectClip(made[0]);
+}
+
 /** An asset whose length ffprobe could not report is measured by the browser
  *  instead, once. Without this every clip of it would be five seconds long.
  *
@@ -904,6 +1006,7 @@ function checkLutFiles() {
 
 function refresh() {
   renderAssets();
+  renderSourceMonitor();
   renderTimeline();
   checkLutFiles();
   el('menu-delete-project').disabled = !state.path;
@@ -911,6 +1014,7 @@ function refresh() {
     preview.prune();
     preview.layout();
   }
+  if (sourcePreview) sourcePreview.layout();
   updateTitle();
 }
 
@@ -1428,7 +1532,14 @@ function updateLinkUi() {
 
 function selectAsset(assetId) {
   state.selectedAssetId = assetId;
+  const asset = L.findAsset(state.project, assetId);
+  state.sourceSelection = asset ? S.selectionFor(asset, rate()) : null;
+  dom.sourceVideo.checked = Boolean(asset) && (asset.kind === 'video' || asset.kind === 'image');
+  dom.sourceAudio.checked = Boolean(asset) &&
+    (asset.kind === 'audio' || (asset.kind === 'video' && asset.hasAudio));
+  if (sourcePreview) sourcePreview.showAsset(asset);
   renderAssets();
+  renderSourceMonitor();
 }
 
 /** The selection is an id, and clips go away underneath it: opening a project,
@@ -1573,7 +1684,18 @@ function renderInspector() {
   dom.subtitlePanel.hidden = !text || !subtitle;
   dom.shapePanel.hidden = !shape;
   dom.clipPanel.hidden = !clip;
+  dom.transformPanel.hidden = !item;
   dom.inspectorEmpty.hidden = Boolean(item || clip);
+  if (item) {
+    const transform = item.transform;
+    dom.transformX.value = transform.x;
+    dom.transformY.value = transform.y;
+    dom.transformWidth.value = transform.width;
+    dom.transformHeight.value = transform.height;
+    dom.transformRotation.value = transform.rotation;
+    dom.transformOpacity.value = transform.opacity;
+    dom.transformOpacityValue.value = transform.opacity;
+  }
   if (clip) {
     const asset = L.findAsset(state.project, clip.clip.assetId);
     dom.clipSummary.textContent = `${asset ? asset.name || baseName(asset.path) : 'missing file'} · ${clip.track.name}`;
@@ -1611,6 +1733,27 @@ function renderInspector() {
   dom.textStrokeColor.value = hexColor(style.strokeColor, '#000000');
   dom.textStrokeWidth.value = style.strokeWidth || 0;
   dom.textShadowColor.value = hexColor(style.shadowColor, '#000000');
+}
+
+function updateSelectedTransform(event) {
+  const item = selectedVisualItem();
+  if (!item) return;
+  if (event && event.target === dom.transformOpacity) {
+    dom.transformOpacityValue.value = dom.transformOpacity.value;
+  } else if (event && event.target === dom.transformOpacityValue) {
+    dom.transformOpacity.value = dom.transformOpacityValue.value;
+  }
+  const transform = {
+    x: Number(dom.transformX.value),
+    y: Number(dom.transformY.value),
+    width: Math.max(1, Number(dom.transformWidth.value) || 1),
+    height: Math.max(1, Number(dom.transformHeight.value) || 1),
+    rotation: Number(dom.transformRotation.value),
+    opacity: Math.max(0, Math.min(1, Number(dom.transformOpacityValue.value) || 0)),
+  };
+  edit({ op: 'setVisualTransform', itemId: item.id, transform })
+    .then(() => selectVisualItem(item.id))
+    .catch((error) => reportError(error, 'transform:edit'));
 }
 
 function updateSelectedShape() {
@@ -2323,11 +2466,16 @@ function loadDocument(doc, path) {
   state.selectedClipId = null;
   state.selectedVisualItemId = null;
   state.selectedAssetId = null;
+  state.sourceSelection = null;
   state.targetTrackId = null;
   state.proxies = {};
   state.waveforms = {};
   preview.clear();
   preview.showTimeline();
+  if (sourcePreview) {
+    sourcePreview.clear();
+    sourcePreview.showAsset(null);
+  }
   for (const asset of state.project.assets) hydrateDuration(asset);
   refresh();
   prepareDerivedMedia();
@@ -2885,6 +3033,16 @@ function wireMenus() {
 
 function wireAssets() {
   dom.btnImport.addEventListener('click', importViaDialog);
+  dom.sourcePlay.addEventListener('click', () => sourcePreview.toggle());
+  dom.sourceSeek.addEventListener('input', () => sourcePreview.seek(Number(dom.sourceSeek.value)));
+  dom.sourceMarkIn.addEventListener('click', () => setSourceMark('in'));
+  dom.sourceMarkOut.addEventListener('click', () => setSourceMark('out'));
+  dom.sourceInsert.addEventListener('click', () => placeSource('insert'));
+  dom.sourceOverwrite.addEventListener('click', () => placeSource('overwrite'));
+  dom.sourceAppend.addEventListener('click', () => placeSource('append'));
+  for (const input of [dom.sourceVideo, dom.sourceAudio, dom.sourceRipple]) {
+    input.addEventListener('change', renderSourceMonitor);
+  }
   dom.btnDebug.addEventListener('click', () => {
     if (dom.debugPanel.hidden) showDebug();
     else hideDebug();
@@ -3027,6 +3185,12 @@ function wireTimeline() {
   }
   for (const input of [dom.clipOpacity, dom.clipVolume]) {
     input.addEventListener('change', updateSelectedClipGain);
+  }
+  for (const input of [
+    dom.transformX, dom.transformY, dom.transformWidth, dom.transformHeight,
+    dom.transformRotation, dom.transformOpacity, dom.transformOpacityValue,
+  ]) {
+    input.addEventListener('change', updateSelectedTransform);
   }
   dom.lanes.addEventListener('pointerdown', (event) => {
     const visual = event.target.closest('[data-visual-item-id]');
@@ -3353,6 +3517,19 @@ function subscribe(source, register, handler) {
 
 async function boot() {
   state.pxPerSecond = zoomToPxPerSecond(dom.zoom.value);
+
+  sourcePreview = globalThis.previewLib.createPreview({
+    stage: dom.sourceStage,
+    inner: dom.sourceStageInner,
+    wrap: dom.sourceStageWrap,
+    getProject: () => state.project,
+    playbackPath,
+    onTick: (frame, playing) => {
+      dom.sourceClock.textContent = sourceTime(frame);
+      dom.sourceSeek.value = String(Math.round(frame));
+      dom.sourcePlay.textContent = playing ? '❚❚' : '▶';
+    },
+  });
 
   qualityMonitor = globalThis.qualityLib.createQualityMonitor({});
   mediaPreview = globalThis.previewLib.createPreview({

--- a/product/akbun-makevideo/workspace/src/source.js
+++ b/product/akbun-makevideo/workspace/src/source.js
@@ -1,0 +1,80 @@
+'use strict';
+
+(function () {
+
+const T =
+  typeof module !== 'undefined' && module.exports ? require('./time.js') : globalThis.timeLib;
+
+function sourceLimitFrames(asset, rate) {
+  if (!asset) return 0;
+  if (asset.kind === 'image' || !(asset.durationMs > 0)) {
+    return Math.max(1, Math.round(4 * T.rateToNumber(rate)));
+  }
+  return Math.max(1, T.framesFromMillis(asset.durationMs, rate));
+}
+
+function selectionFor(asset, rate) {
+  return { inPoint: 0, outPoint: sourceLimitFrames(asset, rate) };
+}
+
+function markIn(selection, frame) {
+  const outPoint = Math.max(1, Math.round(selection.outPoint));
+  return {
+    inPoint: Math.max(0, Math.min(Math.round(frame), outPoint - 1)),
+    outPoint,
+  };
+}
+
+function markOut(selection, frame, limit) {
+  const inPoint = Math.max(0, Math.round(selection.inPoint));
+  return {
+    inPoint,
+    outPoint: Math.max(inPoint + 1, Math.min(Math.round(frame), Math.max(1, limit))),
+  };
+}
+
+function targetTrack(project, kind, preferredId) {
+  const preferred = project.tracks.find(
+    (track) => track.id === preferredId && track.kind === kind
+  );
+  return preferred || project.tracks.find((track) => track.kind === kind) || null;
+}
+
+function commandFor(mode, project, asset, selection, options) {
+  if (!['insert', 'overwrite', 'append'].includes(mode)) return null;
+  if (!project || !asset || !selection) return null;
+  const settings = options || {};
+  const wantsVideo = Boolean(settings.video) && (asset.kind === 'video' || asset.kind === 'image');
+  const wantsAudio = Boolean(settings.audio) &&
+    (asset.kind === 'audio' || (asset.kind === 'video' && asset.hasAudio));
+  const video = wantsVideo ? targetTrack(project, 'video', settings.targetTrackId) : null;
+  const audio = wantsAudio ? targetTrack(project, 'audio', settings.targetTrackId) : null;
+  if ((wantsVideo && !video) || (wantsAudio && !audio) || (!wantsVideo && !wantsAudio)) return null;
+  const command = {
+    op: `${mode}Source`,
+    assetId: asset.id,
+    videoTrackId: video ? video.id : null,
+    audioTrackId: audio ? audio.id : null,
+    inPoint: Math.max(0, Math.round(selection.inPoint)),
+    outPoint: Math.max(1, Math.round(selection.outPoint)),
+  };
+  if (mode !== 'append') command.start = Math.max(0, Math.round(settings.start || 0));
+  if (mode === 'insert') command.rippleAllTracks = Boolean(settings.rippleAllTracks);
+  return command;
+}
+
+const exported = {
+  sourceLimitFrames,
+  selectionFor,
+  markIn,
+  markOut,
+  targetTrack,
+  commandFor,
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = exported;
+} else {
+  globalThis.sourceLib = exported;
+}
+})();

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -455,7 +455,88 @@ select {
 #preview-panel {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
+  min-width: 0;
   min-height: 0;
+  overflow: hidden;
+}
+
+#monitor-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+}
+
+#source-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px solid var(--border);
+}
+
+.monitor-stage-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--stage);
+}
+
+.monitor-stage {
+  position: relative;
+  overflow: hidden;
+  background: #000;
+}
+
+.monitor-stage-inner {
+  position: absolute;
+  inset: 0;
+  transform-origin: 0 0;
+}
+
+#source-hint {
+  position: absolute;
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #d8dade;
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.monitor-transport,
+#source-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  background: var(--panel);
+  border-top: 1px solid var(--border);
+}
+
+#source-actions {
+  flex-wrap: wrap;
+  font-size: 11px;
+}
+
+#source-actions button,
+#source-actions select,
+.monitor-transport button {
+  padding: 3px 7px;
+  font-size: 11px;
+}
+
+#source-range {
+  flex: 1 1 100%;
+}
+
+#source-seek {
+  flex: 1 1 100%;
+  width: 100%;
 }
 
 .segmented {
@@ -484,6 +565,7 @@ select {
   align-items: center;
   justify-content: center;
   min-height: 0;
+  min-width: 0;
   background: var(--stage);
   overflow: hidden;
 }
@@ -598,6 +680,8 @@ audio.stage-media {
   padding: 6px 10px;
   background: var(--panel);
   border-top: 1px solid var(--border);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 #btn-play {
@@ -829,6 +913,30 @@ button.icon.on {
   flex: 1 1 auto;
   min-width: 0;
   max-width: 168px;
+}
+
+#inspector-body .field-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+#inspector-body .field-pair label {
+  display: grid;
+  gap: 3px;
+  font-size: 11px;
+  color: var(--dim);
+}
+
+#inspector-body .field-pair input,
+#inspector-body .compact-number {
+  min-width: 0;
+  width: 100%;
+}
+
+#inspector-body .compact-number {
+  flex: 0 0 62px;
 }
 
 #marker-panel {

--- a/product/akbun-makevideo/workspace/test/source.test.js
+++ b/product/akbun-makevideo/workspace/test/source.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const S = require('../src/source.js');
+const T = require('../src/time.js');
+
+const rate = T.fps(30);
+const video = {
+  id: 'v',
+  kind: 'video',
+  durationMs: 10000,
+  hasAudio: true,
+};
+const project = {
+  tracks: [
+    { id: 'v1', kind: 'video' },
+    { id: 'v2', kind: 'video' },
+    { id: 'a1', kind: 'audio' },
+  ],
+};
+
+test('a new source range uses frame boundaries and the whole asset', () => {
+  assert.deepStrictEqual(S.selectionFor(video, rate), { inPoint: 0, outPoint: 300 });
+  assert.deepStrictEqual(S.markIn({ inPoint: 0, outPoint: 300 }, 40.6), {
+    inPoint: 41,
+    outPoint: 300,
+  });
+  assert.deepStrictEqual(S.markOut({ inPoint: 41, outPoint: 300 }, 200.4, 300), {
+    inPoint: 41,
+    outPoint: 200,
+  });
+});
+
+test('in and out cannot cross or leave the source', () => {
+  assert.deepStrictEqual(S.markIn({ inPoint: 0, outPoint: 20 }, 99), {
+    inPoint: 19,
+    outPoint: 20,
+  });
+  assert.deepStrictEqual(S.markOut({ inPoint: 19, outPoint: 20 }, 999, 300), {
+    inPoint: 19,
+    outPoint: 300,
+  });
+});
+
+test('placement names a target per media kind and keeps the chosen range', () => {
+  assert.deepStrictEqual(
+    S.commandFor('insert', project, video, { inPoint: 30, outPoint: 120 }, {
+      video: true,
+      audio: true,
+      targetTrackId: 'v2',
+      start: 90.4,
+      rippleAllTracks: true,
+    }),
+    {
+      op: 'insertSource',
+      assetId: 'v',
+      videoTrackId: 'v2',
+      audioTrackId: 'a1',
+      inPoint: 30,
+      outPoint: 120,
+      start: 90,
+      rippleAllTracks: true,
+    }
+  );
+});
+
+test('video-only, audio-only and append are explicit commands', () => {
+  const selection = { inPoint: 0, outPoint: 60 };
+  assert.deepStrictEqual(
+    S.commandFor('overwrite', project, video, selection, {
+      video: true,
+      audio: false,
+      start: 10,
+    }),
+    {
+      op: 'overwriteSource',
+      assetId: 'v',
+      videoTrackId: 'v1',
+      audioTrackId: null,
+      inPoint: 0,
+      outPoint: 60,
+      start: 10,
+    }
+  );
+  assert.deepStrictEqual(
+    S.commandFor('append', project, video, selection, {
+      video: false,
+      audio: true,
+    }),
+    {
+      op: 'appendSource',
+      assetId: 'v',
+      videoTrackId: null,
+      audioTrackId: 'a1',
+      inPoint: 0,
+      outPoint: 60,
+    }
+  );
+});


### PR DESCRIPTION
# 구현

Inspector 공통 변형 편집과 독립 Source Monitor, 세 가지 타임라인 배치 명령 추가
- JavaScript 123개, edit 58개, render 100개, CPU compositor 47개 테스트 통과

# 어려웠던 점

연결된 클립을 유지하며 삽입·덮어쓰기 구간 분할
- 새 오른쪽 조각에 별도 link group을 부여하고 전체 변경을 단일 역연산 transaction으로 기록

# 리스크

Source Monitor와 Program Monitor 동시 재생 시 같은 장치에서 두 오디오 스트림 출력
- 재생 상태를 독립 소유하는 요구에 따른 동작

Issue #683
Issue #685
