### PR TITLE
akbun-makevideo: Source Monitor In·Out 마커 표시

### DIFF
--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.33.1",
+      "version": "0.34.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -143,7 +143,13 @@
             <button id="source-mark-out" title="Set the source out point">Out</button>
           </div>
           <div id="source-actions">
-            <input id="source-seek" type="range" min="0" max="1" step="1" value="0" aria-label="Source position" />
+            <div id="source-seek-wrap">
+              <input id="source-seek" type="range" min="0" max="1" step="1" value="0" aria-label="Source position" />
+              <div id="source-marker-layer" aria-hidden="true" hidden>
+                <span id="source-in-marker" class="source-boundary-marker in" data-label="IN"></span>
+                <span id="source-out-marker" class="source-boundary-marker out" data-label="OUT"></span>
+              </div>
+            </div>
             <span id="source-range" class="mono dim">0:00:00:00 – 0:00:00:00</span>
             <label class="check"><input id="source-video" type="checkbox" checked /> Video</label>
             <label class="check"><input id="source-audio" type="checkbox" checked /> Audio</label>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -86,6 +86,9 @@ const dom = {
   sourceMarkIn: el('source-mark-in'),
   sourceMarkOut: el('source-mark-out'),
   sourceSeek: el('source-seek'),
+  sourceMarkerLayer: el('source-marker-layer'),
+  sourceInMarker: el('source-in-marker'),
+  sourceOutMarker: el('source-out-marker'),
   sourceRange: el('source-range'),
   sourceVideo: el('source-video'),
   sourceAudio: el('source-audio'),
@@ -616,6 +619,11 @@ function renderSourceMonitor() {
   dom.sourceSeek.max = String(Math.max(1, limit));
   dom.sourceSeek.value = String(Math.min(limit, Math.round(sourcePreview ? sourcePreview.position() : 0)));
   dom.sourceSeek.disabled = !asset || asset.kind === 'image';
+  dom.sourceMarkerLayer.hidden = !selection || !asset || asset.kind === 'image';
+  if (selection) {
+    dom.sourceInMarker.style.left = `${S.markerPercent(selection.inPoint, limit)}%`;
+    dom.sourceOutMarker.style.left = `${S.markerPercent(selection.outPoint, limit)}%`;
+  }
   dom.sourceRange.textContent = selection
     ? `${sourceTime(selection.inPoint)} – ${sourceTime(selection.outPoint)}`
     : `${sourceTime(0)} – ${sourceTime(0)}`;

--- a/product/akbun-makevideo/workspace/src/source.js
+++ b/product/akbun-makevideo/workspace/src/source.js
@@ -33,6 +33,12 @@ function markOut(selection, frame, limit) {
   };
 }
 
+function markerPercent(frame, limit) {
+  const end = Math.max(1, Math.round(Number(limit) || 0));
+  const position = Math.max(0, Math.min(Number(frame) || 0, end));
+  return position / end * 100;
+}
+
 function targetTrack(project, kind, preferredId) {
   const preferred = project.tracks.find(
     (track) => track.id === preferredId && track.kind === kind
@@ -68,6 +74,7 @@ const exported = {
   selectionFor,
   markIn,
   markOut,
+  markerPercent,
   targetTrack,
   commandFor,
 };

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -22,6 +22,8 @@
   --clip-visual-edge: #9a79dd;
   --select: #f0a52f;
   --danger: #d0453b;
+  --mark-in: #168a4d;
+  --mark-out: #d46713;
   --stage: #0b0b0d;
   --shadow: 0 8px 30px rgba(15, 18, 25, 0.18);
 
@@ -50,6 +52,8 @@
     --clip-visual-edge: #9a79dd;
     --select: #f0a52f;
     --danger: #e2695f;
+    --mark-in: #54d68c;
+    --mark-out: #ff9b4a;
     --stage: #000000;
     --shadow: 0 8px 30px rgba(0, 0, 0, 0.55);
   }
@@ -539,9 +543,64 @@ select {
   flex: 1 1 100%;
 }
 
-#source-seek {
+#source-seek-wrap {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
   flex: 1 1 100%;
+  height: 30px;
+}
+
+#source-seek {
   width: 100%;
+  margin: 0;
+}
+
+#source-marker-layer {
+  position: absolute;
+  inset: 0 7px 2px;
+  pointer-events: none;
+}
+
+.source-boundary-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  border-radius: 1px;
+  background: currentColor;
+  transform: translateX(-1px);
+}
+
+.source-boundary-marker::before {
+  position: absolute;
+  top: 0;
+  padding: 0 3px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  background: var(--panel);
+  content: attr(data-label);
+  font-size: 8px;
+  font-weight: 700;
+  line-height: 11px;
+}
+
+.source-boundary-marker.in {
+  color: var(--mark-in);
+}
+
+.source-boundary-marker.in::before {
+  left: 0;
+}
+
+.source-boundary-marker.out {
+  color: var(--mark-out);
+}
+
+.source-boundary-marker.out::before {
+  top: auto;
+  right: 0;
+  bottom: 0;
 }
 
 .segmented {

--- a/product/akbun-makevideo/workspace/test/source.test.js
+++ b/product/akbun-makevideo/workspace/test/source.test.js
@@ -43,6 +43,14 @@ test('in and out cannot cross or leave the source', () => {
   });
 });
 
+test('source boundary markers stay on the seek range', () => {
+  assert.strictEqual(S.markerPercent(0, 300), 0);
+  assert.strictEqual(S.markerPercent(75, 300), 25);
+  assert.strictEqual(S.markerPercent(300, 300), 100);
+  assert.strictEqual(S.markerPercent(-30, 300), 0);
+  assert.strictEqual(S.markerPercent(400, 300), 100);
+});
+
 test('placement names a target per media kind and keeps the chosen range', () => {
   assert.deepStrictEqual(
     S.commandFor('insert', project, video, { inPoint: 30, outPoint: 120 }, {


### PR DESCRIPTION
# 구현

Source Monitor seek bar에 색상과 라벨로 구분한 In·Out 세로 마커 추가
- JavaScript 테스트 127개와 내장 브라우저 위치·색상 검증 통과

# 어려웠던 점

가까운 In·Out 지점의 색상 외 구분 보장
- IN은 상단, OUT은 하단 라벨로 배치해 겹침과 색상 의존 축소

# 리스크

seek bar native thumb 폭을 7px inset으로 근사
- 브라우저별 native range thumb 크기 차이로 끝점에서 수 px 오차 가능

Issue #992
