### PR TITLE
akbun-makevideo: Source Monitor 드롭과 Inspector 선택 수정

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-inspector-follows-timeline-media.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-inspector-follows-timeline-media.md
@@ -1,0 +1,22 @@
+---
+type: Decision
+title: Inspector는 타임라인에서 선택한 미디어 트랙을 따른다
+description: 연결된 clip의 Video와 Audio 속성을 분리하고 선택한 트랙의 탭을 먼저 보여 주는 결정.
+tags: [makevideo, inspector, timeline, selection]
+timestamp: 2026-08-19T10:59:15Z
+---
+
+# Inspector는 타임라인에서 선택한 미디어 트랙을 따른다
+
+## 결정
+
+* Inspector는 별도 드롭 대상이 아니라 타임라인 clip 선택을 자동 반영
+* 연결된 영상과 오디오는 Video와 Audio 탭으로 속성을 분리
+* 선택한 트랙 종류와 같은 탭을 먼저 표시
+* 영상에 내장 오디오만 있고 연결된 audio clip이 없으면 영상 clip을 Audio 속성 대상으로 사용
+
+## 이유
+
+* Inspector에 미디어를 다시 드롭하면 타임라인 선택과 편집 대상이 서로 달라질 수 있음
+* opacity와 volume을 한 화면에 두면 연결된 clip 중 어느 속성을 바꾸는지 구분하기 어려움
+* video-only 배치에서도 원본 영상의 내장 오디오 volume은 조절할 수 있어야 함

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,7 @@
 
 ## 목록
 
+* [Inspector는 타임라인에서 선택한 미디어 트랙을 따른다](2026-08-inspector-follows-timeline-media.md) - 연결된 clip의 속성을 Video와 Audio 탭으로 분리하고 선택한 트랙 탭을 먼저 보여 주는 결정.
 * [native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다](2026-08-native-monitor-is-a-window-overlay.md) - GPU surface를 WebKit hierarchy에서 분리하고 실제 view 사이 좌표 변환을 AppKit에 맡긴 결정.
 * [첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다](2026-08-first-video-defines-default-canvas-shape.md) - 첫 영상 비율을 채택하되 기본 긴 변 해상도를 유지하는 결정.
 * [native view 좌표는 superview에게 원점을 물어본다](2026-08-native-view-asks-its-superview-for-the-origin.md) - WKWebView가 flipped view라 bottom-left 가정이 monitor를 뒤집힌 위치에 놓은 뒤 정한 규칙.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-19
+
+* [Inspector는 타임라인에서 선택한 미디어 트랙을 따른다](decisions/2026-08-inspector-follows-timeline-media.md) 결정 기록. 연결된 영상과 오디오의 속성 대상과 기본 탭을 타임라인 선택에 맞춤.
+
 ## 2026-08-12
 
 * [native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다](decisions/2026-08-native-monitor-is-a-window-overlay.md) 결정 기록. GPU preview 오프셋을 WebKit 내부 layer 문제가 아닌 window overlay 좌표 변환 문제로 분리함.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -202,12 +202,19 @@
             <label class="row">Opacity <input id="transform-opacity" type="range" min="0" max="1" step="0.01" /><input id="transform-opacity-value" class="compact-number" type="number" min="0" max="1" step="0.01" /></label>
           </div>
           <div id="clip-panel" hidden>
-            <h3>Clip</h3>
             <p id="clip-summary" class="dim small-text"></p>
-            <label class="row" id="clip-opacity-row">Opacity <input id="clip-opacity" type="range" min="0" max="1" step="0.01" /></label>
-            <!-- 0..1 because that is what the edit model stores; a wider
-                 slider would snap back on release. -->
-            <label class="row" id="clip-volume-row">Volume <input id="clip-volume" type="range" min="0" max="1" step="0.01" /></label>
+            <div id="clip-tabs" class="inspector-tabs" role="tablist" aria-label="Clip properties">
+              <button id="clip-video-tab" type="button" role="tab">Video</button>
+              <button id="clip-audio-tab" type="button" role="tab">Audio</button>
+            </div>
+            <div id="clip-video-panel" role="tabpanel">
+              <label class="row">Opacity <input id="clip-opacity" type="range" min="0" max="1" step="0.01" /></label>
+            </div>
+            <div id="clip-audio-panel" role="tabpanel">
+              <!-- 0..1 because that is what the edit model stores; a wider
+                   slider would snap back on release. -->
+              <label class="row">Volume <input id="clip-volume" type="range" min="0" max="1" step="0.01" /></label>
+            </div>
           </div>
           <div id="text-panel" hidden>
             <h3>Text</h3>
@@ -528,6 +535,7 @@
   <script src="geometry.js"></script>
   <script src="timeline.js"></script>
   <script src="source.js"></script>
+  <script src="inspector.js"></script>
   <script src="shortcuts.js"></script>
   <script src="quality.js"></script>
   <script src="preview.js"></script>

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -204,13 +204,13 @@
           <div id="clip-panel" hidden>
             <p id="clip-summary" class="dim small-text"></p>
             <div id="clip-tabs" class="inspector-tabs" role="tablist" aria-label="Clip properties">
-              <button id="clip-video-tab" type="button" role="tab">Video</button>
-              <button id="clip-audio-tab" type="button" role="tab">Audio</button>
+              <button id="clip-video-tab" type="button" role="tab" aria-controls="clip-video-panel" aria-selected="false" tabindex="-1">Video</button>
+              <button id="clip-audio-tab" type="button" role="tab" aria-controls="clip-audio-panel" aria-selected="false" tabindex="-1">Audio</button>
             </div>
-            <div id="clip-video-panel" role="tabpanel">
+            <div id="clip-video-panel" role="tabpanel" aria-labelledby="clip-video-tab">
               <label class="row">Opacity <input id="clip-opacity" type="range" min="0" max="1" step="0.01" /></label>
             </div>
-            <div id="clip-audio-panel" role="tabpanel">
+            <div id="clip-audio-panel" role="tabpanel" aria-labelledby="clip-audio-tab">
               <!-- 0..1 because that is what the edit model stores; a wider
                    slider would snap back on release. -->
               <label class="row">Volume <input id="clip-volume" type="range" min="0" max="1" step="0.01" /></label>

--- a/product/akbun-makevideo/workspace/src/inspector.js
+++ b/product/akbun-makevideo/workspace/src/inspector.js
@@ -1,0 +1,51 @@
+'use strict';
+
+(function () {
+
+function findClip(project, clipId) {
+  for (const track of (project && project.tracks) || []) {
+    const clip = (track.clips || []).find((entry) => entry.id === clipId);
+    if (clip) return { track, clip };
+  }
+  return null;
+}
+
+function findAsset(project, assetId) {
+  return ((project && project.assets) || []).find((asset) => asset.id === assetId) || null;
+}
+
+function clipTargets(project, clipId) {
+  const selected = findClip(project, clipId);
+  if (!selected) return null;
+  const linked = selected.clip.linkGroup
+    ? project.tracks.flatMap((track) => (track.clips || [])
+      .filter((clip) => clip.linkGroup === selected.clip.linkGroup)
+      .map((clip) => ({ track, clip })))
+    : [selected];
+  const video = linked.find((entry) => entry.track.kind === 'video') || null;
+  let audio = linked.find((entry) => entry.track.kind === 'audio') || null;
+  if (!audio && video) {
+    const asset = findAsset(project, video.clip.assetId);
+    if (asset && asset.kind === 'video' && asset.hasAudio) audio = video;
+  }
+  return { selected, video, audio };
+}
+
+function activeTab(targets, preferred) {
+  if (!targets) return null;
+  if (preferred === 'video' && targets.video) return 'video';
+  if (preferred === 'audio' && targets.audio) return 'audio';
+  const selectedKind = targets.selected.track.kind;
+  if (selectedKind === 'video' && targets.video) return 'video';
+  if (selectedKind === 'audio' && targets.audio) return 'audio';
+  return targets.video ? 'video' : targets.audio ? 'audio' : null;
+}
+
+const exported = { clipTargets, activeTab };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = exported;
+} else {
+  globalThis.inspectorLib = exported;
+}
+})();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1713,6 +1713,8 @@ function renderInspector() {
     dom.clipAudioTab.hidden = !clipTargets.audio;
     dom.clipVideoTab.setAttribute('aria-selected', String(state.inspectorTab === 'video'));
     dom.clipAudioTab.setAttribute('aria-selected', String(state.inspectorTab === 'audio'));
+    dom.clipVideoTab.tabIndex = state.inspectorTab === 'video' ? 0 : -1;
+    dom.clipAudioTab.tabIndex = state.inspectorTab === 'audio' ? 0 : -1;
     dom.clipVideoPanel.hidden = state.inspectorTab !== 'video';
     dom.clipAudioPanel.hidden = state.inspectorTab !== 'audio';
     if (clipTargets.video) dom.clipOpacity.value = String(clipTargets.video.clip.opacity ?? 1);
@@ -1874,6 +1876,22 @@ function updateSelectedAudioVolume() {
     clipId: targets.audio.clip.id,
     volume: Math.max(0, Math.min(1, Number(dom.clipVolume.value) || 0)),
   }).catch((error) => reportError(error, 'clip:volume'));
+}
+
+function activateInspectorTab(tab) {
+  state.inspectorTab = tab;
+  renderInspector();
+}
+
+function moveInspectorTab(event) {
+  if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+  const tabs = [dom.clipVideoTab, dom.clipAudioTab].filter((tab) => !tab.hidden);
+  const current = tabs.indexOf(event.currentTarget);
+  const offset = event.key === 'ArrowRight' ? 1 : -1;
+  const next = tabs[(current + offset + tabs.length) % tabs.length];
+  activateInspectorTab(next === dom.clipVideoTab ? 'video' : 'audio');
+  next.focus();
+  event.preventDefault();
 }
 
 /** Delete, or delete and close the gap behind it. Ripple is destructive in a
@@ -3238,13 +3256,13 @@ function wireTimeline() {
     input.addEventListener('change', updateSubtitleStyle);
   }
   dom.clipVideoTab.addEventListener('click', () => {
-    state.inspectorTab = 'video';
-    renderInspector();
+    activateInspectorTab('video');
   });
   dom.clipAudioTab.addEventListener('click', () => {
-    state.inspectorTab = 'audio';
-    renderInspector();
+    activateInspectorTab('audio');
   });
+  dom.clipVideoTab.addEventListener('keydown', moveInspectorTab);
+  dom.clipAudioTab.addEventListener('keydown', moveInspectorTab);
   dom.clipOpacity.addEventListener('change', updateSelectedVideoOpacity);
   dom.clipVolume.addEventListener('change', updateSelectedAudioVolume);
   for (const input of [

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -22,6 +22,7 @@ const K = globalThis.shortcutLib;
 const X = globalThis.transformLib;
 const G = globalThis.guideLib;
 const S = globalThis.sourceLib;
+const I = globalThis.inspectorLib;
 
 // Pointer distance from a clip edge that starts a trim instead of a move.
 const HANDLE_PX = 8;
@@ -74,6 +75,7 @@ const dom = {
   assetsPanel: el('assets-panel'),
   btnImport: el('btn-import'),
   btnDebug: el('btn-debug'),
+  sourcePanel: el('source-panel'),
   sourceStageWrap: el('source-stage-wrap'),
   sourceStage: el('source-stage'),
   sourceStageInner: el('source-stage-inner'),
@@ -141,8 +143,10 @@ const dom = {
   transformOpacityValue: el('transform-opacity-value'),
   clipPanel: el('clip-panel'),
   clipSummary: el('clip-summary'),
-  clipOpacityRow: el('clip-opacity-row'),
-  clipVolumeRow: el('clip-volume-row'),
+  clipVideoTab: el('clip-video-tab'),
+  clipAudioTab: el('clip-audio-tab'),
+  clipVideoPanel: el('clip-video-panel'),
+  clipAudioPanel: el('clip-audio-panel'),
   clipOpacity: el('clip-opacity'),
   clipVolume: el('clip-volume'),
   fontOptions: el('font-options'),
@@ -211,6 +215,7 @@ const state = {
   waveforms: {},
   selectedClipId: null,
   selectedVisualItemId: null,
+  inspectorTab: null,
   selectedAssetId: null,
   sourceSelection: null,
   targetTrackId: null,
@@ -657,8 +662,7 @@ async function placeSource(mode) {
   });
   if (!command) return;
   const made = await edit(command);
-  if (!made || !made.length) return;
-  selectClip(made[0]);
+  selectMadeOnTrack(made, command.videoTrackId || command.audioTrackId);
 }
 
 /** An asset whose length ffprobe could not report is measured by the browser
@@ -1115,6 +1119,8 @@ function scheduleExactFrame() {
 
 function selectClip(clipId) {
   state.selectedClipId = clipId;
+  const targets = clipId ? I.clipTargets(state.project, clipId) : null;
+  state.inspectorTab = I.activeTab(targets);
   // One selection at a time, so the inspector always shows the thing that was
   // picked last rather than whichever kind happens to win a tie.
   if (clipId && state.selectedVisualItemId) selectVisualItem(null);
@@ -1679,7 +1685,10 @@ function renderInspector() {
   const shape = item && item.content && item.content.kind === 'shape' ? item.content : null;
   const track = item && state.project.tracks.find((candidate) => (candidate.visualItems || []).some((entry) => entry.id === item.id));
   const subtitle = track && track.kind === 'subtitle';
-  const clip = !item && liveSelection() ? L.findClip(state.project, liveSelection()) : null;
+  const clipTargets = !item && liveSelection()
+    ? I.clipTargets(state.project, liveSelection())
+    : null;
+  const clip = clipTargets && clipTargets.selected;
   dom.textPanel.hidden = !text || subtitle;
   dom.subtitlePanel.hidden = !text || !subtitle;
   dom.shapePanel.hidden = !shape;
@@ -1699,10 +1708,15 @@ function renderInspector() {
   if (clip) {
     const asset = L.findAsset(state.project, clip.clip.assetId);
     dom.clipSummary.textContent = `${asset ? asset.name || baseName(asset.path) : 'missing file'} · ${clip.track.name}`;
-    dom.clipOpacityRow.hidden = clip.track.kind !== 'video';
-    dom.clipVolumeRow.hidden = Boolean(asset) && asset.kind === 'image';
-    dom.clipOpacity.value = String(clip.clip.opacity ?? 1);
-    dom.clipVolume.value = String(clip.clip.volume ?? 1);
+    state.inspectorTab = I.activeTab(clipTargets, state.inspectorTab);
+    dom.clipVideoTab.hidden = !clipTargets.video;
+    dom.clipAudioTab.hidden = !clipTargets.audio;
+    dom.clipVideoTab.setAttribute('aria-selected', String(state.inspectorTab === 'video'));
+    dom.clipAudioTab.setAttribute('aria-selected', String(state.inspectorTab === 'audio'));
+    dom.clipVideoPanel.hidden = state.inspectorTab !== 'video';
+    dom.clipAudioPanel.hidden = state.inspectorTab !== 'audio';
+    if (clipTargets.video) dom.clipOpacity.value = String(clipTargets.video.clip.opacity ?? 1);
+    if (clipTargets.audio) dom.clipVolume.value = String(clipTargets.audio.clip.volume ?? 1);
   }
   if (shape) {
     dom.shapeKind.value = shape.shape || 'rectangle';
@@ -1836,17 +1850,30 @@ async function removeSelectedVisualItem() {
   if (done) selectVisualItem(null);
 }
 
-/** The clip inspector's two sliders. One command with both values: Rust takes
- *  either as optional, and sending both keeps this one function. */
-function updateSelectedClipGain() {
+/** Resolve both halves of a linked timeline selection for the Inspector tabs. */
+function selectedClipTargets() {
   const clipId = liveSelection();
-  if (!clipId) return;
+  return clipId ? I.clipTargets(state.project, clipId) : null;
+}
+
+function updateSelectedVideoOpacity() {
+  const targets = selectedClipTargets();
+  if (!targets || !targets.video) return;
   edit({
     op: 'setClipGain',
-    clipId,
+    clipId: targets.video.clip.id,
     opacity: Math.max(0, Math.min(1, Number(dom.clipOpacity.value) || 0)),
+  }).catch((error) => reportError(error, 'clip:opacity'));
+}
+
+function updateSelectedAudioVolume() {
+  const targets = selectedClipTargets();
+  if (!targets || !targets.audio) return;
+  edit({
+    op: 'setClipGain',
+    clipId: targets.audio.clip.id,
     volume: Math.max(0, Math.min(1, Number(dom.clipVolume.value) || 0)),
-  }).catch((error) => reportError(error, 'clip:gain'));
+  }).catch((error) => reportError(error, 'clip:volume'));
 }
 
 /** Delete, or delete and close the gap behind it. Ripple is destructive in a
@@ -2230,6 +2257,21 @@ function laneAtPoint(x, y) {
   return under.closest('.lane');
 }
 
+function sourcePanelAtPoint(x, y) {
+  const under = document.elementFromPoint(x, y);
+  if (!under || !under.closest) return null;
+  return under.closest('#source-panel');
+}
+
+function selectMadeOnTrack(made, trackId) {
+  if (!made || !made.length) return;
+  const selected = made.find((clipId) => {
+    const found = L.findClip(state.project, clipId);
+    return found && found.track.id === trackId;
+  });
+  selectClip(selected || made[0]);
+}
+
 /** Dragging an asset out of the panel and onto a lane runs on pointer events
  *  rather than HTML5 drag and drop.
  *
@@ -2264,9 +2306,11 @@ function updateAssetDrag(event) {
   assetDrag.ghost.style.left = `${event.clientX + 12}px`;
   assetDrag.ghost.style.top = `${event.clientY + 12}px`;
   const lane = laneAtPoint(event.clientX, event.clientY);
+  const sourcePanel = sourcePanelAtPoint(event.clientX, event.clientY);
   for (const node of dom.lanes.querySelectorAll('.lane')) {
     node.classList.toggle('drop-target', node === lane);
   }
+  dom.sourcePanel.classList.toggle('drop-target', Boolean(sourcePanel) && !lane);
 }
 
 /** Put the page back the way it was and report the drag that was running, if it
@@ -2283,6 +2327,7 @@ function clearAssetDrag() {
   current.ghost.remove();
   document.body.classList.remove('dragging');
   for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
+  dom.sourcePanel.classList.remove('drop-target');
   return current;
 }
 
@@ -2291,6 +2336,10 @@ async function endAssetDrag(event) {
   if (!current) return;
 
   const lane = laneAtPoint(event.clientX, event.clientY);
+  if (sourcePanelAtPoint(event.clientX, event.clientY)) {
+    selectAsset(current.asset.id);
+    return;
+  }
   if (!lane) return;
   const at = L.snapTime(state.project, frameAtClientX(event.clientX), snapTolerance());
   const commands = dropCommands(lane.dataset.trackId, [current.asset], at);
@@ -2301,7 +2350,7 @@ async function endAssetDrag(event) {
     return;
   }
   const made = await edit(...commands);
-  if (made && made.length) selectClip(made[made.length - 1]);
+  selectMadeOnTrack(made, lane.dataset.trackId);
 }
 
 async function handleOsDrop(payload) {
@@ -2309,14 +2358,17 @@ async function handleOsDrop(payload) {
     const point = payload.position || { x: 0, y: 0 };
     const ratio = window.devicePixelRatio || 1;
     const lane = laneAtPoint(point.x / ratio, point.y / ratio);
+    const sourcePanel = sourcePanelAtPoint(point.x / ratio, point.y / ratio);
     for (const node of dom.lanes.querySelectorAll('.lane')) {
       node.classList.toggle('drop-target', node === lane);
     }
-    dom.assetsPanel.classList.toggle('drop-target', !lane);
+    dom.sourcePanel.classList.toggle('drop-target', Boolean(sourcePanel) && !lane);
+    dom.assetsPanel.classList.toggle('drop-target', !lane && !sourcePanel);
     return;
   }
   for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
   dom.assetsPanel.classList.remove('drop-target');
+  dom.sourcePanel.classList.remove('drop-target');
   if (payload.type !== 'drop') return;
 
   // The event carries physical pixels; elementFromPoint wants CSS pixels.
@@ -2325,6 +2377,7 @@ async function handleOsDrop(payload) {
   const x = point.x / ratio;
   const y = point.y / ratio;
   const lane = laneAtPoint(x, y);
+  const sourcePanel = sourcePanelAtPoint(x, y);
 
   const found = await probePaths(payload.paths || []);
   if (!found.length) return;
@@ -2342,7 +2395,8 @@ async function handleOsDrop(payload) {
     { op: 'addAssets', assets: found },
     ...commands
   );
-  if (made && made.length) selectClip(made[made.length - 1]);
+  if (sourcePanel) selectAsset(found[0].id);
+  else if (lane) selectMadeOnTrack(made, lane.dataset.trackId);
   for (const asset of found) hydrateDuration(asset);
 }
 
@@ -3183,9 +3237,16 @@ function wireTimeline() {
   for (const input of [dom.subtitleFont, dom.subtitleSize, dom.subtitleColor]) {
     input.addEventListener('change', updateSubtitleStyle);
   }
-  for (const input of [dom.clipOpacity, dom.clipVolume]) {
-    input.addEventListener('change', updateSelectedClipGain);
-  }
+  dom.clipVideoTab.addEventListener('click', () => {
+    state.inspectorTab = 'video';
+    renderInspector();
+  });
+  dom.clipAudioTab.addEventListener('click', () => {
+    state.inspectorTab = 'audio';
+    renderInspector();
+  });
+  dom.clipOpacity.addEventListener('change', updateSelectedVideoOpacity);
+  dom.clipVolume.addEventListener('change', updateSelectedAudioVolume);
   for (const input of [
     dom.transformX, dom.transformY, dom.transformWidth, dom.transformHeight,
     dom.transformRotation, dom.transformOpacity, dom.transformOpacityValue,

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -945,8 +945,7 @@ button.icon.on {
 }
 
 .inspector-tabs {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
   gap: 4px;
   margin: 8px 0 12px;
   padding: 3px;
@@ -955,6 +954,7 @@ button.icon.on {
 }
 
 .inspector-tabs button {
+  flex: 1;
   border-color: transparent;
   background: transparent;
 }

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -382,6 +382,11 @@ select {
   outline-offset: -4px;
 }
 
+#source-panel.drop-target {
+  outline: 2px dashed var(--accent);
+  outline-offset: -4px;
+}
+
 #asset-list {
   margin: 0;
   padding: 6px;
@@ -937,6 +942,31 @@ button.icon.on {
 
 #inspector-body .compact-number {
   flex: 0 0 62px;
+}
+
+.inspector-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin: 8px 0 12px;
+  padding: 3px;
+  border-radius: 7px;
+  background: var(--panel-2);
+}
+
+.inspector-tabs button {
+  border-color: transparent;
+  background: transparent;
+}
+
+.inspector-tabs button[aria-selected='true'] {
+  border-color: var(--border);
+  background: var(--panel);
+  color: var(--accent);
+}
+
+.inspector-tabs button[hidden] {
+  display: none;
 }
 
 #marker-panel {

--- a/product/akbun-makevideo/workspace/test/inspector.test.js
+++ b/product/akbun-makevideo/workspace/test/inspector.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const I = require('../src/inspector.js');
+
+function clip(id, assetId, linkGroup = null) {
+  return { id, assetId, linkGroup, opacity: 1, volume: 1 };
+}
+
+const project = {
+  assets: [
+    { id: 'movie', kind: 'video', hasAudio: true },
+    { id: 'still', kind: 'image', hasAudio: false },
+  ],
+  tracks: [
+    { id: 'v1', kind: 'video', clips: [clip('v', 'movie', 'g1'), clip('still', 'still')] },
+    { id: 'a1', kind: 'audio', clips: [clip('a', 'movie', 'g1')] },
+  ],
+};
+
+test('a linked timeline selection exposes separate video and audio targets', () => {
+  const fromVideo = I.clipTargets(project, 'v');
+  assert.strictEqual(fromVideo.video.clip.id, 'v');
+  assert.strictEqual(fromVideo.audio.clip.id, 'a');
+  assert.strictEqual(I.activeTab(fromVideo), 'video');
+
+  const fromAudio = I.clipTargets(project, 'a');
+  assert.strictEqual(fromAudio.video.clip.id, 'v');
+  assert.strictEqual(fromAudio.audio.clip.id, 'a');
+  assert.strictEqual(I.activeTab(fromAudio), 'audio');
+});
+
+test('a video-only placement keeps its embedded audio in the audio tab', () => {
+  const single = {
+    assets: project.assets,
+    tracks: [{ id: 'v1', kind: 'video', clips: [clip('v', 'movie')] }],
+  };
+  const targets = I.clipTargets(single, 'v');
+  assert.strictEqual(targets.video.clip.id, 'v');
+  assert.strictEqual(targets.audio.clip.id, 'v');
+  assert.strictEqual(I.activeTab(targets, 'audio'), 'audio');
+});
+
+test('an image has a video tab and no audio tab', () => {
+  const targets = I.clipTargets(project, 'still');
+  assert.strictEqual(targets.video.clip.id, 'still');
+  assert.strictEqual(targets.audio, null);
+  assert.strictEqual(I.activeTab(targets, 'audio'), 'video');
+});


### PR DESCRIPTION
# 구현

Source Monitor 드롭 할당과 타임라인 선택 기반 Video·Audio Inspector 탭 분리
- JavaScript 126개, edit 58개, cargo check와 Tauri 디버그 앱 UI 검증 통과

# 어려웠던 점

연결된 영상·오디오 중 실제 선택 트랙과 속성 대상 일치
- 드롭·삽입 결과의 마지막 ID 대신 대상 트랙에서 생성된 clip 선택

# 리스크

연결 audio clip이 없는 영상은 영상 clip을 Audio 속성 대상으로 사용
- video-only 배치에서도 내장 오디오 volume 편집 유지

Issue #980
Issue #683
Issue #685
