### PR TITLE
feat(gitdesktop): show repo sizes and resize panels

### DIFF
--- a/product/akbun-gitdesktop/package-lock.json
+++ b/product/akbun-gitdesktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-gitdesktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-gitdesktop",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.8",

--- a/product/akbun-gitdesktop/package.json
+++ b/product/akbun-gitdesktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-gitdesktop",
   "productName": "akbun-gitdesktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Git graph desktop viewer for local repositories and worktrees",
   "main": "out/main/index.js",
   "author": "akbun",

--- a/product/akbun-gitdesktop/src/main/directorySize.ts
+++ b/product/akbun-gitdesktop/src/main/directorySize.ts
@@ -1,0 +1,22 @@
+import { lstat, opendir } from 'node:fs/promises'
+import path from 'node:path'
+
+export async function directorySize(rootPath: string): Promise<number> {
+  const pending = [rootPath]
+  let bytes = 0
+
+  while (pending.length > 0) {
+    const current = pending.pop()!
+    const entries = await opendir(current)
+    for await (const entry of entries) {
+      const entryPath = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        pending.push(entryPath)
+      } else {
+        bytes += (await lstat(entryPath)).size
+      }
+    }
+  }
+
+  return bytes
+}

--- a/product/akbun-gitdesktop/src/main/git.ts
+++ b/product/akbun-gitdesktop/src/main/git.ts
@@ -65,6 +65,10 @@ export async function isGitRepository(path: string): Promise<boolean> {
   }
 }
 
+export async function getGitDirectoryPath(repoPath: string): Promise<string> {
+  return (await runGit(repoPath, ['rev-parse', '--absolute-git-dir'])).trim()
+}
+
 export async function getLog(repoPath: string): Promise<CommitInfo[]> {
   const format = ['%H', '%P', '%an', '%ad', '%D', '%s'].join(FIELD_SEP)
   const out = await runGit(repoPath, [

--- a/product/akbun-gitdesktop/src/main/index.ts
+++ b/product/akbun-gitdesktop/src/main/index.ts
@@ -7,6 +7,7 @@ import * as git from './git'
 import * as github from './github'
 import { openInApp, listOpenerApps } from './openWith'
 import { addRepo, loadRepos, removeRepo } from './repoStore'
+import { loadRepoSizes } from './repoSize'
 import { loadSettings, saveForceRemoveWorktree, saveTheme } from './settingsStore'
 import { checkUpdate, cleanupTempDirs, downloadDmg, spawnSwap } from './update'
 
@@ -43,6 +44,7 @@ async function wrap<T>(action: () => Promise<T>): Promise<GitResult<T>> {
 function registerIpcHandlers(): void {
   ipcMain.handle('tools:check', () => wrap(() => git.checkCliTools()))
   ipcMain.handle('repos:list', () => wrap(() => loadRepos()))
+  ipcMain.handle('repos:sizes', () => wrap(() => loadRepoSizes()))
   ipcMain.handle('repos:remove', (_event, repoPath: string) => wrap(() => removeRepo(repoPath)))
 
   ipcMain.handle('settings:get', () => wrap(() => loadSettings()))

--- a/product/akbun-gitdesktop/src/main/repoSize.ts
+++ b/product/akbun-gitdesktop/src/main/repoSize.ts
@@ -1,0 +1,18 @@
+import type { RepoSizeInfo } from '../shared/types'
+import { directorySize } from './directorySize'
+import { getGitDirectoryPath } from './git'
+import { loadRepos } from './repoStore'
+
+async function measureRepo(repoPath: string): Promise<RepoSizeInfo> {
+  try {
+    const gitDirectory = await getGitDirectoryPath(repoPath)
+    return { path: repoPath, bytes: await directorySize(gitDirectory) }
+  } catch {
+    return { path: repoPath, bytes: null }
+  }
+}
+
+export async function loadRepoSizes(): Promise<RepoSizeInfo[]> {
+  const repos = await loadRepos()
+  return Promise.all(repos.map((repo) => measureRepo(repo.path)))
+}

--- a/product/akbun-gitdesktop/src/preload/index.d.ts
+++ b/product/akbun-gitdesktop/src/preload/index.d.ts
@@ -11,6 +11,7 @@ import type {
   ProjectListResult,
   PullRequestInfo,
   RepoEntry,
+  RepoSizeInfo,
   ThemePreference,
   ThreadDetail,
   WorktreeInfo
@@ -24,6 +25,7 @@ export interface GitDesktopApi {
   checkForUpdates: () => Promise<void>
 
   listRepos: () => Promise<GitResult<RepoEntry[]>>
+  getRepoSizes: () => Promise<GitResult<RepoSizeInfo[]>>
   importRepo: () => Promise<GitResult<RepoEntry[]>>
   removeRepo: (repoPath: string) => Promise<GitResult<RepoEntry[]>>
 

--- a/product/akbun-gitdesktop/src/preload/index.ts
+++ b/product/akbun-gitdesktop/src/preload/index.ts
@@ -10,6 +10,7 @@ const api = {
   checkForUpdates: () => ipcRenderer.invoke('update:check'),
 
   listRepos: () => ipcRenderer.invoke('repos:list'),
+  getRepoSizes: () => ipcRenderer.invoke('repos:sizes'),
   importRepo: () => ipcRenderer.invoke('repos:import'),
   removeRepo: (repoPath: string) => ipcRenderer.invoke('repos:remove', repoPath),
 

--- a/product/akbun-gitdesktop/src/renderer/src/App.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import BranchPanel from './components/BranchPanel'
 import DiffDrawer, { type DiffSource } from './components/DiffDrawer'
 import GraphView from './components/GraphView'
 import IssuePanel from './components/IssuePanel'
+import { ResizeAfterPanel, ResizeBeforePanel } from './components/PanelResizer'
 import PrPanel from './components/PrPanel'
 import ProjectPanel from './components/ProjectPanel'
 import RepoSidebar from './components/RepoSidebar'
@@ -12,6 +13,7 @@ import ThreadDrawer, { type ThreadRef } from './components/ThreadDrawer'
 import TopBar from './components/TopBar'
 import WorktreePanel from './components/WorktreePanel'
 import { useCliStatus } from './lib/useCliStatus'
+import { usePanelWidth } from './lib/usePanelWidth'
 import { useTheme } from './lib/useTheme'
 
 type Tab = 'graph' | 'branches' | 'prs' | 'issues' | 'projects'
@@ -24,6 +26,10 @@ const TAB_LABELS: Array<[Tab, string]> = [
   ['projects', 'Projects']
 ]
 
+const REPO_PANEL = { defaultWidth: 220, minWidth: 160, maxWidth: 420 }
+const WORKTREE_PANEL = { defaultWidth: 280, minWidth: 200, maxWidth: 520 }
+const DETAIL_PANEL = { defaultWidth: 560, minWidth: 320, maxWidth: 900 }
+
 /** The git tabs show a diff on the right, the GitHub tabs show an issue or a pull request. */
 function isGitTab(tab: Tab): boolean {
   return tab === 'graph' || tab === 'branches'
@@ -31,6 +37,7 @@ function isGitTab(tab: Tab): boolean {
 
 export default function App(): JSX.Element {
   const [repos, setRepos] = useState<RepoEntry[]>([])
+  const [repoSizes, setRepoSizes] = useState<Record<string, number | null>>({})
   const [selectedRepo, setSelectedRepo] = useState<RepoEntry | null>(null)
   const [worktrees, setWorktrees] = useState<WorktreeInfo[]>([])
   const [selectedWorktree, setSelectedWorktree] = useState<WorktreeInfo | null>(null)
@@ -42,10 +49,35 @@ export default function App(): JSX.Element {
   const [defaultBranch, setDefaultBranch] = useState('HEAD')
   const [diffSource, setDiffSource] = useState<DiffSource | null>(null)
   const [thread, setThread] = useState<ThreadRef | null>(null)
+  const [repoPanelWidth, setRepoPanelWidth] = usePanelWidth(
+    'panel-width:repositories',
+    REPO_PANEL.defaultWidth,
+    REPO_PANEL.minWidth,
+    REPO_PANEL.maxWidth
+  )
+  const [worktreePanelWidth, setWorktreePanelWidth] = usePanelWidth(
+    'panel-width:worktrees',
+    WORKTREE_PANEL.defaultWidth,
+    WORKTREE_PANEL.minWidth,
+    WORKTREE_PANEL.maxWidth
+  )
+  const [detailPanelWidth, setDetailPanelWidth] = usePanelWidth(
+    'panel-width:details',
+    DETAIL_PANEL.defaultWidth,
+    DETAIL_PANEL.minWidth,
+    DETAIL_PANEL.maxWidth
+  )
   const theme = useTheme()
   const cli = useCliStatus()
   // The repository whose default branch lookup is still allowed to win.
   const pendingRepoPath = useRef('')
+
+  const refreshRepoSizes = useCallback(async () => {
+    const result = await window.gitdesktop.getRepoSizes()
+    if (result.ok) {
+      setRepoSizes(Object.fromEntries(result.data.map((entry) => [entry.path, entry.bytes])))
+    }
+  }, [])
 
   useEffect(() => {
     window.gitdesktop.listRepos().then((result) => {
@@ -57,7 +89,8 @@ export default function App(): JSX.Element {
     window.gitdesktop.getSettings().then((result) => {
       if (result.ok) setForceRemoveWorktree(result.data.forceRemoveWorktree)
     })
-  }, [])
+    refreshRepoSizes()
+  }, [refreshRepoSizes])
 
   const changeForceRemoveWorktree = useCallback(async (enabled: boolean) => {
     const result = await window.gitdesktop.setForceRemoveWorktree(enabled)
@@ -105,16 +138,18 @@ export default function App(): JSX.Element {
     if (result.ok) {
       setRepos(result.data)
       setError('')
+      refreshRepoSizes()
     } else {
       setError(result.error)
     }
-  }, [])
+  }, [refreshRepoSizes])
 
   const removeRepo = useCallback(
     async (repo: RepoEntry) => {
       const result = await window.gitdesktop.removeRepo(repo.path)
       if (result.ok) {
         setRepos(result.data)
+        refreshRepoSizes()
         if (selectedRepo?.path === repo.path) {
           pendingRepoPath.current = ''
           setSelectedRepo(null)
@@ -127,7 +162,7 @@ export default function App(): JSX.Element {
         setError(result.error)
       }
     },
-    [selectedRepo]
+    [refreshRepoSizes, selectedRepo]
   )
 
   const targetPath = selectedWorktree?.path ?? selectedRepo?.path ?? ''
@@ -195,9 +230,18 @@ export default function App(): JSX.Element {
         <RepoSidebar
           repos={repos}
           selectedRepo={selectedRepo}
+          repoSizes={repoSizes}
+          width={repoPanelWidth}
           onSelect={selectRepo}
           onImport={importRepo}
           onRemove={removeRepo}
+        />
+        <ResizeAfterPanel
+          label="Resize repository panel"
+          width={repoPanelWidth}
+          minWidth={REPO_PANEL.minWidth}
+          maxWidth={REPO_PANEL.maxWidth}
+          onChange={setRepoPanelWidth}
         />
         {selectedRepo ? (
           <>
@@ -206,9 +250,17 @@ export default function App(): JSX.Element {
               worktrees={worktrees}
               selectedWorktree={selectedWorktree}
               openerApps={openerApps}
+              width={worktreePanelWidth}
               onSelect={selectWorktree}
               onChanged={() => refreshWorktrees(selectedRepo)}
               onError={setError}
+            />
+            <ResizeAfterPanel
+              label="Resize worktree panel"
+              width={worktreePanelWidth}
+              minWidth={WORKTREE_PANEL.minWidth}
+              maxWidth={WORKTREE_PANEL.maxWidth}
+              onChange={setWorktreePanelWidth}
             />
             <main className="main-view">
               <nav className="tabs">
@@ -264,10 +316,36 @@ export default function App(): JSX.Element {
                   )}
                 </div>
                 {isGitTab(tab) && diffSource && (
-                  <DiffDrawer source={diffSource} onClose={() => setDiffSource(null)} />
+                  <>
+                    <ResizeBeforePanel
+                      label="Resize diff panel"
+                      width={detailPanelWidth}
+                      minWidth={DETAIL_PANEL.minWidth}
+                      maxWidth={DETAIL_PANEL.maxWidth}
+                      onChange={setDetailPanelWidth}
+                    />
+                    <DiffDrawer
+                      source={diffSource}
+                      width={detailPanelWidth}
+                      onClose={() => setDiffSource(null)}
+                    />
+                  </>
                 )}
                 {!isGitTab(tab) && thread && (
-                  <ThreadDrawer thread={thread} onClose={() => setThread(null)} />
+                  <>
+                    <ResizeBeforePanel
+                      label="Resize detail panel"
+                      width={detailPanelWidth}
+                      minWidth={DETAIL_PANEL.minWidth}
+                      maxWidth={DETAIL_PANEL.maxWidth}
+                      onChange={setDetailPanelWidth}
+                    />
+                    <ThreadDrawer
+                      thread={thread}
+                      width={detailPanelWidth}
+                      onClose={() => setThread(null)}
+                    />
+                  </>
                 )}
               </div>
             </main>

--- a/product/akbun-gitdesktop/src/renderer/src/components/DiffDrawer.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/DiffDrawer.tsx
@@ -10,6 +10,7 @@ export type DiffSource =
 interface Props {
   source: DiffSource
   onClose: () => void
+  width: number
 }
 
 function sourceKey(source: DiffSource): string {
@@ -50,7 +51,7 @@ function readDiff(source: DiffSource, filePath: string): ReturnType<typeof windo
  * Side panel that lists the files a commit or branch touched and shows the
  * git diff of the file the user clicks.
  */
-export default function DiffDrawer({ source, onClose }: Props): JSX.Element {
+export default function DiffDrawer({ source, onClose, width }: Props): JSX.Element {
   const [files, setFiles] = useState<FileChange[]>([])
   const [selectedFile, setSelectedFile] = useState('')
   const [diff, setDiff] = useState('')
@@ -107,7 +108,7 @@ export default function DiffDrawer({ source, onClose }: Props): JSX.Element {
   const lines = diff.trim().length > 0 ? diff.split('\n') : []
 
   return (
-    <aside className="diff-drawer">
+    <aside className="diff-drawer" style={{ width }}>
       <div className="diff-drawer-header">
         <div className="diff-drawer-title">
           <strong title={source.title}>{source.title}</strong>

--- a/product/akbun-gitdesktop/src/renderer/src/components/PanelResizer.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/PanelResizer.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, type JSX, type KeyboardEvent, type PointerEvent } from 'react'
+import { clampPanelWidth } from '../lib/usePanelWidth'
+
+interface Props {
+  label: string
+  width: number
+  minWidth: number
+  maxWidth: number
+  onChange: (width: number) => void
+}
+
+interface ResizerProps extends Props {
+  widthFromDelta: (startWidth: number, deltaX: number) => number
+  widthFromKey: (width: number, key: string) => number | null
+}
+
+function PanelResizer({
+  label,
+  width,
+  minWidth,
+  maxWidth,
+  onChange,
+  widthFromDelta,
+  widthFromKey
+}: ResizerProps): JSX.Element {
+  const drag = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null)
+
+  useEffect(() => () => document.body.classList.remove('panel-resizing'), [])
+
+  const stopResize = (event: PointerEvent<HTMLDivElement>): void => {
+    if (drag.current?.pointerId !== event.pointerId) return
+    drag.current = null
+    document.body.classList.remove('panel-resizing')
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const onPointerDown = (event: PointerEvent<HTMLDivElement>): void => {
+    event.preventDefault()
+    drag.current = { pointerId: event.pointerId, startX: event.clientX, startWidth: width }
+    document.body.classList.add('panel-resizing')
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const onPointerMove = (event: PointerEvent<HTMLDivElement>): void => {
+    if (drag.current?.pointerId !== event.pointerId) return
+    const nextWidth = widthFromDelta(drag.current.startWidth, event.clientX - drag.current.startX)
+    onChange(clampPanelWidth(nextWidth, minWidth, maxWidth))
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    const nextWidth = widthFromKey(width, event.key)
+    if (nextWidth === null) return
+    event.preventDefault()
+    onChange(clampPanelWidth(nextWidth, minWidth, maxWidth))
+  }
+
+  return (
+    <div
+      className="panel-resizer"
+      role="separator"
+      aria-label={label}
+      aria-orientation="vertical"
+      aria-valuemin={minWidth}
+      aria-valuemax={maxWidth}
+      aria-valuenow={Math.round(width)}
+      tabIndex={0}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={stopResize}
+      onPointerCancel={stopResize}
+      onKeyDown={onKeyDown}
+    />
+  )
+}
+
+export function ResizeAfterPanel(props: Props): JSX.Element {
+  return (
+    <PanelResizer
+      {...props}
+      widthFromDelta={(startWidth, deltaX) => startWidth + deltaX}
+      widthFromKey={(width, key) => {
+        if (key === 'ArrowLeft') return width - 16
+        if (key === 'ArrowRight') return width + 16
+        return null
+      }}
+    />
+  )
+}
+
+export function ResizeBeforePanel(props: Props): JSX.Element {
+  return (
+    <PanelResizer
+      {...props}
+      widthFromDelta={(startWidth, deltaX) => startWidth - deltaX}
+      widthFromKey={(width, key) => {
+        if (key === 'ArrowLeft') return width + 16
+        if (key === 'ArrowRight') return width - 16
+        return null
+      }}
+    />
+  )
+}

--- a/product/akbun-gitdesktop/src/renderer/src/components/RepoSidebar.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/RepoSidebar.tsx
@@ -1,17 +1,34 @@
 import type { JSX } from 'react'
 import type { RepoEntry } from '../../../shared/types'
+import { formatBytes } from '../lib/formatBytes'
 
 interface Props {
   repos: RepoEntry[]
   selectedRepo: RepoEntry | null
+  repoSizes: Record<string, number | null>
+  width: number
   onSelect: (repo: RepoEntry) => void
   onImport: () => void
   onRemove: (repo: RepoEntry) => void
 }
 
-export default function RepoSidebar({ repos, selectedRepo, onSelect, onImport, onRemove }: Props): JSX.Element {
+function sizeLabel(bytes: number | null | undefined): string {
+  if (bytes === undefined) return '…'
+  if (bytes === null) return '—'
+  return formatBytes(bytes)
+}
+
+export default function RepoSidebar({
+  repos,
+  selectedRepo,
+  repoSizes,
+  width,
+  onSelect,
+  onImport,
+  onRemove
+}: Props): JSX.Element {
   return (
-    <aside className="repo-sidebar">
+    <aside className="repo-sidebar" style={{ width }}>
       <div className="panel-header">
         <span>Repositories</span>
         <button className="primary" onClick={onImport} title="Import a git folder">
@@ -27,6 +44,9 @@ export default function RepoSidebar({ repos, selectedRepo, onSelect, onImport, o
             title={repo.path}
           >
             <span className="repo-name">{repo.name}</span>
+            <span className="repo-size" title=".git folder size">
+              {sizeLabel(repoSizes[repo.path])}
+            </span>
             <button
               className="icon-button"
               title="Remove from the list"

--- a/product/akbun-gitdesktop/src/renderer/src/components/ThreadDrawer.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/ThreadDrawer.tsx
@@ -13,6 +13,7 @@ export interface ThreadRef {
 interface Props {
   thread: ThreadRef
   onClose: () => void
+  width: number
 }
 
 function loadThread(thread: ThreadRef): ReturnType<typeof window.gitdesktop.getIssueDetail> {
@@ -39,7 +40,7 @@ function Labels({ labels }: { labels: string[] }): JSX.Element | null {
  * comments. Bodies are GitHub Markdown and are shown as the plain text they are,
  * because rendering them would mean pulling a Markdown parser into the app.
  */
-export default function ThreadDrawer({ thread, onClose }: Props): JSX.Element {
+export default function ThreadDrawer({ thread, onClose, width }: Props): JSX.Element {
   const [detail, setDetail] = useState<ThreadDetail | null>(null)
   const [loadError, setLoadError] = useState('')
   const [loading, setLoading] = useState(true)
@@ -69,7 +70,7 @@ export default function ThreadDrawer({ thread, onClose }: Props): JSX.Element {
   const url = detail?.url ?? ''
 
   return (
-    <aside className="diff-drawer">
+    <aside className="diff-drawer" style={{ width }}>
       <div className="diff-drawer-header">
         <div className="diff-drawer-title">
           <strong title={detail?.title ?? thread.title}>{detail?.title ?? thread.title}</strong>

--- a/product/akbun-gitdesktop/src/renderer/src/components/WorktreePanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/WorktreePanel.tsx
@@ -6,6 +6,7 @@ interface Props {
   worktrees: WorktreeInfo[]
   selectedWorktree: WorktreeInfo | null
   openerApps: OpenerApp[]
+  width: number
   onSelect: (worktree: WorktreeInfo) => void
   onChanged: () => void
   onError: (message: string) => void
@@ -16,6 +17,7 @@ export default function WorktreePanel({
   worktrees,
   selectedWorktree,
   openerApps,
+  width,
   onSelect,
   onChanged,
   onError
@@ -53,7 +55,7 @@ export default function WorktreePanel({
   }
 
   return (
-    <aside className="worktree-panel">
+    <aside className="worktree-panel" style={{ width }}>
       <div className="panel-header">
         <span>Worktree</span>
       </div>

--- a/product/akbun-gitdesktop/src/renderer/src/lib/formatBytes.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/lib/formatBytes.ts
@@ -1,0 +1,9 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB']
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const unit = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), UNITS.length - 1)
+  const value = bytes / 1024 ** unit
+  const precision = unit > 0 && value < 10 && !Number.isInteger(value) ? 1 : 0
+  return `${value.toFixed(precision)} ${UNITS[unit]}`
+}

--- a/product/akbun-gitdesktop/src/renderer/src/lib/usePanelWidth.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/lib/usePanelWidth.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react'
+
+export function clampPanelWidth(width: number, minWidth: number, maxWidth: number): number {
+  return Math.min(Math.max(width, minWidth), maxWidth)
+}
+
+function loadWidth(key: string, defaultWidth: number, minWidth: number, maxWidth: number): number {
+  const stored = Number(localStorage.getItem(key))
+  return Number.isFinite(stored) && stored > 0
+    ? clampPanelWidth(stored, minWidth, maxWidth)
+    : defaultWidth
+}
+
+export function usePanelWidth(
+  key: string,
+  defaultWidth: number,
+  minWidth: number,
+  maxWidth: number
+): [number, (width: number) => void] {
+  const [width, setStoredWidth] = useState(() => loadWidth(key, defaultWidth, minWidth, maxWidth))
+  const setWidth = useCallback(
+    (nextWidth: number) => {
+      const clamped = clampPanelWidth(nextWidth, minWidth, maxWidth)
+      setStoredWidth(clamped)
+      localStorage.setItem(key, String(clamped))
+    },
+    [key, maxWidth, minWidth]
+  )
+  return [width, setWidth]
+}

--- a/product/akbun-gitdesktop/src/renderer/src/styles.css
+++ b/product/akbun-gitdesktop/src/renderer/src/styles.css
@@ -279,10 +279,8 @@ button:focus-visible,
 /* Repository sidebar */
 
 .repo-sidebar {
-  width: 220px;
-  min-width: 220px;
+  flex-shrink: 0;
   background: var(--bg-panel);
-  border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
 }
@@ -300,6 +298,7 @@ button:focus-visible,
   padding: 8px 12px;
   cursor: pointer;
   border-left: 3px solid transparent;
+  gap: 8px;
 }
 
 .repo-list li:hover {
@@ -313,18 +312,26 @@ button:focus-visible,
 }
 
 .repo-name {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.repo-size {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Worktree panel */
 
 .worktree-panel {
-  width: 280px;
-  min-width: 280px;
+  flex-shrink: 0;
   background: var(--bg-panel);
-  border-right: 1px solid var(--border);
   display: flex;
   flex-direction: column;
 }
@@ -945,14 +952,46 @@ button:focus-visible,
 /* Diff drawer */
 
 .diff-drawer {
-  width: 46%;
-  min-width: 360px;
-  max-width: 760px;
+  flex-shrink: 0;
   background: var(--bg-panel);
-  border-left: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+
+/* Panel resize handles */
+
+.panel-resizer {
+  position: relative;
+  flex: 0 0 7px;
+  width: 7px;
+  min-width: 7px;
+  align-self: stretch;
+  cursor: col-resize;
+  touch-action: none;
+  outline: none;
+}
+
+.panel-resizer::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: var(--border);
+}
+
+.panel-resizer:hover::after,
+.panel-resizer:focus-visible::after {
+  left: 2px;
+  width: 3px;
+  background: var(--accent);
+}
+
+body.panel-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .diff-drawer-header {

--- a/product/akbun-gitdesktop/src/shared/types.ts
+++ b/product/akbun-gitdesktop/src/shared/types.ts
@@ -3,6 +3,11 @@ export interface RepoEntry {
   name: string
 }
 
+export interface RepoSizeInfo {
+  path: string
+  bytes: number | null
+}
+
 export interface CommitInfo {
   hash: string
   parents: string[]

--- a/product/akbun-gitdesktop/test/renderer-utils.test.js
+++ b/product/akbun-gitdesktop/test/renderer-utils.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test')
+const assert = require('node:assert')
+
+test('formatBytes는 읽기 쉬운 이진 단위로 표시한다', async () => {
+  const { formatBytes } = await import('../src/renderer/src/lib/formatBytes.ts')
+
+  assert.strictEqual(formatBytes(0), '0 B')
+  assert.strictEqual(formatBytes(1024), '1 KB')
+  assert.strictEqual(formatBytes(1536), '1.5 KB')
+  assert.strictEqual(formatBytes(25 * 1024 * 1024), '25 MB')
+})
+
+test('clampPanelWidth는 패널 너비를 허용 범위에 둔다', async () => {
+  const { clampPanelWidth } = await import('../src/renderer/src/lib/usePanelWidth.ts')
+
+  assert.strictEqual(clampPanelWidth(100, 160, 420), 160)
+  assert.strictEqual(clampPanelWidth(240, 160, 420), 240)
+  assert.strictEqual(clampPanelWidth(600, 160, 420), 420)
+})

--- a/product/akbun-gitdesktop/test/repo-size.test.js
+++ b/product/akbun-gitdesktop/test/repo-size.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+test('directorySize는 하위 디렉터리의 파일 크기를 합산한다', async () => {
+  const { directorySize } = await import('../src/main/directorySize.ts')
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'akbun-gitdesktop-size-'))
+  const nested = path.join(root, 'objects', 'pack')
+  fs.mkdirSync(nested, { recursive: true })
+  fs.writeFileSync(path.join(root, 'HEAD'), 'abc')
+  fs.writeFileSync(path.join(nested, 'pack-file'), '12345')
+
+  try {
+    assert.strictEqual(await directorySize(root), 8)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
# 구현

저장소 Git 데이터 용량 표시와 세 영역 패널 너비 조절
- 타입 검사, 자동화 테스트 10개, 프로덕션 빌드, 내장 브라우저 UI 검증 통과

# 리스크

Git 데이터 크기 계산이 저장소 수와 객체 수에 비례한 파일 시스템 순회
- 크기 조회 실패 시 목록에 대시 표시하고 나머지 저장소 조회 지속

Issue #1053
Issue #1054