### PR TITLE
akbun-makevideo: monitor를 그림으로 가득 채우고 두 monitor의 행 맞추기

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-08-monitor-fills-the-panel.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-monitor-fills-the-panel.md
@@ -1,0 +1,28 @@
+---
+type: Decision
+title: monitor는 패널을 채우고 source monitor는 에셋 비율로 맞춘다
+description: stage 여백을 없애고 source monitor의 fit 기준을 프로젝트에서 에셋으로 바꾸고 두 monitor가 subgrid로 같은 행을 쓰게 한 결정.
+tags: [makevideo, preview, layout, css]
+timestamp: 2026-08-22T00:00:00Z
+---
+
+# monitor는 패널을 채우고 source monitor는 에셋 비율로 맞춘다
+
+## 결정
+
+* `STAGE_PADDING`은 0. monitor의 그림과 패널 사이에 남는 것은 비율이 요구하는 레터박스뿐임
+* source monitor의 stage는 asset 모드에서 프로젝트 해상도가 아니라 선택한 에셋 자신의 해상도로 fit. timeline 모드는 그대로 프로젝트 canvas
+* Source와 Program 두 panel이 `#monitor-workspace`의 행을 `grid-template-rows: subgrid`로 공유하고, Program transport가 chrome 두 행을 차지
+
+## 이유
+
+* 그림이 패널의 90% 근처까지 줄어든 원인이 셋이었음. 14px 여백, 비율 레터박스, 그리고 source monitor에서 프로젝트 비율 stage와 `object-fit: contain`이 겹친 이중 레터박스
+* source monitor가 보여 주는 것은 프로젝트 canvas가 아니라 파일 자신임. 프로젝트 비율로 먼저 줄이면 4:3 클립이 16:9 프로젝트에서 두 번 줄어듦
+* chrome 행 수가 달라(Source 2행, Program 1행) 각 panel이 자기 여유를 따로 계산했고, 그래서 두 그림의 시작과 끝 행이 어긋났음. subgrid는 그 계산이 둘로 갈라지는 구조 자체를 없앰
+* subgrid를 모르는 WebView는 두 선언을 버리고 per-panel 행으로 되돌아감. 예전 레이아웃이지 깨진 레이아웃이 아님
+
+남는 trade off 하나. 에셋 비율이 프로젝트 비율과 다르면 두 monitor의 박스는 같아도 안쪽 레터박스가 달라 그림의 끝 행이 어긋남. [첫 영상이 canvas 비율을 정하는 규칙](./2026-08-first-video-defines-default-canvas-shape.md) 덕에 보통은 같음.
+
+## Citations
+
+1. [preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다](./2026-08-one-geometry-in-points-for-the-monitor.md)

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -12,3 +12,4 @@
 * [경계 stub은 실제 API 이름만 가진다](2026-08-seam-stubs-carry-only-real-api-names.md) - 무엇에나 답하는 Proxy stub이 없는 메서드 호출을 숨긴 뒤 정한 규칙.
 * [preview 배치는 한 곳에서 계산하고 point 단위로 넘긴다](2026-08-one-geometry-in-points-for-the-monitor.md) - devicePixelRatio 왕복과 크기만 보는 ResizeObserver를 없애고 배치 계산을 한 곳에 모은 결정.
 * [CSS viewport 원점은 native bounds origin에서 시작한다](2026-08-css-viewport-starts-at-native-bounds-origin.md) - page 좌표를 native frame으로 옮길 때 NSView bounds origin을 반영하는 결정.
+* [monitor는 패널을 채우고 source monitor는 에셋 비율로 맞춘다](2026-08-monitor-fills-the-panel.md) - stage 여백을 없애고 source monitor의 fit 기준을 에셋으로 바꾸고 두 monitor가 subgrid로 같은 행을 쓰게 한 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-08-22
+
+* [monitor는 패널을 채우고 source monitor는 에셋 비율로 맞춘다](decisions/2026-08-monitor-fills-the-panel.md) 결정 기록. 그림이 패널에 못 미치던 원인을 여백과 이중 레터박스로 좁히고, 두 monitor의 행이 어긋나던 것을 subgrid 공유로 바꿈.
+
 ## 2026-08-19
 
 * [Inspector는 타임라인에서 선택한 미디어 트랙을 따른다](decisions/2026-08-inspector-follows-timeline-media.md) 결정 기록. 연결된 영상과 오디오의 속성 대상과 기본 탭을 타임라인 선택에 맞춤.

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/geometry.js
+++ b/product/akbun-makevideo/workspace/src/geometry.js
@@ -40,7 +40,11 @@
 // falls past it is a stretched picture, which is the other half of the same
 // bug.
 
-const STAGE_PADDING = 14;
+// No inset. A monitor shows the picture as large as the panel allows, so the
+// only thing between the picture and the panel edge is the letterbox the shape
+// itself demands. Kept as a named constant because `stageBoxOf` still takes one
+// and a caller may want an inset that this app does not.
+const STAGE_PADDING = 0;
 
 const DEFAULT_SHAPE = Object.freeze({ width: 1920, height: 1080 });
 

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -92,6 +92,21 @@ function createPreview(options) {
     return T.framesToSeconds(positionFrames, rate());
   }
 
+  /** What the stage is a box for.
+   *
+   *  The timeline is the project canvas, but an asset preview is the file
+   *  itself, and fitting the file into a project-shaped stage fitted it twice —
+   *  a 4:3 clip in a 16:9 project got the bars the stage already had plus the
+   *  ones `object-fit: contain` then added, and the picture came out well short
+   *  of the panel. `stageBoxOf` only reads `settings.width` and `height`, so
+   *  the asset's own shape is handed over in that shape. */
+  function stageShape() {
+    if (mode === 'asset' && assetShown && assetShown.width > 0 && assetShown.height > 0) {
+      return { settings: { width: assetShown.width, height: assetShown.height } };
+    }
+    return getProject();
+  }
+
   /** Size the stage to the fitted box, then lay the media out at the quality
    *  scale and scale it back up so it still fills that box.
    *
@@ -107,7 +122,7 @@ function createPreview(options) {
    *  width. */
   function layout() {
     if (!wrap) return;
-    const box = GEO.stageBoxOf(wrap.getBoundingClientRect(), getProject());
+    const box = GEO.stageBoxOf(wrap.getBoundingClientRect(), stageShape());
     stage.style.width = `${box.width}px`;
     stage.style.height = `${box.height}px`;
     if (!GEO.isDrawable(box)) {
@@ -442,6 +457,7 @@ function createPreview(options) {
     assetShown = asset || null;
     if (!asset) {
       assetElement = null;
+      layout();
       return;
     }
     const made = makeElement(asset, asset.kind !== 'audio');
@@ -451,6 +467,7 @@ function createPreview(options) {
     assetElement.style.zIndex = '50';
     inner.appendChild(assetElement);
     positionFrames = 0;
+    layout();
   }
 
   function showTimeline() {
@@ -465,6 +482,7 @@ function createPreview(options) {
     }
     assetShown = null;
     positionFrames = 0;
+    layout();
   }
 
   /** Show one frame drawn by the Rust compositor — the same shader, the same

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -99,12 +99,23 @@ function createPreview(options) {
    *  a 4:3 clip in a 16:9 project got the bars the stage already had plus the
    *  ones `object-fit: contain` then added, and the picture came out well short
    *  of the panel. `stageBoxOf` only reads `settings.width` and `height`, so
-   *  the asset's own shape is handed over in that shape. */
+   *  the asset's own shape is handed over in that shape.
+   *
+   *  The shape is read off the project's copy of the asset rather than the one
+   *  handed to `showAsset`. A file ffprobe could not measure gets its size from
+   *  the browser afterwards, and that arrives as a *new* project — the object
+   *  this module was given still says zero, and a layout that trusted it would
+   *  keep the project's shape for as long as the asset stayed selected. */
   function stageShape() {
-    if (mode === 'asset' && assetShown && assetShown.width > 0 && assetShown.height > 0) {
-      return { settings: { width: assetShown.width, height: assetShown.height } };
+    const project = getProject();
+    const assets = project && project.assets;
+    const shown = Array.isArray(assets) && assetShown
+      ? assets.find((asset) => asset.id === assetShown.id) || assetShown
+      : assetShown;
+    if (mode === 'asset' && shown && shown.width > 0 && shown.height > 0) {
+      return { settings: { width: shown.width, height: shown.height } };
     }
-    return getProject();
+    return project;
   }
 
   /** Size the stage to the fitted box, then lay the media out at the quality

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -503,8 +503,9 @@ select {
    Monitor's one — so the two pictures started and ended on different lines.
    Sharing the parent's rows makes the header row, the stage row and the chrome
    rows one height each, which is what puts the two pictures on the same line.
-   A WebView without subgrid drops these two declarations and falls back to the
-   per-panel rows above, which is the old layout rather than a broken one. */
+   A WebView without subgrid drops only the subgrid declaration — `grid-row`
+   still applies — and each panel keeps the rows it declares above, which is the
+   old layout rather than a broken one. */
 #source-panel,
 #preview-panel {
   grid-row: 1 / -1;

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -473,6 +473,7 @@ select {
 
 #preview-panel {
   display: grid;
+  grid-column: 2;
   grid-template-rows: auto minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
@@ -482,16 +483,38 @@ select {
 #monitor-workspace {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
   min-width: 0;
   min-height: 0;
 }
 
 #source-panel {
   display: grid;
+  grid-column: 1;
   grid-template-rows: auto minmax(0, 1fr) auto auto;
   min-width: 0;
   min-height: 0;
   border-right: 1px solid var(--border);
+}
+
+/* Both monitors on the same rows.
+   Left to themselves the two panels each fit a picture into whatever their own
+   chrome left over, and the Source Monitor's chrome is two rows to the Program
+   Monitor's one — so the two pictures started and ended on different lines.
+   Sharing the parent's rows makes the header row, the stage row and the chrome
+   rows one height each, which is what puts the two pictures on the same line.
+   A WebView without subgrid drops these two declarations and falls back to the
+   per-panel rows above, which is the old layout rather than a broken one. */
+#source-panel,
+#preview-panel {
+  grid-row: 1 / -1;
+  grid-template-rows: subgrid;
+}
+
+/* The Program Monitor has nothing to put in the fourth row, so its transport
+   takes both and centres itself in them rather than leaving a blank strip. */
+#transport {
+  grid-row: 3 / 5;
 }
 
 .monitor-stage-wrap {

--- a/product/akbun-makevideo/workspace/test/geometry.test.js
+++ b/product/akbun-makevideo/workspace/test/geometry.test.js
@@ -54,10 +54,19 @@ test('the panel offset is carried through, because the answer is placed as it is
 // stacking order, so the panel's `overflow: hidden` does not clip it — what
 // hangs over the edge is drawn over the timeline.
 test('a panel with no room in it has no box, rather than a small one', () => {
-  for (const [width, height] of [[0, 600], [800, 0], [-100, 600], [2, 2]]) {
+  for (const [width, height] of [[0, 600], [800, 0], [-100, 600]]) {
     const box = G.stageBoxOf({ left: 0, top: 0, width, height }, HD);
     assert.ok(!G.isDrawable(box), `${width}x${height}`);
   }
+  // Padded past its own size is the same nothing: the room, not the panel, is
+  // what a box is fitted into.
+  assert.ok(!G.isDrawable(G.stageBoxOf({ left: 0, top: 0, width: 20, height: 20 }, HD, 10)));
+});
+
+test('the box fills the panel, because a monitor is not a picture with a margin', () => {
+  const box = G.stageBoxOf({ left: 0, top: 0, width: 800, height: 600 }, HD);
+  assert.strictEqual(box.left, 0);
+  assert.strictEqual(box.width, 800);
 });
 
 test('a box never reaches past the panel it was fitted into', () => {

--- a/product/akbun-makevideo/workspace/test/preview.test.js
+++ b/product/akbun-makevideo/workspace/test/preview.test.js
@@ -178,3 +178,51 @@ test('pre-roll waits for media and followers correct drift without seeking', asy
   assert.strictEqual(reference.currentTime, 0.5);
   assert.strictEqual(follower.currentTime, 0.5);
 });
+
+test('an asset measured after it was shown still gets its own shape', async (context) => {
+  // ffprobe cannot always report a file's size, and what the browser measures
+  // afterwards arrives as a new project rather than as a change to the object
+  // the preview was handed. Reading the shape off the stale object left the
+  // Source Monitor on the project's shape for as long as the asset stayed
+  // selected, which is the double letterbox this fit exists to remove.
+  const original = {
+    document: global.document,
+    window: global.window,
+    timelineLib: global.timelineLib,
+    requestAnimationFrame: global.requestAnimationFrame,
+  };
+  context.after(() => Object.assign(global, original));
+
+  global.requestAnimationFrame = () => 0;
+  global.document = { createElement: (tagName) => fakeMedia(tagName.toUpperCase(), () => Promise.resolve()) };
+  global.window = { api: { fileUrl: (path) => path } };
+  global.timelineLib = { tracksOf: () => [], clipsAt: () => [], projectDurationFrames: () => 0 };
+
+  const unmeasured = { id: 'a', kind: 'video', path: '/a.mp4', width: 0, height: 0 };
+  const settings = { width: 1920, height: 1080, rate: T.fps(30) };
+  let project = { settings, tracks: [], assets: [unmeasured] };
+  const stage = { style: {} };
+  const preview = require('../src/preview.js').createPreview({
+    stage,
+    inner: { style: {}, appendChild() {} },
+    wrap: { getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }) },
+    exactCanvas: null,
+    getProject: () => project,
+    onTick: () => {},
+  });
+
+  preview.showAsset(unmeasured);
+  assert.strictEqual(stage.style.width, '800px', 'an unmeasured asset falls back to the project');
+  assert.strictEqual(stage.style.height, '450px');
+
+  // The measurement lands as a whole new project, exactly as describe_asset
+  // returns it. The asset object the preview holds is not touched.
+  project = {
+    settings,
+    tracks: [],
+    assets: [{ ...unmeasured, width: 1080, height: 1080 }],
+  };
+  preview.layout();
+  assert.strictEqual(stage.style.width, '600px', 'the square asset fills the height');
+  assert.strictEqual(stage.style.height, '600px');
+});


### PR DESCRIPTION
# 구현

stage 여백 0, Source Monitor는 에셋 해상도로 fit, 두 monitor panel이 subgrid로 행 공유
- geometry 단위 테스트 추가 포함 132개 통과

# 어려웠던 점

브라우저 프리뷰가 로컬 HTML을 정적 스냅샷으로만 열어 DOM 측정이 막힘
- 실행한 앱 화면으로만 확인했고 박스 수치 계측은 못 함

# 리스크

에셋 비율이 프로젝트 비율과 다르면 두 박스는 같아도 안쪽 레터박스가 달라 그림의 끝 행이 어긋남
- subgrid 미지원 WebView는 두 선언을 버리고 이전 per-panel 행으로 되돌아감

Issue #1036