### PR TITLE
fix: macOS 테스트 전 스캐너 빌드

### DIFF
--- a/.github/workflows/release-akbun-macdiskviewer.yml
+++ b/.github/workflows/release-akbun-macdiskviewer.yml
@@ -51,6 +51,34 @@ jobs:
       - name: Run tests
         run: npm test
 
+  verify-macos:
+    if: github.event_name == 'pull_request'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            product/akbun-macdiskviewer/workspace/scanner -> target
+            product/akbun-macdiskviewer/workspace/src-tauri -> target
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: product/akbun-macdiskviewer/workspace/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run macOS tests
+        run: npm run test:mac
+
   release:
     if: github.event_name != 'pull_request'
     runs-on: macos-latest
@@ -86,7 +114,7 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test
+        run: npm run test:mac
 
       - name: Build dmg
         run: npm run dist

--- a/product/akbun-macdiskviewer/workspace/package.json
+++ b/product/akbun-macdiskviewer/workspace/package.json
@@ -10,6 +10,7 @@
     "start": "tauri dev",
     "dev": "tauri dev",
     "test": "npm run test:js && npm run test:rust",
+    "test:mac": "npm run build:scanner:mac && npm test",
     "test:js": "node --test test/*.test.js",
     "test:rust": "cargo test --manifest-path scanner/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml",
     "check:rust": "cargo clippy --all-targets --manifest-path scanner/Cargo.toml -- -D warnings && cargo clippy --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings",

--- a/product/akbun-macdiskviewer/workspace/test/view-model.test.js
+++ b/product/akbun-macdiskviewer/workspace/test/view-model.test.js
@@ -57,12 +57,14 @@ test('macOS scanner resource stays out of the cross-platform Tauri config', () =
 
 test('macOS release tests build the bundled scanner first', () => {
   const workspaceDirectory = path.join(__dirname, '..');
-  const packageConfig = JSON.parse(fs.readFileSync(path.join(workspaceDirectory, 'package.json')));
+  const packageConfig = JSON.parse(fs.readFileSync(path.join(workspaceDirectory, 'package.json'), 'utf8'));
   const workflowPath = path.join(workspaceDirectory, '..', '..', '..', '.github', 'workflows',
     'release-akbun-macdiskviewer.yml');
   const workflow = fs.readFileSync(workflowPath, 'utf8');
+  const verifyMac = workflow.slice(workflow.indexOf('\n  verify-macos:\n'), workflow.indexOf('\n  release:\n'));
+  const release = workflow.slice(workflow.indexOf('\n  release:\n'));
 
   assert.equal(packageConfig.scripts['test:mac'], 'npm run build:scanner:mac && npm test');
-  assert.match(workflow, /\n  verify-macos:\n/);
-  assert.equal(workflow.match(/run: npm run test:mac/g)?.length, 2);
+  assert.match(verifyMac, /run: npm run test:mac/);
+  assert.match(release, /run: npm run test:mac/);
 });

--- a/product/akbun-macdiskviewer/workspace/test/view-model.test.js
+++ b/product/akbun-macdiskviewer/workspace/test/view-model.test.js
@@ -54,3 +54,15 @@ test('macOS scanner resource stays out of the cross-platform Tauri config', () =
   assert.equal(macConfig.bundle.resources[scannerPath], 'bin/akbun-macdiskviewer-scanner');
   assert.deepEqual(macConfig.bundle.targets, ['dmg']);
 });
+
+test('macOS release tests build the bundled scanner first', () => {
+  const workspaceDirectory = path.join(__dirname, '..');
+  const packageConfig = JSON.parse(fs.readFileSync(path.join(workspaceDirectory, 'package.json')));
+  const workflowPath = path.join(workspaceDirectory, '..', '..', '..', '.github', 'workflows',
+    'release-akbun-macdiskviewer.yml');
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+
+  assert.equal(packageConfig.scripts['test:mac'], 'npm run build:scanner:mac && npm test');
+  assert.match(workflow, /\n  verify-macos:\n/);
+  assert.equal(workflow.match(/run: npm run test:mac/g)?.length, 2);
+});


### PR DESCRIPTION
# 구현

macOS 테스트 전에 bundled arm64 스캐너 빌드
- PR용 macOS 검증 job 추가, JavaScript 회귀 테스트 6개 통과

# 어려웠던 점

Linux PR 검증에서는 macOS 전용 resource 설정이 병합되지 않음
- master release job에서만 누락된 scanner resource 경로가 검증됨

# 리스크

PR마다 macOS 검증 job 실행으로 CI 시간 증가
- 병합 후 release 실패를 사전에 차단하기 위한 비용

Issue #1039