### PR TITLE
docs: SearXNG 프로덕션 주의사항과 봇 탐지 핸즈온

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 93. Amazon Bedrock 모델 호출(Runtime, Mantle, Playground) (26.8.16) - [링크](./aws/bedrock/model-inference/)
 94. Web search tool 실행 위치 비교(Client, LiteLLM, Bedrock, vLLM) (26.8.17) - [링크](./computer_science/ai/web-search-tool/)
 95. LLM serving challenge와 essential optimization Chapter 5-6 핸즈온 (26.8.22) - [링크](./computer_science/ai/study-llmserving/ch5-6/)
+96. SearXNG 프로덕션 주의사항과 봇 탐지 핸즈온 (26.8.23) - [링크](./computer_science/ai/searxng-production/)
 
 ## 직접 만든 제품
 

--- a/computer_science/ai/searxng-production/Makefile
+++ b/computer_science/ai/searxng-production/Makefile
@@ -1,0 +1,10 @@
+.PHONY: up down verify
+
+up:
+	docker compose up -d --wait
+
+down:
+	docker compose down -v
+
+verify:
+	sh scripts/verify.sh

--- a/computer_science/ai/searxng-production/README.md
+++ b/computer_science/ai/searxng-production/README.md
@@ -1,0 +1,5 @@
+# SearXNG production hands-on
+
+- [프로덕션에서 먼저 확인할 것](./docs/1-production.md)
+- [실습 환경](./docs/2-setup.md)
+- [인증, HA, 봇 탐지 재현](./docs/3-hands-on.md)

--- a/computer_science/ai/searxng-production/compose.yaml
+++ b/computer_science/ai/searxng-production/compose.yaml
@@ -1,0 +1,90 @@
+name: searxng-production-lab
+
+x-searxng: &searxng
+  image: docker.io/searxng/searxng:2026.8.16-b2da6b90f
+  restart: unless-stopped
+  environment:
+    FORCE_OWNERSHIP: "false"
+    SEARXNG_BASE_URL: http://localhost:8088/
+    SEARXNG_SECRET: local-lab-secret-do-not-use-in-production
+    SEARXNG_VALKEY_URL: valkey://valkey:6379/0
+  volumes:
+    - ./searxng:/etc/searxng:ro
+  depends_on:
+    valkey:
+      condition: service_healthy
+    mock-engine:
+      condition: service_started
+  healthcheck:
+    test:
+      - CMD
+      - python
+      - -c
+      - "import socket; socket.create_connection(('127.0.0.1', 8080), 1).close()"
+    interval: 5s
+    timeout: 2s
+    retries: 20
+  networks:
+    - lab
+
+services:
+  gateway:
+    image: docker.io/library/nginx:1.29-alpine
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:8088:8080
+    volumes:
+      - ./gateway/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./gateway/htpasswd:/etc/nginx/htpasswd:ro
+    depends_on:
+      searxng-a:
+        condition: service_healthy
+      searxng-b:
+        condition: service_healthy
+    networks:
+      - lab
+
+  searxng-a:
+    <<: *searxng
+    volumes:
+      - ./searxng:/etc/searxng:ro
+      - searxng-a-cache:/var/cache/searxng
+
+  searxng-b:
+    <<: *searxng
+    volumes:
+      - ./searxng:/etc/searxng:ro
+      - searxng-b-cache:/var/cache/searxng
+
+  valkey:
+    image: docker.io/valkey/valkey:9-alpine
+    restart: unless-stopped
+    command: valkey-server --save 30 1 --loglevel warning
+    healthcheck:
+      test: [CMD, valkey-cli, ping]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    volumes:
+      - valkey-data:/data
+    networks:
+      - lab
+
+  mock-engine:
+    image: docker.io/library/nginx:1.29-alpine
+    restart: unless-stopped
+    volumes:
+      - ./mock-engine/nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - lab
+
+networks:
+  lab:
+    ipam:
+      config:
+        - subnet: 172.28.240.0/24
+
+volumes:
+  searxng-a-cache:
+  searxng-b-cache:
+  valkey-data:

--- a/computer_science/ai/searxng-production/docs/1-production.md
+++ b/computer_science/ai/searxng-production/docs/1-production.md
@@ -1,0 +1,101 @@
+# SearXNG를 두 대 띄워도 프로덕션이 되지 않는 이유
+
+SearXNG replica 두 대가 모두 `healthy`인데 검색 결과가 사라질 수 있습니다. 장애 지점이 SearXNG 안이 아니라, 같은 egress IP를 보는 외부 검색 엔진에 있기 때문입니다. **프로덕션의 핵심은 replica 수보다 누가 얼마나 검색하게 할지 통제하는 것입니다.**
+
+## 봇 탐지는 두 방향에서 일어납니다
+
+SearXNG의 limiter와 외부 검색 엔진의 봇 탐지는 목적도 결과도 다릅니다.
+
+| 방향 | 탐지 주체 | 대표 신호 | 관찰되는 결과 |
+| --- | --- | --- | --- |
+| Client → SearXNG | SearXNG limiter | 비정상 header, IP별 burst, JSON API 반복 호출 | SearXNG가 `429` 반환 |
+| SearXNG → Origin | Google, Bing, DuckDuckGo 등 | egress IP의 요청량·동시성, TLS/HTTP fingerprint, query 패턴 | Origin이 CAPTCHA, `403`, `429` 반환 |
+
+SearXNG limiter가 필요한 이유는 단순히 자기 서버의 CPU를 보호하기 위해서가 아닙니다. 들어오는 자동화 요청을 그대로 통과시키면 모든 사용자의 검색이 몇 개의 egress IP로 합쳐집니다. 외부 검색 엔진 입장에서는 SearXNG 자체가 대규모 bot으로 보입니다.
+
+### 사용자를 봇으로 판정하는 과정
+
+SearXNG limiter는 Valkey에 IP별 sliding window를 기록합니다. 현재 기본값은 burst 20초 동안 15회, 장기 10분 동안 150회, JSON 같은 API 형식은 1시간 동안 4회입니다. `curl` 같은 User-Agent와 `text/html`이 없는 `Accept` header도 의심 신호가 됩니다.
+
+여기서 보통 "로그인한 사용자면 limiter를 끄면 되지 않나" 하고 묻습니다. 인증은 사용자가 누구인지 증명할 뿐, 그 사용자가 외부 검색 엔진을 고갈시키지 않는다는 보장은 아닙니다. 인증 뒤에도 사용자·tenant·service별 quota와 전체 egress budget이 필요합니다.
+
+[실습](./3-hands-on.md)은 JSON 검색을 반복해 다섯 번째 요청부터 `429`를 발생시킵니다. 실제 임계값은 제품 트래픽에 맞춰 edge gateway 정책과 함께 조정해야 합니다.
+
+### SearXNG가 봇으로 판정되는 과정
+
+외부 검색 엔진은 약관, IP 평판, 요청 빈도, 동시성, protocol fingerprint와 query 패턴을 각자의 기준으로 평가합니다. 판정 기준은 공개되지 않으며 엔진마다 바뀝니다. 같은 NAT Gateway를 쓰는 replica를 늘리면 source IP는 그대로인데 요청량만 늘어 차단을 앞당길 수도 있습니다.
+
+Origin이 CAPTCHA, `403`, `429`를 반환하면 SearXNG는 engine 오류로 분류하고 설정된 시간 동안 해당 engine을 suspend합니다. 문제는 전체 `/search` 응답이 여전히 `200`일 수 있다는 점입니다. 다른 engine 결과만 남거나, `results`가 비고 `unresponsive_engines`에 오류가 기록됩니다. HTTP availability만 보면 검색 품질 장애를 놓칩니다.
+
+실제 검색 엔진을 강제로 차단시키는 부하 테스트는 하지 않습니다. 상대 서비스에 불필요한 트래픽을 만들고 재현성도 없습니다. [로컬 mock 실습](./3-hands-on.md)에서 Origin의 `429`와 SearXNG의 engine suspend를 같은 방식으로 관찰합니다.
+
+## 인증과 인가는 SearXNG 앞에서 끝냅니다
+
+SearXNG의 private engine token은 특정 engine을 숨기는 기능입니다. 사용자 계정, 조직 group, session, per-user quota를 제공하는 일반적인 IAM은 아닙니다. **SearXNG를 private upstream으로 두고 identity-aware gateway를 유일한 진입점으로 사용합니다.**
+
+| 호출자 | 인증 | 인가와 제한 |
+| --- | --- | --- |
+| 사내 사용자 | VPN 또는 OIDC login | IdP group별 route 허용, 사용자별 quota |
+| Backend service | mTLS 또는 짧은 수명의 signed JWT | service identity별 RPS·동시 검색 수 제한 |
+| AI agent | gateway가 발급·검증하는 service credential | model·tenant별 daily budget, 결과 개수 제한 |
+
+Gateway는 인증 실패를 SearXNG에 전달하지 않아야 합니다. `Authorization` header도 upstream에서 제거합니다. 외부에 노출되는 endpoint는 TLS, request size 제한, timeout, audit event가 필요합니다. 검색어는 민감정보가 될 수 있으므로 access log에는 query string을 그대로 남기지 않습니다.
+
+IP limiter를 사용자 quota로 착각하면 안 됩니다. 회사 NAT 뒤의 여러 사용자는 하나의 IP로 합쳐져 함께 차단될 수 있고, 공격자는 IP를 바꿀 수 있습니다. SearXNG limiter는 마지막 방어선으로 유지하고 identity 기반 quota는 gateway에서 별도로 적용합니다.
+
+## HA는 web replica보다 더 넓게 봐야 합니다
+
+권장 구조는 다음과 같습니다.
+
+```mermaid
+flowchart LR
+  C[Client or AI agent] --> G[Multi-AZ gateway\nOIDC or mTLS + quota]
+  G --> A[SearXNG replica A]
+  G --> B[SearXNG replica B]
+  A --> V[(HA Valkey endpoint)]
+  B --> V
+  A --> E[Controlled egress]
+  B --> E
+  E --> O[Search engines]
+```
+
+두 SearXNG replica에는 같은 image version, `settings.yml`, `limiter.toml`, `secret_key`를 배포합니다. limiter가 같은 IP의 요청을 어느 replica에서 받아도 합산하도록 같은 HA Valkey endpoint를 사용합니다. `/var/cache/searxng`는 SQLite 기반 cache를 포함하므로 replica별 volume으로 두고 하나의 writable filesystem을 공유하지 않습니다.
+
+Gateway와 Valkey도 Multi-AZ 또는 자동 failover 구성이어야 합니다. Valkey 장애는 단순 cache miss가 아니라 bot protection 상태 손실로 취급합니다. Edge quota는 Valkey와 독립된 방어선으로 남겨 SearXNG limiter 하나에 의존하지 않습니다.
+
+여기서 보통 "replica마다 egress IP를 나누면 차단도 해결되지 않나" 하고 묻습니다. IP별 요청량은 줄일 수 있지만 origin 정책 준수나 fingerprint 판정을 해결하지는 못합니다. 유료·공식 API가 있는 engine은 그것을 우선하고, 허용된 엔진만 운영하며, engine별 동시성·timeout·오류 budget을 정해야 합니다.
+
+### 검색이 살아 있는지 측정하는 지표
+
+- Gateway: 인증 실패율, identity별 rate limit, queue와 timeout
+- SearXNG: 검색 latency, 빈 결과 비율, `unresponsive_engines`, engine별 오류율
+- Origin: CAPTCHA, `403`, `429`, suspend 시간, engine별 성공 결과 수
+- Valkey: 연결 실패, latency, memory, failover
+- 품질 SLI: 요청당 정상 engine 수와 최소 결과 수
+
+Liveness probe가 `200`인지보다 canary query가 기대한 최소 결과를 돌려주는지가 중요합니다. 다만 canary 자체가 origin 부하가 되지 않도록 낮은 빈도와 별도 budget을 둡니다.
+
+## 프로덕션 전 체크리스트
+
+- SearXNG를 public endpoint로 직접 노출하지 않습니다.
+- Gateway에서 OIDC·mTLS·JWT 중 호출자에 맞는 인증을 적용합니다.
+- Identity quota와 SearXNG IP limiter를 모두 둡니다.
+- 신뢰할 proxy CIDR만 `trusted_proxies`에 넣고 client의 `X-Forwarded-For`를 덮어씁니다.
+- SearXNG replica가 같은 config와 secret을 사용하게 합니다.
+- Limiter용 Valkey를 공유하고 Valkey 장애를 감시합니다.
+- 이미지 tag 대신 검증한 digest를 고정하고 변경 내역을 확인한 뒤 배포합니다.
+- Origin별 `403`, `429`, CAPTCHA와 빈 결과를 alert로 만듭니다.
+- 외부 검색 엔진 약관과 자동화 허용 범위를 확인합니다.
+- 실제 Origin을 향한 차단 유도 부하 테스트를 하지 않습니다.
+
+정리하면, SearXNG의 프로덕션 장애는 process가 죽어서보다 검색할 권한과 속도를 통제하지 못해 발생할 가능성이 큽니다. 인증은 앞단에서, limiter 상태는 공유 Valkey에서, 가용성 판단은 Origin 결과 품질에서 끝까지 확인해야 합니다.
+
+## 참고자료
+
+- [SearXNG Limiter](https://docs.searxng.org/admin/searx.limiter.html)
+- [SearXNG Bot Detection](https://docs.searxng.org/src/searx.botdetection.html)
+- [SearXNG server settings](https://docs.searxng.org/admin/settings/settings_server.html)
+- [SearXNG search settings](https://docs.searxng.org/admin/settings/settings_search.html)
+- [SearXNG private engines](https://docs.searxng.org/admin/settings/settings_engines.html#private-engines-tokens)
+- [SearXNG container installation](https://docs.searxng.org/admin/installation-docker.html)
+- [Why use a private instance?](https://docs.searxng.org/own-instance.html)

--- a/computer_science/ai/searxng-production/docs/2-setup.md
+++ b/computer_science/ai/searxng-production/docs/2-setup.md
@@ -1,0 +1,21 @@
+# SearXNG 프로덕션 실습 환경
+
+Docker Compose로 Basic Auth gateway, SearXNG replica 2개, 공유 Valkey, `429`를 반환하는 mock 검색 엔진을 실행한다.
+
+이 구성은 동작을 재현하는 로컬 환경이다. gateway와 Valkey가 각각 하나이므로 프로덕션 HA로 사용하지 않는다.
+
+## Up
+
+workspace에서 전체 환경을 실행한다.
+
+```bash
+docker compose up -d --wait
+```
+
+## Down
+
+container와 실습용 volume을 정리한다.
+
+```bash
+docker compose down -v
+```

--- a/computer_science/ai/searxng-production/docs/3-hands-on.md
+++ b/computer_science/ai/searxng-production/docs/3-hands-on.md
@@ -1,0 +1,95 @@
+# 인증, HA, 봇 탐지 재현
+
+[실습 환경](./2-setup.md)을 먼저 실행한다. 로컬 계정은 `lab`, 비밀번호는 `production-lab`이다.
+
+## 인증 경계 확인
+
+인증 없이 요청하면 gateway가 SearXNG에 전달하기 전에 거절한다.
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://localhost:8088/
+```
+
+- 기대 결과: `401`
+
+Basic Auth를 통과한 요청만 SearXNG에 도달한다.
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  -u lab:production-lab \
+  -A 'Mozilla/5.0' \
+  -H 'Accept: text/html' \
+  http://localhost:8088/
+```
+
+- 기대 결과: `200`
+- Basic Auth는 인증 경계를 관찰하기 위한 로컬 대체물이다.
+- 프로덕션에서는 OIDC, mTLS 또는 service JWT를 gateway에서 검증한다.
+
+## SearXNG replica 분산 확인
+
+응답의 `X-SearXNG-Upstream`은 요청을 처리한 container 주소다.
+
+```bash
+for i in 1 2 3 4; do
+  curl -sSI \
+    -u lab:production-lab \
+    -A 'Mozilla/5.0' \
+    -H 'Accept: text/html' \
+    http://localhost:8088/ \
+    | awk -F': ' 'tolower($1) == "x-searxng-upstream" {print $2}'
+done
+```
+
+- 두 주소가 번갈아 나오면 gateway가 두 replica에 분산한다.
+- 이 구성의 gateway와 Valkey는 단일 container이므로 프로덕션 HA 구성이 아니다.
+
+## 사용자 요청을 봇으로 판정시키기
+
+실습 순서를 독립적으로 만들기 위해 공유 limiter 상태를 비운다.
+
+```bash
+docker compose exec -T valkey valkey-cli FLUSHDB
+```
+
+JSON API는 기본 limiter에서 IP당 1시간에 4회까지 허용된다. 브라우저 형태의 header를 보내 rate 조건만 확인한다.
+
+```bash
+for i in 1 2 3 4 5 6; do
+  curl -sS --compressed -o /dev/null -w "$i %{http_code}\n" \
+    -u lab:production-lab \
+    -A 'Mozilla/5.0' \
+    -H 'Accept: text/html' \
+    -H 'Accept-Language: en-US,en;q=0.9' \
+    'http://localhost:8088/search?q=rate-limit&format=json&engines=mock%20success'
+done
+```
+
+- 기대 결과: 처음 4개 요청은 `200`, 이후 요청은 `429`
+- `200`은 검색 엔진 성공을 뜻하지 않는다. SearXNG가 검색 엔진 오류를 JSON 응답에 담을 수 있다.
+- `curl` User-Agent, `text/html`이 없는 `Accept`, 압축을 지원하지 않는 `Accept-Encoding`, 비어 있는 `Accept-Language`도 header probe의 봇 판정 조건이다.
+
+## SearXNG가 검색 엔진에서 차단되는 상황 만들기
+
+실제 검색 엔진에 부하를 주지 않고 `mock-engine`이 항상 `429`를 반환하게 했다. limiter 상태를 비운 뒤 mock engine만 지정한다.
+
+```bash
+docker compose exec -T valkey valkey-cli FLUSHDB
+curl -sS --compressed \
+  -u lab:production-lab \
+  -A 'Mozilla/5.0' \
+  -H 'Accept: text/html' \
+  -H 'Accept-Language: en-US,en;q=0.9' \
+  'http://localhost:8088/search?q=origin-block&format=json&engines=mock%20upstream'
+```
+
+- HTTP 응답 자체는 `200`일 수 있다.
+- `results`는 비고 `unresponsive_engines`에 `Too many requests`가 남는다.
+- 해당 SearXNG replica는 `settings.yml`의 `SearxEngineTooManyRequests` 시간 동안 engine을 suspend한다.
+- replica 2개는 같은 시점에 독립적으로 차단을 학습할 수 있다. 공유 Valkey는 inbound limiter 상태를 공유하는 용도다.
+
+전체 검증은 한 명령으로 실행한다.
+
+```bash
+make verify
+```

--- a/computer_science/ai/searxng-production/gateway/htpasswd
+++ b/computer_science/ai/searxng-production/gateway/htpasswd
@@ -1,0 +1,1 @@
+lab:$apr1$eV6gvOHQ$obad.z9QK4Fl9gzf4VL4N/

--- a/computer_science/ai/searxng-production/gateway/nginx.conf
+++ b/computer_science/ai/searxng-production/gateway/nginx.conf
@@ -1,0 +1,32 @@
+events {}
+
+http {
+  upstream searxng {
+    server searxng-a:8080;
+    server searxng-b:8080;
+  }
+
+  server {
+    listen 8080;
+
+    location = /healthz {
+      access_log off;
+      default_type text/plain;
+      return 200 "ok\n";
+    }
+
+    location / {
+      auth_basic "SearXNG production lab";
+      auth_basic_user_file /etc/nginx/htpasswd;
+
+      proxy_pass http://searxng;
+      proxy_set_header Host $host;
+      proxy_set_header X-Forwarded-For $remote_addr;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Authorization "";
+
+      add_header X-SearXNG-Upstream $upstream_addr always;
+    }
+  }
+}

--- a/computer_science/ai/searxng-production/mock-engine/nginx.conf
+++ b/computer_science/ai/searxng-production/mock-engine/nginx.conf
@@ -1,0 +1,17 @@
+events {}
+
+http {
+  server {
+    listen 80;
+
+    location /ok {
+      default_type text/html;
+      return 200 '<html><body><article><a href="https://example.invalid/result">mock result</a><p>local success response</p></article></body></html>';
+    }
+
+    location /search {
+      default_type text/plain;
+      return 429 "mock origin detected automated traffic\n";
+    }
+  }
+}

--- a/computer_science/ai/searxng-production/scripts/verify.sh
+++ b/computer_science/ai/searxng-production/scripts/verify.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -eu
+
+base_url="http://localhost:8088"
+credentials="lab:production-lab"
+browser_user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/140 Safari/537.36"
+
+request_code() {
+  curl -sS --compressed -o /dev/null -w "%{http_code}" "$@"
+}
+
+reset_limiter() {
+  docker compose exec -T valkey valkey-cli FLUSHDB >/dev/null
+}
+
+unauthorized_code=$(request_code "$base_url/")
+authorized_code=$(request_code -u "$credentials" -A "$browser_user_agent" -H "Accept: text/html" "$base_url/")
+
+test "$unauthorized_code" = "401"
+test "$authorized_code" = "200"
+printf 'authentication: unauthenticated=%s authenticated=%s\n' "$unauthorized_code" "$authorized_code"
+
+printf 'upstreams:'
+i=1
+while [ "$i" -le 4 ]; do
+  upstream=$(curl -sSI -u "$credentials" -A "$browser_user_agent" -H "Accept: text/html" "$base_url/" | awk -F': ' 'tolower($1) == "x-searxng-upstream" {gsub("\\r", "", $2); print $2}')
+  printf ' %s' "$upstream"
+  i=$((i + 1))
+done
+printf '\n'
+
+reset_limiter
+printf 'api limiter:'
+i=1
+while [ "$i" -le 6 ]; do
+  code=$(request_code -u "$credentials" -A "$browser_user_agent" -H "Accept: text/html" -H "Accept-Language: en-US,en;q=0.9" "$base_url/search?q=rate-limit&format=json&engines=mock%20success")
+  printf ' %s' "$code"
+  i=$((i + 1))
+done
+printf '\n'
+
+reset_limiter
+mock_response=$(curl -sS --compressed -u "$credentials" -A "$browser_user_agent" -H "Accept: text/html" -H "Accept-Language: en-US,en;q=0.9" "$base_url/search?q=origin-block&format=json&engines=mock%20upstream")
+printf '%s' "$mock_response" | grep -qi 'too many requests'
+printf 'origin bot detection: SearXNG reported Too many requests\n'

--- a/computer_science/ai/searxng-production/scripts/verify.sh
+++ b/computer_science/ai/searxng-production/scripts/verify.sh
@@ -22,12 +22,21 @@ test "$authorized_code" = "200"
 printf 'authentication: unauthenticated=%s authenticated=%s\n' "$unauthorized_code" "$authorized_code"
 
 printf 'upstreams:'
+first_upstream=""
+different_upstream=false
 i=1
 while [ "$i" -le 4 ]; do
   upstream=$(curl -sSI -u "$credentials" -A "$browser_user_agent" -H "Accept: text/html" "$base_url/" | awk -F': ' 'tolower($1) == "x-searxng-upstream" {gsub("\\r", "", $2); print $2}')
+  test -n "$upstream"
+  if [ -z "$first_upstream" ]; then
+    first_upstream="$upstream"
+  elif [ "$upstream" != "$first_upstream" ]; then
+    different_upstream=true
+  fi
   printf ' %s' "$upstream"
   i=$((i + 1))
 done
+test "$different_upstream" = true
 printf '\n'
 
 reset_limiter
@@ -35,6 +44,12 @@ printf 'api limiter:'
 i=1
 while [ "$i" -le 6 ]; do
   code=$(request_code -u "$credentials" -A "$browser_user_agent" -H "Accept: text/html" -H "Accept-Language: en-US,en;q=0.9" "$base_url/search?q=rate-limit&format=json&engines=mock%20success")
+  if [ "$i" -le 4 ]; then
+    expected_code=200
+  else
+    expected_code=429
+  fi
+  test "$code" = "$expected_code"
   printf ' %s' "$code"
   i=$((i + 1))
 done

--- a/computer_science/ai/searxng-production/searxng/limiter.toml
+++ b/computer_science/ai/searxng-production/searxng/limiter.toml
@@ -1,0 +1,9 @@
+[botdetection]
+trusted_proxies = ["172.28.240.0/24"]
+
+[botdetection.ip_limit]
+filter_link_local = true
+link_token = false
+
+[botdetection.ip_lists]
+pass_searxng_org = false

--- a/computer_science/ai/searxng-production/searxng/settings.yml
+++ b/computer_science/ai/searxng-production/searxng/settings.yml
@@ -1,0 +1,52 @@
+use_default_settings:
+  engines:
+    keep_only: []
+
+general:
+  debug: false
+  instance_name: SearXNG production lab
+
+search:
+  autocomplete: ""
+  formats:
+    - html
+    - json
+  suspended_times:
+    SearxEngineTooManyRequests: 30
+
+server:
+  secret_key: local-lab-secret-do-not-use-in-production
+  limiter: true
+  public_instance: false
+  image_proxy: true
+
+valkey:
+  url: valkey://valkey:6379/0
+
+outgoing:
+  request_timeout: 2.0
+
+engines:
+  - name: mock success
+    engine: xpath
+    shortcut: mockok
+    categories: general
+    disabled: false
+    enable_http: true
+    search_url: http://mock-engine/ok?q={query}
+    results_xpath: //article
+    url_xpath: ./a/@href
+    title_xpath: ./a
+    content_xpath: ./p
+
+  - name: mock upstream
+    engine: xpath
+    shortcut: mock
+    categories: general
+    disabled: false
+    enable_http: true
+    search_url: http://mock-engine/search?q={query}
+    results_xpath: //article
+    url_xpath: ./a/@href
+    title_xpath: ./a
+    content_xpath: ./p


### PR DESCRIPTION
# 구현

SearXNG 운영 문서와 로컬 Compose 재현 환경 추가
- 인증 401/200, replica 교대 처리, API limiter 200 4회 후 429, Origin 차단 오류 확인

# 어려웠던 점

실제 검색 엔진 차단 유도 없이 outbound 봇 탐지 결과 재현
- 정상 mock engine과 429 mock engine 분리로 inbound limiter와 Origin 차단 조건 격리

# 리스크

SearXNG upgrade 시 고정 image tag와 limiter 기본 임계값 재검토 필요
- 현재 검증 버전 2026.8.16-b2da6b90f 기준 설정과 문서 작성

Issue #1051