### PR TITLE
akbun-visualizellm: config.json으로 LLM 아키텍처를 2D/3D로 보는 웹 페이지 추가

### DIFF
--- a/.github/workflows/verify-akbun-visualizellm.yml
+++ b/.github/workflows/verify-akbun-visualizellm.yml
@@ -1,0 +1,38 @@
+name: verify-akbun-visualizellm
+
+# Deployment is a Cloudflare Pages build on push to master, so there is nothing
+# to release here. This job only proves the page still tests and builds.
+on:
+  pull_request:
+    paths:
+      - 'product/akbun-visualizellm/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: product/akbun-visualizellm/workspace
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: product/akbun-visualizellm/workspace/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # src/lib is DOM free, so this needs no browser and no display.
+      - name: Run tests
+        run: npm test
+
+      - name: Build the page
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 - [AWS profile로 로그인해 EC2를 조회하는 macOS 데스크톱 앱 (akbun-awsviewer)](./product/akbun-awsviewer/) (26.8.6)
 - [HTTP 요청, 폴더 관리, 공통 변수, curl 변환, .http 가져오기 데스크톱 앱 (akbun-requesthttp)](./product/akbun-requesthttp/) (26.8.6)
 - [제품 목록을 모아 저장소로 보내는 카탈로그 웹 페이지 (products.akbun.com)](./product/akbun-productcatalog/) (26.8.10)
+- [모델 config.json으로 LLM 아키텍처를 2D와 3D로 보는 웹 페이지 (visualizellm.akbun.com)](./product/akbun-visualizellm/) (26.8.18)
 
 ## Dockerfile
 

--- a/product/README.md
+++ b/product/README.md
@@ -18,6 +18,7 @@
 | [akbun-rendermermaid](./akbun-rendermermaid/) | mermaid 코드를 왼쪽에 쓰면 오른쪽에 렌더링하고 PNG로 저장하는 웹 페이지 |
 | [akbun-requesthttp](./akbun-requesthttp/) | HTTP(S) 요청, 응답 확인, 폴더 관리, 공통 변수, curl 변환, .http 가져오기를 갖춘 데스크톱 HTTP 클라이언트 |
 | [akbun-openapiviewer](./akbun-openapiviewer/) | OpenAPI 스펙을 붙여넣거나 파일로 열어 API 목록과 상세를 탐색하는 웹 페이지 |
+| [akbun-visualizellm](./akbun-visualizellm/) | 모델 config.json을 읽어 LLM 아키텍처를 2D 흐름도와 3D 가중치 배치로 보여주는 웹 페이지 |
 | [akbun-productcatalog](./akbun-productcatalog/) | product 디렉터리의 제품을 카드로 모아 저장소로 보내는 카탈로그 웹 페이지 |
 | [akbun-mactaskbar](./akbun-mactaskbar/) | 메뉴바 아이콘을 구간으로 나눠 숨기고 목록으로 보는 macOS 메뉴바 관리 앱 |
 | [akbun-screenshot](./akbun-screenshot/) | 영역 캡처, 클립보드 복사, 미리보기 저장을 지원하는 macOS 메뉴바 스크린샷 앱 |

--- a/product/akbun-visualizellm/README.md
+++ b/product/akbun-visualizellm/README.md
@@ -1,0 +1,58 @@
+# akbun-visualizellm
+
+A web page that reads a model `config.json` and draws the architecture it describes. The 2D view is the whole stack in one column, every block explaining its own job when the pointer rests on it. The 3D view is the same model as every weight matrix it actually holds, sized by its shape and placed along the flow. No account, no upload, no server: the config is read in the browser that opened the page.
+
+Deployed as a static Astro build on Cloudflare at [visualizellm.akbun.com](https://visualizellm.akbun.com).
+
+## What it does
+
+| Feature | How it works |
+|---|---|
+| Load | Paste a `config.json`, open the file, or start from one of four samples. A JSON object without a hidden size or a layer count is rejected with the reason |
+| Field aliases | `hidden_size`, `n_embd`, `d_model` and `dim` are the same field. Each one is read through its alias list, so a GPT-2 era config draws the same as a current one |
+| 2D map | Token ids to logits in one column: embedding, the transformer layer drawn once and marked with its repeat count, final norm, LM head. Blocks are colored by what they are, not by where they sit |
+| Roles | Hovering any block explains what it does in the model and why it is shaped that way, with its parameter count and the config fields behind it |
+| Config arrows | Every config field the diagram used sits in a lane beside the drawing with an arrow into each block its value shaped. The header switch turns the lane off, and hovering a chip, a config line or a block lights up the whole chain |
+| 3D view | Every weight matrix as a box, its height and depth log scaled from its real dimensions, laid along the residual stream one layer after another. Orbit, zoom, pan, and hover a box to read the same explanation. Attention scores are drawn translucent because they are built at run time and are not weights |
+| Shape reading | Grouped-query attention shows as K and V boxes visibly thinner than Q; a mixture model shows the router and its expert copies; a tied LM head is named as tied and left out of the count |
+| Parameters | Estimated from the shapes alone, per block, per layer and in total, so a config that never shipped a weight file still reports a size |
+| Restore | The loaded config, the view mode and the arrow switch are kept in `localStorage` |
+| Phone | Below 860px the config pane becomes a drawer and the arrow lane folds into a field list under each block |
+
+## Directory layout
+
+| Directory | Description |
+|---|---|
+| `workspace/src/pages/` | The single Astro page |
+| `workspace/src/scripts/` | The DOM side: the 2D drawing, the arrow lane, tooltips, and the three.js view loaded on first use |
+| `workspace/src/lib/` | Config parsing, the derived model, the 2D block list and the 3D layout, none of which touch the DOM |
+| `workspace/src/styles/` | The stylesheet |
+| `workspace/test/` | Tests over `src/lib`, run on plain node with no browser |
+| `wiki/` | Project notes the next agent reads before taking over |
+| `adr/` | Architecture decision records |
+| `knowledge/` | Reusable notes from building it |
+
+## Quick start
+
+Install dependencies and start the dev server:
+
+```bash
+cd workspace
+npm install
+npm run dev
+```
+
+Run the tests, which need neither a browser nor a build:
+
+```bash
+npm test
+```
+
+Build the static site and preview the build:
+
+```bash
+npm run build
+npm run preview
+```
+
+Deployment is a Cloudflare Pages build on push to master. The setup steps are in [wiki/development.md](./wiki/development.md).

--- a/product/akbun-visualizellm/README.md
+++ b/product/akbun-visualizellm/README.md
@@ -14,6 +14,7 @@ Deployed as a static Astro build on Cloudflare at [visualizellm.akbun.com](https
 | Roles | Hovering any block explains what it does in the model and why it is shaped that way, with its parameter count and the config fields behind it |
 | Config arrows | Every config field the diagram used sits in a lane beside the drawing with an arrow into each block its value shaped. The header switch turns the lane off, and hovering a chip, a config line or a block lights up the whole chain |
 | 3D view | Every weight matrix as a box, its height and depth log scaled from its real dimensions, laid along the residual stream one layer after another. Orbit, zoom, pan, and hover a box to read the same explanation. Attention scores are drawn translucent because they are built at run time and are not weights |
+| Layer and part filter | The 3D view carries a layer slider and a legend that doubles as a switch: isolate one layer of the stack, or hide attention, feed-forward or normalization to see what is left. The embedding and the head stay, because they are what the stack sits between |
 | Shape reading | Grouped-query attention shows as K and V boxes visibly thinner than Q; a mixture model shows the router and its expert copies; a tied LM head is named as tied and left out of the count |
 | Parameters | Estimated from the shapes alone, per block, per layer and in total, so a config that never shipped a weight file still reports a size |
 | Restore | The loaded config, the view mode and the arrow switch are kept in `localStorage` |

--- a/product/akbun-visualizellm/adr/2026-08-arrows-in-content-coordinates.md
+++ b/product/akbun-visualizellm/adr/2026-08-arrows-in-content-coordinates.md
@@ -1,0 +1,11 @@
+# Arrows are drawn in content coordinates, not over the viewport
+
+## Decision
+
+The field chips and the blocks are two columns of one scrolling grid, and the SVG holding the arrows covers that grid. Endpoints are computed from element rectangles once and stored relative to the grid, not to the window. They are recomputed only when the content moves: a resize, a new config, the switch, and the web fonts finishing.
+
+## Reason
+
+The obvious build is a fixed overlay redrawn on every scroll event. It costs a listener on a hot path, it drifts on momentum scrolling where the frame lands after the paint, and it needs clipping logic for arrows whose targets have left the screen. Putting the arrows inside the scrolled content deletes all three problems: the browser moves them with the blocks because they are part of the same layer.
+
+The cost is that a layout change nobody thought about leaves stale arrows. Web fonts were exactly that case, landing after the first paint and shifting every block a few pixels, which is why `document.fonts.ready` triggers a relayout.

--- a/product/akbun-visualizellm/adr/2026-08-astro-static-on-cloudflare.md
+++ b/product/akbun-visualizellm/adr/2026-08-astro-static-on-cloudflare.md
@@ -1,0 +1,9 @@
+# An Astro static page on Cloudflare Pages
+
+## Decision
+
+Build the page as a static Astro site, deployed by a Cloudflare Pages build on push to master, the same shape as akbun-openapiviewer and akbun-rendermermaid. The pull request job only tests and builds; there is no release job, no tag and no artifact.
+
+## Reason
+
+The product reads a text file in the browser and draws it. Nothing needs a server, so the cheapest deployment that already works in this repository wins: the Pages project, the watch paths and the custom domain routine were debugged once and copy over unchanged. A release workflow with tags would add the silent failure modes the product rules warn about while delivering nothing a static host does not.

--- a/product/akbun-visualizellm/adr/2026-08-field-aliases-with-sources.md
+++ b/product/akbun-visualizellm/adr/2026-08-field-aliases-with-sources.md
@@ -1,0 +1,11 @@
+# Config fields are read through alias lists
+
+## Decision
+
+Every quantity has an alias list, `hidden` being `hidden_size`, `n_embd`, `d_model`, `dim`, and the first alias present wins. The alias that matched is kept as `sources[key]`, next to the value.
+
+## Reason
+
+A config.json is not a schema. The same model shape is spelled one way by a current decoder and another way by a GPT-2 era one, and a page that reads `hidden_size` directly renders half the files on Hugging Face as an error message. The alias list makes support for a family a one line change.
+
+Keeping the matched name is what turns the drawing into an answer about the file the reader has open, rather than about models in general. The arrows, the highlighted config lines and the tooltip footers all point at a field name that is literally in the pasted text, and a field that is absent produces no arrow rather than a lie.

--- a/product/akbun-visualizellm/adr/2026-08-legend-doubles-as-the-filter.md
+++ b/product/akbun-visualizellm/adr/2026-08-legend-doubles-as-the-filter.md
@@ -1,0 +1,13 @@
+# The legend is the part filter
+
+## Decision
+
+The 3D legend rows are buttons. Clicking one hides that part of the model, and the row dims to show it is off. The layer slider beside it isolates a single layer, keeping the embedding, the final norm and the head visible. Both feed one filter object into `visibleBlocks` in the scene library.
+
+## Reason
+
+A deep model is a wall of boxes, and the question a reader usually has is narrower than the whole wall: what does one layer hold, or where does the feed-forward weight actually sit. A filter answers that without a second view.
+
+Putting it on the legend rather than beside it is the part worth recording. The legend already names exactly the five groups a filter would offer, in the same colors, so a separate control panel would have been the same list written twice, and the two would drift the first time a group was added. The cost is that a legend now looks like something to click, which the hint line says out loud.
+
+Keeping the surrounding blocks when a layer is isolated is the other deliberate choice: a layer floating alone loses the thing that makes it legible, which is that it sits between an embedding and a head.

--- a/product/akbun-visualizellm/adr/2026-08-one-derived-model-for-both-views.md
+++ b/product/akbun-visualizellm/adr/2026-08-one-derived-model-for-both-views.md
@@ -1,0 +1,9 @@
+# Both views read one derived model
+
+## Decision
+
+`deriveModel` produces one object holding dimensions, shape flags, the config field each value came from, and a parameter estimate. `buildDiagram` and `buildScene` are two readers of that object, and neither one looks at the raw config.
+
+## Reason
+
+The 2D map and the 3D view answer the same question at two zoom levels, so any disagreement between them is a bug that a reader would blame on their own understanding rather than on the page. Deriving once also puts every awkward rule in one place: the head dimension falls back to hidden over heads, key/value heads fall back to the query heads, and a gated MLP holds three matrices instead of two. Written twice, those rules drift; a test that the 3D boxes add up to the 2D estimate is only meaningful because both come from the same source.

--- a/product/akbun-visualizellm/adr/2026-08-parameters-estimated-from-shapes.md
+++ b/product/akbun-visualizellm/adr/2026-08-parameters-estimated-from-shapes.md
@@ -1,0 +1,11 @@
+# Parameters are estimated from the shapes
+
+## Decision
+
+Compute the parameter count from the config alone, per block, per layer and in total, and label it as an estimate everywhere it is shown.
+
+## Reason
+
+Size is the first question anyone asks of a model, and a config.json is often all that is at hand: the weights are tens of gigabytes away and a page that reads them in the browser is a different product. The shapes in the config determine the count to within a percent, so the estimate is worth far more than a blank.
+
+It is called an estimate because the parts left out are real: biases where a family uses them, learned position tables, and anything an architecture adds outside the standard block. Rather than chase those, the count is checked from a second direction, by asserting that the boxes placed in the 3D scene add up to the same number. A matrix added to one and forgotten in the other fails that test.

--- a/product/akbun-visualizellm/adr/2026-08-three-js-loaded-on-demand.md
+++ b/product/akbun-visualizellm/adr/2026-08-three-js-loaded-on-demand.md
@@ -1,0 +1,11 @@
+# three.js for the 3D view, imported on first use
+
+## Decision
+
+Render the 3D view with three.js and its OrbitControls, in a module imported dynamically the first time the 3D button is pressed.
+
+## Reason
+
+The view needs orbiting, zooming, panning and pointer picking against a few hundred boxes. Hand rolling that on a 2D canvas means a projection, a painter's algorithm, and hit testing against projected polygons, which is more code than the box drawing itself and worse at the one thing that matters, reading depth. three.js does it with a raycaster and a camera.
+
+Loading it eagerly would put roughly half a megabyte in front of a page whose first view is HTML boxes, so it is a dynamic import and lands in its own chunk. The scene layout stays in `src/lib/scene.js` with no three.js import, so the geometry is tested on plain node while only the instantiation depends on WebGL.

--- a/product/akbun-visualizellm/adr/index.md
+++ b/product/akbun-visualizellm/adr/index.md
@@ -10,3 +10,4 @@ Decision records for akbun-visualizellm in "decision - reason" form. Filenames f
 * [Arrows are drawn in content coordinates, not over the viewport](2026-08-arrows-in-content-coordinates.md) - Scrolling then moves the arrows with the blocks and no scroll handler exists.
 * [three.js for the 3D view, imported on first use](2026-08-three-js-loaded-on-demand.md) - Orbiting and picking are solved problems, and the cost stays off the first paint.
 * [Parameters are estimated from the shapes](2026-08-parameters-estimated-from-shapes.md) - A config.json carries no weights, and a size is the first question anyone asks of a model.
+* [The legend is the part filter](2026-08-legend-doubles-as-the-filter.md) - Two lists of the same five parts, one to read and one to click, is one list too many.

--- a/product/akbun-visualizellm/adr/index.md
+++ b/product/akbun-visualizellm/adr/index.md
@@ -1,0 +1,12 @@
+# ADR
+
+Decision records for akbun-visualizellm in "decision - reason" form. Filenames follow `YYYY-MM-<topic>.md`.
+
+## Contents
+
+* [An Astro static page on Cloudflare Pages](2026-08-astro-static-on-cloudflare.md) - The deployment shape of the other web products in this repository, with no release job, no tag and no version a build looks at.
+* [Both views read one derived model](2026-08-one-derived-model-for-both-views.md) - A 2D map and a 3D detail view of the same thing must never disagree about what the config said.
+* [Config fields are read through alias lists](2026-08-field-aliases-with-sources.md) - The same quantity is spelled four ways across model families, and the alias that matched is what the arrows point at.
+* [Arrows are drawn in content coordinates, not over the viewport](2026-08-arrows-in-content-coordinates.md) - Scrolling then moves the arrows with the blocks and no scroll handler exists.
+* [three.js for the 3D view, imported on first use](2026-08-three-js-loaded-on-demand.md) - Orbiting and picking are solved problems, and the cost stays off the first paint.
+* [Parameters are estimated from the shapes](2026-08-parameters-estimated-from-shapes.md) - A config.json carries no weights, and a size is the first question anyone asks of a model.

--- a/product/akbun-visualizellm/knowledge/decisions/2026-08-annotation-arrows-in-content-coordinates.md
+++ b/product/akbun-visualizellm/knowledge/decisions/2026-08-annotation-arrows-in-content-coordinates.md
@@ -1,0 +1,22 @@
+---
+type: Decision
+title: 주석 화살표는 viewport가 아니라 content 좌표에 그린다
+description: 스크롤되는 도형에 SVG 화살표를 붙일 때 overlay 대신 스크롤 콘텐츠 안에 SVG를 두기로 한 결정.
+tags: [visualizellm, web, svg, layout]
+timestamp: 2026-08-18T00:00:00Z
+---
+
+# 주석 화살표는 viewport가 아니라 content 좌표에 그린다
+
+## 결정
+
+* 라벨 열과 도형 열을 같은 grid에 넣고, 그 grid를 덮는 SVG를 스크롤되는 콘텐츠의 자식으로 둠
+* 끝점은 `getBoundingClientRect`로 한 번 계산해 grid 기준 좌표로 저장하고, scroll event는 듣지 않음
+* 다시 계산하는 시점은 콘텐츠가 실제로 움직일 때뿐: resize, 데이터 교체, 기능 on/off, 그리고 web font 로드 완료
+
+## 이유
+
+* fixed overlay 방식은 scroll handler가 hot path에 붙고, 관성 스크롤에서 프레임이 paint보다 늦어 화살표가 밀려 보임
+* 화면 밖으로 나간 대상의 화살표를 잘라내는 clipping 처리가 추가로 필요함
+* 콘텐츠 안에 두면 브라우저가 도형과 같은 레이어로 함께 옮기므로 위 세 가지가 모두 사라짐
+* 대신 레이아웃이 조용히 바뀌면 화살표가 남음. web font가 first paint 뒤에 도착해 블록을 몇 px씩 밀어내는 경우가 실제로 그랬고, `document.fonts.ready`에서 재배치를 호출해 막음

--- a/product/akbun-visualizellm/knowledge/decisions/index.md
+++ b/product/akbun-visualizellm/knowledge/decisions/index.md
@@ -1,0 +1,3 @@
+# Decisions
+
+* [주석 화살표는 viewport가 아니라 content 좌표에 그린다](2026-08-annotation-arrows-in-content-coordinates.md)

--- a/product/akbun-visualizellm/knowledge/index.md
+++ b/product/akbun-visualizellm/knowledge/index.md
@@ -1,0 +1,7 @@
+# Knowledge
+
+akbun-visualizellm의 구현 판단과 반복 절차 기록.
+
+## 분류
+
+* [Decisions](./decisions/index.md)

--- a/product/akbun-visualizellm/knowledge/log.md
+++ b/product/akbun-visualizellm/knowledge/log.md
@@ -1,0 +1,5 @@
+# Knowledge Update Log
+
+## 2026-08-18
+
+* [주석 화살표는 viewport가 아니라 content 좌표에 그린다](decisions/2026-08-annotation-arrows-in-content-coordinates.md) 결정 기록. config 필드에서 도형으로 향하는 화살표를 만들면서 overlay 방식의 스크롤 문제와 web font 재배치 필요를 확인함.

--- a/product/akbun-visualizellm/wiki/architecture.md
+++ b/product/akbun-visualizellm/wiki/architecture.md
@@ -49,6 +49,8 @@ Recomputing is needed only when the content itself moves: a resize, a reload of 
 
 `buildScene` places one box per matrix along x, layer after layer, with height and depth log scaled from the matrix dimensions. Log scale is not cosmetic: a vocabulary of 150,000 next to a head dimension of 128 is a thousandfold range that no linear scale can show on one screen.
 
+The layer slider and the legend switches feed one filter object into `visibleBlocks`, in `scene.js`, and the view only turns its answer into visibility flags and a new pick list. Nothing is rebuilt on a filter change, and hiding a block also removes it from the raycaster, so a hidden matrix cannot be hovered through a visible one. Isolating a layer keeps the embedding, the final norm and the head, because a layer with nothing on either side of it stops being a place in the model.
+
 Colors come from the CSS variables at build time of the scene, so the boxes follow the page theme. The camera opens on the first layers at reading distance, because framing the whole model turns every matrix into a speck; "Fit all" is the button for the other question.
 
 ## State

--- a/product/akbun-visualizellm/wiki/architecture.md
+++ b/product/akbun-visualizellm/wiki/architecture.md
@@ -1,0 +1,56 @@
+# Architecture
+
+One page, no framework, no server. A config goes in, two views come out of the same derived model.
+
+## The pipeline
+
+```text
+config.json text
+  -> parseConfig()    validate, unwrap a multimodal config
+  -> deriveModel()    dims, flags, per-field sources, parameter estimate
+  -> buildDiagram()   the 2D block list                -> src/scripts/main.js
+  -> buildScene()     the 3D box layout                -> src/scripts/view3d.js
+```
+
+Both views read the same model object. A change to how a field is read lands in both at once, and neither view re-derives anything of its own.
+
+## src/lib, which the tests cover
+
+| File | Holds |
+|---|---|
+| `model.js` | Alias tables, parsing, `deriveModel`, `countParams`, `humanCount`, `summary` |
+| `diagram.js` | `buildDiagram` (sections and blocks with roles), `annotations` (field to block targets) |
+| `scene.js` | `buildScene` (a box per matrix with a position and a size), `side` (the log scale) |
+| `samples.js` | Four configs written the way each family spells its fields |
+
+None of these import anything from the DOM, so `npm test` runs on plain node.
+
+## The derived model
+
+`deriveModel` resolves every field through its alias list and keeps two things: the value, and `sources[key]`, the config field name the value came from. The sources are what make the arrows possible, the config pane highlighting, and the "from hidden_size, rms_norm_eps" line in a tooltip. A field the config never spelled has a `null` source, and everything downstream skips it, which is why a GPT-2 config draws no rotary block and shows no `rope_theta` chip.
+
+`flags` carries the shape decisions that change the drawing: `MHA`/`GQA`/`MQA` from the head counts, whether the MLP is gated, whether the output weights are tied, and the mixture-of-experts counts when there are any.
+
+## The 2D view
+
+`buildDiagram` returns three sections: input, the layer stack, output. The stack is one layer drawn once with its repeat count on the head, because 32 identical drawings teach nothing that "x 32" does not.
+
+Every block carries a `role`, which is the sentence the tooltip shows. Roles are written in the library, not in the DOM code, so they are data and change with the model: the attention role names the actual head split, the MLP role names the actual width.
+
+## The arrow lane
+
+The lane and the blocks are two columns of one grid, and the SVG covers the grid. Chip positions and arrow endpoints are computed once from `getBoundingClientRect` and stored as content coordinates, so scrolling moves the arrows with the blocks for free and no scroll handler exists. Chips are placed at the height of their first target and pushed down when two would collide.
+
+Recomputing is needed only when the content itself moves: a resize, a reload of the config, the switch being toggled, and the web fonts finishing, which shifts every block a few pixels after the first paint.
+
+## The 3D view
+
+`view3d.js` is imported dynamically the first time the 3D button is pressed, so three.js is a separate chunk and never touches the first paint.
+
+`buildScene` places one box per matrix along x, layer after layer, with height and depth log scaled from the matrix dimensions. Log scale is not cosmetic: a vocabulary of 150,000 next to a head dimension of 128 is a thousandfold range that no linear scale can show on one screen.
+
+Colors come from the CSS variables at build time of the scene, so the boxes follow the page theme. The camera opens on the first layers at reading distance, because framing the whole model turns every matrix into a speck; "Fit all" is the button for the other question.
+
+## State
+
+`localStorage` keeps the config text, the view mode and the arrow switch. Nothing else is persisted, and a failure to write is swallowed rather than losing the view.

--- a/product/akbun-visualizellm/wiki/development.md
+++ b/product/akbun-visualizellm/wiki/development.md
@@ -1,0 +1,68 @@
+# Development
+
+Node and npm only. There is no Rust toolchain, no app binary and no platform requirement.
+
+## Run
+
+Start the dev server with hot reload:
+
+```bash
+cd product/akbun-visualizellm/workspace
+npm install
+npm run dev
+```
+
+## Test
+
+The tests cover `src/lib`, which is DOM free, so they run without a browser and without a build:
+
+```bash
+npm test
+```
+
+This is what the pull request job runs, together with a build to prove the page still compiles.
+
+## Build
+
+Produce the static site in `dist/` and serve it locally:
+
+```bash
+npm run build
+npm run preview
+```
+
+The build warns that a chunk is over 500 kB. That chunk is three.js, and it is already split out of the entry: the warning is about its size, not about it loading on the first paint.
+
+## Deploy
+
+Cloudflare Pages builds on push to master. There is no GitHub Actions release job and no tag, so nothing breaks when the version in `package.json` stands still. It is bumped anyway, by the repository rule that a change under `workspace/` carries one.
+
+First time setup, once:
+
+1. Cloudflare Dashboard, Workers & Pages, Create, Pages, Connect to Git.
+2. Pick `choisungwook/portfolio`.
+3. Build settings:
+   - Build command: `cd product/akbun-visualizellm/workspace && npm install && npm run build`
+   - Deploy command: `cd product/akbun-visualizellm/workspace && npm run deploy`
+   - Build output directory: `product/akbun-visualizellm/workspace/dist`
+   - Root directory: `/`, since this is a monorepo
+4. Custom domains, add `visualizellm.akbun.com`. Cloudflare writes the CNAME and issues the certificate.
+5. Settings, Builds & deployments, Build watch paths:
+   - Include: `product/akbun-visualizellm/**`
+   - Exclude: `product/akbun-visualizellm/*.md`
+
+Without the watch paths every commit anywhere in the repository triggers a build of this page.
+
+## Caveats
+
+**A config field is read through an alias list, never directly.** Adding a field means adding it to `FIELD_ALIASES` in `model.js` and nowhere else. Reading `config.hidden_size` somewhere in the DOM code is how the page starts working for one model family and quietly failing for another.
+
+**Keep the source with the value.** Everything that points at the config, the arrows, the highlighted lines and the tooltip footers, works off `model.sources`. A new value derived without recording which field it came from cannot be pointed at.
+
+**The parameter estimate is checked against the 3D scene.** `scene.test.js` asserts the boxes add up to `countParams` within one percent. If a matrix is added to one and not the other, that test is what says so, and it is the reason to change both together.
+
+**The arrows live in content coordinates.** They are drawn once from element rectangles and are correct only while nothing has moved. Anything that changes layout, including a font load, has to call `layoutLane()` again.
+
+**Blocks are built as HTML strings.** Every value that came from the config goes through `esc()` before it is interpolated. A pasted config is untrusted input; skipping the escape on a new field is a script injection on a page that stores state in `localStorage`.
+
+**Framing the whole model is the wrong opening shot.** A 32 layer model is several hundred units long and a few units wide, so it renders as a diagonal thread. The camera opens near the embedding; that is deliberate, not an unfinished default.

--- a/product/akbun-visualizellm/wiki/index.md
+++ b/product/akbun-visualizellm/wiki/index.md
@@ -1,0 +1,10 @@
+# akbun-visualizellm Wiki
+
+This is the record the next agent reads before taking over this project. Read [adr/index.md](../adr/index.md) together for the reasoning behind decisions.
+
+## Contents
+
+| Document | Description |
+|---|---|
+| [architecture.md](architecture.md) | The derived model every view reads, the split between DOM code and pure logic, the arrow lane, the 3D scene |
+| [development.md](development.md) | Run, test, build, the Cloudflare Pages setup, and caveats worth knowing before changing anything |

--- a/product/akbun-visualizellm/workspace/.gitignore
+++ b/product/akbun-visualizellm/workspace/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.astro/
+.wrangler/

--- a/product/akbun-visualizellm/workspace/astro.config.mjs
+++ b/product/akbun-visualizellm/workspace/astro.config.mjs
@@ -1,0 +1,5 @@
+import { defineConfig } from 'astro/config';
+
+// Static output is the default. The config is read in the browser, so the page
+// needs nothing at runtime beyond the assets Cloudflare serves.
+export default defineConfig({});

--- a/product/akbun-visualizellm/workspace/package-lock.json
+++ b/product/akbun-visualizellm/workspace/package-lock.json
@@ -1,0 +1,5750 @@
+{
+  "name": "akbun-visualizellm",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "akbun-visualizellm",
+      "version": "0.1.0",
+      "dependencies": {
+        "astro": "^7.2.3",
+        "three": "^0.185.1"
+      },
+      "devDependencies": {
+        "wrangler": "^4.124.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.2.tgz",
+      "integrity": "sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@astrojs/compiler-binding-darwin-arm64": "0.3.2",
+        "@astrojs/compiler-binding-darwin-x64": "0.3.2",
+        "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.2",
+        "@astrojs/compiler-binding-linux-arm64-musl": "0.3.2",
+        "@astrojs/compiler-binding-linux-x64-gnu": "0.3.2",
+        "@astrojs/compiler-binding-linux-x64-musl": "0.3.2",
+        "@astrojs/compiler-binding-wasm32-wasi": "0.3.2",
+        "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.2",
+        "@astrojs/compiler-binding-win32-x64-msvc": "0.3.2"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.2.tgz",
+      "integrity": "sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/compiler-rs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.2.tgz",
+      "integrity": "sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-binding": "0.3.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/internal-helpers": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.3.tgz",
+      "integrity": "sha512-HIx/t1NywcqSTFaVwZh15n8JsC3YQdCaJZDaTS/aurYTEvNiWDXUGS3Z9uQX3bFB+B1pCgN/nljckkzYTpHZ2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "js-yaml": "^4.3.0",
+        "picomatch": "^4.0.4",
+        "retext-smartypants": "^6.2.0",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/markdown-satteri": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.6.tgz",
+      "integrity": "sha512-kkeWP4Lh6Do/qz2R0DIAtPWCh6WPr1J4UrzDItVmHMK1HwyLHxG4JxM8uBNavhD7ivGOO9BUTsAP5D7ppa68CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.10.3",
+        "@astrojs/prism": "4.0.2",
+        "github-slugger": "^2.0.0",
+        "hast-util-from-html": "^2.0.3",
+        "satteri": "^0.9.1"
+      }
+    },
+    "node_modules/@astrojs/prism": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+      "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismjs": "^1.30.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/telemetry": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
+      "integrity": "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^4.4.0",
+        "dset": "^3.1.4",
+        "is-docker": "^4.0.0",
+        "package-manager-detector": "^1.6.0"
+      },
+      "engines": {
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bruits/satteri-darwin-arm64": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
+      "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-darwin-x64": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
+      "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-gnu": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
+      "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-arm64-musl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
+      "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-gnu": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
+      "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-linux-x64-musl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
+      "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
+      "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@bruits/satteri-win32-arm64-msvc": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
+      "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@bruits/satteri-win32-x64-msvc": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
+      "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
+      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.3.tgz",
+      "integrity": "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4"
+      }
+    },
+    "node_modules/@oslojs/encoding": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+      "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+      "integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+      "integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+      "integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+      "integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+      "integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+      "integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+      "integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/nlcst": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
+    "node_modules/am-i-vibing": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
+      "integrity": "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==",
+      "license": "MIT",
+      "dependencies": {
+        "process-ancestry": "^0.1.0"
+      },
+      "bin": {
+        "am-i-vibing": "dist/cli.mjs"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/astro": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.3.tgz",
+      "integrity": "sha512-CDf55Cw2nOev5BAM72yn7JQMpK/ByTY5tLSybbHbtZNSiMKk0OeyvCjA2foEUXfHXbATpHQQPBgfuXL8PdofcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler-rs": "^0.3.2",
+        "@astrojs/internal-helpers": "0.10.3",
+        "@astrojs/markdown-satteri": "0.3.6",
+        "@astrojs/telemetry": "3.3.3",
+        "@capsizecss/unpack": "^4.0.0",
+        "@clack/prompts": "^1.1.0",
+        "@oslojs/encoding": "^1.1.0",
+        "am-i-vibing": "^0.4.0",
+        "aria-query": "^5.3.2",
+        "axobject-query": "^4.1.0",
+        "ci-info": "^4.4.0",
+        "clsx": "^2.1.1",
+        "common-ancestor-path": "^2.0.0",
+        "cookie": "^2.0.1",
+        "devalue": "^5.8.1",
+        "diff": "^8.0.3",
+        "dset": "^3.1.4",
+        "es-module-lexer": "^2.0.0",
+        "esbuild": "^0.28.0",
+        "find-process": "^2.1.1",
+        "flattie": "^1.1.1",
+        "fontace": "~0.4.1",
+        "get-tsconfig": "5.0.0-beta.4",
+        "github-slugger": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "js-yaml": "^4.3.0",
+        "jsonc-parser": "^3.3.1",
+        "magic-string": "^1.0.0",
+        "magicast": "^0.5.2",
+        "mrmime": "^2.0.1",
+        "neotraverse": "^1.0.1",
+        "obug": "^2.1.1",
+        "p-limit": "^7.3.0",
+        "p-queue": "^9.1.0",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.4",
+        "semver": "^7.7.4",
+        "shiki": "^4.0.2",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
+        "tinyglobby": "^0.2.15",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.5",
+        "unstorage": "^1.17.5",
+        "vite": "^8.0.13",
+        "vitefu": "^1.1.2",
+        "xxhash-wasm": "^1.1.0",
+        "yargs-parser": "^22.0.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "astro": "bin/astro.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
+      "optionalDependencies": {
+        "sharp": "^0.34.0 || ^0.35.0"
+      },
+      "peerDependencies": {
+        "@astrojs/markdown-remark": "7.2.3"
+      },
+      "peerDependenciesMeta": {
+        "@astrojs/markdown-remark": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/common-ancestor-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+      "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-process": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-2.1.1.tgz",
+      "integrity": "sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "~4.1.2",
+        "commander": "^14.0.3",
+        "loglevel": "^1.9.2"
+      },
+      "bin": {
+        "find-process": "dist/cjs/bin/find-process.js"
+      }
+    },
+    "node_modules/flattie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+      "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+      "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.2"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "5.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+      "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20.20.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.0.tgz",
+      "integrity": "sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260815.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/miniflare/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neotraverse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-1.0.1.tgz",
+      "integrity": "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/nlcst-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.5.tgz",
+      "integrity": "sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+      "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+      "license": "ISC"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/process-ancestry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/process-ancestry/-/process-ancestry-0.1.0.tgz",
+      "integrity": "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retext-smartypants": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/nlcst": "^2.0.0",
+        "nlcst-to-string": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
+    "node_modules/satteri": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
+      "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.5",
+        "@types/hast": "^3.0.4",
+        "@types/mdast": "^4.0.4",
+        "@types/unist": "^3.0.3"
+      },
+      "optionalDependencies": {
+        "@bruits/satteri-darwin-arm64": "0.9.5",
+        "@bruits/satteri-darwin-x64": "0.9.5",
+        "@bruits/satteri-linux-arm64-gnu": "0.9.5",
+        "@bruits/satteri-linux-arm64-musl": "0.9.5",
+        "@bruits/satteri-linux-x64-gnu": "0.9.5",
+        "@bruits/satteri-linux-x64-musl": "0.9.5",
+        "@bruits/satteri-wasm32-wasi": "0.9.5",
+        "@bruits/satteri-win32-arm64-msvc": "0.9.5",
+        "@bruits/satteri-win32-x64-msvc": "0.9.5"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+      "integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.3",
+        "@shikijs/engine-javascript": "4.4.3",
+        "@shikijs/engine-oniguruma": "4.4.3",
+        "@shikijs/langs": "4.4.3",
+        "@shikijs/themes": "4.4.3",
+        "@shikijs/types": "4.4.3",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.5.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.15.tgz",
+      "integrity": "sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/ultrahtml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+      "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.5.tgz",
+      "integrity": "sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ohash": "^2.0.11",
+        "undici": "^8.0.0"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260815.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260815.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260815.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/product/akbun-visualizellm/workspace/package.json
+++ b/product/akbun-visualizellm/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-visualizellm",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-visualizellm/workspace/package.json
+++ b/product/akbun-visualizellm/workspace/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "akbun-visualizellm",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "deploy": "wrangler deploy",
+    "test": "node --test test/*.test.js"
+  },
+  "dependencies": {
+    "astro": "^7.2.3",
+    "three": "^0.185.1"
+  },
+  "devDependencies": {
+    "wrangler": "^4.124.0"
+  }
+}

--- a/product/akbun-visualizellm/workspace/package.json
+++ b/product/akbun-visualizellm/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-visualizellm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-visualizellm/workspace/src/lib/diagram.js
+++ b/product/akbun-visualizellm/workspace/src/lib/diagram.js
@@ -1,0 +1,237 @@
+// The 2D view: the whole model as one column of blocks, with the role of each
+// block and the config fields that decided its shape. Pure data, no DOM.
+
+import { humanCount } from './model.js';
+
+// A block's shape line: one entry per tensor, matrix dimensions inside an entry.
+const shape = (...parts) => parts.join(' \u00b7 ');
+
+/**
+ * Build the block list the 2D view draws.
+ * @param {object} model the model from deriveModel
+ * @returns {{sections: Array<object>}} sections in flow order
+ */
+export function buildDiagram(model) {
+  return { sections: [inputSection(model), layerSection(model), outputSection(model)] };
+}
+
+function inputSection(model) {
+  const { dims, sources } = model;
+  return {
+    id: 'input',
+    kind: 'flow',
+    title: 'Input',
+    nodes: [
+      {
+        id: 'tokens',
+        tone: 'io',
+        title: 'Token IDs',
+        shape: shape('T tokens'),
+        role: 'The tokenizer has already turned the prompt into integers. Each one is a row number, nothing more, and T is how many of them the prompt became.',
+        fields: [],
+      },
+      {
+        id: 'embedding',
+        tone: 'embed',
+        title: 'Token Embedding',
+        shape: shape(`vocab ${dims.vocab} x hidden ${dims.hidden}`),
+        role: 'A lookup table with one row per vocabulary entry. Each token id is replaced by its row, so the sequence becomes a stack of vectors the layers can work on.',
+        fields: [sources.vocab, sources.hidden],
+        params: dims.vocab * dims.hidden,
+      },
+      positionNode(model),
+    ].filter(Boolean),
+  };
+}
+
+function positionNode(model) {
+  if (model.flags.rope === null) return null;
+  return {
+    id: 'rope',
+    tone: 'embed',
+    title: 'Rotary Position (RoPE)',
+    shape: shape(`theta ${model.flags.rope}`, `up to ${model.dims.context} tokens`),
+    role: 'Position is not added to the vector, it is rotated into the query and key of every layer. The angle grows with the distance between two tokens, which is how attention can tell "before" from "after". A larger theta stretches the same rotation over a longer context.',
+    fields: [model.sources.ropeTheta, model.sources.context],
+  };
+}
+
+function layerSection(model) {
+  const { dims, flags, sources } = model;
+  const qDim = dims.heads * dims.headDim;
+  const kvDim = dims.kvHeads * dims.headDim;
+  const nodes = [
+    normNode(model, 'norm-in', 'Input Norm'),
+    {
+      id: 'qkv',
+      tone: 'attn',
+      title: 'Q, K, V Projections',
+      shape: shape(`Q ${dims.hidden} -> ${qDim}`, `K,V ${dims.hidden} -> ${kvDim}`),
+      role: `Three matrices read the same vector and produce three different views of it: what this token is looking for, how it advertises itself, and what it hands over when picked. ${attentionNote(model)}`,
+      fields: [sources.heads, sources.kvHeads, sources.headDim],
+      params: dims.hidden * qDim + dims.hidden * kvDim * 2,
+    },
+    {
+      id: 'scores',
+      tone: 'attn',
+      title: 'Attention Scores + Softmax',
+      shape: shape(`${dims.heads} heads`, 'T x T per head'),
+      role: `Every query is compared against every key, which is why cost grows with the square of the sequence. A causal mask blanks out the future, softmax turns what is left into weights, and each head mixes the values with them.${windowNote(model)}`,
+      fields: [sources.heads, sources.context, model.sources.slidingWindow].filter(Boolean),
+    },
+    {
+      id: 'attn-out',
+      tone: 'attn',
+      title: 'Output Projection',
+      shape: shape(`${qDim} x hidden ${dims.hidden}`),
+      role: 'The heads are concatenated and mapped back to the hidden width, so the block returns exactly the shape it was given and can be added back to the stream.',
+      fields: [sources.hidden],
+      params: qDim * dims.hidden,
+    },
+    residualNode('residual-attn', 'the attention block'),
+    normNode(model, 'norm-post', 'Post-Attention Norm'),
+    ...mlpNodes(model),
+    residualNode('residual-mlp', 'the feed-forward block'),
+  ];
+  return {
+    id: 'layer',
+    kind: 'stack',
+    title: `Transformer Layer x ${dims.layers}`,
+    repeat: dims.layers,
+    subtitle: `${humanCount(model.params.perLayer)} parameters per layer, the same shape repeated ${dims.layers} times`,
+    fields: [sources.layers],
+    role: 'One layer reads the whole sequence, writes what it learned back into the residual stream, and hands it on unchanged in shape. Depth is this block repeated, not a different block each time.',
+    nodes,
+    flags,
+  };
+}
+
+function attentionNote(model) {
+  const { attention } = model.flags;
+  if (attention === 'MQA') {
+    return 'All query heads share a single key and value head, which shrinks the cache that has to be kept for every token generated so far.';
+  }
+  if (attention === 'GQA') {
+    return `Query heads outnumber key/value heads ${model.dims.heads} to ${model.dims.kvHeads}, so several queries share one cached key and value. That is the memory the KV cache does not have to hold.`;
+  }
+  return 'Each query head has its own key and value head.';
+}
+
+function windowNote(model) {
+  if (model.flags.slidingWindow === null) return '';
+  return ` This model limits the view to the last ${model.flags.slidingWindow} tokens, so the square never grows past the window.`;
+}
+
+function normNode(model, id, title) {
+  return {
+    id,
+    tone: 'norm',
+    title: `${title} (${model.flags.normKind})`,
+    shape: shape(`hidden ${model.dims.hidden}`),
+    role: 'Rescales the vector to a stable size before the next block reads it. It holds one weight per hidden channel, which is a rounding error in the parameter count and the difference between a model that trains and one that does not.',
+    fields: [model.sources.normEps, model.sources.hidden].filter(Boolean),
+    params: model.dims.hidden,
+  };
+}
+
+function residualNode(id, what) {
+  return {
+    id,
+    tone: 'residual',
+    title: 'Residual Add',
+    shape: 'in + out',
+    role: `The input of ${what} is added back to its output. The stream running down the model is never replaced, only written into, which is what lets gradients reach the first layer.`,
+    fields: [],
+  };
+}
+
+function mlpNodes(model) {
+  const { dims, flags, sources } = model;
+  const matrices = flags.gated ? 3 : 2;
+  const expertParams = matrices * dims.hidden * dims.intermediate;
+  if (!flags.moe) {
+    return [
+      {
+        id: 'mlp',
+        tone: 'mlp',
+        title: flags.gated ? 'Gated MLP' : 'MLP',
+        shape: shape(`${dims.hidden} -> ${dims.intermediate}`, `${dims.intermediate} -> ${dims.hidden}`),
+        role: `Each token is widened to ${dims.intermediate} channels, passed through ${flags.activation}, and squeezed back. Attention moves information between tokens; this block is where a token thinks about itself, and it holds most of the weights.${flags.gated ? ' The gate projection is a second wide matrix that decides how much of the first one survives.' : ''}`,
+        fields: [sources.intermediate, sources.activation],
+        params: expertParams,
+      },
+    ];
+  }
+  return [
+    {
+      id: 'router',
+      tone: 'mlp',
+      title: 'Router',
+      shape: shape(`hidden ${dims.hidden} x ${flags.moe.experts} experts`),
+      role: `A small matrix scores the experts for this token and keeps the top ${flags.moe.topK}. Routing is per token, not per sequence, so two words in the same sentence can be handled by different experts.`,
+      fields: [sources.experts, sources.expertsPerToken],
+      params: dims.hidden * flags.moe.experts,
+    },
+    {
+      id: 'experts',
+      tone: 'mlp',
+      title: `Expert MLPs x ${flags.moe.experts}`,
+      shape: shape(`${dims.hidden} -> ${dims.intermediate}`, `${flags.moe.topK} of ${flags.moe.experts} run per token`),
+      role: `Every expert is an ordinary MLP of the same shape. All of them sit in memory, only ${flags.moe.topK} run for a given token, which is why a mixture model is far larger on disk than it is expensive per token.`,
+      fields: [sources.intermediate, sources.experts, sources.expertsPerToken],
+      params: expertParams * flags.moe.experts,
+    },
+  ];
+}
+
+function outputSection(model) {
+  const { dims, flags, sources } = model;
+  return {
+    id: 'output',
+    kind: 'flow',
+    title: 'Output',
+    nodes: [
+      normNode(model, 'norm-final', 'Final Norm'),
+      {
+        id: 'lm-head',
+        tone: 'head',
+        title: flags.tied ? 'LM Head (tied)' : 'LM Head',
+        shape: shape(`hidden ${dims.hidden} x vocab ${dims.vocab}`),
+        role: flags.tied
+          ? 'Scores every vocabulary entry against the final vector, reusing the embedding matrix transposed instead of holding its own copy. That saves one of the largest matrices in a small model.'
+          : 'Scores every vocabulary entry against the final vector. One number per token in the vocabulary, before any temperature or sampling is applied.',
+        fields: [sources.vocab, sources.tieEmbeddings].filter(Boolean),
+        params: flags.tied ? 0 : dims.vocab * dims.hidden,
+      },
+      {
+        id: 'logits',
+        tone: 'io',
+        title: 'Logits -> Next Token',
+        shape: shape(`vocab ${dims.vocab}`),
+        role: 'Softmax turns the scores into a distribution and the sampler picks one token. That token is appended to the prompt and the whole column runs again.',
+        fields: [],
+      },
+    ],
+  };
+}
+
+/**
+ * List every config field the diagram points at, with its value and targets.
+ * @param {object} model the model from deriveModel
+ * @param {object} diagram the diagram from buildDiagram
+ * @returns {Array<{field: string, value: *, nodes: string[]}>} one row per field
+ */
+export function annotations(model, diagram) {
+  const byField = new Map();
+  for (const section of diagram.sections) {
+    const targets = [{ id: section.id, fields: section.fields ?? [] }, ...section.nodes.map((n) => ({ id: n.id, fields: n.fields }))];
+    for (const target of targets) {
+      for (const field of target.fields) {
+        if (!field) continue;
+        if (!byField.has(field)) byField.set(field, { field, value: model.config[field], nodes: [] });
+        byField.get(field).nodes.push(target.id);
+      }
+    }
+  }
+  return [...byField.values()];
+}

--- a/product/akbun-visualizellm/workspace/src/lib/model.js
+++ b/product/akbun-visualizellm/workspace/src/lib/model.js
@@ -1,0 +1,268 @@
+// Reads a Hugging Face style config.json and turns it into the model the rest
+// of the page draws. Nothing here touches the DOM, so the tests run on plain
+// node without a browser and without a build.
+
+// Every field a config may spell differently. The first alias present wins, and
+// the alias that matched is kept as `source` so the page can point an arrow at
+// the exact line of the config the reader is looking at.
+export const FIELD_ALIASES = {
+  hidden: ['hidden_size', 'n_embd', 'd_model', 'dim'],
+  layers: ['num_hidden_layers', 'n_layer', 'num_layers', 'n_layers'],
+  heads: ['num_attention_heads', 'n_head', 'num_heads'],
+  kvHeads: ['num_key_value_heads', 'num_kv_heads'],
+  headDim: ['head_dim'],
+  intermediate: ['intermediate_size', 'n_inner', 'ffn_dim', 'd_ff'],
+  vocab: ['vocab_size'],
+  context: ['max_position_embeddings', 'n_positions', 'max_sequence_length'],
+  activation: ['hidden_act', 'activation_function', 'hidden_activation'],
+  normEps: ['rms_norm_eps', 'layer_norm_epsilon', 'layer_norm_eps'],
+  ropeTheta: ['rope_theta'],
+  experts: ['num_local_experts', 'num_experts', 'n_routed_experts'],
+  expertsPerToken: ['num_experts_per_tok', 'num_experts_per_token', 'top_k'],
+  slidingWindow: ['sliding_window'],
+  tieEmbeddings: ['tie_word_embeddings'],
+};
+
+// Activations whose MLP has a gate projection, so the block holds three
+// matrices instead of two. Getting this wrong misses a third of the parameters.
+const GATED_ACTIVATIONS = ['silu', 'swish', 'swiglu', 'geglu', 'gelu_pytorch_tanh'];
+
+/**
+ * Parse config.json text.
+ * @param {string} text raw file or pasted document
+ * @returns {object} the parsed config
+ * @throws {Error} when the text is not JSON or not a model config
+ */
+export function parseConfig(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    throw new Error('Paste a config.json or open one.');
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Not valid JSON: ${error.message}`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('A config.json is a JSON object.');
+  }
+  const config = unwrapTextConfig(parsed);
+  if (readField(config, 'hidden') === null || readField(config, 'layers') === null) {
+    throw new Error('No hidden size or layer count found. This does not look like a model config.json.');
+  }
+  return config;
+}
+
+// Multimodal configs keep the language model one level down. The page draws the
+// text stack, so it is the nested object that matters.
+function unwrapTextConfig(config) {
+  if (readField(config, 'hidden') !== null) return config;
+  for (const key of ['text_config', 'llm_config', 'language_config', 'decoder']) {
+    const nested = config[key];
+    if (nested && typeof nested === 'object' && readField(nested, 'hidden') !== null) {
+      return { ...nested, model_type: nested.model_type ?? config.model_type, architectures: config.architectures };
+    }
+  }
+  return config;
+}
+
+/**
+ * Read one logical field through its aliases.
+ * @param {object} config parsed config
+ * @param {string} key a key of FIELD_ALIASES
+ * @returns {{value: *, source: string}|null} the value and the config field it came from
+ */
+export function readField(config, key) {
+  for (const alias of FIELD_ALIASES[key] ?? []) {
+    const value = config[alias];
+    if (value !== undefined && value !== null) return { value, source: alias };
+  }
+  return null;
+}
+
+function numberField(config, key, fallback = null) {
+  const found = readField(config, key);
+  if (found === null || typeof found.value !== 'number') {
+    return fallback === null ? null : { value: fallback, source: null };
+  }
+  return found;
+}
+
+/**
+ * Turn a config into the model description the 2D and 3D views read.
+ * @param {object} config parsed config
+ * @returns {object} dims, flags, per-field sources and a parameter estimate
+ */
+export function deriveModel(config) {
+  const hidden = numberField(config, 'hidden');
+  const layers = numberField(config, 'layers');
+  const heads = numberField(config, 'heads', 1);
+  const kvHeads = numberField(config, 'kvHeads', heads.value);
+  const headDim = numberField(config, 'headDim', Math.floor(hidden.value / heads.value));
+  const intermediate = numberField(config, 'intermediate', hidden.value * 4);
+  const vocab = numberField(config, 'vocab', 32000);
+  const context = numberField(config, 'context', 2048);
+  const experts = numberField(config, 'experts');
+  const expertsPerToken = numberField(config, 'expertsPerToken', 1);
+  const activation = readField(config, 'activation') ?? { value: 'silu', source: null };
+  const normEps = readField(config, 'normEps');
+  const ropeTheta = readField(config, 'ropeTheta');
+  const slidingWindow = readField(config, 'slidingWindow');
+  const tie = readField(config, 'tieEmbeddings');
+
+  const sources = {
+    hidden: hidden.source,
+    layers: layers.source,
+    heads: heads.source,
+    kvHeads: kvHeads.source,
+    headDim: headDim.source,
+    intermediate: intermediate.source,
+    vocab: vocab.source,
+    context: context.source,
+    activation: activation.source,
+    normEps: normEps?.source ?? null,
+    ropeTheta: ropeTheta?.source ?? null,
+    experts: experts?.source ?? null,
+    expertsPerToken: expertsPerToken?.source ?? null,
+    slidingWindow: slidingWindow?.source ?? null,
+    tieEmbeddings: tie?.source ?? null,
+  };
+
+  const dims = {
+    hidden: hidden.value,
+    layers: layers.value,
+    heads: heads.value,
+    kvHeads: kvHeads.value,
+    headDim: headDim.value,
+    intermediate: intermediate.value,
+    vocab: vocab.value,
+    context: context.value,
+  };
+
+  const flags = {
+    attention: attentionKind(dims.heads, dims.kvHeads),
+    gated: GATED_ACTIVATIONS.includes(String(activation.value).toLowerCase()),
+    activation: String(activation.value),
+    normKind: normEps?.source === 'rms_norm_eps' ? 'RMSNorm' : 'LayerNorm',
+    normEps: normEps?.value ?? null,
+    rope: ropeTheta?.value ?? null,
+    slidingWindow: typeof slidingWindow?.value === 'number' ? slidingWindow.value : null,
+    tied: tie?.value === true,
+    moe: experts === null ? null : { experts: experts.value, topK: expertsPerToken.value },
+  };
+
+  const model = {
+    name: modelName(config),
+    modelType: config.model_type ?? null,
+    architectures: Array.isArray(config.architectures) ? config.architectures : [],
+    dims,
+    flags,
+    sources,
+    config,
+  };
+  model.params = countParams(model);
+  return model;
+}
+
+function modelName(config) {
+  if (Array.isArray(config.architectures) && config.architectures.length > 0) {
+    return config.architectures[0];
+  }
+  return config.model_type ?? 'model';
+}
+
+/**
+ * Name the attention scheme from the head counts.
+ * @param {number} heads query heads
+ * @param {number} kvHeads key and value heads
+ * @returns {'MHA'|'GQA'|'MQA'} the scheme
+ */
+export function attentionKind(heads, kvHeads) {
+  if (kvHeads === 1 && heads > 1) return 'MQA';
+  if (kvHeads < heads) return 'GQA';
+  return 'MHA';
+}
+
+/**
+ * Estimate the parameter count from the shapes alone.
+ * @param {object} model the model from deriveModel
+ * @returns {object} per-part counts and the total
+ */
+export function countParams(model) {
+  const { hidden, layers, heads, kvHeads, headDim, intermediate, vocab } = model.dims;
+  const qDim = heads * headDim;
+  const kvDim = kvHeads * headDim;
+  const attentionPerLayer = hidden * qDim + hidden * kvDim * 2 + qDim * hidden;
+  const mlpMatrices = model.flags.gated ? 3 : 2;
+  const expertCount = model.flags.moe ? model.flags.moe.experts : 1;
+  const router = model.flags.moe ? hidden * model.flags.moe.experts : 0;
+  const mlpPerLayer = mlpMatrices * hidden * intermediate * expertCount + router;
+  const normsPerLayer = hidden * 2;
+
+  const embedding = vocab * hidden;
+  const attention = attentionPerLayer * layers;
+  const mlp = mlpPerLayer * layers;
+  const norms = normsPerLayer * layers + hidden;
+  const lmHead = model.flags.tied ? 0 : vocab * hidden;
+  return {
+    embedding,
+    attention,
+    mlp,
+    norms,
+    lmHead,
+    perLayer: attentionPerLayer + mlpPerLayer + normsPerLayer,
+    total: embedding + attention + mlp + norms + lmHead,
+  };
+}
+
+/**
+ * Format a count the way model cards do.
+ * @param {number} n a parameter count
+ * @returns {string} for example "6.7B"
+ */
+export function humanCount(n) {
+  if (!Number.isFinite(n)) return '-';
+  if (n >= 1e12) return `${(n / 1e12).toFixed(2)}T`;
+  if (n >= 1e9) return `${(n / 1e9).toFixed(n / 1e9 >= 10 ? 0 : 1)}B`;
+  if (n >= 1e6) return `${(n / 1e6).toFixed(n / 1e6 >= 10 ? 0 : 1)}M`;
+  if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
+  return String(n);
+}
+
+/**
+ * The headline facts shown above the diagram.
+ * @param {object} model the model from deriveModel
+ * @returns {Array<{label: string, value: string, field: string|null}>} summary rows
+ */
+export function summary(model) {
+  const { dims, flags } = model;
+  const rows = [
+    { label: 'Parameters', value: `${humanCount(model.params.total)} (estimated)`, field: null },
+    { label: 'Layers', value: String(dims.layers), field: model.sources.layers },
+    { label: 'Hidden size', value: String(dims.hidden), field: model.sources.hidden },
+    { label: 'Attention', value: `${flags.attention}, ${dims.heads} heads / ${dims.kvHeads} kv`, field: model.sources.heads },
+    { label: 'Head dim', value: String(dims.headDim), field: model.sources.headDim },
+    { label: 'MLP width', value: String(dims.intermediate), field: model.sources.intermediate },
+    { label: 'Vocabulary', value: String(dims.vocab), field: model.sources.vocab },
+    { label: 'Context', value: `${dims.context} tokens`, field: model.sources.context },
+    { label: 'Activation', value: flags.activation, field: model.sources.activation },
+    { label: 'Normalization', value: flags.normKind, field: model.sources.normEps },
+  ];
+  if (flags.rope !== null) {
+    rows.push({ label: 'RoPE theta', value: String(flags.rope), field: model.sources.ropeTheta });
+  }
+  if (flags.slidingWindow !== null) {
+    rows.push({ label: 'Sliding window', value: `${flags.slidingWindow} tokens`, field: model.sources.slidingWindow });
+  }
+  if (flags.moe) {
+    rows.push({
+      label: 'Experts',
+      value: `${flags.moe.experts}, ${flags.moe.topK} active per token`,
+      field: model.sources.experts,
+    });
+  }
+  if (flags.tied) {
+    rows.push({ label: 'Output weights', value: 'tied to the embedding', field: model.sources.tieEmbeddings });
+  }
+  return rows;
+}

--- a/product/akbun-visualizellm/workspace/src/lib/model.js
+++ b/product/akbun-visualizellm/workspace/src/lib/model.js
@@ -47,10 +47,28 @@ export function parseConfig(text) {
     throw new Error('A config.json is a JSON object.');
   }
   const config = unwrapTextConfig(parsed);
-  if (readField(config, 'hidden') === null || readField(config, 'layers') === null) {
+  const hidden = readField(config, 'hidden');
+  const layers = readField(config, 'layers');
+  if (hidden === null || layers === null) {
     throw new Error('No hidden size or layer count found. This does not look like a model config.json.');
   }
+  // Present but unusable is its own failure. Without this the page would carry
+  // a string or a zero all the way to a NaN in the drawing.
+  for (const found of [hidden, layers]) {
+    if (!isPositiveNumber(found.value)) {
+      throw new Error(`${found.source} has to be a positive number, not ${JSON.stringify(found.value)}.`);
+    }
+  }
   return config;
+}
+
+/**
+ * Whether a value can be used as a dimension.
+ * @param {*} value anything read from a config
+ * @returns {boolean} true for a finite number above zero
+ */
+export function isPositiveNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
 }
 
 // Multimodal configs keep the language model one level down. The page draws the
@@ -80,9 +98,11 @@ export function readField(config, key) {
   return null;
 }
 
+// A field is only taken when it is a usable dimension. A zero head count or a
+// string width falls back rather than turning into Infinity or NaN downstream.
 function numberField(config, key, fallback = null) {
   const found = readField(config, key);
-  if (found === null || typeof found.value !== 'number') {
+  if (found === null || !isPositiveNumber(found.value)) {
     return fallback === null ? null : { value: fallback, source: null };
   }
   return found;
@@ -98,7 +118,7 @@ export function deriveModel(config) {
   const layers = numberField(config, 'layers');
   const heads = numberField(config, 'heads', 1);
   const kvHeads = numberField(config, 'kvHeads', heads.value);
-  const headDim = numberField(config, 'headDim', Math.floor(hidden.value / heads.value));
+  const headDim = numberField(config, 'headDim', Math.max(1, Math.floor(hidden.value / heads.value)));
   const intermediate = numberField(config, 'intermediate', hidden.value * 4);
   const vocab = numberField(config, 'vocab', 32000);
   const context = numberField(config, 'context', 2048);

--- a/product/akbun-visualizellm/workspace/src/lib/samples.js
+++ b/product/akbun-visualizellm/workspace/src/lib/samples.js
@@ -1,0 +1,99 @@
+// Configs to start from, written the way each family actually spells its
+// fields. They exist so the page has something to draw before the reader has
+// found a config.json of their own.
+
+export const SAMPLES = [
+  {
+    id: 'dense-7b',
+    label: 'Dense 7B',
+    note: 'The common decoder: 32 layers, multi-head attention, gated MLP',
+    config: {
+      architectures: ['LlamaForCausalLM'],
+      model_type: 'llama',
+      hidden_size: 4096,
+      intermediate_size: 11008,
+      num_hidden_layers: 32,
+      num_attention_heads: 32,
+      num_key_value_heads: 32,
+      max_position_embeddings: 4096,
+      vocab_size: 32000,
+      hidden_act: 'silu',
+      rms_norm_eps: 1e-5,
+      rope_theta: 10000.0,
+      tie_word_embeddings: false,
+      torch_dtype: 'bfloat16',
+    },
+  },
+  {
+    id: 'gqa-1_5b',
+    label: 'Small chat 1.5B',
+    note: 'Grouped-query attention, a sliding window, output weights tied to the embedding',
+    config: {
+      architectures: ['Qwen2ForCausalLM'],
+      model_type: 'qwen2',
+      hidden_size: 1536,
+      intermediate_size: 8960,
+      num_hidden_layers: 28,
+      num_attention_heads: 12,
+      num_key_value_heads: 2,
+      max_position_embeddings: 32768,
+      sliding_window: 4096,
+      vocab_size: 151936,
+      hidden_act: 'silu',
+      rms_norm_eps: 1e-6,
+      rope_theta: 1000000.0,
+      tie_word_embeddings: true,
+      torch_dtype: 'bfloat16',
+    },
+  },
+  {
+    id: 'moe-8x7b',
+    label: 'Mixture of experts 8x7B',
+    note: 'Eight expert MLPs per layer, two of them run for any one token',
+    config: {
+      architectures: ['MixtralForCausalLM'],
+      model_type: 'mixtral',
+      hidden_size: 4096,
+      intermediate_size: 14336,
+      num_hidden_layers: 32,
+      num_attention_heads: 32,
+      num_key_value_heads: 8,
+      num_local_experts: 8,
+      num_experts_per_tok: 2,
+      max_position_embeddings: 32768,
+      vocab_size: 32000,
+      hidden_act: 'silu',
+      rms_norm_eps: 1e-5,
+      rope_theta: 1000000.0,
+      tie_word_embeddings: false,
+      torch_dtype: 'bfloat16',
+    },
+  },
+  {
+    id: 'gpt2',
+    label: 'GPT-2 small',
+    note: 'The older field names: n_embd, n_layer, n_head, learned positions instead of RoPE',
+    config: {
+      architectures: ['GPT2LMHeadModel'],
+      model_type: 'gpt2',
+      n_embd: 768,
+      n_layer: 12,
+      n_head: 12,
+      n_positions: 1024,
+      n_inner: 3072,
+      vocab_size: 50257,
+      activation_function: 'gelu_new',
+      layer_norm_epsilon: 1e-5,
+      tie_word_embeddings: true,
+    },
+  },
+];
+
+/**
+ * Find a sample by id.
+ * @param {string} id the sample id
+ * @returns {object|undefined} the sample entry
+ */
+export function sampleById(id) {
+  return SAMPLES.find((sample) => sample.id === id);
+}

--- a/product/akbun-visualizellm/workspace/src/lib/scene.js
+++ b/product/akbun-visualizellm/workspace/src/lib/scene.js
@@ -230,3 +230,35 @@ function matrix({ id, tone, label, rows, cols, rowsLabel, colsLabel, role }) {
 export function sceneParams(scene) {
   return scene.blocks.reduce((sum, b) => sum + (b.params ?? 0) * (b.copies ?? 1), 0);
 }
+
+/**
+ * The blocks a filter leaves visible.
+ * @param {{blocks: Array<object>}} scene the scene from buildScene
+ * @param {{layer?: number|null, tones?: Array<string>|null}} filter a layer to isolate and the tones to keep
+ * @returns {Array<object>} the visible blocks
+ */
+export function visibleBlocks(scene, filter = {}) {
+  const { layer = null, tones = null } = filter;
+  return scene.blocks.filter((block) => {
+    // The embedding, the final norm and the head belong to no layer, so
+    // isolating a layer keeps them: they are what the layer sits between.
+    if (layer !== null && block.layer !== undefined && block.layer !== layer) return false;
+    return tones === null || tones.includes(block.tone);
+  });
+}
+
+/**
+ * The extent of a set of blocks along the flow axis.
+ * @param {Array<object>} blocks blocks from the scene
+ * @returns {{minX: number, maxX: number, centerX: number, width: number}|null} the extent, or null when empty
+ */
+export function bounds(blocks) {
+  if (blocks.length === 0) return null;
+  let minX = Infinity;
+  let maxX = -Infinity;
+  for (const block of blocks) {
+    minX = Math.min(minX, block.x - block.w / 2);
+    maxX = Math.max(maxX, block.x + block.w / 2);
+  }
+  return { minX, maxX, centerX: (minX + maxX) / 2, width: maxX - minX };
+}

--- a/product/akbun-visualizellm/workspace/src/lib/scene.js
+++ b/product/akbun-visualizellm/workspace/src/lib/scene.js
@@ -64,7 +64,7 @@ export function buildScene(model) {
     colsLabel: 'scale',
     role: 'The last rescale before the vocabulary scores are read off.',
   }));
-  push(matrix({
+  const head = matrix({
     id: 'lm-head',
     tone: 'head',
     label: model.flags.tied ? 'LM Head (tied to the embedding)' : 'LM Head',
@@ -73,7 +73,14 @@ export function buildScene(model) {
     rowsLabel: 'hidden',
     colsLabel: 'vocab',
     role: 'Scores every vocabulary entry against the final vector. The sampler reads these numbers and picks the next token.',
-  }));
+  });
+  if (model.flags.tied) {
+    // Drawn at full size because the matrix is still used, but it is the
+    // embedding transposed, so counting it again would double it.
+    head.params = 0;
+    head.role += ' Tied here: it is the embedding matrix transposed, so it holds no weights of its own.';
+  }
+  push(head);
 
   return { blocks, span: x, layerSpan, layers: model.dims.layers };
 }

--- a/product/akbun-visualizellm/workspace/src/lib/scene.js
+++ b/product/akbun-visualizellm/workspace/src/lib/scene.js
@@ -1,0 +1,232 @@
+// The 3D view: every weight matrix of the model placed in space, sized by its
+// shape. Pure geometry, so the layout is testable without a WebGL context.
+
+const MIN_SIDE = 0.5;
+const MAX_SIDE = 9;
+const GAP = 0.9;
+const LAYER_GAP = 2.4;
+
+/**
+ * Log scale a dimension into a drawable side length.
+ * @param {number} n a tensor dimension
+ * @returns {number} a side length between MIN_SIDE and MAX_SIDE
+ */
+export function side(n) {
+  const scaled = Math.log2(Math.max(n, 2)) / 2;
+  return Math.min(MAX_SIDE, Math.max(MIN_SIDE, scaled));
+}
+
+/**
+ * Place every matrix of the model along the flow axis.
+ * @param {object} model the model from deriveModel
+ * @returns {{blocks: Array<object>, span: number, layerSpan: number, layers: number}} the scene
+ */
+export function buildScene(model) {
+  const blocks = [];
+  let x = 0;
+
+  const push = (block) => {
+    const width = block.w ?? 0.55;
+    blocks.push({ ...block, w: width, x: x + width / 2 });
+    x += width + GAP;
+    return blocks[blocks.length - 1];
+  };
+
+  push(matrix({
+    id: 'embedding',
+    tone: 'embed',
+    label: 'Token Embedding',
+    rows: model.dims.vocab,
+    cols: model.dims.hidden,
+    rowsLabel: 'vocab',
+    colsLabel: 'hidden',
+    role: 'One row per vocabulary entry. A token id selects a row, and that row is the vector the layers work on.',
+  }));
+
+  const layerStart = x;
+  const layerBlocks = layerTemplate(model);
+  for (let i = 0; i < model.dims.layers; i += 1) {
+    for (const block of layerBlocks) {
+      push({ ...block, id: `layer${i}-${block.id}`, layer: i, label: `${block.label} (layer ${i})` });
+    }
+    x += LAYER_GAP - GAP;
+  }
+  const layerSpan = model.dims.layers > 0 ? (x - layerStart) / model.dims.layers : 0;
+  x -= LAYER_GAP - GAP;
+
+  push(matrix({
+    id: 'norm-final',
+    tone: 'norm',
+    label: `Final ${model.flags.normKind}`,
+    rows: model.dims.hidden,
+    cols: 1,
+    rowsLabel: 'hidden',
+    colsLabel: 'scale',
+    role: 'The last rescale before the vocabulary scores are read off.',
+  }));
+  push(matrix({
+    id: 'lm-head',
+    tone: 'head',
+    label: model.flags.tied ? 'LM Head (tied to the embedding)' : 'LM Head',
+    rows: model.dims.hidden,
+    cols: model.dims.vocab,
+    rowsLabel: 'hidden',
+    colsLabel: 'vocab',
+    role: 'Scores every vocabulary entry against the final vector. The sampler reads these numbers and picks the next token.',
+  }));
+
+  return { blocks, span: x, layerSpan, layers: model.dims.layers };
+}
+
+function layerTemplate(model) {
+  const { dims, flags } = model;
+  const qDim = dims.heads * dims.headDim;
+  const kvDim = dims.kvHeads * dims.headDim;
+  const blocks = [
+    matrix({
+      id: 'norm-in',
+      tone: 'norm',
+      label: `Input ${flags.normKind}`,
+      rows: dims.hidden,
+      cols: 1,
+      rowsLabel: 'hidden',
+      colsLabel: 'scale',
+      role: 'One weight per channel, applied before attention reads the stream.',
+    }),
+    matrix({
+      id: 'q',
+      tone: 'attn',
+      label: 'Q Projection',
+      rows: dims.hidden,
+      cols: qDim,
+      rowsLabel: 'hidden',
+      colsLabel: `${dims.heads} heads x ${dims.headDim}`,
+      role: 'What this token is looking for, split across the query heads.',
+    }),
+    matrix({
+      id: 'k',
+      tone: 'attn',
+      label: 'K Projection',
+      rows: dims.hidden,
+      cols: kvDim,
+      rowsLabel: 'hidden',
+      colsLabel: `${dims.kvHeads} heads x ${dims.headDim}`,
+      role: 'How this token advertises itself to the queries. Its output is what the KV cache stores.',
+    }),
+    matrix({
+      id: 'v',
+      tone: 'attn',
+      label: 'V Projection',
+      rows: dims.hidden,
+      cols: kvDim,
+      rowsLabel: 'hidden',
+      colsLabel: `${dims.kvHeads} heads x ${dims.headDim}`,
+      role: 'What this token hands over when a query picks it. Cached alongside K.',
+    }),
+    scores(model),
+    matrix({
+      id: 'o',
+      tone: 'attn',
+      label: 'Output Projection',
+      rows: qDim,
+      cols: dims.hidden,
+      rowsLabel: 'heads',
+      colsLabel: 'hidden',
+      role: 'Folds the heads back to the hidden width so the result can be added to the stream.',
+    }),
+    matrix({
+      id: 'norm-post',
+      tone: 'norm',
+      label: `Post-Attention ${flags.normKind}`,
+      rows: dims.hidden,
+      cols: 1,
+      rowsLabel: 'hidden',
+      colsLabel: 'scale',
+      role: 'The second rescale, in front of the feed-forward block.',
+    }),
+  ];
+  return blocks.concat(mlpTemplate(model));
+}
+
+function scores(model) {
+  const { dims } = model;
+  const width = side(dims.context) / 2;
+  return {
+    id: 'scores',
+    tone: 'attn',
+    kind: 'activation',
+    label: 'Attention Scores',
+    shape: `${dims.heads} heads x T x T`,
+    rows: dims.context,
+    cols: dims.context,
+    h: side(dims.context),
+    d: side(dims.context),
+    w: width,
+    params: 0,
+    role: 'Not a weight. It is built at run time, one T by T square per head, which is why long prompts cost memory that the file size never shows.',
+  };
+}
+
+function mlpTemplate(model) {
+  const { dims, flags } = model;
+  const names = flags.gated
+    ? [['gate', 'Gate Projection', 'Decides how much of the widened vector survives.'], ['up', 'Up Projection', 'Widens the vector to the MLP width.'], ['down', 'Down Projection', 'Squeezes it back to the hidden width.']]
+    : [['up', 'Up Projection', 'Widens the vector to the MLP width.'], ['down', 'Down Projection', 'Squeezes it back to the hidden width.']];
+
+  const single = names.map(([id, label, role]) => matrix({
+    id,
+    tone: 'mlp',
+    label,
+    rows: id === 'down' ? dims.intermediate : dims.hidden,
+    cols: id === 'down' ? dims.hidden : dims.intermediate,
+    rowsLabel: id === 'down' ? 'mlp' : 'hidden',
+    colsLabel: id === 'down' ? 'hidden' : 'mlp',
+    role,
+  }));
+
+  if (!flags.moe) return single;
+
+  const router = matrix({
+    id: 'router',
+    tone: 'mlp',
+    label: 'Router',
+    rows: dims.hidden,
+    cols: flags.moe.experts,
+    rowsLabel: 'hidden',
+    colsLabel: 'experts',
+    role: `Scores the experts for this token and keeps the top ${flags.moe.topK}.`,
+  });
+  // Every expert is the same stack of matrices, so they are drawn as copies
+  // offset along z rather than as separate entries in the flow.
+  const experts = single.map((block) => ({
+    ...block,
+    label: `${block.label} x ${flags.moe.experts} experts`,
+    copies: flags.moe.experts,
+    role: `${block.role} One per expert, all resident, ${flags.moe.topK} of them run for a given token.`,
+  }));
+  return [router, ...experts];
+}
+
+function matrix({ id, tone, label, rows, cols, rowsLabel, colsLabel, role }) {
+  return {
+    id,
+    tone,
+    kind: 'weight',
+    label,
+    rows,
+    cols,
+    shape: `${rowsLabel} ${rows} x ${colsLabel} ${cols}`,
+    params: rows * cols,
+    h: side(rows),
+    d: side(cols),
+  };
+}
+
+/**
+ * Sum the weights actually placed in the scene.
+ * @param {{blocks: Array<object>}} scene the scene from buildScene
+ * @returns {number} parameter count of every weight block
+ */
+export function sceneParams(scene) {
+  return scene.blocks.reduce((sum, b) => sum + (b.params ?? 0) * (b.copies ?? 1), 0);
+}

--- a/product/akbun-visualizellm/workspace/src/pages/index.astro
+++ b/product/akbun-visualizellm/workspace/src/pages/index.astro
@@ -1,0 +1,98 @@
+---
+import '../styles/global.css';
+---
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>akbun visualize llm</title>
+  <meta name="description" content="Open a model config.json and read the architecture it describes: a 2D map of the whole stack with the role of every block, and a 3D view of every weight matrix. Runs entirely in the browser.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Outfit:wght@400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="app-header">
+    <button id="toggle-side" class="nav-toggle ghost" type="button"
+            aria-controls="pane-side" aria-expanded="false">
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" aria-hidden="true">
+        <path d="M3 5h14M3 10h14M3 15h14"></path>
+      </svg>
+      <span class="nav-toggle-label">Config</span>
+    </button>
+    <div class="app-title">
+      <h1>akbun visualize llm</h1>
+      <p>Open a model config.json and see the architecture it describes.</p>
+    </div>
+    <div class="header-actions">
+      <div class="mode-switch" role="group" aria-label="View mode">
+        <button id="mode-2d" class="mode-button is-active" type="button" aria-pressed="true">2D</button>
+        <button id="mode-3d" class="mode-button" type="button" aria-pressed="false">3D</button>
+      </div>
+      <label class="toggle" title="Draw an arrow from each config field to the blocks it shapes">
+        <input id="toggle-annotations" type="checkbox" checked>
+        <span>Config arrows</span>
+      </label>
+      <button id="open-loader" type="button">Load config</button>
+    </div>
+  </header>
+
+  <main class="split">
+    <div id="pane-backdrop" class="pane-backdrop" hidden></div>
+    <aside id="pane-side" class="pane-side">
+      <div class="model-head">
+        <h2 id="model-name">No config loaded</h2>
+        <p id="model-type" class="model-type"></p>
+      </div>
+      <dl id="summary" class="summary"></dl>
+      <h3 class="side-heading">config.json</h3>
+      <pre id="config-view" class="config-view" aria-label="Loaded config"></pre>
+    </aside>
+
+    <section class="pane-main">
+      <div id="view-2d" class="view-2d">
+        <div id="diagram" class="diagram">
+          <svg id="arrows" class="arrows" aria-hidden="true"></svg>
+          <div id="lane" class="lane"></div>
+          <div id="blocks" class="blocks"></div>
+        </div>
+      </div>
+      <div id="view-3d" class="view-3d" hidden>
+        <canvas id="scene"></canvas>
+        <div class="scene-controls">
+          <button id="view-start" class="ghost" type="button">Start</button>
+          <button id="view-all" class="ghost" type="button">Fit all</button>
+        </div>
+        <div class="scene-hint">Drag to orbit, scroll to zoom, right-drag to pan. Hover a block to read it.</div>
+        <div class="scene-legend" id="legend"></div>
+      </div>
+      <div id="tip" class="tip" role="tooltip" hidden></div>
+    </section>
+  </main>
+
+  <div id="loader" class="loader" role="dialog" aria-modal="true" aria-label="Load a model config">
+    <div class="loader-card">
+      <h2>Load a model config.json</h2>
+      <p>Paste the file, open it from disk, or start from one of the samples. The config is read in this browser and uploaded nowhere.</p>
+      <textarea id="config-input" spellcheck="false" autocomplete="off"
+                placeholder='{"model_type": "llama", "hidden_size": 4096, "num_hidden_layers": 32, ... }'
+                aria-label="Model config"></textarea>
+      <div id="load-status" class="status" role="status" aria-live="polite"></div>
+      <div class="samples" id="samples"></div>
+      <div class="loader-actions">
+        <button id="load-config" type="button">Load</button>
+        <button id="pick-file" class="ghost" type="button">Open file…</button>
+        <input id="file-input" type="file" accept=".json,application/json" hidden>
+        <button id="close-loader" class="ghost" type="button">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    import '../scripts/main.js';
+  </script>
+</body>
+</html>

--- a/product/akbun-visualizellm/workspace/src/pages/index.astro
+++ b/product/akbun-visualizellm/workspace/src/pages/index.astro
@@ -65,8 +65,13 @@ import '../styles/global.css';
         <div class="scene-controls">
           <button id="view-start" class="ghost" type="button">Start</button>
           <button id="view-all" class="ghost" type="button">Fit all</button>
+          <label class="layer-pick">
+            <span id="layer-label">All layers</span>
+            <input id="layer-range" type="range" min="-1" max="0" value="-1" step="1"
+                   aria-label="Layer to isolate">
+          </label>
         </div>
-        <div class="scene-hint">Drag to orbit, scroll to zoom, right-drag to pan. Hover a block to read it.</div>
+        <div class="scene-hint">Drag to orbit, scroll to zoom, right-drag to pan. Hover a block to read it, and click a legend entry to hide that part.</div>
         <div class="scene-legend" id="legend"></div>
       </div>
       <div id="tip" class="tip" role="tooltip" hidden></div>

--- a/product/akbun-visualizellm/workspace/src/scripts/main.js
+++ b/product/akbun-visualizellm/workspace/src/scripts/main.js
@@ -1,0 +1,458 @@
+// The DOM side. Everything that needs arithmetic, parsing or layout is handed
+// to src/lib, which is what the tests cover. The 3D view is imported only when
+// it is first opened, so three.js stays out of the first paint.
+import { parseConfig, deriveModel, summary, humanCount } from '../lib/model.js';
+import { buildDiagram, annotations } from '../lib/diagram.js';
+import { SAMPLES } from '../lib/samples.js';
+
+const STORAGE_KEY = 'akbun-visualizellm.state';
+
+const el = (id) => document.getElementById(id);
+const sidePane = el('pane-side');
+const backdrop = el('pane-backdrop');
+const modelName = el('model-name');
+const modelType = el('model-type');
+const summaryList = el('summary');
+const configView = el('config-view');
+const diagramEl = el('diagram');
+const laneEl = el('lane');
+const blocksEl = el('blocks');
+const arrowsEl = el('arrows');
+const tip = el('tip');
+const view2d = el('view-2d');
+const view3d = el('view-3d');
+const loader = el('loader');
+const configInput = el('config-input');
+const loadStatus = el('load-status');
+const fileInput = el('file-input');
+const samplesEl = el('samples');
+const annotationsToggle = el('toggle-annotations');
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+// Matches the phone breakpoint in global.css. The two have to move together.
+const phoneQuery = window.matchMedia('(max-width: 860px)');
+
+const state = {
+  model: null,
+  diagram: null,
+  fields: [],
+  mode: '2d',
+  showAnnotations: true,
+  drawer: false,
+};
+
+let scene3d = null;
+
+function esc(value) {
+  return String(value ?? '').replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+// ===== Loading =====
+
+function loadText(text, label) {
+  try {
+    const config = parseConfig(text);
+    const model = deriveModel(config);
+    state.model = model;
+    state.diagram = buildDiagram(model);
+    state.fields = annotations(model, state.diagram);
+    save(text);
+    renderAll();
+    closeLoader();
+    return true;
+  } catch (error) {
+    setStatus(error.message, true);
+    if (label) console.warn(`${label}: ${error.message}`);
+    return false;
+  }
+}
+
+function setStatus(message, isError = false) {
+  loadStatus.textContent = message;
+  loadStatus.classList.toggle('is-error', isError);
+}
+
+function save(text) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      text,
+      mode: state.mode,
+      showAnnotations: state.showAnnotations,
+    }));
+  } catch {
+    // A full or blocked storage is not a reason to lose the view.
+  }
+}
+
+function restore() {
+  let saved = null;
+  try {
+    saved = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null');
+  } catch {
+    saved = null;
+  }
+  if (saved && typeof saved.showAnnotations === 'boolean') {
+    state.showAnnotations = saved.showAnnotations;
+    annotationsToggle.checked = saved.showAnnotations;
+  }
+  const text = saved?.text ?? JSON.stringify(SAMPLES[0].config, null, 2);
+  configInput.value = text;
+  if (!loadText(text) && text !== null) {
+    loadText(JSON.stringify(SAMPLES[0].config, null, 2));
+  }
+  if (saved?.mode === '3d') setMode('3d');
+}
+
+// ===== Side pane =====
+
+function renderSide() {
+  const model = state.model;
+  modelName.textContent = model.name;
+  modelType.textContent = [model.modelType, `${humanCount(model.params.total)} params (estimated)`]
+    .filter(Boolean).join(' · ');
+
+  summaryList.innerHTML = summary(model).map((row) => `
+    <dt>${esc(row.label)}</dt>
+    <dd${row.field ? ` data-field="${esc(row.field)}"` : ''}>${esc(row.value)}</dd>
+  `).join('');
+
+  configView.innerHTML = configLines(model);
+  for (const line of configView.querySelectorAll('.used')) {
+    line.addEventListener('mouseenter', () => highlight(line.dataset.field));
+    line.addEventListener('mouseleave', () => highlight(null));
+  }
+}
+
+// The config is printed as it was loaded, with the fields the diagram reads
+// marked. Hovering one lights up the blocks its value shaped.
+function configLines(model) {
+  const used = new Set(state.fields.map((row) => row.field));
+  const json = JSON.stringify(model.config, null, 2);
+  return json.split('\n').map((line) => {
+    const match = line.match(/^\s*"([^"]+)":/);
+    if (match && used.has(match[1])) {
+      return `<span class="used" data-field="${esc(match[1])}">${esc(line)}</span>`;
+    }
+    return esc(line);
+  }).join('\n');
+}
+
+// ===== 2D diagram =====
+
+function render2D() {
+  const parts = [];
+  for (const section of state.diagram.sections) {
+    if (section.kind === 'stack') {
+      parts.push(`
+        <div class="stack">
+          <div class="stack-head" data-node="${esc(section.id)}">
+            <h3>${esc(section.title)}</h3>
+            <span>${esc(section.subtitle)}</span>
+          </div>
+          ${section.nodes.map(blockHtml).join('<div class="connector"></div>')}
+        </div>
+      `);
+    } else {
+      parts.push(`<div class="section-title">${esc(section.title)}</div>`);
+      parts.push(section.nodes.map(blockHtml).join('<div class="connector"></div>'));
+    }
+  }
+  blocksEl.innerHTML = parts.join('<div class="connector"></div>');
+  wireBlockTips();
+  layoutLane();
+}
+
+function blockHtml(node) {
+  const fields = node.fields.filter(Boolean);
+  return `
+    <div class="block" data-node="${esc(node.id)}" style="--tone: var(--t-${esc(node.tone)})">
+      <div class="block-title">${esc(node.title)}</div>
+      <div class="block-shape">${esc(node.shape)}</div>
+      <div class="block-fields${fields.length ? ' has-fields' : ''}">${fields.map((f) => `${esc(f)}`).join(' · ')}</div>
+    </div>
+  `;
+}
+
+function nodeById(id) {
+  for (const section of state.diagram.sections) {
+    if (section.id === id) return section;
+    const found = section.nodes.find((node) => node.id === id);
+    if (found) return found;
+  }
+  return null;
+}
+
+function wireBlockTips() {
+  for (const element of blocksEl.querySelectorAll('[data-node]')) {
+    const node = nodeById(element.dataset.node);
+    if (!node) continue;
+    element.addEventListener('mouseenter', (event) => {
+      showTip(tipHtml(node), event);
+      highlight(null, node.id);
+    });
+    element.addEventListener('mousemove', (event) => placeTip(event));
+    element.addEventListener('mouseleave', () => {
+      hideTip();
+      highlight(null);
+    });
+  }
+}
+
+function tipHtml(node) {
+  const fields = (node.fields ?? []).filter(Boolean);
+  return `
+    <h4>${esc(node.title ?? node.subtitle ?? '')}</h4>
+    ${node.shape ? `<div class="tip-shape">${esc(node.shape)}</div>` : ''}
+    <p>${esc(node.role)}</p>
+    ${node.params ? `<div class="tip-fields">${humanCount(node.params)} parameters</div>` : ''}
+    ${fields.length ? `<div class="tip-fields">from ${fields.map(esc).join(', ')}</div>` : ''}
+  `;
+}
+
+// Chips sit in their own column beside the blocks, each one at the height of
+// the first block it points at, pushed down when two would collide. Both
+// columns scroll together, so the arrows are drawn once in content
+// coordinates and never have to follow a scroll event.
+function layoutLane() {
+  laneEl.innerHTML = '';
+  arrowsEl.innerHTML = '';
+  const off = !state.showAnnotations || phoneQuery.matches;
+  diagramEl.classList.toggle('no-lane', !state.showAnnotations);
+  if (off) return;
+
+  const base = diagramEl.getBoundingClientRect();
+  const rows = state.fields
+    .map((row) => ({ row, targets: row.nodes.map((id) => blocksEl.querySelector(`[data-node="${id}"]`)).filter(Boolean) }))
+    .filter((entry) => entry.targets.length > 0)
+    .map((entry) => ({ ...entry, y: centerY(entry.targets[0], base) }))
+    .sort((a, b) => a.y - b.y);
+
+  let lastBottom = -Infinity;
+  for (const entry of rows) {
+    const chip = document.createElement('div');
+    chip.className = 'chip';
+    chip.dataset.field = entry.row.field;
+    chip.innerHTML = `<b>${esc(entry.row.field)}</b>: ${esc(formatValue(entry.row.value))}`;
+    laneEl.appendChild(chip);
+    const height = chip.getBoundingClientRect().height;
+    const top = Math.max(entry.y - height / 2, lastBottom + 6);
+    chip.style.top = `${top}px`;
+    lastBottom = top + height;
+    entry.chip = chip;
+    chip.addEventListener('mouseenter', () => highlight(entry.row.field));
+    chip.addEventListener('mouseleave', () => highlight(null));
+  }
+
+  for (const entry of rows) {
+    const from = entry.chip.getBoundingClientRect();
+    for (const target of entry.targets) {
+      const to = target.getBoundingClientRect();
+      arrowsEl.appendChild(arrowPath(
+        from.right - base.left,
+        from.top + from.height / 2 - base.top,
+        to.left - base.left - 2,
+        to.top + Math.min(to.height / 2, 22) - base.top,
+        entry.row.field,
+      ));
+    }
+  }
+}
+
+function formatValue(value) {
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'string') return value;
+  return JSON.stringify(value);
+}
+
+function centerY(element, base) {
+  const rect = element.getBoundingClientRect();
+  return rect.top + rect.height / 2 - base.top;
+}
+
+function arrowPath(x1, y1, x2, y2, field) {
+  const group = document.createElementNS(SVG_NS, 'g');
+  group.dataset.field = field;
+  const mid = x1 + (x2 - x1) * 0.55;
+  const path = document.createElementNS(SVG_NS, 'path');
+  path.setAttribute('d', `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`);
+  path.setAttribute('fill', 'none');
+  path.setAttribute('stroke', 'var(--accent)');
+  path.setAttribute('stroke-width', '1.5');
+  path.setAttribute('opacity', '0.75');
+  const head = document.createElementNS(SVG_NS, 'path');
+  head.setAttribute('d', `M ${x2} ${y2} l -6 -3.5 l 0 7 z`);
+  head.setAttribute('fill', 'var(--accent)');
+  group.append(path, head);
+  return group;
+}
+
+// Hover anywhere in the chain (chip, config line, block) and the rest of the
+// chain lights up, which is the whole point of the arrows.
+function highlight(field, nodeId = null) {
+  const fields = field ? [field] : (nodeId ? fieldsOf(nodeId) : []);
+  const nodes = new Set(nodeId ? [nodeId] : []);
+  for (const row of state.fields) {
+    if (!fields.includes(row.field)) continue;
+    for (const id of row.nodes) nodes.add(id);
+  }
+  for (const chip of laneEl.querySelectorAll('.chip')) {
+    chip.classList.toggle('is-hot', fields.includes(chip.dataset.field));
+  }
+  for (const group of arrowsEl.querySelectorAll('g')) {
+    group.setAttribute('opacity', fields.length === 0 || fields.includes(group.dataset.field) ? '1' : '0.15');
+  }
+  for (const line of configView.querySelectorAll('.used')) {
+    line.classList.toggle('is-hot', fields.includes(line.dataset.field));
+  }
+  for (const block of blocksEl.querySelectorAll('[data-node]')) {
+    block.classList.toggle('is-hot', field !== null && nodes.has(block.dataset.node));
+  }
+}
+
+function fieldsOf(nodeId) {
+  return state.fields.filter((row) => row.nodes.includes(nodeId)).map((row) => row.field);
+}
+
+// ===== Tooltip =====
+
+function showTip(html, event) {
+  tip.innerHTML = html;
+  tip.hidden = false;
+  placeTip(event);
+}
+
+function placeTip(event) {
+  if (tip.hidden) return;
+  const rect = tip.getBoundingClientRect();
+  const x = Math.min(event.clientX + 16, window.innerWidth - rect.width - 10);
+  const y = Math.min(event.clientY + 16, window.innerHeight - rect.height - 10);
+  tip.style.left = `${Math.max(8, x)}px`;
+  tip.style.top = `${Math.max(8, y)}px`;
+}
+
+function hideTip() {
+  tip.hidden = true;
+}
+
+// ===== Modes =====
+
+async function setMode(mode) {
+  state.mode = mode;
+  el('mode-2d').classList.toggle('is-active', mode === '2d');
+  el('mode-3d').classList.toggle('is-active', mode === '3d');
+  el('mode-2d').setAttribute('aria-pressed', String(mode === '2d'));
+  el('mode-3d').setAttribute('aria-pressed', String(mode === '3d'));
+  view2d.hidden = mode !== '2d';
+  view3d.hidden = mode !== '3d';
+  hideTip();
+  if (mode === '3d') {
+    if (!scene3d) {
+      const module = await import('./view3d.js');
+      scene3d = module.createSceneView({
+        canvas: el('scene'),
+        legend: el('legend'),
+        // A scene block names itself `label`; the tooltip is shared with the
+        // 2D view, which calls that `title`.
+        onHover: (block, event) => (block ? showTip(tipHtml({ ...block, title: block.label }), event) : hideTip()),
+      });
+      el('view-start').addEventListener('click', () => scene3d.focusStart());
+      el('view-all').addEventListener('click', () => scene3d.fitAll());
+    }
+    scene3d.show(state.model);
+  } else if (scene3d) {
+    scene3d.hide();
+    layoutLane();
+  }
+  save(configInput.value);
+}
+
+function renderAll() {
+  renderSide();
+  render2D();
+  if (state.mode === '3d' && scene3d) scene3d.show(state.model);
+}
+
+// ===== Loader dialog =====
+
+function openLoader() {
+  loader.classList.add('is-open');
+  setStatus('');
+  configInput.focus();
+}
+
+function closeLoader() {
+  loader.classList.remove('is-open');
+}
+
+function renderSamples() {
+  samplesEl.innerHTML = SAMPLES.map((sample) => `
+    <button class="sample-button" type="button" data-sample="${esc(sample.id)}">
+      <b>${esc(sample.label)}</b><span>${esc(sample.note)}</span>
+    </button>
+  `).join('');
+  for (const button of samplesEl.querySelectorAll('[data-sample]')) {
+    button.addEventListener('click', () => {
+      const sample = SAMPLES.find((entry) => entry.id === button.dataset.sample);
+      configInput.value = JSON.stringify(sample.config, null, 2);
+      loadText(configInput.value, sample.id);
+    });
+  }
+}
+
+function setDrawer(open) {
+  state.drawer = open;
+  sidePane.classList.toggle('is-open', open);
+  backdrop.hidden = !open;
+  el('toggle-side').setAttribute('aria-expanded', String(open));
+}
+
+// ===== Wiring =====
+
+el('open-loader').addEventListener('click', openLoader);
+el('close-loader').addEventListener('click', closeLoader);
+el('load-config').addEventListener('click', () => loadText(configInput.value));
+el('pick-file').addEventListener('click', () => fileInput.click());
+fileInput.addEventListener('change', async () => {
+  const file = fileInput.files?.[0];
+  if (!file) return;
+  const text = await file.text();
+  configInput.value = text;
+  loadText(text, file.name);
+  fileInput.value = '';
+});
+loader.addEventListener('click', (event) => {
+  if (event.target === loader) closeLoader();
+});
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape') {
+    closeLoader();
+    setDrawer(false);
+  }
+});
+
+el('mode-2d').addEventListener('click', () => setMode('2d'));
+el('mode-3d').addEventListener('click', () => setMode('3d'));
+annotationsToggle.addEventListener('change', () => {
+  state.showAnnotations = annotationsToggle.checked;
+  save(configInput.value);
+  layoutLane();
+});
+el('toggle-side').addEventListener('click', () => setDrawer(!state.drawer));
+backdrop.addEventListener('click', () => setDrawer(false));
+
+let resizeTimer = null;
+window.addEventListener('resize', () => {
+  clearTimeout(resizeTimer);
+  resizeTimer = setTimeout(() => {
+    if (state.mode === '2d') layoutLane();
+  }, 120);
+});
+
+// Web fonts land after the first paint and move every block a few pixels, which
+// would leave the arrows pointing at where the blocks used to be.
+if (document.fonts?.ready) document.fonts.ready.then(() => layoutLane());
+
+renderSamples();
+restore();

--- a/product/akbun-visualizellm/workspace/src/scripts/main.js
+++ b/product/akbun-visualizellm/workspace/src/scripts/main.js
@@ -27,6 +27,8 @@ const loadStatus = el('load-status');
 const fileInput = el('file-input');
 const samplesEl = el('samples');
 const annotationsToggle = el('toggle-annotations');
+const layerRange = el('layer-range');
+const layerLabel = el('layer-label');
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 // Matches the phone breakpoint in global.css. The two have to move together.
@@ -359,7 +361,14 @@ async function setMode(mode) {
       });
       el('view-start').addEventListener('click', () => scene3d.focusStart());
       el('view-all').addEventListener('click', () => scene3d.fitAll());
+      layerRange.addEventListener('input', () => {
+        const value = Number(layerRange.value);
+        const layer = value < 0 ? null : value;
+        layerLabel.textContent = layer === null ? 'All layers' : `Layer ${layer}`;
+        scene3d.setLayer(layer);
+      });
     }
+    syncLayerControl();
     scene3d.show(state.model);
   } else if (scene3d) {
     scene3d.hide();
@@ -368,10 +377,21 @@ async function setMode(mode) {
   save(configInput.value);
 }
 
+// A new model resets the layer control, because the view it drives is rebuilt
+// with the whole stack showing.
+function syncLayerControl() {
+  layerRange.max = String(Math.max(0, state.model.dims.layers - 1));
+  layerRange.value = '-1';
+  layerLabel.textContent = 'All layers';
+}
+
 function renderAll() {
   renderSide();
   render2D();
-  if (state.mode === '3d' && scene3d) scene3d.show(state.model);
+  if (state.mode === '3d' && scene3d) {
+    syncLayerControl();
+    scene3d.show(state.model);
+  }
 }
 
 // ===== Loader dialog =====

--- a/product/akbun-visualizellm/workspace/src/scripts/main.js
+++ b/product/akbun-visualizellm/workspace/src/scripts/main.js
@@ -220,9 +220,11 @@ function tipHtml(node) {
 function layoutLane() {
   laneEl.innerHTML = '';
   arrowsEl.innerHTML = '';
-  const off = !state.showAnnotations || phoneQuery.matches;
-  diagramEl.classList.toggle('no-lane', !state.showAnnotations);
-  if (off) return;
+  // On a phone the switch is out of reach, so the field list under each block
+  // stays whatever the last desktop visit left behind unless the class is
+  // decided here too. The lane itself is off either way.
+  diagramEl.classList.toggle('no-lane', !state.showAnnotations && !phoneQuery.matches);
+  if (!state.showAnnotations || phoneQuery.matches) return;
 
   const base = diagramEl.getBoundingClientRect();
   const rows = state.fields
@@ -308,8 +310,11 @@ function highlight(field, nodeId = null) {
   for (const line of configView.querySelectorAll('.used')) {
     line.classList.toggle('is-hot', fields.includes(line.dataset.field));
   }
+  // Hovering a block is the other direction of the same chain, and it arrives
+  // with no field, so the check is whether anything is highlighted at all.
+  const active = fields.length > 0 || nodeId !== null;
   for (const block of blocksEl.querySelectorAll('[data-node]')) {
-    block.classList.toggle('is-hot', field !== null && nodes.has(block.dataset.node));
+    block.classList.toggle('is-hot', active && nodes.has(block.dataset.node));
   }
 }
 

--- a/product/akbun-visualizellm/workspace/src/scripts/view3d.js
+++ b/product/akbun-visualizellm/workspace/src/scripts/view3d.js
@@ -1,0 +1,238 @@
+// The 3D view. Every weight matrix of the model is a box, sized by its shape
+// and placed along the flow by src/lib/scene.js, which is where the arithmetic
+// lives. This file only turns that list into three.js objects.
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { buildScene } from '../lib/scene.js';
+
+const TONE_VARS = {
+  embed: '--t-embed',
+  attn: '--t-attn',
+  norm: '--t-norm',
+  mlp: '--t-mlp',
+  head: '--t-head',
+  io: '--t-io',
+};
+
+const LEGEND = [
+  ['embed', 'Embedding'],
+  ['norm', 'Normalization'],
+  ['attn', 'Attention'],
+  ['mlp', 'Feed-forward'],
+  ['head', 'Output head'],
+];
+
+// Experts are all the same matrix, so a handful of copies reads as "many"
+// without putting a thousand boxes on the screen.
+const MAX_COPIES = 5;
+
+/**
+ * Mount the 3D view on a canvas.
+ * @param {{canvas: HTMLCanvasElement, legend: HTMLElement, onHover: Function}} options
+ * @returns {{show: Function, hide: Function}} the view handle
+ */
+export function createSceneView({ canvas, legend, onHover }) {
+  const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 8000);
+  const controls = new OrbitControls(camera, canvas);
+  controls.enableDamping = true;
+
+  scene.add(new THREE.HemisphereLight(0xffffff, 0x404050, 2.2));
+  const sun = new THREE.DirectionalLight(0xffffff, 1.4);
+  sun.position.set(1, 2, 1.5);
+  scene.add(sun);
+
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const geometry = new THREE.BoxGeometry(1, 1, 1);
+  const raycaster = new THREE.Raycaster();
+  const pointer = new THREE.Vector2();
+  let meshes = [];
+  let hovered = null;
+  let frame = null;
+  let currentModel = null;
+  let lastLayout = null;
+
+  legend.innerHTML = LEGEND.map(([tone, label]) => `
+    <div class="legend-row">
+      <span class="legend-dot" style="background: var(${TONE_VARS[tone]})"></span>${label}
+    </div>
+  `).join('');
+
+  function cssColor(name) {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return new THREE.Color(value || '#888888');
+  }
+
+  function clear() {
+    for (const mesh of group.children) {
+      if (mesh.material) mesh.material.dispose();
+      if (mesh.material?.map) mesh.material.map.dispose();
+    }
+    group.clear();
+    meshes = [];
+    hovered = null;
+  }
+
+  function build(model) {
+    clear();
+    scene.background = cssColor('--scene-bg');
+    const layout = buildScene(model);
+    const materials = new Map();
+    const materialFor = (tone, activation) => {
+      const key = `${tone}:${activation}`;
+      if (!materials.has(key)) {
+        materials.set(key, new THREE.MeshLambertMaterial({
+          color: cssColor(TONE_VARS[tone] ?? '--t-io'),
+          transparent: activation,
+          opacity: activation ? 0.35 : 1,
+        }));
+      }
+      return materials.get(key);
+    };
+
+    for (const block of layout.blocks) {
+      const material = materialFor(block.tone, block.kind === 'activation');
+      const copies = Math.min(block.copies ?? 1, MAX_COPIES);
+      for (let c = 0; c < copies; c += 1) {
+        const mesh = new THREE.Mesh(geometry, material);
+        mesh.scale.set(block.w, block.h, block.d);
+        mesh.position.set(block.x, block.h / 2 + 0.35, c * 0.5);
+        mesh.userData.block = block;
+        group.add(mesh);
+        meshes.push(mesh);
+      }
+    }
+
+    // The residual stream: the one thing that runs the whole length of the
+    // model, drawn as the rail every block sits on.
+    const rail = new THREE.Mesh(geometry, new THREE.MeshLambertMaterial({ color: cssColor('--t-residual') }));
+    rail.scale.set(layout.span + 2, 0.12, 0.12);
+    rail.position.set(layout.span / 2 - 1, 0.06, 0);
+    rail.userData.block = {
+      label: 'Residual stream',
+      shape: `hidden ${model.dims.hidden} per token`,
+      role: 'The vector every block reads from and writes back into. It is never replaced, only added to, which is why the model can be this deep.',
+      params: 0,
+    };
+    group.add(rail);
+    meshes.push(rail);
+
+    addLabels(layout, model);
+    lastLayout = layout;
+    focusStart();
+    currentModel = model;
+  }
+
+  function addLabels(layout, model) {
+    const step = Math.max(1, Math.round(model.dims.layers / 6));
+    const marks = [{ x: layout.blocks[0].x, text: 'Embedding', y: -2.6 }];
+    for (let i = 0; i < model.dims.layers; i += step) {
+      const first = layout.blocks.find((block) => block.layer === i);
+      if (first) marks.push({ x: first.x, text: `Layer ${i}`, y: -1.2 });
+    }
+    marks.push({ x: layout.blocks.at(-1).x, text: 'LM Head', y: -2.6 });
+    for (const mark of marks) {
+      const sprite = textSprite(mark.text);
+      sprite.position.set(mark.x, mark.y, 0);
+      group.add(sprite);
+    }
+  }
+
+  function textSprite(text) {
+    const canvasEl = document.createElement('canvas');
+    canvasEl.width = 256;
+    canvasEl.height = 64;
+    const ctx = canvasEl.getContext('2d');
+    ctx.fillStyle = `#${cssColor('--text').getHexString()}`;
+    ctx.font = '600 34px Outfit, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(text, 128, 32);
+    const texture = new THREE.CanvasTexture(canvasEl);
+    const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map: texture, transparent: true }));
+    sprite.scale.set(6, 1.5, 1);
+    return sprite;
+  }
+
+  // A whole model is hundreds of units long and a few units wide, so framing all
+  // of it turns every matrix into a speck. The opening shot is the first layers
+  // at reading distance; "Fit all" is a button for when the shape is the point.
+  function focusStart() {
+    if (!lastLayout) return;
+    const reach = Math.max(lastLayout.layerSpan * 2.2, 22);
+    const x = Math.min(lastLayout.layerSpan * 0.7, lastLayout.span / 2);
+    look(new THREE.Vector3(x, 3, 0), new THREE.Vector3(x - reach * 0.55, reach * 0.42, reach * 0.8));
+  }
+
+  function fitAll() {
+    if (!lastLayout) return;
+    const center = new THREE.Vector3(lastLayout.span / 2, 2, 0);
+    look(center, new THREE.Vector3(center.x - lastLayout.span * 0.25, lastLayout.span * 0.3, lastLayout.span * 0.45));
+  }
+
+  function look(target, position) {
+    controls.target.copy(target);
+    camera.position.copy(position);
+    camera.updateProjectionMatrix();
+    controls.update();
+  }
+
+  function resize() {
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    if (width === 0 || height === 0) return;
+    renderer.setSize(width, height, false);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  }
+
+  function pick(event) {
+    const rect = canvas.getBoundingClientRect();
+    pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    raycaster.setFromCamera(pointer, camera);
+    const hit = raycaster.intersectObjects(meshes, false)[0];
+    const block = hit?.object.userData.block ?? null;
+    if (block !== hovered) {
+      hovered = block;
+      onHover(block, event);
+    } else if (block) {
+      onHover(block, event);
+    }
+  }
+
+  canvas.addEventListener('pointermove', pick);
+  canvas.addEventListener('pointerleave', () => {
+    hovered = null;
+    onHover(null);
+  });
+
+  const observer = new ResizeObserver(resize);
+  observer.observe(canvas);
+
+  function tick() {
+    frame = requestAnimationFrame(tick);
+    controls.update();
+    renderer.render(scene, camera);
+  }
+
+  return {
+    show(model) {
+      if (model !== currentModel) build(model);
+      resize();
+      if (frame === null) tick();
+    },
+    focusStart,
+    fitAll,
+    hide() {
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = null;
+      hovered = null;
+    },
+  };
+}

--- a/product/akbun-visualizellm/workspace/src/scripts/view3d.js
+++ b/product/akbun-visualizellm/workspace/src/scripts/view3d.js
@@ -1,9 +1,10 @@
 // The 3D view. Every weight matrix of the model is a box, sized by its shape
 // and placed along the flow by src/lib/scene.js, which is where the arithmetic
-// lives. This file only turns that list into three.js objects.
+// lives. This file only turns that list into three.js objects and hides the
+// ones the filter has switched off.
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { buildScene } from '../lib/scene.js';
+import { buildScene, visibleBlocks, bounds } from '../lib/scene.js';
 
 const TONE_VARS = {
   embed: '--t-embed',
@@ -14,13 +15,15 @@ const TONE_VARS = {
   io: '--t-io',
 };
 
-const LEGEND = [
+export const LEGEND = [
   ['embed', 'Embedding'],
   ['norm', 'Normalization'],
   ['attn', 'Attention'],
   ['mlp', 'Feed-forward'],
   ['head', 'Output head'],
 ];
+
+const ALL_TONES = LEGEND.map(([tone]) => tone);
 
 // Experts are all the same matrix, so a handful of copies reads as "many"
 // without putting a thousand boxes on the screen.
@@ -29,7 +32,7 @@ const MAX_COPIES = 5;
 /**
  * Mount the 3D view on a canvas.
  * @param {{canvas: HTMLCanvasElement, legend: HTMLElement, onHover: Function}} options
- * @returns {{show: Function, hide: Function}} the view handle
+ * @returns {object} the view handle
  */
 export function createSceneView({ canvas, legend, onHover }) {
   const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
@@ -51,17 +54,24 @@ export function createSceneView({ canvas, legend, onHover }) {
   const geometry = new THREE.BoxGeometry(1, 1, 1);
   const raycaster = new THREE.Raycaster();
   const pointer = new THREE.Vector2();
-  let meshes = [];
+  let boxes = [];
+  let marks = [];
+  let pickable = [];
   let hovered = null;
   let frame = null;
   let currentModel = null;
-  let lastLayout = null;
+  let layout = null;
+  // layer null means the whole stack; tones is the set of parts left switched on.
+  const filter = { layer: null, tones: [...ALL_TONES] };
 
   legend.innerHTML = LEGEND.map(([tone, label]) => `
-    <div class="legend-row">
+    <button class="legend-row is-on" type="button" data-tone="${tone}" aria-pressed="true">
       <span class="legend-dot" style="background: var(${TONE_VARS[tone]})"></span>${label}
-    </div>
+    </button>
   `).join('');
+  for (const button of legend.querySelectorAll('[data-tone]')) {
+    button.addEventListener('click', () => toggleTone(button.dataset.tone));
+  }
 
   function cssColor(name) {
     const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
@@ -69,19 +79,21 @@ export function createSceneView({ canvas, legend, onHover }) {
   }
 
   function clear() {
-    for (const mesh of group.children) {
-      if (mesh.material) mesh.material.dispose();
-      if (mesh.material?.map) mesh.material.map.dispose();
+    for (const child of group.children) {
+      if (child.material?.map) child.material.map.dispose();
+      if (child.material) child.material.dispose();
     }
     group.clear();
-    meshes = [];
+    boxes = [];
+    marks = [];
+    pickable = [];
     hovered = null;
   }
 
   function build(model) {
     clear();
     scene.background = cssColor('--scene-bg');
-    const layout = buildScene(model);
+    layout = buildScene(model);
     const materials = new Map();
     const materialFor = (tone, activation) => {
       const key = `${tone}:${activation}`;
@@ -104,15 +116,16 @@ export function createSceneView({ canvas, legend, onHover }) {
         mesh.position.set(block.x, block.h / 2 + 0.35, c * 0.5);
         mesh.userData.block = block;
         group.add(mesh);
-        meshes.push(mesh);
+        boxes.push(mesh);
       }
     }
 
     // The residual stream: the one thing that runs the whole length of the
-    // model, drawn as the rail every block sits on.
+    // model, drawn as the rail every block sits on. No filter hides it.
     const rail = new THREE.Mesh(geometry, new THREE.MeshLambertMaterial({ color: cssColor('--t-residual') }));
     rail.scale.set(layout.span + 2, 0.12, 0.12);
     rail.position.set(layout.span / 2 - 1, 0.06, 0);
+    rail.userData.always = true;
     rail.userData.block = {
       label: 'Residual stream',
       shape: `hidden ${model.dims.hidden} per token`,
@@ -120,26 +133,30 @@ export function createSceneView({ canvas, legend, onHover }) {
       params: 0,
     };
     group.add(rail);
-    meshes.push(rail);
+    boxes.push(rail);
 
-    addLabels(layout, model);
-    lastLayout = layout;
-    focusStart();
+    addLabels(model);
     currentModel = model;
+    filter.layer = null;
+    filter.tones = [...ALL_TONES];
+    applyFilter();
+    focusStart();
   }
 
-  function addLabels(layout, model) {
+  function addLabels(model) {
     const step = Math.max(1, Math.round(model.dims.layers / 6));
-    const marks = [{ x: layout.blocks[0].x, text: 'Embedding', y: -2.6 }];
+    const wanted = [{ x: layout.blocks[0].x, text: 'Embedding', y: -2.6, layer: null }];
     for (let i = 0; i < model.dims.layers; i += step) {
       const first = layout.blocks.find((block) => block.layer === i);
-      if (first) marks.push({ x: first.x, text: `Layer ${i}`, y: -1.2 });
+      if (first) wanted.push({ x: first.x, text: `Layer ${i}`, y: -1.2, layer: i });
     }
-    marks.push({ x: layout.blocks.at(-1).x, text: 'LM Head', y: -2.6 });
-    for (const mark of marks) {
+    wanted.push({ x: layout.blocks.at(-1).x, text: 'LM Head', y: -2.6, layer: null });
+    for (const mark of wanted) {
       const sprite = textSprite(mark.text);
       sprite.position.set(mark.x, mark.y, 0);
+      sprite.userData.layer = mark.layer;
       group.add(sprite);
+      marks.push(sprite);
     }
   }
 
@@ -159,20 +176,60 @@ export function createSceneView({ canvas, legend, onHover }) {
     return sprite;
   }
 
+  // Which boxes a layer choice and the legend switches leave standing. The
+  // decision itself is in scene.js so it can be tested; here it only turns into
+  // visibility flags and a new pick list.
+  function applyFilter() {
+    if (!layout) return;
+    const shown = new Set(visibleBlocks(layout, filter));
+    pickable = [];
+    for (const mesh of boxes) {
+      mesh.visible = mesh.userData.always === true || shown.has(mesh.userData.block);
+      if (mesh.visible) pickable.push(mesh);
+    }
+    for (const sprite of marks) {
+      sprite.visible = filter.layer === null || sprite.userData.layer === null || sprite.userData.layer === filter.layer;
+    }
+    if (hovered && !shown.has(hovered)) {
+      hovered = null;
+      onHover(null);
+    }
+  }
+
+  function setLayer(value) {
+    filter.layer = value;
+    applyFilter();
+    if (value === null) {
+      focusStart();
+      return;
+    }
+    const extent = bounds(visibleBlocks(layout, { layer: value, tones: filter.tones }).filter((b) => b.layer === value));
+    if (extent) look(new THREE.Vector3(extent.centerX, 3, 0), new THREE.Vector3(extent.centerX - extent.width * 0.6, extent.width * 0.55, extent.width * 1.1));
+  }
+
+  function toggleTone(tone) {
+    const on = filter.tones.includes(tone);
+    filter.tones = on ? filter.tones.filter((t) => t !== tone) : [...filter.tones, tone];
+    const button = legend.querySelector(`[data-tone="${tone}"]`);
+    button.classList.toggle('is-on', !on);
+    button.setAttribute('aria-pressed', String(!on));
+    applyFilter();
+  }
+
   // A whole model is hundreds of units long and a few units wide, so framing all
   // of it turns every matrix into a speck. The opening shot is the first layers
   // at reading distance; "Fit all" is a button for when the shape is the point.
   function focusStart() {
-    if (!lastLayout) return;
-    const reach = Math.max(lastLayout.layerSpan * 2.2, 22);
-    const x = Math.min(lastLayout.layerSpan * 0.7, lastLayout.span / 2);
+    if (!layout) return;
+    const reach = Math.max(layout.layerSpan * 2.2, 22);
+    const x = Math.min(layout.layerSpan * 0.7, layout.span / 2);
     look(new THREE.Vector3(x, 3, 0), new THREE.Vector3(x - reach * 0.55, reach * 0.42, reach * 0.8));
   }
 
   function fitAll() {
-    if (!lastLayout) return;
-    const center = new THREE.Vector3(lastLayout.span / 2, 2, 0);
-    look(center, new THREE.Vector3(center.x - lastLayout.span * 0.25, lastLayout.span * 0.3, lastLayout.span * 0.45));
+    if (!layout) return;
+    const center = new THREE.Vector3(layout.span / 2, 2, 0);
+    look(center, new THREE.Vector3(center.x - layout.span * 0.25, layout.span * 0.3, layout.span * 0.45));
   }
 
   function look(target, position) {
@@ -196,14 +253,9 @@ export function createSceneView({ canvas, legend, onHover }) {
     pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
     raycaster.setFromCamera(pointer, camera);
-    const hit = raycaster.intersectObjects(meshes, false)[0];
-    const block = hit?.object.userData.block ?? null;
-    if (block !== hovered) {
-      hovered = block;
-      onHover(block, event);
-    } else if (block) {
-      onHover(block, event);
-    }
+    const hit = raycaster.intersectObjects(pickable, false)[0];
+    hovered = hit?.object.userData.block ?? null;
+    onHover(hovered, event);
   }
 
   canvas.addEventListener('pointermove', pick);
@@ -229,6 +281,7 @@ export function createSceneView({ canvas, legend, onHover }) {
     },
     focusStart,
     fitAll,
+    setLayer,
     hide() {
       if (frame !== null) cancelAnimationFrame(frame);
       frame = null;

--- a/product/akbun-visualizellm/workspace/src/styles/global.css
+++ b/product/akbun-visualizellm/workspace/src/styles/global.css
@@ -1,0 +1,551 @@
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+
+:root {
+  --bg: #FAFAFA;
+  --surface: #FFFFFF;
+  --surface-sub: #F2F1EE;
+  --text: #2D2A26;
+  --text-sub: #6B6560;
+  --accent: #5C6BC0;
+  --accent-dark: #4A5AB0;
+  --divider: #D6D0C4;
+  --danger: #b3261e;
+  --danger-bg: #FDECEA;
+  --danger-border: #F3C7C2;
+  --font-title: 'Sora', sans-serif;
+  --font-body: 'Outfit', sans-serif;
+  --font-mono: 'Fira Code', monospace;
+  --header-height: 76px;
+  --t-io: #6B6560;
+  --t-embed: #7C5CD6;
+  --t-attn: #2F6FDD;
+  --t-norm: #B7791F;
+  --t-mlp: #1E8E5A;
+  --t-residual: #8A8A8A;
+  --t-head: #C0392B;
+  --scene-bg: #F3F4F8;
+}
+
+/* Light is the base, dark is the same palette turned down. The page follows the
+   system setting and offers no toggle of its own. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #16171A;
+    --surface: #1E2024;
+    --surface-sub: #26282D;
+    --text: #E8E6E3;
+    --text-sub: #A29D97;
+    --accent: #8A96E8;
+    --accent-dark: #A2ACF0;
+    --divider: #383B41;
+    --danger: #F2857C;
+    --danger-bg: #3A2523;
+    --danger-border: #6B3B36;
+    --t-io: #A29D97;
+    --t-embed: #B49BFF;
+    --t-attn: #6FA6FF;
+    --t-norm: #E3B65C;
+    --t-mlp: #5CC698;
+    --t-residual: #8A8A8A;
+    --t-head: #F58A7C;
+    --scene-bg: #101216;
+  }
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -webkit-text-size-adjust: 100%;
+}
+
+html, body { height: 100vh; height: 100dvh; }
+
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border: 2px solid var(--text);
+  border-radius: 10px;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.4rem 0.9rem;
+  font-weight: 600;
+}
+
+button:hover { background: var(--accent-dark); }
+
+button.ghost {
+  background: transparent;
+  color: var(--text);
+}
+
+button.ghost:hover { background: var(--surface-sub); }
+
+/* ===== Header ===== */
+.app-header {
+  flex-shrink: 0;
+  min-height: var(--header-height);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1.25rem;
+  border-bottom: 3px solid var(--text);
+  background: var(--surface);
+}
+
+.app-title { flex: 1 1 auto; min-width: 0; }
+
+.app-title h1 {
+  font-family: var(--font-title);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-title p {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.mode-switch {
+  display: flex;
+  border: 2px solid var(--text);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.mode-button {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  padding: 0.35rem 0.85rem;
+}
+
+.mode-button:hover { background: var(--surface-sub); }
+
+.mode-button.is-active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--text-sub);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.toggle input { width: 1.05rem; height: 1.05rem; accent-color: var(--accent); }
+
+.nav-toggle { display: none; align-items: center; gap: 0.4rem; }
+.nav-toggle svg { width: 1.1rem; height: 1.1rem; }
+
+/* ===== Split ===== */
+.split {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+}
+
+.pane-side {
+  width: 340px;
+  flex-shrink: 0;
+  border-right: 3px solid var(--text);
+  background: var(--surface);
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.model-head h2 {
+  font-family: var(--font-title);
+  font-size: 1.15rem;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.model-type {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-sub);
+}
+
+.summary {
+  margin: 0.9rem 0 1.2rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.3rem 0.8rem;
+  font-size: 0.9rem;
+}
+
+.summary dt { color: var(--text-sub); }
+.summary dd { font-weight: 600; text-align: right; word-break: break-word; }
+
+.side-heading {
+  font-family: var(--font-title);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-sub);
+  border-top: 1px solid var(--divider);
+  padding-top: 0.7rem;
+}
+
+.config-view {
+  margin-top: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-sub);
+}
+
+.config-view .used {
+  color: var(--text);
+  background: var(--surface-sub);
+  border-radius: 4px;
+  padding: 0 0.15rem;
+  cursor: pointer;
+}
+
+.config-view .used.is-hot { background: var(--accent); color: #fff; }
+
+.pane-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  position: relative;
+  display: flex;
+}
+
+.view-2d {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 1.5rem 1.5rem 4rem;
+}
+
+/* ===== 2D diagram ===== */
+.diagram {
+  position: relative;
+  display: grid;
+  grid-template-columns: 230px minmax(0, 1fr);
+  gap: 0;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.diagram.no-lane { grid-template-columns: 0 minmax(0, 1fr); }
+
+.arrows {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.lane { position: relative; }
+
+.chip {
+  position: absolute;
+  right: 1.6rem;
+  max-width: 200px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.35;
+  background: var(--surface);
+  border: 1.5px solid var(--accent);
+  border-radius: 8px;
+  padding: 0.2rem 0.45rem;
+  color: var(--text);
+  word-break: break-word;
+  cursor: default;
+}
+
+.chip b { color: var(--accent-dark); font-weight: 600; }
+.chip.is-hot { background: var(--accent); color: #fff; border-color: var(--accent); }
+.chip.is-hot b { color: #fff; }
+
+.blocks { display: flex; flex-direction: column; align-items: stretch; }
+
+.section-title {
+  font-family: var(--font-title);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-sub);
+  margin-bottom: 0.4rem;
+}
+
+.stack {
+  border: 2px dashed var(--divider);
+  border-radius: 14px;
+  padding: 0.8rem;
+  margin: 0.6rem 0;
+  background: color-mix(in srgb, var(--surface) 55%, transparent);
+}
+
+.stack-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+  cursor: help;
+}
+
+.stack-head h3 { font-family: var(--font-title); font-size: 1rem; }
+.stack-head span { font-size: 0.78rem; color: var(--text-sub); text-align: right; }
+
+.block {
+  border: 2px solid var(--text);
+  border-left: 8px solid var(--tone, var(--text));
+  border-radius: 10px;
+  background: var(--surface);
+  padding: 0.5rem 0.75rem;
+  cursor: help;
+}
+
+.block:hover { border-color: var(--accent); }
+.block.is-hot { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 45%, transparent); }
+
+.block-title { font-weight: 600; font-size: 0.95rem; }
+
+.block-shape {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  word-break: break-word;
+}
+
+.connector {
+  height: 18px;
+  width: 2px;
+  background: var(--divider);
+  margin: 0 auto;
+  position: relative;
+}
+
+.connector::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 5px solid transparent;
+  border-top-color: var(--divider);
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-sub);
+  padding: 4rem 1rem;
+}
+
+/* ===== 3D view ===== */
+.view-3d {
+  flex: 1 1 auto;
+  position: relative;
+  background: var(--scene-bg);
+  min-width: 0;
+}
+
+.view-3d canvas { display: block; width: 100%; height: 100%; }
+
+.scene-hint, .scene-legend {
+  position: absolute;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  border: 1.5px solid var(--divider);
+  border-radius: 10px;
+  font-size: 0.78rem;
+  color: var(--text-sub);
+  padding: 0.35rem 0.6rem;
+  pointer-events: none;
+}
+
+.scene-hint { left: 0.9rem; bottom: 0.9rem; }
+
+.scene-controls {
+  position: absolute;
+  left: 0.9rem;
+  top: 0.9rem;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.scene-controls button {
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  font-size: 0.8rem;
+  padding: 0.25rem 0.6rem;
+}
+.scene-legend { right: 0.9rem; top: 0.9rem; display: grid; gap: 0.2rem; }
+
+.legend-row { display: flex; align-items: center; gap: 0.4rem; }
+.legend-dot { width: 0.7rem; height: 0.7rem; border-radius: 3px; }
+
+/* ===== Tooltip ===== */
+.tip {
+  position: fixed;
+  z-index: 40;
+  max-width: 340px;
+  background: var(--surface);
+  border: 2px solid var(--text);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  pointer-events: none;
+}
+
+.tip h4 { font-family: var(--font-title); font-size: 0.95rem; }
+.tip .tip-shape { font-family: var(--font-mono); font-size: 0.75rem; color: var(--accent-dark); }
+.tip p { font-size: 0.85rem; line-height: 1.5; margin-top: 0.3rem; }
+.tip .tip-fields { font-family: var(--font-mono); font-size: 0.72rem; color: var(--text-sub); margin-top: 0.35rem; }
+
+/* ===== Loader ===== */
+.loader {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.45);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.loader.is-open { display: flex; }
+
+.loader-card {
+  width: min(680px, 100%);
+  max-height: 90dvh;
+  overflow-y: auto;
+  background: var(--surface);
+  border: 3px solid var(--text);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.loader-card h2 { font-family: var(--font-title); font-size: 1.2rem; }
+.loader-card p { font-size: 0.9rem; color: var(--text-sub); }
+
+#config-input {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  min-height: 200px;
+  resize: vertical;
+  padding: 0.6rem;
+  border: 2px solid var(--divider);
+  border-radius: 10px;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.samples { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+.sample-button {
+  background: transparent;
+  color: var(--text);
+  border: 2px solid var(--divider);
+  text-align: left;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+}
+
+.sample-button:hover { background: var(--surface-sub); }
+.sample-button b { display: block; font-weight: 600; }
+.sample-button span { color: var(--text-sub); font-size: 0.75rem; }
+
+.loader-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+.status { font-size: 0.85rem; min-height: 1.2rem; color: var(--text-sub); }
+
+.status.is-error {
+  color: var(--danger);
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+  border-radius: 8px;
+  padding: 0.3rem 0.5rem;
+}
+
+.pane-backdrop { display: none; }
+
+/* ===== Phones ===== */
+@media (max-width: 860px) {
+  .nav-toggle { display: inline-flex; }
+  .app-title p { display: none; }
+
+  /* The arrows do not fit a phone, so neither does their switch. */
+  .toggle { display: none; }
+
+  .pane-side {
+    position: fixed;
+    z-index: 30;
+    top: var(--header-height);
+    bottom: 0;
+    left: 0;
+    width: min(320px, 86vw);
+    transform: translateX(-102%);
+    transition: transform 0.18s ease-out;
+  }
+
+  .pane-side.is-open { transform: translateX(0); }
+
+  .pane-backdrop {
+    display: block;
+    position: fixed;
+    inset: var(--header-height) 0 0 0;
+    z-index: 20;
+    background: rgba(0, 0, 0, 0.35);
+  }
+
+  .pane-backdrop[hidden] { display: none; }
+
+  /* The annotation lane needs room the screen does not have, so on a phone the
+     arrows fold into a field list under each block. */
+  .diagram, .diagram.no-lane { grid-template-columns: minmax(0, 1fr); }
+  .lane, .arrows { display: none; }
+  .view-2d { padding: 1rem 1rem 3rem; }
+}
+
+.block-fields {
+  display: none;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--accent-dark);
+  margin-top: 0.2rem;
+}
+
+@media (max-width: 860px) {
+  .diagram .block-fields.has-fields { display: block; }
+  .diagram.no-lane .block-fields { display: none; }
+}

--- a/product/akbun-visualizellm/workspace/src/styles/global.css
+++ b/product/akbun-visualizellm/workspace/src/styles/global.css
@@ -386,8 +386,9 @@ button.ghost:hover { background: var(--surface-sub); }
   font-size: 0.78rem;
   color: var(--text-sub);
   padding: 0.35rem 0.6rem;
-  pointer-events: none;
 }
+
+.scene-hint { pointer-events: none; }
 
 .scene-hint { left: 0.9rem; bottom: 0.9rem; }
 
@@ -406,8 +407,39 @@ button.ghost:hover { background: var(--surface-sub); }
 }
 .scene-legend { right: 0.9rem; top: 0.9rem; display: grid; gap: 0.2rem; }
 
-.legend-row { display: flex; align-items: center; gap: 0.4rem; }
+/* The legend is the part filter: each row switches its own boxes off. */
+.legend-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-sub);
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.1rem 0.25rem;
+  opacity: 0.4;
+}
+
+.legend-row:hover { background: var(--surface-sub); }
+.legend-row.is-on { opacity: 1; color: var(--text); }
 .legend-dot { width: 0.7rem; height: 0.7rem; border-radius: 3px; }
+
+.layer-pick {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  border: 2px solid var(--text);
+  border-radius: 10px;
+  padding: 0.15rem 0.6rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.layer-pick span { min-width: 5.5rem; }
+.layer-pick input { width: 9rem; accent-color: var(--accent); }
 
 /* ===== Tooltip ===== */
 .tip {

--- a/product/akbun-visualizellm/workspace/test/diagram.test.js
+++ b/product/akbun-visualizellm/workspace/test/diagram.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveModel } from '../src/lib/model.js';
+import { buildDiagram, annotations } from '../src/lib/diagram.js';
+import { sampleById } from '../src/lib/samples.js';
+
+const dense = deriveModel(sampleById('dense-7b').config);
+const moe = deriveModel(sampleById('moe-8x7b').config);
+const gpt2 = deriveModel(sampleById('gpt2').config);
+
+const nodeIds = (diagram) => diagram.sections.flatMap((section) => section.nodes.map((node) => node.id));
+
+test('the diagram runs from token ids to logits with the layer stack between', () => {
+  const diagram = buildDiagram(dense);
+  assert.deepEqual(diagram.sections.map((s) => s.id), ['input', 'layer', 'output']);
+  assert.equal(diagram.sections[1].repeat, 32);
+  const ids = nodeIds(diagram);
+  assert.ok(ids.indexOf('tokens') < ids.indexOf('embedding'));
+  assert.ok(ids.indexOf('qkv') < ids.indexOf('scores'));
+  assert.ok(ids.indexOf('mlp') < ids.indexOf('lm-head'));
+  assert.equal(ids.at(-1), 'logits');
+});
+
+test('every node carries a role sentence and a shape', () => {
+  for (const node of buildDiagram(dense).sections.flatMap((s) => s.nodes)) {
+    assert.ok(node.role.length > 40, node.id);
+    assert.ok(node.shape.length > 0, node.id);
+  }
+});
+
+test('a mixture model draws a router and expert copies instead of one MLP', () => {
+  const ids = nodeIds(buildDiagram(moe));
+  assert.ok(ids.includes('router'));
+  assert.ok(ids.includes('experts'));
+  assert.ok(!ids.includes('mlp'));
+});
+
+test('a model without RoPE draws no rotary block', () => {
+  assert.ok(!nodeIds(buildDiagram(gpt2)).includes('rope'));
+  assert.ok(nodeIds(buildDiagram(dense)).includes('rope'));
+});
+
+test('annotations point a config field at every block its value shaped', () => {
+  const diagram = buildDiagram(dense);
+  const rows = annotations(dense, diagram);
+  const hidden = rows.find((row) => row.field === 'hidden_size');
+  assert.equal(hidden.value, 4096);
+  assert.ok(hidden.nodes.includes('embedding'));
+  assert.ok(hidden.nodes.includes('attn-out'));
+
+  const layers = rows.find((row) => row.field === 'num_hidden_layers');
+  assert.deepEqual(layers.nodes, ['layer']);
+  assert.ok(rows.every((row) => row.value !== undefined));
+});
+
+test('a field the config never spelled produces no annotation', () => {
+  const rows = annotations(gpt2, buildDiagram(gpt2));
+  assert.ok(!rows.some((row) => row.field === 'rope_theta'));
+  assert.ok(rows.some((row) => row.field === 'n_embd'));
+});

--- a/product/akbun-visualizellm/workspace/test/model.test.js
+++ b/product/akbun-visualizellm/workspace/test/model.test.js
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseConfig, deriveModel, readField, attentionKind, humanCount, summary } from '../src/lib/model.js';
+import { SAMPLES, sampleById } from '../src/lib/samples.js';
+
+const dense = sampleById('dense-7b').config;
+
+test('parseConfig rejects text that is not JSON', () => {
+  assert.throws(() => parseConfig('hidden_size: 4096'), /Not valid JSON/);
+});
+
+test('parseConfig rejects JSON that is not a model config', () => {
+  assert.throws(() => parseConfig('{"name": "hello"}'), /does not look like a model config/);
+  assert.throws(() => parseConfig('[1, 2]'), /JSON object/);
+  assert.throws(() => parseConfig('   '), /Paste a config/);
+});
+
+test('parseConfig unwraps the language model of a multimodal config', () => {
+  const config = parseConfig(JSON.stringify({
+    model_type: 'vision-language',
+    vision_config: { hidden_size: 1024 },
+    text_config: { hidden_size: 4096, num_hidden_layers: 32 },
+  }));
+  assert.equal(config.hidden_size, 4096);
+  assert.equal(config.num_hidden_layers, 32);
+});
+
+test('readField reports which alias supplied the value', () => {
+  assert.deepEqual(readField({ n_embd: 768 }, 'hidden'), { value: 768, source: 'n_embd' });
+  assert.equal(readField({}, 'hidden'), null);
+});
+
+test('deriveModel reads the legacy GPT-2 field names', () => {
+  const model = deriveModel(sampleById('gpt2').config);
+  assert.equal(model.dims.hidden, 768);
+  assert.equal(model.dims.layers, 12);
+  assert.equal(model.dims.heads, 12);
+  assert.equal(model.dims.intermediate, 3072);
+  assert.equal(model.sources.hidden, 'n_embd');
+  assert.equal(model.sources.context, 'n_positions');
+  assert.equal(model.flags.normKind, 'LayerNorm');
+  assert.equal(model.flags.gated, false);
+});
+
+test('deriveModel fills head_dim and kv heads when the config omits them', () => {
+  const model = deriveModel({ hidden_size: 4096, num_hidden_layers: 32, num_attention_heads: 32 });
+  assert.equal(model.dims.headDim, 128);
+  assert.equal(model.dims.kvHeads, 32);
+  assert.equal(model.sources.headDim, null);
+});
+
+test('attentionKind names the scheme from the head counts', () => {
+  assert.equal(attentionKind(32, 32), 'MHA');
+  assert.equal(attentionKind(32, 8), 'GQA');
+  assert.equal(attentionKind(32, 1), 'MQA');
+});
+
+test('the dense 7B sample estimates close to 7B parameters', () => {
+  const model = deriveModel(dense);
+  assert.equal(model.flags.attention, 'MHA');
+  assert.equal(model.flags.gated, true);
+  assert.ok(model.params.total > 6.5e9 && model.params.total < 7.1e9, `got ${model.params.total}`);
+});
+
+test('tied output weights drop the lm head from the count', () => {
+  const model = deriveModel(sampleById('gqa-1_5b').config);
+  assert.equal(model.flags.tied, true);
+  assert.equal(model.params.lmHead, 0);
+  assert.equal(model.flags.slidingWindow, 4096);
+});
+
+test('the mixture model counts every expert, not just the active ones', () => {
+  const model = deriveModel(sampleById('moe-8x7b').config);
+  assert.deepEqual(model.flags.moe, { experts: 8, topK: 2 });
+  assert.ok(model.params.total > 4e10 && model.params.total < 5e10, `got ${model.params.total}`);
+});
+
+test('humanCount formats the way model cards do', () => {
+  assert.equal(humanCount(6.7e9), '6.7B');
+  assert.equal(humanCount(1.24e8), '124M');
+  assert.equal(humanCount(4.67e10), '47B');
+  assert.equal(humanCount(512), '512');
+});
+
+test('summary links each row back to the config field it came from', () => {
+  const rows = summary(deriveModel(dense));
+  const layers = rows.find((row) => row.label === 'Layers');
+  assert.equal(layers.field, 'num_hidden_layers');
+  assert.equal(rows.find((row) => row.label === 'Parameters').field, null);
+});
+
+test('every sample derives without throwing', () => {
+  for (const sample of SAMPLES) {
+    const model = deriveModel(parseConfig(JSON.stringify(sample.config)));
+    assert.ok(model.params.total > 0, sample.id);
+  }
+});

--- a/product/akbun-visualizellm/workspace/test/model.test.js
+++ b/product/akbun-visualizellm/workspace/test/model.test.js
@@ -95,3 +95,21 @@ test('every sample derives without throwing', () => {
     assert.ok(model.params.total > 0, sample.id);
   }
 });
+
+test('a dimension that is present but unusable is rejected by name', () => {
+  assert.throws(
+    () => parseConfig('{"hidden_size": "4096", "num_hidden_layers": 32}'),
+    /hidden_size has to be a positive number/,
+  );
+  assert.throws(
+    () => parseConfig('{"hidden_size": 4096, "n_layer": 0}'),
+    /n_layer has to be a positive number/,
+  );
+});
+
+test('a zero head count falls back instead of producing NaN', () => {
+  const model = deriveModel({ hidden_size: 4096, num_hidden_layers: 32, num_attention_heads: 0 });
+  assert.equal(model.dims.heads, 1);
+  assert.equal(model.dims.headDim, 4096);
+  assert.ok(Number.isFinite(model.params.total));
+});

--- a/product/akbun-visualizellm/workspace/test/scene.test.js
+++ b/product/akbun-visualizellm/workspace/test/scene.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { deriveModel } from '../src/lib/model.js';
-import { buildScene, sceneParams, side } from '../src/lib/scene.js';
+import { buildScene, sceneParams, side, visibleBlocks, bounds } from '../src/lib/scene.js';
 import { sampleById } from '../src/lib/samples.js';
 
 const dense = deriveModel(sampleById('dense-7b').config);
@@ -59,4 +59,36 @@ test('the scene weights add up to the estimate from the config', () => {
     const ratio = counted / model.params.total;
     assert.ok(ratio > 0.99 && ratio < 1.01, `${model.name}: ${counted} vs ${model.params.total}`);
   }
+});
+
+test('isolating a layer keeps that layer and the blocks outside the stack', () => {
+  const scene = buildScene(dense);
+  const shown = visibleBlocks(scene, { layer: 5 });
+  const layers = new Set(shown.filter((b) => b.layer !== undefined).map((b) => b.layer));
+  assert.deepEqual([...layers], [5]);
+  assert.ok(shown.some((b) => b.id === 'embedding'));
+  assert.ok(shown.some((b) => b.id === 'lm-head'));
+  assert.ok(shown.some((b) => b.id === 'norm-final'));
+});
+
+test('a tone filter drops the parts it does not name', () => {
+  const scene = buildScene(dense);
+  const shown = visibleBlocks(scene, { tones: ['attn'] });
+  assert.ok(shown.length > 0);
+  assert.ok(shown.every((b) => b.tone === 'attn'));
+  assert.equal(visibleBlocks(scene, { tones: [] }).length, 0);
+});
+
+test('an empty filter shows everything', () => {
+  const scene = buildScene(dense);
+  assert.equal(visibleBlocks(scene).length, scene.blocks.length);
+});
+
+test('bounds measure the extent of what is visible', () => {
+  const scene = buildScene(dense);
+  const all = bounds(scene.blocks);
+  const one = bounds(visibleBlocks(scene, { layer: 5, tones: ['attn'] }));
+  assert.ok(one.width < all.width);
+  assert.ok(one.centerX > all.minX && one.centerX < all.maxX);
+  assert.equal(bounds([]), null);
 });

--- a/product/akbun-visualizellm/workspace/test/scene.test.js
+++ b/product/akbun-visualizellm/workspace/test/scene.test.js
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveModel } from '../src/lib/model.js';
+import { buildScene, sceneParams, side } from '../src/lib/scene.js';
+import { sampleById } from '../src/lib/samples.js';
+
+const dense = deriveModel(sampleById('dense-7b').config);
+const moe = deriveModel(sampleById('moe-8x7b').config);
+
+test('side compresses a 1000x range into a drawable one', () => {
+  assert.ok(side(128) < side(4096));
+  assert.ok(side(150000) <= 9);
+  assert.ok(side(1) >= 0.5);
+});
+
+test('the scene holds one block per matrix of every layer', () => {
+  const scene = buildScene(dense);
+  const perLayer = scene.blocks.filter((block) => block.layer === 0);
+  assert.deepEqual(perLayer.map((b) => b.id.replace('layer0-', '')),
+    ['norm-in', 'q', 'k', 'v', 'scores', 'o', 'norm-post', 'gate', 'up', 'down']);
+  assert.equal(scene.layers, 32);
+  assert.equal(scene.blocks.filter((b) => b.layer !== undefined).length, 32 * 10);
+});
+
+test('blocks are laid out in flow order and never overlap', () => {
+  const scene = buildScene(dense);
+  for (let i = 1; i < scene.blocks.length; i += 1) {
+    const prev = scene.blocks[i - 1];
+    const next = scene.blocks[i];
+    assert.ok(next.x - next.w / 2 >= prev.x + prev.w / 2 - 1e-9, `${prev.id} overlaps ${next.id}`);
+  }
+  assert.ok(scene.span > 0);
+  assert.ok(scene.layerSpan > 0);
+});
+
+test('the embedding and the lm head bracket the layer stack', () => {
+  const scene = buildScene(dense);
+  assert.equal(scene.blocks[0].id, 'embedding');
+  assert.equal(scene.blocks.at(-1).id, 'lm-head');
+  assert.equal(scene.blocks.at(-2).id, 'norm-final');
+});
+
+test('the attention score square is marked as run time, not as a weight', () => {
+  const block = buildScene(dense).blocks.find((b) => b.id === 'layer0-scores');
+  assert.equal(block.kind, 'activation');
+  assert.equal(block.params, 0);
+});
+
+test('expert MLPs are drawn as copies of one block', () => {
+  const scene = buildScene(moe);
+  const gate = scene.blocks.find((b) => b.id === 'layer0-gate');
+  assert.equal(gate.copies, 8);
+  assert.ok(scene.blocks.some((b) => b.id === 'layer0-router'));
+});
+
+test('the scene weights add up to the estimate from the config', () => {
+  for (const model of [dense, moe]) {
+    const counted = sceneParams(buildScene(model));
+    const ratio = counted / model.params.total;
+    assert.ok(ratio > 0.99 && ratio < 1.01, `${model.name}: ${counted} vs ${model.params.total}`);
+  }
+});

--- a/product/akbun-visualizellm/workspace/test/scene.test.js
+++ b/product/akbun-visualizellm/workspace/test/scene.test.js
@@ -6,6 +6,7 @@ import { sampleById } from '../src/lib/samples.js';
 
 const dense = deriveModel(sampleById('dense-7b').config);
 const moe = deriveModel(sampleById('moe-8x7b').config);
+const tied = deriveModel(sampleById('gqa-1_5b').config);
 
 test('side compresses a 1000x range into a drawable one', () => {
   assert.ok(side(128) < side(4096));
@@ -53,8 +54,15 @@ test('expert MLPs are drawn as copies of one block', () => {
   assert.ok(scene.blocks.some((b) => b.id === 'layer0-router'));
 });
 
+test('a tied lm head is drawn but counted once', () => {
+  const head = buildScene(tied).blocks.find((b) => b.id === 'lm-head');
+  assert.equal(head.params, 0);
+  assert.ok(head.h > 0 && head.d > 0);
+  assert.equal(buildScene(dense).blocks.find((b) => b.id === 'lm-head').params, 4096 * 32000);
+});
+
 test('the scene weights add up to the estimate from the config', () => {
-  for (const model of [dense, moe]) {
+  for (const model of [dense, moe, tied]) {
     const counted = sceneParams(buildScene(model));
     const ratio = counted / model.params.total;
     assert.ok(ratio > 0.99 && ratio < 1.01, `${model.name}: ${counted} vs ${model.params.total}`);

--- a/product/akbun-visualizellm/workspace/tsconfig.json
+++ b/product/akbun-visualizellm/workspace/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}

--- a/product/akbun-visualizellm/workspace/wrangler.json
+++ b/product/akbun-visualizellm/workspace/wrangler.json
@@ -1,0 +1,7 @@
+{
+  "name": "akbun-visualizellm",
+  "compatibility_date": "2026-08-18",
+  "assets": {
+    "directory": "./dist"
+  }
+}

--- a/product/products.json
+++ b/product/products.json
@@ -1,7 +1,16 @@
 {
   "repoBase": "https://github.com/choisungwook/portfolio/tree/master/product",
-  "updated": "2026-08-15",
+  "updated": "2026-08-18",
   "products": [
+    {
+      "id": "akbun-visualizellm",
+      "name": "akbun-visualizellm",
+      "description": "모델 config.json을 읽어 LLM 아키텍처를 2D 흐름도와 3D 가중치 배치로 보여주는 웹 페이지",
+      "kind": "web",
+      "tags": ["astro", "llm", "cloudflare"],
+      "site": "https://visualizellm.akbun.com",
+      "released": "2026-08-18"
+    },
     {
       "id": "akbun-productcatalog",
       "name": "akbun-productcatalog",


### PR DESCRIPTION
# 구현

config.json에서 파생 모델 하나를 만들고 2D 흐름도, 3D 가중치 배치, config 필드 화살표가 그 하나를 읽음
- lib 테스트 26개가 브라우저 없이 통과하고, 3D scene의 상자 합계가 config 기반 파라미터 추정치와 1% 이내로 일치

# 어려웠던 점

3D 기본 시점을 모델 전체에 맞추면 32층이 화면에서 대각선 실 한 가닥이 됨
- 길이 수백 단위에 폭 몇 단위라 전체 맞춤은 Fit all 버튼으로 빼고, 시작 시점은 embedding 부근 몇 개 층으로 고정

화살표가 web font 로드 뒤 블록이 몇 px 밀리면서 어긋남
- 스크롤 대응은 콘텐츠 좌표로 해결되지만 폰트는 별개라 document.fonts.ready에서 재배치 호출

# 리스크

파라미터 수는 shape 기반 추정이라 bias, 학습형 position table, 계열 고유 구조가 빠짐
- 표기를 estimated로 고정하고, 한쪽에만 행렬을 추가하는 실수는 scene 합계 대조 테스트로 막음

three.js 청크가 500KB를 넘어 빌드 경고가 남음
- 동적 import라 첫 페인트에는 없고, 3D를 처음 열 때만 내려받음

Issue #978


---
_Generated by [Claude Code](https://claude.ai/code/session_016wy4KF1UwE1KL7eSZfwYd5)_