### PR TITLE
akbun-makevideo: 선택 패널 기반 UI 재구성

### DIFF
--- a/product/akbun-makevideo/README.md
+++ b/product/akbun-makevideo/README.md
@@ -9,6 +9,7 @@ Desktop video editor: a multi track timeline, a live preview, and a render to FH
 - Assets panel: drop files from Finder or import them, with kind, length and size read by ffprobe. **Importing references the file where it is — media is never copied into the project**
 - Program monitor: the render's own compositor draws straight onto a surface in the window, and the audio clock decides when each frame is shown. Playing and stopped are the same picture, so what is on screen is what will be in the file
 - Source monitor: preview an asset independently, mark frame-aligned in and out points, then insert, overwrite or append video, audio or both
+- Global Action Bar: toggle Inspector, Shape, Marker and Debug in the shared right panel
 - Inspector: edit a selected layer's position, size, rotation and opacity, plus text, shape, subtitle or clip-specific properties
 - The older preview — stacked media elements, with the composited frame swapped in when the playhead stops — is still there as a setting and as the automatic fallback when the monitor cannot start
 - Timeline: up to four video and four audio tracks, linked picture and sound from video assets, drag to move, drag an edge to trim
@@ -59,6 +60,7 @@ Cmd on macOS, Ctrl elsewhere.
 | Directory | Description |
 |---|---|
 | [workspace/](./workspace/) | Source code: the page in src/, the Tauri shell and the model, render and compositor crates in src-tauri/ |
+| [designs/](./designs/) | Figma-importable SVG layout, design tokens and UI interaction rules |
 | [wiki/](./wiki/) | What the next agent reads before taking over, one page per part under [wiki/architecture/](./wiki/architecture/) |
 | [adr/](./adr/) | Decision records |
 | [quality/](./quality/) | Playback quality harnesses, thresholds and baseline |

--- a/product/akbun-makevideo/designs/README.md
+++ b/product/akbun-makevideo/designs/README.md
@@ -1,0 +1,25 @@
+# Editor UI design
+
+## Source of truth
+
+- [editor-layout.svg](./editor-layout.svg): Figma에서 import 가능한 편집기 레이아웃
+- [tokens.tokens.json](./tokens.tokens.json): Design Tokens Community Group 형식의 크기와 색상
+- [../adr/index.md](../adr/index.md): UI 구현에 영향을 주는 아키텍처 결정
+
+## Layout
+
+- Title Bar: 좌측 메뉴, 우측 Global Action Bar
+- 기본 상태: 우측 선택 패널 닫힘
+- 열린 상태: Assets 264px / Source 1fr / Program 1fr / Selected Panel 280px
+- Global Action Bar: Inspector / Shape / Marker / Debug
+- Panel Tab Bar: Video / Audio / Effects / Transition / Image / File
+- Timeline: 편집 툴바 / ruler와 tracks
+
+## Interaction
+
+- 닫힌 Global Action을 누르면 해당 선택 패널을 연다.
+- 열린 Global Action을 다시 누르면 선택 패널을 닫는다.
+- 다른 Global Action을 누르면 같은 영역에서 패널 내용만 바꾼다.
+- Shape 버튼은 클릭하면 playhead에 추가하고 drag하면 video track에 추가한다.
+- Marker 패널은 marker를 timeline frame 오름차순으로 표시한다.
+- Debug는 선택 패널 안에서 갱신하며 별도 floating aside를 만들지 않는다.

--- a/product/akbun-makevideo/designs/editor-layout.svg
+++ b/product/akbun-makevideo/designs/editor-layout.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #1a1a1c; }
+    .label { font-size: 12px; font-weight: 600; letter-spacing: .8px; fill: #6a6d73; }
+    .small { font-size: 11px; fill: #6a6d73; }
+    .control { fill: #f7f8fa; stroke: #dcdfe4; }
+  </style>
+  <rect width="1440" height="900" fill="#f2f3f5"/>
+  <rect width="1440" height="42" fill="#ffffff" stroke="#dcdfe4"/>
+  <text x="16" y="26" font-size="13">Project　 Edit　 Render　 Playback　 Settings</text>
+  <g transform="translate(1010 8)">
+    <rect class="control" width="94" height="26" rx="6" fill="#2f6df0"/>
+    <text x="14" y="18" font-size="12" fill="#ffffff">◫ Inspector</text>
+    <rect class="control" x="98" width="76" height="26" rx="6"/><text x="110" y="18" font-size="12">◇ Shape</text>
+    <rect class="control" x="178" width="80" height="26" rx="6"/><text x="190" y="18" font-size="12">⌖ Marker</text>
+    <rect class="control" x="262" width="76" height="26" rx="6"/><text x="274" y="18" font-size="12">※ Debug</text>
+  </g>
+
+  <g transform="translate(0 42)">
+    <rect width="264" height="508" fill="#ffffff" stroke="#dcdfe4"/>
+    <text class="label" x="12" y="26">ASSETS</text>
+    <rect class="control" x="190" y="8" width="62" height="24" rx="6"/><text class="small" x="203" y="24">Import…</text>
+
+    <rect x="264" width="448" height="508" fill="#ffffff" stroke="#dcdfe4"/>
+    <text class="label" x="276" y="26">SOURCE MONITOR</text>
+    <rect x="264" y="38" width="448" height="390" fill="#0b0b0d"/>
+    <rect x="264" y="428" width="448" height="80" fill="#ffffff" stroke="#dcdfe4"/>
+
+    <rect x="712" width="448" height="508" fill="#ffffff" stroke="#dcdfe4"/>
+    <text class="label" x="724" y="26">PROGRAM MONITOR</text>
+    <rect x="712" y="38" width="448" height="426" fill="#0b0b0d"/>
+    <rect x="712" y="464" width="448" height="44" fill="#ffffff" stroke="#dcdfe4"/>
+
+    <rect x="1160" width="280" height="508" fill="#ffffff" stroke="#dcdfe4"/>
+    <text class="label" x="1172" y="26">INSPECTOR</text>
+    <rect x="1160" y="38" width="280" height="34" fill="#f7f8fa" stroke="#dcdfe4"/>
+    <text class="small" x="1168" y="59">Video　Audio　Effects　Transition　Image　File</text>
+    <text x="1174" y="102" font-size="13" font-weight="600">Transform</text>
+    <rect class="control" x="1174" y="116" width="118" height="28" rx="6"/>
+    <rect class="control" x="1302" y="116" width="118" height="28" rx="6"/>
+  </g>
+
+  <g transform="translate(0 550)">
+    <rect width="1440" height="44" fill="#ffffff" stroke="#dcdfe4"/>
+    <text x="14" y="27" font-size="12">✂　⌁　⌫　⇥　 Link Clips　 + Text　│　+ Video track　+ Audio track　+ Subtitle track</text>
+    <rect y="44" width="132" height="306" fill="#ffffff" stroke="#dcdfe4"/>
+    <rect x="132" y="44" width="1308" height="306" fill="#f2f3f5" stroke="#dcdfe4"/>
+    <line x1="132" y1="80" x2="1440" y2="80" stroke="#dcdfe4"/>
+    <line x1="132" y1="144" x2="1440" y2="144" stroke="#dcdfe4"/>
+    <line x1="132" y1="208" x2="1440" y2="208" stroke="#dcdfe4"/>
+    <text class="label" x="14" y="118">VIDEO 1</text>
+    <text class="label" x="14" y="182">VIDEO 2</text>
+    <text class="label" x="14" y="246">AUDIO 1</text>
+    <rect x="196" y="94" width="360" height="38" rx="5" fill="#cfe0ff" stroke="#5b8def"/>
+    <rect x="360" y="222" width="420" height="34" rx="5" fill="#d3efdd" stroke="#41a86a"/>
+    <line x1="480" y1="44" x2="480" y2="350" stroke="#f0a52f" stroke-width="2"/>
+  </g>
+</svg>

--- a/product/akbun-makevideo/designs/tokens.tokens.json
+++ b/product/akbun-makevideo/designs/tokens.tokens.json
@@ -1,0 +1,22 @@
+{
+  "color": {
+    "background": { "$type": "color", "$value": "#f2f3f5" },
+    "panel": { "$type": "color", "$value": "#ffffff" },
+    "panelSubtle": { "$type": "color", "$value": "#f7f8fa" },
+    "text": { "$type": "color", "$value": "#1a1a1c" },
+    "textMuted": { "$type": "color", "$value": "#6a6d73" },
+    "border": { "$type": "color", "$value": "#dcdfe4" },
+    "accent": { "$type": "color", "$value": "#2f6df0" },
+    "monitor": { "$type": "color", "$value": "#0b0b0d" }
+  },
+  "size": {
+    "assetsPanelWidth": { "$type": "dimension", "$value": { "value": 264, "unit": "px" } },
+    "selectedPanelWidth": { "$type": "dimension", "$value": { "value": 280, "unit": "px" } },
+    "trackHeaderWidth": { "$type": "dimension", "$value": { "value": 132, "unit": "px" } },
+    "panelGap": { "$type": "dimension", "$value": { "value": 1, "unit": "px" } }
+  },
+  "radius": {
+    "control": { "$type": "dimension", "$value": { "value": 6, "unit": "px" } },
+    "panel": { "$type": "dimension", "$value": { "value": 8, "unit": "px" } }
+  }
+}

--- a/product/akbun-makevideo/workspace/AGENTS.md
+++ b/product/akbun-makevideo/workspace/AGENTS.md
@@ -1,0 +1,6 @@
+# Workspace guide
+
+- UI를 수정하기 전에 [designs](../designs/README.md)를 읽고 SVG와 token을 기준으로 삼는다.
+- 구조나 동작 경계를 수정하기 전에 [ADR index](../adr/index.md)에서 관련 결정을 읽는다.
+- `src/`는 build step 없는 HTML, CSS, JavaScript다.
+- 페이지에서 검증할 수 있는 UI는 `src/`를 정적 서버로 열어 확인한다.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -29,6 +29,23 @@
         <path d="M3 6h9M6.5 6V4h3v2M5 6l.7 10h4.6l.7-10" />
         <path d="M17 11H12M14.5 8.5 17 11l-2.5 2.5" />
       </g>
+      <g id="icon-inspector">
+        <path d="M4 5h12M4 10h12M4 15h12" />
+        <circle cx="8" cy="5" r="1.7" />
+        <circle cx="13" cy="10" r="1.7" />
+        <circle cx="7" cy="15" r="1.7" />
+      </g>
+      <g id="icon-shape">
+        <rect x="3.5" y="4" width="9" height="9" rx="1.5" />
+        <circle cx="13.5" cy="12.5" r="3.5" />
+      </g>
+      <g id="icon-marker">
+        <path d="M10 17s5-4.2 5-9a5 5 0 1 0-10 0c0 4.8 5 9 5 9Z" />
+        <circle cx="10" cy="8" r="1.6" />
+      </g>
+      <g id="icon-debug">
+        <path d="M6 7.5h8v5a4 4 0 0 1-8 0v-5ZM8 7.5V5a2 2 0 0 1 4 0v2.5M3.5 9h2.5M14 9h2.5M3.5 13h2.5M14 13h2.5M6 16l-2 2M14 16l2 2" />
+      </g>
     </defs>
   </svg>
 
@@ -109,7 +126,24 @@
     <span class="menubar-gap"></span>
     <button id="tool-warning" hidden title="Rendering needs ffmpeg on this machine">ffmpeg not found</button>
     <span id="playback-warning" class="dim small-text" hidden></span>
-    <span id="project-name">Untitled</span>
+    <div id="global-actions" role="toolbar" aria-label="Global panels">
+      <button class="global-action" type="button" data-panel-action="inspector" aria-controls="selected-panel" aria-expanded="false" aria-pressed="false">
+        <svg viewBox="0 0 20 20" aria-hidden="true"><use href="#icon-inspector" /></svg>
+        <span>Inspector</span>
+      </button>
+      <button class="global-action" type="button" data-panel-action="shape" aria-controls="selected-panel" aria-expanded="false" aria-pressed="false">
+        <svg viewBox="0 0 20 20" aria-hidden="true"><use href="#icon-shape" /></svg>
+        <span>Shape</span>
+      </button>
+      <button class="global-action" type="button" data-panel-action="marker" aria-controls="selected-panel" aria-expanded="false" aria-pressed="false">
+        <svg viewBox="0 0 20 20" aria-hidden="true"><use href="#icon-marker" /></svg>
+        <span>Marker</span>
+      </button>
+      <button class="global-action" type="button" data-panel-action="debug" aria-controls="selected-panel" aria-expanded="false" aria-pressed="false">
+        <svg viewBox="0 0 20 20" aria-hidden="true"><use href="#icon-debug" /></svg>
+        <span>Debug</span>
+      </button>
+    </div>
   </header>
 
   <main id="panels">
@@ -165,7 +199,6 @@
         <section id="preview-panel">
           <header class="panel-head">
             <h2>Program Monitor</h2>
-            <button id="btn-debug" class="small" type="button">Debug</button>
           </header>
           <div id="stage-wrap">
             <div id="stage">
@@ -194,11 +227,20 @@
         </section>
       </div>
 
-      <aside id="inspector-panel">
+      <aside id="selected-panel" hidden>
         <header class="panel-head">
-          <h2>Inspector</h2>
+          <h2 id="selected-panel-title">Inspector</h2>
         </header>
-        <div id="inspector-body">
+        <div id="panel-tab-bar" role="tablist" aria-label="Inspector category">
+          <button id="panel-tab-video" type="button" role="tab" data-inspector-tab="video" aria-selected="true">Video</button>
+          <button id="panel-tab-audio" type="button" role="tab" data-inspector-tab="audio" aria-selected="false" tabindex="-1">Audio</button>
+          <button id="panel-tab-effects" type="button" role="tab" data-inspector-tab="effects" aria-selected="false" tabindex="-1">Effects</button>
+          <button id="panel-tab-transition" type="button" role="tab" data-inspector-tab="transition" aria-selected="false" tabindex="-1">Transition</button>
+          <button id="panel-tab-image" type="button" role="tab" data-inspector-tab="image" aria-selected="false" tabindex="-1">Image</button>
+          <button id="panel-tab-file" type="button" role="tab" data-inspector-tab="file" aria-selected="false" tabindex="-1">File</button>
+        </div>
+        <div id="inspector-view" class="selected-panel-view">
+          <div id="inspector-body">
           <p id="inspector-empty" class="dim small-text">Select a clip or a layer to edit its properties.</p>
           <div id="transform-panel" hidden>
             <h3>Transform</h3>
@@ -209,14 +251,10 @@
           </div>
           <div id="clip-panel" hidden>
             <p id="clip-summary" class="dim small-text"></p>
-            <div id="clip-tabs" class="inspector-tabs" role="tablist" aria-label="Clip properties">
-              <button id="clip-video-tab" type="button" role="tab" aria-controls="clip-video-panel" aria-selected="false" tabindex="-1">Video</button>
-              <button id="clip-audio-tab" type="button" role="tab" aria-controls="clip-audio-panel" aria-selected="false" tabindex="-1">Audio</button>
-            </div>
-            <div id="clip-video-panel" role="tabpanel" aria-labelledby="clip-video-tab">
+            <div id="clip-video-panel" role="tabpanel" aria-labelledby="panel-tab-video">
               <label class="row">Opacity <input id="clip-opacity" type="range" min="0" max="1" step="0.01" /></label>
             </div>
-            <div id="clip-audio-panel" role="tabpanel" aria-labelledby="clip-audio-tab">
+            <div id="clip-audio-panel" role="tabpanel" aria-labelledby="panel-tab-audio">
               <!-- 0..1 because that is what the edit model stores; a wider
                    slider would snap back on release. -->
               <label class="row">Volume <input id="clip-volume" type="range" min="0" max="1" step="0.01" /></label>
@@ -259,7 +297,29 @@
             </div>
           </div>
           <datalist id="font-options"></datalist>
+          </div>
         </div>
+        <section id="shape-tool-view" class="selected-panel-view" hidden>
+          <h3>Shape</h3>
+          <p class="dim small-text">Add at the playhead, or drag the button onto a video track.</p>
+          <button id="btn-add-shape" type="button">+ Shape</button>
+        </section>
+        <section id="marker-tool-view" class="selected-panel-view" hidden>
+          <div class="selected-panel-actions">
+            <h3>Markers</h3>
+            <button id="btn-add-marker" class="small" type="button">+ Marker</button>
+          </div>
+          <p id="marker-empty" class="dim small-text">No markers on the timeline.</p>
+          <div id="marker-list"></div>
+        </section>
+        <section id="debug-view" class="selected-panel-view" hidden>
+          <div id="debug-metrics" class="debug-block"></div>
+          <div class="debug-actions">
+            <button id="btn-refresh-debug" class="small" type="button">Refresh</button>
+            <button id="btn-toggle-logs" class="small" type="button">Show error log</button>
+          </div>
+          <pre id="debug-log" class="debug-log" hidden></pre>
+        </section>
       </aside>
     </section>
 
@@ -279,8 +339,6 @@
         </button>
         <button id="btn-link" class="small" title="Link or unlink synchronized audio and video clips">Link Clips</button>
         <button id="btn-add-text" class="small" title="Add a 4 second title at the playhead — or drag onto a video track">+ Text</button>
-        <button id="btn-add-shape" class="small" title="Add a 4 second shape at the playhead — or drag onto a video track">+ Shape</button>
-        <button id="btn-add-marker" class="small" title="Add a marker at the playhead">+ Marker</button>
         <span class="sep-v"></span>
         <button id="btn-add-video" class="small">+ Video track</button>
         <button id="btn-add-audio" class="small">+ Audio track</button>
@@ -302,25 +360,8 @@
           </div>
         </div>
       </div>
-      <details id="marker-panel">
-        <summary>Markers</summary>
-        <div id="marker-list"></div>
-      </details>
     </section>
   </main>
-
-  <aside id="debug-panel" hidden>
-    <header class="panel-head">
-      <h2>Debug</h2>
-      <button id="btn-close-debug" class="small" type="button">Close</button>
-    </header>
-    <div id="debug-metrics" class="debug-block"></div>
-    <div class="debug-actions">
-      <button id="btn-refresh-debug" class="small" type="button">Refresh</button>
-      <button id="btn-toggle-logs" class="small" type="button">Show error log</button>
-    </div>
-    <pre id="debug-log" class="debug-log" hidden></pre>
-  </aside>
 
   <div id="timeline-context-menu" class="timeline-context-menu" hidden></div>
 
@@ -542,6 +583,7 @@
   <script src="timeline.js"></script>
   <script src="source.js"></script>
   <script src="inspector.js"></script>
+  <script src="panel.js"></script>
   <script src="shortcuts.js"></script>
   <script src="quality.js"></script>
   <script src="preview.js"></script>

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -231,13 +231,13 @@
         <header class="panel-head">
           <h2 id="selected-panel-title">Inspector</h2>
         </header>
-        <div id="panel-tab-bar" role="tablist" aria-label="Inspector category">
-          <button id="panel-tab-video" type="button" role="tab" data-inspector-tab="video" aria-selected="true">Video</button>
-          <button id="panel-tab-audio" type="button" role="tab" data-inspector-tab="audio" aria-selected="false" tabindex="-1">Audio</button>
-          <button id="panel-tab-effects" type="button" role="tab" data-inspector-tab="effects" aria-selected="false" tabindex="-1">Effects</button>
-          <button id="panel-tab-transition" type="button" role="tab" data-inspector-tab="transition" aria-selected="false" tabindex="-1">Transition</button>
-          <button id="panel-tab-image" type="button" role="tab" data-inspector-tab="image" aria-selected="false" tabindex="-1">Image</button>
-          <button id="panel-tab-file" type="button" role="tab" data-inspector-tab="file" aria-selected="false" tabindex="-1">File</button>
+        <div id="panel-tab-bar" role="toolbar" aria-label="Inspector category">
+          <button id="panel-tab-video" type="button" data-inspector-tab="video" aria-pressed="true">Video</button>
+          <button id="panel-tab-audio" type="button" data-inspector-tab="audio" aria-pressed="false" tabindex="-1">Audio</button>
+          <button id="panel-tab-effects" type="button" data-inspector-tab="effects" aria-pressed="false" tabindex="-1">Effects</button>
+          <button id="panel-tab-transition" type="button" data-inspector-tab="transition" aria-pressed="false" tabindex="-1">Transition</button>
+          <button id="panel-tab-image" type="button" data-inspector-tab="image" aria-pressed="false" tabindex="-1">Image</button>
+          <button id="panel-tab-file" type="button" data-inspector-tab="file" aria-pressed="false" tabindex="-1">File</button>
         </div>
         <div id="inspector-view" class="selected-panel-view">
           <div id="inspector-body">
@@ -251,10 +251,10 @@
           </div>
           <div id="clip-panel" hidden>
             <p id="clip-summary" class="dim small-text"></p>
-            <div id="clip-video-panel" role="tabpanel" aria-labelledby="panel-tab-video">
+            <div id="clip-video-panel">
               <label class="row">Opacity <input id="clip-opacity" type="range" min="0" max="1" step="0.01" /></label>
             </div>
-            <div id="clip-audio-panel" role="tabpanel" aria-labelledby="panel-tab-audio">
+            <div id="clip-audio-panel">
               <!-- 0..1 because that is what the edit model stores; a wider
                    slider would snap back on release. -->
               <label class="row">Volume <input id="clip-volume" type="range" min="0" max="1" step="0.01" /></label>

--- a/product/akbun-makevideo/workspace/src/panel.js
+++ b/product/akbun-makevideo/workspace/src/panel.js
@@ -1,0 +1,29 @@
+'use strict';
+
+(function () {
+
+const TABS = ['video', 'audio', 'effects', 'transition', 'image', 'file'];
+
+function toggledPanel(active, requested) {
+  return active === requested ? null : requested;
+}
+
+function orderedMarkers(markers) {
+  return [...(markers || [])].sort((left, right) =>
+    left.frame - right.frame || String(left.id).localeCompare(String(right.id))
+  );
+}
+
+function adjacentTab(current, offset) {
+  const index = Math.max(0, TABS.indexOf(current));
+  return TABS[(index + offset + TABS.length) % TABS.length];
+}
+
+const exported = { TABS, toggledPanel, orderedMarkers, adjacentTab };
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = exported;
+} else {
+  globalThis.panelLib = exported;
+}
+})();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -23,6 +23,7 @@ const X = globalThis.transformLib;
 const G = globalThis.guideLib;
 const S = globalThis.sourceLib;
 const I = globalThis.inspectorLib;
+const P = globalThis.panelLib;
 
 // Pointer distance from a clip edge that starts a trim instead of a move.
 const HANDLE_PX = 8;
@@ -67,14 +68,20 @@ const el = (id) => document.getElementById(id);
 
 const dom = {
   menus: el('menus'),
-  projectName: el('project-name'),
+  upper: el('upper'),
+  globalActions: el('global-actions'),
+  selectedPanel: el('selected-panel'),
+  selectedPanelTitle: el('selected-panel-title'),
+  panelTabBar: el('panel-tab-bar'),
+  inspectorView: el('inspector-view'),
+  shapeToolView: el('shape-tool-view'),
+  markerToolView: el('marker-tool-view'),
   toolWarning: el('tool-warning'),
   playbackWarning: el('playback-warning'),
   assetList: el('asset-list'),
   assetEmpty: el('asset-empty'),
   assetsPanel: el('assets-panel'),
   btnImport: el('btn-import'),
-  btnDebug: el('btn-debug'),
   sourcePanel: el('source-panel'),
   sourceStageWrap: el('source-stage-wrap'),
   sourceStage: el('source-stage'),
@@ -96,10 +103,9 @@ const dom = {
   sourceInsert: el('source-insert'),
   sourceOverwrite: el('source-overwrite'),
   sourceAppend: el('source-append'),
-  debugPanel: el('debug-panel'),
+  debugPanel: el('debug-view'),
   debugMetrics: el('debug-metrics'),
   debugLog: el('debug-log'),
-  btnCloseDebug: el('btn-close-debug'),
   btnRefreshDebug: el('btn-refresh-debug'),
   btnToggleLogs: el('btn-toggle-logs'),
   stageWrap: el('stage-wrap'),
@@ -135,6 +141,7 @@ const dom = {
   content: el('timeline-content'),
   ruler: el('ruler'),
   markerList: el('marker-list'),
+  markerEmpty: el('marker-empty'),
   inspectorEmpty: el('inspector-empty'),
   transformPanel: el('transform-panel'),
   transformX: el('transform-x'),
@@ -146,8 +153,6 @@ const dom = {
   transformOpacityValue: el('transform-opacity-value'),
   clipPanel: el('clip-panel'),
   clipSummary: el('clip-summary'),
-  clipVideoTab: el('clip-video-tab'),
-  clipAudioTab: el('clip-audio-tab'),
   clipVideoPanel: el('clip-video-panel'),
   clipAudioPanel: el('clip-audio-panel'),
   clipOpacity: el('clip-opacity'),
@@ -218,7 +223,8 @@ const state = {
   waveforms: {},
   selectedClipId: null,
   selectedVisualItemId: null,
-  inspectorTab: null,
+  activePanel: null,
+  inspectorTab: 'video',
   selectedAssetId: null,
   sourceSelection: null,
   targetTrackId: null,
@@ -305,7 +311,6 @@ function isDirty() {
 function updateTitle() {
   const name = projectName();
   const mark = isDirty() ? ' •' : '';
-  dom.projectName.textContent = `${name}${mark}`;
   window.api.setTitle(`akbun-makevideo — ${name}${mark}`);
 }
 
@@ -506,16 +511,47 @@ async function refreshDebug() {
   }
 }
 
-function showDebug() {
-  dom.debugPanel.hidden = false;
+function startDebug() {
   void refreshDebug();
   if (debugTimer === null) debugTimer = window.setInterval(() => void refreshDebug(), 1000);
 }
 
-function hideDebug() {
-  dom.debugPanel.hidden = true;
+function stopDebug() {
   if (debugTimer !== null) window.clearInterval(debugTimer);
   debugTimer = null;
+}
+
+const PANEL_TITLES = {
+  inspector: 'Inspector',
+  shape: 'Shape',
+  marker: 'Marker',
+  debug: 'Debug',
+};
+
+function activateSelectedPanel(panel) {
+  state.activePanel = panel;
+  dom.selectedPanel.hidden = !panel;
+  dom.upper.classList.toggle('panel-open', Boolean(panel));
+  dom.inspectorView.hidden = panel !== 'inspector';
+  dom.shapeToolView.hidden = panel !== 'shape';
+  dom.markerToolView.hidden = panel !== 'marker';
+  dom.debugPanel.hidden = panel !== 'debug';
+  dom.selectedPanelTitle.textContent = panel ? PANEL_TITLES[panel] : 'Inspector';
+  for (const button of dom.globalActions.querySelectorAll('[data-panel-action]')) {
+    const active = button.dataset.panelAction === panel;
+    button.setAttribute('aria-pressed', String(active));
+    button.setAttribute('aria-expanded', String(active));
+  }
+  if (panel === 'debug') startDebug();
+  else stopDebug();
+  window.requestAnimationFrame(() => {
+    if (preview) preview.layout();
+    if (sourcePreview) sourcePreview.layout();
+  });
+}
+
+function toggleSelectedPanel(panel) {
+  activateSelectedPanel(P.toggledPanel(state.activePanel, panel));
 }
 
 async function prepareProxies() {
@@ -930,7 +966,9 @@ function renderRuler() {
 
 function renderMarkerList() {
   dom.markerList.textContent = '';
-  for (const marker of state.project.markers || []) {
+  const markers = P.orderedMarkers(state.project.markers);
+  dom.markerEmpty.hidden = markers.length > 0;
+  for (const marker of markers) {
     const row = document.createElement('div');
     row.className = 'marker-row';
     const seek = document.createElement('button');
@@ -1128,7 +1166,7 @@ function scheduleExactFrame() {
 function selectClip(clipId) {
   state.selectedClipId = clipId;
   const targets = clipId ? I.clipTargets(state.project, clipId) : null;
-  state.inspectorTab = I.activeTab(targets);
+  if (targets) state.inspectorTab = I.activeTab(targets);
   // One selection at a time, so the inspector always shows the thing that was
   // picked last rather than whichever kind happens to win a tie.
   if (clipId && state.selectedVisualItemId) selectVisualItem(null);
@@ -1168,6 +1206,7 @@ function overlayScale() {
 
 function selectVisualItem(itemId) {
   state.selectedVisualItemId = itemId || null;
+  if (itemId) state.inspectorTab = 'video';
   if (itemId && state.selectedClipId) selectClip(null);
   for (const node of dom.lanes.querySelectorAll('[data-visual-item-id]')) {
     node.classList.toggle('selected', node.dataset.visualItemId === state.selectedVisualItemId);
@@ -1554,6 +1593,7 @@ function selectAsset(assetId) {
   if (sourcePreview) sourcePreview.showAsset(asset);
   renderAssets();
   renderSourceMonitor();
+  renderInspector();
 }
 
 /** The selection is an id, and clips go away underneath it: opening a project,
@@ -1685,6 +1725,26 @@ function preserveAlpha(color, previous) {
   return `${color}${alpha}`;
 }
 
+function inspectorMessage(tab, item, clipTargets) {
+  if (tab === 'effects') return 'No effect is selected.';
+  if (tab === 'transition') return 'No transition is selected.';
+  if (tab === 'image') {
+    const asset = L.findAsset(state.project, state.selectedAssetId);
+    return asset && asset.kind === 'image'
+      ? `Image — ${asset.name || baseName(asset.path)}`
+      : 'Select an image asset to inspect it.';
+  }
+  if (tab === 'file') {
+    const selected = clipTargets && clipTargets.selected;
+    const asset = selected
+      ? L.findAsset(state.project, selected.clip.assetId)
+      : L.findAsset(state.project, state.selectedAssetId);
+    return asset ? `File — ${asset.name || baseName(asset.path)}` : 'Select an asset or clip to inspect its file.';
+  }
+  if (tab === 'audio') return 'Select a clip with audio properties.';
+  return item ? 'No video properties are available.' : 'Select a clip or a layer to edit its properties.';
+}
+
 /** The inspector beside the preview. One switch over what is selected: a text,
  *  shape or subtitle layer, else the selected clip, else the empty hint. */
 function renderInspector() {
@@ -1697,12 +1757,23 @@ function renderInspector() {
     ? I.clipTargets(state.project, liveSelection())
     : null;
   const clip = clipTargets && clipTargets.selected;
-  dom.textPanel.hidden = !text || subtitle;
-  dom.subtitlePanel.hidden = !text || !subtitle;
-  dom.shapePanel.hidden = !shape;
-  dom.clipPanel.hidden = !clip;
-  dom.transformPanel.hidden = !item;
-  dom.inspectorEmpty.hidden = Boolean(item || clip);
+  const tab = state.inspectorTab || 'video';
+  const video = tab === 'video';
+  const audio = tab === 'audio';
+  const hasProperties = (video && Boolean(item || (clipTargets && clipTargets.video))) ||
+    (audio && Boolean(clipTargets && clipTargets.audio));
+  dom.textPanel.hidden = !video || !text || subtitle;
+  dom.subtitlePanel.hidden = !video || !text || !subtitle;
+  dom.shapePanel.hidden = !video || !shape;
+  dom.clipPanel.hidden = !clip || (!video && !audio);
+  dom.transformPanel.hidden = !video || !item;
+  dom.inspectorEmpty.hidden = hasProperties;
+  dom.inspectorEmpty.textContent = inspectorMessage(tab, item, clipTargets);
+  for (const button of dom.panelTabBar.querySelectorAll('[data-inspector-tab]')) {
+    const active = button.dataset.inspectorTab === tab;
+    button.setAttribute('aria-selected', String(active));
+    button.tabIndex = active ? 0 : -1;
+  }
   if (item) {
     const transform = item.transform;
     dom.transformX.value = transform.x;
@@ -1716,15 +1787,8 @@ function renderInspector() {
   if (clip) {
     const asset = L.findAsset(state.project, clip.clip.assetId);
     dom.clipSummary.textContent = `${asset ? asset.name || baseName(asset.path) : 'missing file'} · ${clip.track.name}`;
-    state.inspectorTab = I.activeTab(clipTargets, state.inspectorTab);
-    dom.clipVideoTab.hidden = !clipTargets.video;
-    dom.clipAudioTab.hidden = !clipTargets.audio;
-    dom.clipVideoTab.setAttribute('aria-selected', String(state.inspectorTab === 'video'));
-    dom.clipAudioTab.setAttribute('aria-selected', String(state.inspectorTab === 'audio'));
-    dom.clipVideoTab.tabIndex = state.inspectorTab === 'video' ? 0 : -1;
-    dom.clipAudioTab.tabIndex = state.inspectorTab === 'audio' ? 0 : -1;
-    dom.clipVideoPanel.hidden = state.inspectorTab !== 'video';
-    dom.clipAudioPanel.hidden = state.inspectorTab !== 'audio';
+    dom.clipVideoPanel.hidden = !video || !clipTargets.video;
+    dom.clipAudioPanel.hidden = !audio || !clipTargets.audio;
     if (clipTargets.video) dom.clipOpacity.value = String(clipTargets.video.clip.opacity ?? 1);
     if (clipTargets.audio) dom.clipVolume.value = String(clipTargets.audio.clip.volume ?? 1);
   }
@@ -1888,16 +1952,16 @@ function updateSelectedAudioVolume() {
 
 function activateInspectorTab(tab) {
   state.inspectorTab = tab;
+  activateSelectedPanel('inspector');
   renderInspector();
 }
 
 function moveInspectorTab(event) {
   if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
-  const tabs = [dom.clipVideoTab, dom.clipAudioTab].filter((tab) => !tab.hidden);
-  const current = tabs.indexOf(event.currentTarget);
   const offset = event.key === 'ArrowRight' ? 1 : -1;
-  const next = tabs[(current + offset + tabs.length) % tabs.length];
-  activateInspectorTab(next === dom.clipVideoTab ? 'video' : 'audio');
+  const nextName = P.adjacentTab(event.currentTarget.dataset.inspectorTab, offset);
+  const next = dom.panelTabBar.querySelector(`[data-inspector-tab="${nextName}"]`);
+  activateInspectorTab(nextName);
   next.focus();
   event.preventDefault();
 }
@@ -3111,6 +3175,23 @@ function wireMenus() {
   });
 }
 
+function wireSelectedPanel() {
+  dom.globalActions.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-panel-action]');
+    if (button) toggleSelectedPanel(button.dataset.panelAction);
+  });
+  for (const button of dom.panelTabBar.querySelectorAll('[data-inspector-tab]')) {
+    button.addEventListener('click', () => activateInspectorTab(button.dataset.inspectorTab));
+    button.addEventListener('keydown', moveInspectorTab);
+  }
+  dom.btnRefreshDebug.addEventListener('click', () => void refreshDebug());
+  dom.btnToggleLogs.addEventListener('click', () => {
+    dom.debugLog.hidden = !dom.debugLog.hidden;
+    dom.btnToggleLogs.textContent = dom.debugLog.hidden ? 'Show error log' : 'Hide error log';
+    void refreshDebug();
+  });
+}
+
 function wireAssets() {
   dom.btnImport.addEventListener('click', importViaDialog);
   dom.sourcePlay.addEventListener('click', () => sourcePreview.toggle());
@@ -3123,17 +3204,6 @@ function wireAssets() {
   for (const input of [dom.sourceVideo, dom.sourceAudio, dom.sourceRipple]) {
     input.addEventListener('change', renderSourceMonitor);
   }
-  dom.btnDebug.addEventListener('click', () => {
-    if (dom.debugPanel.hidden) showDebug();
-    else hideDebug();
-  });
-  dom.btnCloseDebug.addEventListener('click', hideDebug);
-  dom.btnRefreshDebug.addEventListener('click', () => void refreshDebug());
-  dom.btnToggleLogs.addEventListener('click', () => {
-    dom.debugLog.hidden = !dom.debugLog.hidden;
-    dom.btnToggleLogs.textContent = dom.debugLog.hidden ? 'Show error log' : 'Hide error log';
-    void refreshDebug();
-  });
   dom.assetList.addEventListener('click', (event) => {
     const remove = event.target.closest('[data-remove]');
     if (remove) {
@@ -3263,14 +3333,6 @@ function wireTimeline() {
   for (const input of [dom.subtitleFont, dom.subtitleSize, dom.subtitleColor]) {
     input.addEventListener('change', updateSubtitleStyle);
   }
-  dom.clipVideoTab.addEventListener('click', () => {
-    activateInspectorTab('video');
-  });
-  dom.clipAudioTab.addEventListener('click', () => {
-    activateInspectorTab('audio');
-  });
-  dom.clipVideoTab.addEventListener('keydown', moveInspectorTab);
-  dom.clipAudioTab.addEventListener('keydown', moveInspectorTab);
   dom.clipOpacity.addEventListener('change', updateSelectedVideoOpacity);
   dom.clipVolume.addEventListener('change', updateSelectedAudioVolume);
   for (const input of [
@@ -3692,6 +3754,7 @@ async function boot() {
   updateToolWarning();
 
   wireMenus();
+  wireSelectedPanel();
   wireAssets();
   wireTimeline();
   wireTransport();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -540,7 +540,7 @@ function activateSelectedPanel(panel) {
   for (const button of dom.globalActions.querySelectorAll('[data-panel-action]')) {
     const active = button.dataset.panelAction === panel;
     button.setAttribute('aria-pressed', String(active));
-    button.setAttribute('aria-expanded', String(active));
+    button.setAttribute('aria-expanded', String(Boolean(panel)));
   }
   if (panel === 'debug') startDebug();
   else stopDebug();
@@ -1771,7 +1771,7 @@ function renderInspector() {
   dom.inspectorEmpty.textContent = inspectorMessage(tab, item, clipTargets);
   for (const button of dom.panelTabBar.querySelectorAll('[data-inspector-tab]')) {
     const active = button.dataset.inspectorTab === tab;
-    button.setAttribute('aria-selected', String(active));
+    button.setAttribute('aria-pressed', String(active));
     button.tabIndex = active ? 0 : -1;
   }
   if (item) {

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -973,7 +973,7 @@ button.icon.on {
   font-size: 9px;
 }
 
-#panel-tab-bar button[aria-selected='true'] {
+#panel-tab-bar button[aria-pressed='true'] {
   border-color: var(--border);
   background: var(--panel);
   color: var(--accent);

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -272,10 +272,6 @@ select {
   background: var(--border);
 }
 
-#project-name {
-  color: var(--dim);
-}
-
 /* Next to the ffmpeg warning, and the same kind of thing: a part of the app is
    not running and this says which. Truncated rather than allowed to push the
    project name out of the bar, with the whole reason in the title. */
@@ -293,34 +289,44 @@ select {
   padding: 2px 8px;
 }
 
+#global-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.global-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  border-color: transparent;
+  background: transparent;
+  font-size: 12px;
+}
+
+.global-action svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.global-action[aria-pressed='true'] {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+
 /* --- panels -------------------------------------------------------------- */
 
 #panels {
   display: grid;
   grid-template-rows: minmax(0, 1fr) minmax(260px, 42vh);
   min-height: 0;
-}
-
-/* `display: grid` below beats the `hidden` attribute's UA `display: none`,
-   so hidden has to win again explicitly or the panel is always on screen. */
-#debug-panel[hidden] {
-  display: none;
-}
-
-#debug-panel {
-  position: fixed;
-  z-index: 5;
-  top: 34px;
-  right: 12px;
-  width: min(360px, calc(100vw - 24px));
-  max-height: calc(100vh - 46px);
-  display: grid;
-  grid-template-rows: auto auto auto minmax(0, 1fr);
-  overflow: hidden;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 12px 30px rgb(0 0 0 / 24%);
 }
 
 .debug-block,
@@ -346,9 +352,13 @@ select {
 
 #upper {
   display: grid;
-  grid-template-columns: 264px minmax(0, 1fr) 280px;
+  grid-template-columns: 264px minmax(0, 1fr);
   min-height: 0;
   border-bottom: 1px solid var(--border);
+}
+
+#upper.panel-open {
+  grid-template-columns: 264px minmax(0, 1fr) 280px;
 }
 
 .panel-head {
@@ -764,7 +774,7 @@ audio.stage-media {
 
 #lower {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr);
   min-height: 0;
   background: var(--bg);
 }
@@ -930,14 +940,73 @@ button.icon.on {
   clip-path: polygon(0 0, 100% 0, 50% 100%);
 }
 
-/* --- inspector ----------------------------------------------------------- */
+/* --- selected panel ------------------------------------------------------ */
 
-#inspector-panel {
+#selected-panel[hidden] {
+  display: none;
+}
+
+#selected-panel {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   min-height: 0;
+  min-width: 0;
   border-left: 1px solid var(--border);
   background: var(--panel);
+}
+
+#panel-tab-bar {
+  display: flex;
+  justify-content: space-between;
+  gap: 0;
+  padding: 5px 6px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel-2);
+}
+
+#panel-tab-bar button {
+  flex: 0 0 auto;
+  padding: 2px 4px;
+  border-color: transparent;
+  background: transparent;
+  font-size: 9px;
+}
+
+#panel-tab-bar button[aria-selected='true'] {
+  border-color: var(--border);
+  background: var(--panel);
+  color: var(--accent);
+}
+
+.selected-panel-view {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px 12px;
+}
+
+.selected-panel-view[hidden] {
+  display: none;
+}
+
+.selected-panel-view h3 {
+  margin: 2px 0 10px;
+  font-size: 13px;
+}
+
+.selected-panel-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.selected-panel-actions h3 {
+  margin: 0;
+}
+
+#inspector-view {
+  padding: 0;
 }
 
 #inspector-body {
@@ -1003,56 +1072,38 @@ button.icon.on {
   flex: 0 0 62px;
 }
 
-.inspector-tabs {
-  display: flex;
-  gap: 4px;
-  margin: 8px 0 12px;
-  padding: 3px;
-  border-radius: 7px;
-  background: var(--panel-2);
-}
-
-.inspector-tabs button {
-  flex: 1;
-  border-color: transparent;
-  background: transparent;
-}
-
-.inspector-tabs button[aria-selected='true'] {
-  border-color: var(--border);
-  background: var(--panel);
-  color: var(--accent);
-}
-
-.inspector-tabs button[hidden] {
-  display: none;
-}
-
-#marker-panel {
-  max-height: 160px;
-  overflow: auto;
-  padding: 6px 10px;
-  border-top: 1px solid var(--border);
-  background: var(--panel);
-}
-
-#marker-panel summary {
-  cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
-}
-
 #marker-list {
   display: grid;
   gap: 5px;
-  padding-top: 6px;
+  padding-top: 10px;
 }
 
 .marker-row {
   display: grid;
-  grid-template-columns: 86px 28px minmax(80px, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) 28px auto;
+  grid-template-areas:
+    'time color remove'
+    'name name name';
   gap: 6px;
   align-items: center;
+}
+
+.marker-row [data-marker-seek] {
+  grid-area: time;
+}
+
+.marker-row [data-marker-color] {
+  grid-area: color;
+}
+
+.marker-row [data-marker-name] {
+  grid-area: name;
+  min-width: 0;
+  width: 100%;
+}
+
+.marker-row [data-marker-remove] {
+  grid-area: remove;
 }
 
 .marker-row button {

--- a/product/akbun-makevideo/workspace/test/panel.test.js
+++ b/product/akbun-makevideo/workspace/test/panel.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const P = require('../src/panel.js');
+
+test('clicking the active global action closes the selected panel', () => {
+  assert.equal(P.toggledPanel(null, 'inspector'), 'inspector');
+  assert.equal(P.toggledPanel('inspector', 'inspector'), null);
+  assert.equal(P.toggledPanel('inspector', 'marker'), 'marker');
+});
+
+test('markers are listed in timeline order without mutating the project', () => {
+  const markers = [
+    { id: 'late', frame: 90 },
+    { id: 'early-b', frame: 12 },
+    { id: 'early-a', frame: 12 },
+  ];
+
+  assert.deepEqual(P.orderedMarkers(markers).map((marker) => marker.id), [
+    'early-a', 'early-b', 'late',
+  ]);
+  assert.deepEqual(markers.map((marker) => marker.id), ['late', 'early-b', 'early-a']);
+});
+
+test('inspector tabs wrap in both directions', () => {
+  assert.equal(P.adjacentTab('video', -1), 'file');
+  assert.equal(P.adjacentTab('file', 1), 'video');
+});

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -48,8 +48,14 @@ test('every library the page loads is a script tag on the page', () => {
 
 test('the editor exposes one toggleable selected panel from the title bar', () => {
   const page = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+  const selectedPanel = [...page.matchAll(/<aside\b[^>]*>/g)]
+    .map((match) => match[0])
+    .find((tag) => /\bid="selected-panel"/.test(tag));
 
-  assert.match(page, /<aside id="selected-panel" hidden>/);
+  assert.ok(selectedPanel);
+  assert.match(selectedPanel, /\bhidden\b/);
+  assert.match(page, /id="panel-tab-bar" role="toolbar"/);
+  assert.doesNotMatch(page, /role="tab(?:list|panel)?"/);
   assert.deepStrictEqual(
     [...page.matchAll(/data-panel-action="([^"]+)"/g)].map((match) => match[1]),
     ['inspector', 'shape', 'marker', 'debug'],

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -10,7 +10,7 @@ test('classic page scripts do not leak conflicting declarations', () => {
   const context = vm.createContext({});
   const names = [
     'time.js', 'geometry.js', 'timeline.js', 'shortcuts.js', 'quality.js',
-    'preview.js', 'transform.js', 'guides.js', 'monitor.js',
+    'preview.js', 'transform.js', 'guides.js', 'monitor.js', 'panel.js',
   ];
   for (const name of names) {
     const file = path.join(__dirname, '..', 'src', name);
@@ -24,6 +24,7 @@ test('classic page scripts do not leak conflicting declarations', () => {
   assert.ok(context.qualityLib);
   assert.ok(context.previewLib);
   assert.ok(context.monitorLib);
+  assert.ok(context.panelLib);
 });
 
 // Each of these is loaded with a `<script>` tag and reached through its one
@@ -43,4 +44,19 @@ test('every library the page loads is a script tag on the page', () => {
   assert.ok(loaded.indexOf('geometry.js') < loaded.indexOf('preview.js'));
   assert.ok(loaded.indexOf('geometry.js') < loaded.indexOf('monitor.js'));
   assert.ok(loaded.indexOf('preview.js') < loaded.indexOf('renderer.js'));
+});
+
+test('the editor exposes one toggleable selected panel from the title bar', () => {
+  const page = fs.readFileSync(path.join(__dirname, '..', 'src', 'index.html'), 'utf8');
+
+  assert.match(page, /<aside id="selected-panel" hidden>/);
+  assert.deepStrictEqual(
+    [...page.matchAll(/data-panel-action="([^"]+)"/g)].map((match) => match[1]),
+    ['inspector', 'shape', 'marker', 'debug'],
+  );
+  assert.deepStrictEqual(
+    [...page.matchAll(/data-inspector-tab="([^"]+)"/g)].map((match) => match[1]),
+    ['video', 'audio', 'effects', 'transition', 'image', 'file'],
+  );
+  assert.doesNotMatch(page, /id="project-name"|id="btn-debug"|id="marker-panel"/);
 });


### PR DESCRIPTION
# 구현

Global Action Bar와 기본 닫힘 우측 선택 패널 도입, Shape·Marker·Debug 이동
- Node 테스트 131개 통과, 내장 브라우저에서 280px 패널·6개 탭·토글·DOM·콘솔 확인

# 리스크

Effects, Transition, Image, File 탭은 편집 기능 없이 선택 상태와 안내 정보만 제공
- UI 개선 범위 유지를 위해 기존 Rust 편집 모델 변경 제외

Issue #997
Related #848