### PR TITLE
feat: akbun-gitdesktop worktree 삭제와 앱 메뉴 개선

### DIFF
--- a/product/akbun-gitdesktop/knowledge/decisions/2026-08-gui-app-resolves-cli-paths.md
+++ b/product/akbun-gitdesktop/knowledge/decisions/2026-08-gui-app-resolves-cli-paths.md
@@ -1,0 +1,23 @@
+---
+type: Decision
+title: GUI 앱은 CLI의 알려진 설치 경로를 직접 탐색
+description: Electron 프로세스의 PATH 밖에 설치된 git과 gh를 절대 경로로 찾아 실행한다.
+tags: [electron, cli, macos, github]
+timestamp: 2026-08-23T00:00:00Z
+---
+
+# GUI 앱은 CLI의 알려진 설치 경로를 직접 탐색
+
+## 결정
+
+git과 gh 실행 전에 현재 PATH와 알려진 설치 경로에서 실행 파일을 찾는다.
+
+* Homebrew 기본 경로인 /opt/homebrew/bin과 /usr/local/bin 포함
+* 사용자 도구 경로인 .local/bin, mise, asdf, Nix 경로 포함
+* 탐색에 성공하면 명령 이름이 아니라 절대 경로로 실행
+
+## 이유
+
+Finder에서 실행한 macOS GUI 앱은 터미널의 shell 초기화 파일을 읽지 않는다. 터미널에서는 gh가 동작해도 Electron 프로세스의 PATH에는 Homebrew 경로가 없어 설치되지 않은 것으로 오판할 수 있다.
+
+shell을 띄워 초기화 파일을 실행하면 사용자 설정에 따라 출력과 지연이 달라진다. 알려진 경로를 직접 검사하면 shell 설정에 의존하지 않고 git 실행과 상태 점검이 같은 경로를 사용한다.

--- a/product/akbun-gitdesktop/knowledge/index.md
+++ b/product/akbun-gitdesktop/knowledge/index.md
@@ -1,0 +1,9 @@
+---
+okf_version: "0.1"
+---
+
+# akbun-gitdesktop Knowledge
+
+## Decisions
+
+* [GUI 앱은 CLI의 알려진 설치 경로를 직접 탐색](decisions/2026-08-gui-app-resolves-cli-paths.md)

--- a/product/akbun-gitdesktop/knowledge/log.md
+++ b/product/akbun-gitdesktop/knowledge/log.md
@@ -1,0 +1,5 @@
+# Knowledge Update Log
+
+## 2026-08-23
+
+* **Creation**: [GUI 앱은 CLI의 알려진 설치 경로를 직접 탐색](decisions/2026-08-gui-app-resolves-cli-paths.md) 결정 기록. Finder에서 실행한 Electron 앱의 축소된 PATH에서도 Homebrew의 gh를 찾도록 한 판단을 남김.

--- a/product/akbun-gitdesktop/package-lock.json
+++ b/product/akbun-gitdesktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-gitdesktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-gitdesktop",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.8",

--- a/product/akbun-gitdesktop/package.json
+++ b/product/akbun-gitdesktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-gitdesktop",
   "productName": "akbun-gitdesktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Git graph desktop viewer for local repositories and worktrees",
   "main": "out/main/index.js",
   "author": "akbun",

--- a/product/akbun-gitdesktop/src/main/cli.ts
+++ b/product/akbun-gitdesktop/src/main/cli.ts
@@ -1,0 +1,66 @@
+import { execFile } from 'node:child_process'
+import { constants } from 'node:fs'
+import { access } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+const EXTRA_PATHS = [
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+  '/run/current-system/sw/bin'
+]
+
+export function commandPaths(command: string): string[] {
+  if (!/^[a-zA-Z0-9_-]+$/.test(command)) throw new Error(`Invalid CLI command: ${command}`)
+  if (process.platform === 'win32') return [command]
+
+  const homePaths = [
+    path.join(os.homedir(), 'bin'),
+    path.join(os.homedir(), '.local/bin'),
+    path.join(os.homedir(), '.nix-profile/bin'),
+    path.join(os.homedir(), '.asdf/shims'),
+    path.join(os.homedir(), '.local/share/mise/shims')
+  ]
+  const envPaths = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean)
+  return [...new Set([...envPaths, ...EXTRA_PATHS, ...homePaths])].map((dir) => path.join(dir, command))
+}
+
+export async function resolveCli(command: string): Promise<string> {
+  for (const candidate of commandPaths(command)) {
+    if (process.platform === 'win32') return candidate
+    try {
+      await access(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      continue
+    }
+  }
+  return command
+}
+
+export async function runCli(cwd: string | undefined, command: string, args: string[]): Promise<string> {
+  const executable = await resolveCli(command)
+  return new Promise((resolve, reject) => {
+    execFile(executable, args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(stderr.trim() || error.message))
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+export async function probeCli(
+  command: string,
+  args: string[]
+): Promise<{ ok: boolean; output: string; path: string }> {
+  const executable = await resolveCli(command)
+  return new Promise((resolve) => {
+    execFile(executable, args, (error, stdout, stderr) => {
+      resolve({ ok: !error, output: `${stdout}${stderr}`.trim(), path: error ? '' : executable })
+    })
+  })
+}

--- a/product/akbun-gitdesktop/src/main/git.ts
+++ b/product/akbun-gitdesktop/src/main/git.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process'
 import type {
   BranchInfo,
   CliStatus,
@@ -7,62 +6,42 @@ import type {
   FileChange,
   WorktreeInfo
 } from '../shared/types'
+import { probeCli, runCli } from './cli'
 
 const FIELD_SEP = '\x1f'
 const MAX_LOG_COUNT = 500
 const DEFAULT_BRANCH_CANDIDATES = ['main', 'master', 'develop']
 
 export function runGit(cwd: string, args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile('git', args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error(stderr.trim() || error.message))
-        return
-      }
-      resolve(stdout)
-    })
-  })
-}
-
-/** Runs a command anywhere and reports whether it succeeded, instead of throwing. */
-function probe(command: string, args: string[]): Promise<{ ok: boolean; output: string }> {
-  return new Promise((resolve) => {
-    execFile(command, args, (error, stdout, stderr) => {
-      resolve({ ok: !error, output: `${stdout}${stderr}`.trim() })
-    })
-  })
-}
-
-async function locate(command: string): Promise<string> {
-  const finder = process.platform === 'win32' ? 'where' : 'which'
-  const result = await probe(finder, [command])
-  return result.ok ? result.output.split('\n')[0].trim() : ''
+  return runCli(cwd, 'git', args)
 }
 
 async function inspectGit(): Promise<CliToolStatus> {
-  const version = await probe('git', ['--version'])
+  const version = await probeCli('git', ['--version'])
   return {
     id: 'git',
     label: 'git CLI',
     required: true,
     available: version.ok,
     version: version.ok ? version.output.split('\n')[0] : '',
-    path: version.ok ? await locate('git') : '',
+    path: version.path,
     authStatus: '',
     authenticated: false
   }
 }
 
 async function inspectGh(): Promise<CliToolStatus> {
-  const version = await probe('gh', ['--version'])
-  const auth = version.ok ? await probe('gh', ['auth', 'status']) : { ok: false, output: '' }
+  const version = await probeCli('gh', ['--version'])
+  const auth = version.ok
+    ? await probeCli('gh', ['auth', 'status'])
+    : { ok: false, output: '', path: '' }
   return {
     id: 'gh',
     label: 'gh CLI',
     required: false,
     available: version.ok,
     version: version.ok ? version.output.split('\n')[0] : '',
-    path: version.ok ? await locate('gh') : '',
+    path: version.path,
     authStatus: auth.output,
     authenticated: auth.ok
   }
@@ -219,7 +198,7 @@ export async function getDefaultBranch(repoPath: string): Promise<string> {
       { ref: `refs/remotes/origin/${candidate}`, name: `origin/${candidate}` }
     ]
     for (const { ref, name } of refs) {
-      const found = await probe('git', ['-C', repoPath, 'rev-parse', '--verify', '--quiet', ref])
+      const found = await probeCli('git', ['-C', repoPath, 'rev-parse', '--verify', '--quiet', ref])
       if (found.ok) return name
     }
   }

--- a/product/akbun-gitdesktop/src/main/github.ts
+++ b/product/akbun-gitdesktop/src/main/github.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process'
 import type {
   IssueInfo,
   ProjectBoard,
@@ -10,6 +9,7 @@ import type {
   ThreadComment,
   ThreadDetail
 } from '../shared/types'
+import { runCli } from './cli'
 
 const LIST_LIMIT = 50
 /** Wider than the issue list so every listed issue has its parent looked up. */
@@ -27,15 +27,7 @@ const ISSUE_DETAIL_FIELDS =
   'number,title,state,author,url,createdAt,updatedAt,labels,assignees,body,comments'
 
 function runGh(cwd: string, args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile('gh', args, { cwd, maxBuffer: 32 * 1024 * 1024 }, (error, stdout, stderr) => {
-      if (error) {
-        reject(new Error(stderr.trim() || error.message))
-        return
-      }
-      resolve(stdout)
-    })
-  })
+  return runCli(cwd, 'gh', args)
 }
 
 interface GhActor {

--- a/product/akbun-gitdesktop/src/main/index.ts
+++ b/product/akbun-gitdesktop/src/main/index.ts
@@ -7,7 +7,7 @@ import * as git from './git'
 import * as github from './github'
 import { openInApp, listOpenerApps } from './openWith'
 import { addRepo, loadRepos, removeRepo } from './repoStore'
-import { loadSettings, saveTheme } from './settingsStore'
+import { loadSettings, saveForceRemoveWorktree, saveTheme } from './settingsStore'
 import { checkUpdate, cleanupTempDirs, downloadDmg, spawnSwap } from './update'
 
 function createWindow(): void {
@@ -53,6 +53,9 @@ function registerIpcHandlers(): void {
       return settings
     })
   )
+  ipcMain.handle('settings:setForceRemoveWorktree', (_event, enabled: boolean) =>
+    wrap(() => saveForceRemoveWorktree(enabled))
+  )
 
   ipcMain.handle('repos:import', () =>
     wrap(async () => {
@@ -87,8 +90,25 @@ function registerIpcHandlers(): void {
     (_event, repoPath: string, worktreePath: string, branch: string, createNewBranch: boolean) =>
       wrap(() => git.createWorktree(repoPath, worktreePath, branch, createNewBranch))
   )
-  ipcMain.handle('git:removeWorktree', (_event, repoPath: string, worktreePath: string, force: boolean) =>
-    wrap(() => git.removeWorktree(repoPath, worktreePath, force))
+  ipcMain.handle('git:removeWorktree', (_event, repoPath: string, worktreePath: string) =>
+    wrap(async () => {
+      const settings = await loadSettings()
+      const force = settings.forceRemoveWorktree
+      const answer = await dialog.showMessageBox({
+        type: force ? 'warning' : 'question',
+        message: force ? 'Force remove this worktree?' : 'Remove this worktree?',
+        detail: force
+          ? `${worktreePath}\n\nUncommitted and untracked changes in this worktree can be discarded.`
+          : worktreePath,
+        buttons: [force ? 'Force remove' : 'Remove', 'Cancel'],
+        defaultId: 1,
+        cancelId: 1,
+        noLink: true
+      })
+      if (answer.response !== 0) return false
+      await git.removeWorktree(repoPath, worktreePath, force)
+      return true
+    })
   )
 
   ipcMain.handle('git:commitFiles', (_event, repoPath: string, hash: string) =>
@@ -133,6 +153,7 @@ function registerIpcHandlers(): void {
       return result.canceled || result.filePaths.length === 0 ? '' : result.filePaths[0]
     })
   )
+  ipcMain.handle('update:check', () => runUpdateCheck())
 }
 
 /** 실행 중인 .app 번들 경로. exe는 <앱>.app/Contents/MacOS/<실행파일>이다. */

--- a/product/akbun-gitdesktop/src/main/settingsStore.ts
+++ b/product/akbun-gitdesktop/src/main/settingsStore.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type { AppSettings, ThemePreference } from '../shared/types'
 
-const DEFAULT_SETTINGS: AppSettings = { theme: 'system' }
+const DEFAULT_SETTINGS: AppSettings = { theme: 'system', forceRemoveWorktree: false }
 const THEMES: ThemePreference[] = ['system', 'light', 'dark']
 
 function settingsFilePath(): string {
@@ -17,14 +17,23 @@ export async function loadSettings(): Promise<AppSettings> {
     const theme = THEMES.includes(parsed.theme as ThemePreference)
       ? (parsed.theme as ThemePreference)
       : DEFAULT_SETTINGS.theme
-    return { theme }
+    return { theme, forceRemoveWorktree: parsed.forceRemoveWorktree === true }
   } catch {
     return { ...DEFAULT_SETTINGS }
   }
 }
 
 export async function saveTheme(theme: ThemePreference): Promise<AppSettings> {
-  const settings: AppSettings = { theme: THEMES.includes(theme) ? theme : 'system' }
+  const current = await loadSettings()
+  const settings: AppSettings = { ...current, theme: THEMES.includes(theme) ? theme : 'system' }
+  await fs.mkdir(path.dirname(settingsFilePath()), { recursive: true })
+  await fs.writeFile(settingsFilePath(), JSON.stringify(settings, null, 2), 'utf-8')
+  return settings
+}
+
+export async function saveForceRemoveWorktree(forceRemoveWorktree: boolean): Promise<AppSettings> {
+  const current = await loadSettings()
+  const settings: AppSettings = { ...current, forceRemoveWorktree: forceRemoveWorktree === true }
   await fs.mkdir(path.dirname(settingsFilePath()), { recursive: true })
   await fs.writeFile(settingsFilePath(), JSON.stringify(settings, null, 2), 'utf-8')
   return settings

--- a/product/akbun-gitdesktop/src/preload/index.d.ts
+++ b/product/akbun-gitdesktop/src/preload/index.d.ts
@@ -20,6 +20,8 @@ export interface GitDesktopApi {
   checkCliTools: () => Promise<GitResult<CliStatus>>
   getSettings: () => Promise<GitResult<AppSettings>>
   setTheme: (theme: ThemePreference) => Promise<GitResult<AppSettings>>
+  setForceRemoveWorktree: (enabled: boolean) => Promise<GitResult<AppSettings>>
+  checkForUpdates: () => Promise<void>
 
   listRepos: () => Promise<GitResult<RepoEntry[]>>
   importRepo: () => Promise<GitResult<RepoEntry[]>>
@@ -38,7 +40,7 @@ export interface GitDesktopApi {
     branch: string,
     createNewBranch: boolean
   ) => Promise<GitResult<void>>
-  removeWorktree: (repoPath: string, worktreePath: string, force: boolean) => Promise<GitResult<void>>
+  removeWorktree: (repoPath: string, worktreePath: string) => Promise<GitResult<boolean>>
 
   getCommitFiles: (repoPath: string, hash: string) => Promise<GitResult<FileChange[]>>
   getCommitDiff: (repoPath: string, hash: string, filePath: string) => Promise<GitResult<string>>

--- a/product/akbun-gitdesktop/src/preload/index.ts
+++ b/product/akbun-gitdesktop/src/preload/index.ts
@@ -5,6 +5,9 @@ const api = {
   checkCliTools: () => ipcRenderer.invoke('tools:check'),
   getSettings: () => ipcRenderer.invoke('settings:get'),
   setTheme: (theme: ThemePreference) => ipcRenderer.invoke('settings:setTheme', theme),
+  setForceRemoveWorktree: (enabled: boolean) =>
+    ipcRenderer.invoke('settings:setForceRemoveWorktree', enabled),
+  checkForUpdates: () => ipcRenderer.invoke('update:check'),
 
   listRepos: () => ipcRenderer.invoke('repos:list'),
   importRepo: () => ipcRenderer.invoke('repos:import'),
@@ -21,8 +24,8 @@ const api = {
     ipcRenderer.invoke('git:deleteBranch', repoPath, name, force),
   createWorktree: (repoPath: string, worktreePath: string, branch: string, createNewBranch: boolean) =>
     ipcRenderer.invoke('git:createWorktree', repoPath, worktreePath, branch, createNewBranch),
-  removeWorktree: (repoPath: string, worktreePath: string, force: boolean) =>
-    ipcRenderer.invoke('git:removeWorktree', repoPath, worktreePath, force),
+  removeWorktree: (repoPath: string, worktreePath: string) =>
+    ipcRenderer.invoke('git:removeWorktree', repoPath, worktreePath),
 
   getCommitFiles: (repoPath: string, hash: string) => ipcRenderer.invoke('git:commitFiles', repoPath, hash),
   getCommitDiff: (repoPath: string, hash: string, filePath: string) =>

--- a/product/akbun-gitdesktop/src/renderer/src/App.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/App.tsx
@@ -38,6 +38,7 @@ export default function App(): JSX.Element {
   const [tab, setTab] = useState<Tab>('graph')
   const [error, setError] = useState<string>('')
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [forceRemoveWorktree, setForceRemoveWorktree] = useState(false)
   const [defaultBranch, setDefaultBranch] = useState('HEAD')
   const [diffSource, setDiffSource] = useState<DiffSource | null>(null)
   const [thread, setThread] = useState<ThreadRef | null>(null)
@@ -53,6 +54,19 @@ export default function App(): JSX.Element {
     window.gitdesktop.listOpenerApps().then((result) => {
       if (result.ok) setOpenerApps(result.data)
     })
+    window.gitdesktop.getSettings().then((result) => {
+      if (result.ok) setForceRemoveWorktree(result.data.forceRemoveWorktree)
+    })
+  }, [])
+
+  const changeForceRemoveWorktree = useCallback(async (enabled: boolean) => {
+    const result = await window.gitdesktop.setForceRemoveWorktree(enabled)
+    if (result.ok) {
+      setForceRemoveWorktree(result.data.forceRemoveWorktree)
+      setError('')
+    } else {
+      setError(result.error)
+    }
   }, [])
 
   const refreshWorktrees = useCallback(async (repo: RepoEntry) => {
@@ -170,7 +184,13 @@ export default function App(): JSX.Element {
 
   return (
     <div className="app-shell">
-      <TopBar status={cli.status} onOpenSettings={() => setSettingsOpen(true)} />
+      <TopBar
+        status={cli.status}
+        onImportRepo={importRepo}
+        onOpenSettings={() => setSettingsOpen(true)}
+        onRecheckCli={cli.recheck}
+        onCheckForUpdates={() => window.gitdesktop.checkForUpdates()}
+      />
       <div className="app">
         <RepoSidebar
           repos={repos}
@@ -264,6 +284,8 @@ export default function App(): JSX.Element {
           theme={theme.preference}
           resolvedTheme={theme.resolved}
           onThemeChange={theme.setPreference}
+          forceRemoveWorktree={forceRemoveWorktree}
+          onForceRemoveWorktreeChange={changeForceRemoveWorktree}
           status={cli.status}
           checking={cli.checking}
           onRecheck={cli.recheck}

--- a/product/akbun-gitdesktop/src/renderer/src/components/SettingsDialog.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/SettingsDialog.tsx
@@ -6,6 +6,8 @@ interface Props {
   theme: ThemePreference
   resolvedTheme: ResolvedTheme
   onThemeChange: (theme: ThemePreference) => void
+  forceRemoveWorktree: boolean
+  onForceRemoveWorktreeChange: (enabled: boolean) => void
   status: CliStatus | null
   checking: boolean
   onRecheck: () => void
@@ -67,6 +69,8 @@ export default function SettingsDialog({
   theme,
   resolvedTheme,
   onThemeChange,
+  forceRemoveWorktree,
+  onForceRemoveWorktreeChange,
   status,
   checking,
   onRecheck,
@@ -106,6 +110,21 @@ export default function SettingsDialog({
               ? `Following the system setting, currently ${resolvedTheme}.`
               : `Always ${theme}, ignoring the system setting.`}
           </p>
+        </section>
+
+        <section className="modal-section">
+          <h3>Worktrees</h3>
+          <label className="setting-toggle">
+            <input
+              type="checkbox"
+              checked={forceRemoveWorktree}
+              onChange={(event) => onForceRemoveWorktreeChange(event.target.checked)}
+            />
+            <span>
+              <strong>Force worktree removal</strong>
+              <small>Use git worktree remove --force. A warning dialog is always shown first.</small>
+            </span>
+          </label>
         </section>
 
         <section className="modal-section">

--- a/product/akbun-gitdesktop/src/renderer/src/components/TopBar.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/TopBar.tsx
@@ -86,8 +86,8 @@ export default function TopBar({
               Repository
             </button>
             {openMenu === 'repository' && (
-              <div className="menu-list" role="menu">
-                <button role="menuitem" onClick={() => run(onImportRepo)}>
+              <div className="menu-list">
+                <button onClick={() => run(onImportRepo)}>
                   Import Repository…
                 </button>
               </div>
@@ -102,15 +102,15 @@ export default function TopBar({
               Settings
             </button>
             {openMenu === 'settings' && (
-              <div className="menu-list" role="menu">
-                <button role="menuitem" onClick={() => run(onOpenSettings)}>
+              <div className="menu-list">
+                <button onClick={() => run(onOpenSettings)}>
                   Preferences…
                 </button>
-                <button role="menuitem" onClick={() => run(onRecheckCli)}>
+                <button onClick={() => run(onRecheckCli)}>
                   Recheck Command Line Tools
                 </button>
-                <div className="menu-separator" role="separator" />
-                <button role="menuitem" onClick={() => run(onCheckForUpdates)}>
+                <div className="menu-separator" />
+                <button onClick={() => run(onCheckForUpdates)}>
                   Check for Updates…
                 </button>
               </div>

--- a/product/akbun-gitdesktop/src/renderer/src/components/TopBar.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/TopBar.tsx
@@ -1,12 +1,16 @@
-import type { JSX } from 'react'
+import { useEffect, useRef, useState, type JSX } from 'react'
 import type { CliStatus, CliToolStatus } from '../../../shared/types'
 
 interface Props {
   status: CliStatus | null
+  onImportRepo: () => void
   onOpenSettings: () => void
+  onRecheckCli: () => void
+  onCheckForUpdates: () => void
 }
 
-/** Chip class for one tool: missing, degraded (gh without login) or ready. */
+type MenuName = 'repository' | 'settings'
+
 function chipClass(tool: CliToolStatus): string {
   if (!tool.available) return 'tool-chip tool-chip-missing'
   if (tool.id === 'gh' && !tool.authenticated) return 'tool-chip tool-chip-warn'
@@ -32,18 +36,88 @@ function noticeFor(status: CliStatus): string {
   return ''
 }
 
-/**
- * Fixed top bar. It shows how the app depends on the two CLIs it shells out to,
- * git for everything and gh for the GitHub tabs, and opens the settings dialog.
- */
-export default function TopBar({ status, onOpenSettings }: Props): JSX.Element {
+export default function TopBar({
+  status,
+  onImportRepo,
+  onOpenSettings,
+  onRecheckCli,
+  onCheckForUpdates
+}: Props): JSX.Element {
+  const [openMenu, setOpenMenu] = useState<MenuName | null>(null)
+  const menuRef = useRef<HTMLElement>(null)
   const notice = status ? noticeFor(status) : ''
   const blocking = status ? !status.git.available : false
+
+  useEffect(() => {
+    const closeOutside = (event: PointerEvent): void => {
+      if (!menuRef.current?.contains(event.target as Node)) setOpenMenu(null)
+    }
+    const closeOnEscape = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') setOpenMenu(null)
+    }
+    document.addEventListener('pointerdown', closeOutside)
+    document.addEventListener('keydown', closeOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', closeOutside)
+      document.removeEventListener('keydown', closeOnEscape)
+    }
+  }, [])
+
+  const toggleMenu = (menu: MenuName): void => {
+    setOpenMenu((current) => (current === menu ? null : menu))
+  }
+
+  const run = (action: () => void): void => {
+    setOpenMenu(null)
+    action()
+  }
 
   return (
     <>
       <header className="top-bar">
         <span className="top-bar-title">akbun-gitdesktop</span>
+        <nav className="app-menus" ref={menuRef} aria-label="Application menu">
+          <div className="app-menu">
+            <button
+              className={openMenu === 'repository' ? 'menu-title open' : 'menu-title'}
+              aria-expanded={openMenu === 'repository'}
+              onClick={() => toggleMenu('repository')}
+            >
+              Repository
+            </button>
+            {openMenu === 'repository' && (
+              <div className="menu-list" role="menu">
+                <button role="menuitem" onClick={() => run(onImportRepo)}>
+                  Import Repository…
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="app-menu">
+            <button
+              className={openMenu === 'settings' ? 'menu-title open' : 'menu-title'}
+              aria-expanded={openMenu === 'settings'}
+              onClick={() => toggleMenu('settings')}
+            >
+              Settings
+            </button>
+            {openMenu === 'settings' && (
+              <div className="menu-list" role="menu">
+                <button role="menuitem" onClick={() => run(onOpenSettings)}>
+                  Preferences…
+                </button>
+                <button role="menuitem" onClick={() => run(onRecheckCli)}>
+                  Recheck Command Line Tools
+                </button>
+                <div className="menu-separator" role="separator" />
+                <button role="menuitem" onClick={() => run(onCheckForUpdates)}>
+                  Check for Updates…
+                </button>
+              </div>
+            )}
+          </div>
+        </nav>
+        <span className="top-bar-spacer" />
         {status && (
           <>
             <span className={chipClass(status.git)} title={status.git.version || 'git CLI not found'}>
@@ -54,10 +128,6 @@ export default function TopBar({ status, onOpenSettings }: Props): JSX.Element {
             </span>
           </>
         )}
-        <span className="top-bar-spacer" />
-        <button onClick={onOpenSettings} title="Open settings">
-          Settings
-        </button>
       </header>
       {notice && <div className={blocking ? 'notice-bar notice-warn' : 'notice-bar'}>{notice}</div>}
     </>

--- a/product/akbun-gitdesktop/src/renderer/src/components/WorktreePanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/WorktreePanel.tsx
@@ -44,11 +44,10 @@ export default function WorktreePanel({
   }
 
   const removeWorktree = async (worktree: WorktreeInfo): Promise<void> => {
-    if (!window.confirm(`Remove this worktree?\n${worktree.path}`)) return
-    const result = await window.gitdesktop.removeWorktree(repo.path, worktree.path, false)
-    if (result.ok) {
+    const result = await window.gitdesktop.removeWorktree(repo.path, worktree.path)
+    if (result.ok && result.data) {
       onChanged()
-    } else {
+    } else if (!result.ok) {
       onError(result.error)
     }
   }

--- a/product/akbun-gitdesktop/src/renderer/src/styles.css
+++ b/product/akbun-gitdesktop/src/renderer/src/styles.css
@@ -105,6 +105,61 @@ body {
 .top-bar-title {
   font-weight: 700;
   letter-spacing: 0.2px;
+  margin-right: 4px;
+}
+
+.app-menus {
+  display: flex;
+  align-self: stretch;
+  align-items: center;
+  gap: 2px;
+}
+
+.app-menu {
+  position: relative;
+}
+
+.menu-title {
+  border: 0;
+  background: transparent;
+  padding: 5px 8px;
+}
+
+.menu-title:hover,
+.menu-title.open {
+  background: var(--bg-hover);
+}
+
+.menu-list {
+  position: absolute;
+  top: calc(100% + 5px);
+  left: 0;
+  z-index: 20;
+  min-width: 220px;
+  padding: 5px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.menu-list button {
+  display: block;
+  width: 100%;
+  padding: 7px 9px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.menu-list button:hover {
+  background: var(--bg-hover);
+}
+
+.menu-separator {
+  height: 1px;
+  margin: 4px;
+  background: var(--border);
 }
 
 .top-bar-spacer {
@@ -1116,6 +1171,28 @@ button:focus-visible,
   color: var(--text-dim);
   font-size: 11px;
   margin-top: 8px;
+}
+
+.setting-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.setting-toggle input {
+  margin-top: 3px;
+}
+
+.setting-toggle span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.setting-toggle small {
+  color: var(--text-dim);
+  font-size: 11px;
 }
 
 .tool-card {

--- a/product/akbun-gitdesktop/src/shared/types.ts
+++ b/product/akbun-gitdesktop/src/shared/types.ts
@@ -148,6 +148,7 @@ export type ThemePreference = 'system' | 'light' | 'dark'
 
 export interface AppSettings {
   theme: ThemePreference
+  forceRemoveWorktree: boolean
 }
 
 /** A single file touched by a commit or by a diff range. */

--- a/product/akbun-gitdesktop/test/cli-path.test.js
+++ b/product/akbun-gitdesktop/test/cli-path.test.js
@@ -1,0 +1,36 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+function loadCliModule() {
+  return import('../src/main/cli.ts')
+}
+
+test('GUI PATH 밖의 Homebrew gh 경로도 검사한다', async () => {
+  const { commandPaths } = await loadCliModule()
+  const paths = commandPaths('gh')
+
+  assert.ok(paths.includes('/opt/homebrew/bin/gh'))
+  assert.ok(paths.includes('/usr/local/bin/gh'))
+})
+
+test('찾은 절대 경로로 CLI를 실행한다', async () => {
+  if (process.platform === 'win32') return
+
+  const { runCli } = await loadCliModule()
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'akbun-gitdesktop-cli-'))
+  const executable = path.join(dir, 'fake-gh')
+  const previousPath = process.env.PATH
+  fs.writeFileSync(executable, '#!/bin/sh\nprintf "found:%s" "$1"\n', { mode: 0o755 })
+  process.env.PATH = dir
+
+  try {
+    const output = await runCli(undefined, 'fake-gh', ['ok'])
+    assert.strictEqual(output, 'found:ok')
+  } finally {
+    process.env.PATH = previousPath
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/product/akbun-gitdesktop/test/cli-path.test.js
+++ b/product/akbun-gitdesktop/test/cli-path.test.js
@@ -9,6 +9,8 @@ function loadCliModule() {
 }
 
 test('GUI PATH 밖의 Homebrew gh 경로도 검사한다', async () => {
+  if (process.platform === 'win32') return
+
   const { commandPaths } = await loadCliModule()
   const paths = commandPaths('gh')
 


### PR DESCRIPTION
# 구현\n\nWorktree force 삭제 설정, HTML 앱 메뉴, 업데이트 IPC, CLI 절대 경로 탐색 추가\n- TypeScript 검사, 테스트 7개, 프로덕션 빌드, 내장 브라우저 메뉴·설정 검증 통과\n\n# 어려웠던 점\n\nGUI 실행 환경과 터미널의 PATH 차이 재현\n- PATH를 /usr/bin:/bin으로 제한한 상태에서도 /opt/homebrew/bin/gh 탐지 및 실행 확인\n\n# 리스크\n\n알려진 경로 밖의 사용자 정의 CLI 설치 위치 탐지 실패 가능\n- 현재 PATH, Homebrew, user bin, mise, asdf, Nix 기본 경로 지원\n\nIssue #1046\nIssue #1047\nIssue #1048\nIssue #1049