### PR TITLE
fix: akbun-macdiskviewer Git 저장소 탐지와 스캔 성능 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@
 - [모델 config.json으로 LLM 아키텍처를 2D와 3D로 보는 웹 페이지 (visualizellm.akbun.com)](./product/akbun-visualizellm/) (26.8.18)
 - [셸을 감싸는 터미널 작업 공간 macOS 데스크톱 앱 (akbun-terminal)](./product/akbun-terminal/) (26.8.19)
 - [LLM serving RPS, latency, and KV cache calculator (akbun-caculatorllm)](./product/akbun-caculatorllm/) (26.8.19)
-- [macOS 전체 디스크와 AI Agent Git worktree 용량을 추적하는 데스크톱 앱 (akbun-macdiskviewer)](./product/akbun-macdiskviewer/) (26.8.22)
+- [macOS 전체 디스크와 Git 저장소·AI Agent worktree 용량을 추적하는 데스크톱 앱 (akbun-macdiskviewer)](./product/akbun-macdiskviewer/) (26.8.22)
 
 ## Dockerfile
 

--- a/product/README.md
+++ b/product/README.md
@@ -9,7 +9,7 @@
 | [akbun-awsviewer](./akbun-awsviewer/) | AWS profile을 골라 IAM Identity Center로 로그인하고 EC2를 조회 전용으로 보는 macOS 데스크톱 앱 |
 | [akbun-gitdesktop](./akbun-gitdesktop/) | git graph, 브랜치, worktree, GitHub PR을 보는 Electron 데스크톱 앱 |
 | [akbun-folderview](./akbun-folderview/) | 직접 추가한 사진과 영상을 태그, 등급, 검색으로 찾는 Windows 데스크톱 앱 |
-| [akbun-macdiskviewer](./akbun-macdiskviewer/) | macOS 전체 디스크와 AI Agent가 만든 Git worktree의 실제 용량을 낮은 부하로 추적하는 데스크톱 앱 |
+| [akbun-macdiskviewer](./akbun-macdiskviewer/) | macOS 전체 디스크와 Git 저장소·AI Agent worktree의 실제 용량을 낮은 부하로 추적하는 데스크톱 앱 |
 | [akbun-makepresentation](./akbun-makepresentation/) | 도형, 텍스트, pptx 열기/저장, pdf 내보내기, 발표 모드를 갖춘 슬라이드 편집 macOS 데스크톱 앱 |
 | [akbun-makevideo](./akbun-makevideo/) | 멀티 트랙 타임라인, 미리보기, ffmpeg FHD/4K 렌더링을 갖춘 영상 편집 macOS 데스크톱 앱 |
 | [cardnews-reference](./cardnews-reference/) | AI agent용 카드뉴스 레이아웃 레퍼런스 |

--- a/product/akbun-macdiskviewer/README.md
+++ b/product/akbun-macdiskviewer/README.md
@@ -1,22 +1,22 @@
 # akbun-macdiskviewer
 
-Tauri macOS app for finding disk pressure from AI-agent Git worktrees while retaining a complete startup-disk browser. Every accessible file and directory is indexed with recursive allocated size and can be sorted by size, modification date, or name.
+Tauri macOS app for finding disk pressure from Git repositories and AI-agent worktrees while retaining a complete startup-disk browser. Every accessible file and directory is indexed with recursive allocated size and can be sorted by size, modification date, or name.
 
-The first run scans `/`. Later runs open the completed SQLite index immediately and scan again only when requested. A low-priority Rust process visits one directory at a time, yields regularly, writes SQLite directly, and can be paused or cancelled.
+The first run scans `/`. Later runs open the completed SQLite index immediately and scan again only when requested. A background-priority Rust process visits one directory at a time, writes SQLite in bounded batches, and can be paused or cancelled.
 
 ## What it does
 
 | Feature | Behavior |
 | --- | --- |
 | Full-disk index | Scans the startup disk and keeps every accessible file, directory, and symbolic link |
-| Worktree storage | Finds linked Git worktrees from `.git` pointer files and shows repository, branch, path, recursive size, and modification date in a separate tab |
+| Git storage | Finds regular repositories and linked worktrees from `.git` directories and pointer files; shows repository, branch, path, recursive size, and modification date in a separate tab |
 | Directory size | Aggregates allocated and logical sizes from descendants; the table sorts by allocated size |
 | Browse and search | Opens directories, searches names, switches between direct children and every descendant, and pages large result sets |
 | Sort | Size, modification date, or name in either direction |
 | Finder | Right click a disk item or worktree and choose Show in Finder |
 | Terminals | Discovers installed terminal apps from bundle metadata; known terminals receive their working-directory option and unknown terminals receive a macOS file-open event |
 | Permissions | Counts unreadable paths and links to macOS Full Disk Access settings |
-| Scan control | Rust scanner with low OS priority, sequential directory reads, timed yielding, pause, resume, and cancel |
+| Scan control | Rust scanner with background I/O and low CPU priority, sequential directory reads, batched SQLite writes, pause, resume, and cancel |
 
 External volumes under `/Volumes`, synthetic device files, APFS duplicate views, VM data, and symbolic-link targets are not traversed. This keeps the result scoped to the startup disk and avoids double counting.
 

--- a/product/akbun-macdiskviewer/adr/2026-08-low-impact-scan.md
+++ b/product/akbun-macdiskviewer/adr/2026-08-low-impact-scan.md
@@ -2,8 +2,8 @@
 
 ## Decision
 
-Run the full-disk scan in a low-priority Rust process. Traverse sequentially, yield regularly, stream progress, and write a new SQLite index that replaces the completed index only after success.
+Run the full-disk scan in a background-I/O, low-CPU-priority Rust process. Traverse sequentially, stream progress, batch SQLite writes, and build query indexes after traversal. Replace the completed index only after success.
 
 ## Reason
 
-Walking the startup disk is unavoidably I/O-heavy. One directory at a time avoids the bursts caused by parallel stat calls, and lower OS priority lets interactive work win CPU time. SQLite keeps millions of entries out of the renderer heap and supports paging and sorting without loading the catalog at once. Keeping the prior index during a scan makes pause, cancellation, failure, and startup recovery safe.
+Walking the startup disk is unavoidably I/O-heavy. One directory at a time avoids bursts from parallel stat calls, while `taskpolicy -b` and `nice -n 10` let interactive work win disk and CPU time. Batching rows and deferring indexes removes per-item sleeps and repeated B-tree updates without increasing traversal concurrency. Keeping the prior index during a scan makes pause, cancellation, failure, and startup recovery safe.

--- a/product/akbun-macdiskviewer/adr/2026-08-worktree-storage.md
+++ b/product/akbun-macdiskviewer/adr/2026-08-worktree-storage.md
@@ -1,9 +1,9 @@
-# Worktree storage is a separate indexed view
+# Git storage is a separate indexed view
 
 ## Decision
 
-Keep the full startup-disk index as the base data source and add a Worktrees tab that identifies linked Git worktrees from `.git` pointer files. Show repository, branch, path, recursive allocated size, modification date, Finder, and terminal actions.
+Keep the full startup-disk index as the base data source and add a Git storage tab that identifies regular repositories and linked worktrees from `.git` directories and pointer files. Show repository, branch, path, recursive allocated size, modification date, Finder, and terminal actions.
 
 ## Reason
 
-AI agents create many linked worktrees whose checked-out files and repeated dependency directories create disk pressure. macOS Storage does not group those directories by repository or branch. Deriving them from the completed disk index avoids a second filesystem traversal and keeps the displayed size consistent with the disk browser.
+Repositories and AI-agent worktrees both contain checked-out files and repeated dependency directories that create disk pressure. macOS Storage does not group those directories by repository or branch. Deriving them from the completed disk index avoids a second filesystem traversal and keeps the displayed size consistent with the disk browser.

--- a/product/akbun-macdiskviewer/adr/index.md
+++ b/product/akbun-macdiskviewer/adr/index.md
@@ -6,9 +6,9 @@ Decision records for akbun-macdiskviewer.
 
 - [Tauri for the macOS application shell](2026-08-tauri-shell.md) - Use the system WebView and a Rust command backend while preserving the separate low-priority scanner.
 - [Electron for the macOS release](2026-08-electron-for-macos.md) - Superseded initial shell decision.
-- [Low-impact scan into a replaceable SQLite index](2026-08-low-impact-scan.md) - Sequential low-priority traversal keeps the computer responsive and the catalog off the renderer heap.
+- [Low-impact scan into a replaceable SQLite index](2026-08-low-impact-scan.md) - Sequential background-priority traversal and batched writes keep the computer responsive.
 - [Rust owns the full-disk scan](2026-08-rust-scanner.md) - Filesystem traversal, recursive aggregation, and SQLite writes remain isolated from the application shell.
-- [Worktree storage is a separate indexed view](2026-08-worktree-storage.md) - Derive linked worktrees from the completed disk index without another full traversal.
+- [Git storage is a separate indexed view](2026-08-worktree-storage.md) - Derive regular repositories and linked worktrees from the completed disk index without another traversal.
 - [Startup-disk boundaries](2026-08-startup-disk-boundaries.md) - Include macOS firmlinked data while excluding external volumes, duplicate APFS views, VM data, and links.
 - [Discover terminal applications from bundle metadata](2026-08-terminal-discovery.md) - Installed apps determine the context menu instead of a fixed preference list.
 - [Hand-written updater for an unsigned Electron build](2026-08-unsigned-self-update.md) - Superseded with the Electron shell.

--- a/product/akbun-macdiskviewer/wiki/architecture.md
+++ b/product/akbun-macdiskviewer/wiki/architecture.md
@@ -6,17 +6,17 @@ Tauri 2 macOS app with a Rust backend, a separate low-priority Rust scanner, and
 
 | Process | Files | Responsibility |
 | --- | --- | --- |
-| Tauri backend | `src-tauri/src/` | Window IPC, read-only SQLite queries, worktree discovery, scan lifecycle, terminal discovery, Finder, and macOS settings |
+| Tauri backend | `src-tauri/src/` | Window IPC, read-only SQLite queries, Git discovery, scan lifecycle, terminal discovery, Finder, and macOS settings |
 | Rust scanner | `scanner/src/main.rs` | Sequential filesystem walk and construction of the next SQLite index |
-| WebView | `src/renderer/` | Disk browser, Worktrees tab, filters, sorting, paging, scan status, and context menu |
+| WebView | `src/renderer/` | Disk browser, Git storage tab, filters, sorting, paging, scan status, and context menu |
 
 The WebView has no Node.js access. `api.js` exposes only named Tauri commands and the scan-state event to the page.
 
 ## Scan flow
 
-1. First start finds no completed index and starts the Rust scanner for `/` through `nice -n 10`.
-2. The scanner opens one directory at a time and sleeps for 8 milliseconds after every 200 entries.
-3. Files are inserted into `disk-index.next.sqlite`; directories are inserted after their children so recursive sizes are complete.
+1. First start finds no completed index, starts the Rust scanner for `/` through `nice -n 10`, and requests `taskpolicy -b` for its PID.
+2. The scanner opens one directory at a time and keeps pause and cancellation checkpoints without forced sleeps.
+3. Files are inserted into `disk-index.next.sqlite` in bounded batches; directories are inserted after their children so recursive sizes are complete.
 4. Rust writes newline-delimited JSON progress to stdout at most four times per second.
 5. A completed database replaces the current index through a backup rename.
 6. Tauri emits the completed scan state and the WebView reloads disk and worktree data.
@@ -31,17 +31,17 @@ The scan stores allocated bytes from Unix filesystem blocks and logical bytes fr
 
 `catalog_query` validates and bounds every input. A query selects direct children or all descendants, applies optional name search, orders by a fixed column map, and returns at most 500 rows.
 
-The SQLite index keeps the full catalog outside the WebView heap. Indexes cover parent path, size, and modification date.
+The SQLite index keeps the full catalog outside the WebView heap. Path, parent, size, and modification indexes are built after traversal so each scanned row does not update four B-trees.
 
-## Worktree flow
+## Git storage flow
 
-1. The completed disk index is queried for `.git` entries whose kind is `file`.
-2. Each pointer file resolves the linked worktree Git directory.
-3. `commondir` identifies the source repository and `HEAD` identifies the worktree branch.
-4. The worktree root row provides recursive allocated size, modification date, and descendant count.
-5. The Worktrees tab filters and sorts the bounded result without another filesystem traversal.
+1. The completed disk index is queried for `.git` files and directories.
+2. A `.git` directory identifies a regular repository; a pointer file resolves a linked worktree Git directory.
+3. `commondir` identifies a linked worktree's source repository and `HEAD` identifies each branch.
+4. The repository or worktree root row provides recursive allocated size, modification date, and descendant count.
+5. The Git storage tab filters and sorts the bounded result without another filesystem traversal.
 
-Regular primary worktrees use a `.git` directory and are not counted as linked agent worktrees. Invalid or stale pointer files are ignored.
+Invalid or stale Git markers are ignored.
 
 ## Tauri command surface
 
@@ -49,7 +49,7 @@ Regular primary worktrees use a `.git` directory and are not counted as linked a
 | --- | --- |
 | `app_state` | Disk capacity, scan state, and completed-index metadata |
 | `catalog_query`, `catalog_issues` | Validated disk rows and unreadable paths |
-| `worktree_catalog` | Linked worktree summary and rows |
+| `worktree_catalog` | Git repository and linked-worktree summary and rows |
 | `scan_start`, `scan_pause`, `scan_resume`, `scan_cancel` | Control the Rust scanner process |
 | `scan-state` | Progress and completion event |
 | `terminals`, `show_in_finder`, `open_in_terminal` | Context actions |

--- a/product/akbun-macdiskviewer/workspace/package-lock.json
+++ b/product/akbun-macdiskviewer/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-macdiskviewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-macdiskviewer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2.11.4"

--- a/product/akbun-macdiskviewer/workspace/package.json
+++ b/product/akbun-macdiskviewer/workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-macdiskviewer",
-  "version": "0.1.0",
-  "description": "Tauri macOS disk and Git worktree storage viewer",
+  "version": "0.1.1",
+  "description": "Tauri macOS disk, Git repository, and worktree storage viewer",
   "author": "akbun",
   "license": "MIT",
   "scripts": {

--- a/product/akbun-macdiskviewer/workspace/scanner/Cargo.toml
+++ b/product/akbun-macdiskviewer/workspace/scanner/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.104"
-rusqlite = { version = "0.40.2", features = ["bundled"] }
+rusqlite = { version = "0.40.2", features = ["bundled", "hooks"] }
 serde_json = "1.0.151"

--- a/product/akbun-macdiskviewer/workspace/scanner/src/main.rs
+++ b/product/akbun-macdiskviewer/workspace/scanner/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result, anyhow};
-use rusqlite::{Connection, params};
+use rusqlite::types::Value as SqlValue;
+use rusqlite::{Connection, params, params_from_iter};
 use serde_json::{Value, json};
 use std::env;
 use std::fs::{self, Metadata};
@@ -12,14 +13,17 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 const SCAN_CANCELLED: &str = "SCAN_CANCELLED";
-const YIELD_EVERY: u64 = 200;
-const THROTTLE_MS: u64 = 8;
+const INSERT_BATCH_SIZE: usize = 1024;
 
 const SCHEMA: &str = r#"
-PRAGMA journal_mode = DELETE;
-PRAGMA synchronous = NORMAL;
+PRAGMA journal_mode = MEMORY;
+PRAGMA synchronous = OFF;
+PRAGMA temp_store = MEMORY;
+PRAGMA locking_mode = EXCLUSIVE;
+PRAGMA cache_size = -32768;
+PRAGMA threads = 2;
 CREATE TABLE entries (
-  path TEXT PRIMARY KEY,
+  path TEXT NOT NULL,
   parent_path TEXT,
   name TEXT NOT NULL,
   kind TEXT NOT NULL,
@@ -36,6 +40,10 @@ CREATE TABLE metadata (
   key TEXT PRIMARY KEY,
   value TEXT NOT NULL
 );
+"#;
+
+const INDEX_SCHEMA: &str = r#"
+CREATE UNIQUE INDEX entries_path ON entries(path);
 CREATE INDEX entries_parent ON entries(parent_path);
 CREATE INDEX entries_size ON entries(size_bytes DESC);
 CREATE INDEX entries_modified ON entries(modified_ms DESC);
@@ -76,11 +84,11 @@ struct Aggregate {
     descendants: u64,
 }
 
-struct EntryRow<'a> {
-    path: &'a str,
-    parent_path: Option<&'a str>,
-    name: &'a str,
-    kind: &'a str,
+struct EntryRow {
+    path: String,
+    parent_path: Option<String>,
+    name: String,
+    kind: &'static str,
     size: u64,
     logical: u64,
     modified: i64,
@@ -91,9 +99,9 @@ struct Scanner<'a> {
     database: &'a Connection,
     control: Arc<Control>,
     counters: Counters,
-    since_yield: u64,
     last_progress: Instant,
     root: PathBuf,
+    pending_entries: Vec<EntryRow>,
 }
 
 impl<'a> Scanner<'a> {
@@ -102,30 +110,19 @@ impl<'a> Scanner<'a> {
             database,
             control,
             counters: Counters::default(),
-            since_yield: 0,
             last_progress: Instant::now() - Duration::from_millis(250),
             root,
+            pending_entries: Vec::with_capacity(INSERT_BATCH_SIZE),
         }
     }
 
     fn checkpoint(&mut self, current_path: &Path) -> Result<()> {
-        if self.control.cancelled.load(Ordering::Relaxed) {
+        if wait_for_control(&self.control) {
             return Err(anyhow!(SCAN_CANCELLED));
         }
-        while self.control.paused.load(Ordering::Relaxed) {
-            if self.control.cancelled.load(Ordering::Relaxed) {
-                return Err(anyhow!(SCAN_CANCELLED));
-            }
-            thread::sleep(Duration::from_millis(50));
-        }
-        self.since_yield += 1;
         if self.last_progress.elapsed() >= Duration::from_millis(250) {
             emit(json!({ "type": "progress", "progress": self.counters.json(current_path) }));
             self.last_progress = Instant::now();
-        }
-        if self.since_yield >= YIELD_EVERY {
-            self.since_yield = 0;
-            thread::sleep(Duration::from_millis(THROTTLE_MS));
         }
         Ok(())
     }
@@ -149,16 +146,16 @@ impl<'a> Scanner<'a> {
                 .file_name()
                 .map_or_else(String::new, |value| value.to_string_lossy().into_owned())
         };
-        let path_text = entry_path.to_string_lossy();
+        let path_text = entry_path.to_string_lossy().into_owned();
         let parent_text = parent_path.map(|value| value.to_string_lossy().into_owned());
         let logical = metadata.len();
         let modified = modified_ms(&metadata);
 
         if metadata.file_type().is_symlink() {
             self.insert_entry(EntryRow {
-                path: &path_text,
-                parent_path: parent_text.as_deref(),
-                name: &name,
+                path: path_text,
+                parent_path: parent_text,
+                name,
                 kind: "link",
                 size: 0,
                 logical,
@@ -175,9 +172,9 @@ impl<'a> Scanner<'a> {
         if !metadata.is_dir() {
             let size = allocated_bytes(&metadata);
             self.insert_entry(EntryRow {
-                path: &path_text,
-                parent_path: parent_text.as_deref(),
-                name: &name,
+                path: path_text,
+                parent_path: parent_text,
+                name,
                 kind: "file",
                 size,
                 logical,
@@ -222,9 +219,9 @@ impl<'a> Scanner<'a> {
             Err(error) => self.record_issue(entry_path, &error),
         }
         self.insert_entry(EntryRow {
-            path: &path_text,
-            parent_path: parent_text.as_deref(),
-            name: &name,
+            path: path_text,
+            parent_path: parent_text,
+            name,
             kind: "directory",
             size: aggregate.size,
             logical: aggregate.logical,
@@ -236,22 +233,40 @@ impl<'a> Scanner<'a> {
         Ok(aggregate)
     }
 
-    fn insert_entry(&mut self, entry: EntryRow<'_>) -> Result<()> {
-        let mut statement = self.database.prepare_cached(
+    fn insert_entry(&mut self, entry: EntryRow) -> Result<()> {
+        self.pending_entries.push(entry);
+        if self.pending_entries.len() >= INSERT_BATCH_SIZE {
+            self.flush_entries()?;
+        }
+        Ok(())
+    }
+
+    fn flush_entries(&mut self) -> Result<()> {
+        if self.pending_entries.is_empty() {
+            return Ok(());
+        }
+        let placeholders =
+            std::iter::repeat_n("(?, ?, ?, ?, ?, ?, ?, ?)", self.pending_entries.len())
+                .collect::<Vec<_>>()
+                .join(", ");
+        let sql = format!(
             "INSERT INTO entries
-        (path, parent_path, name, kind, size_bytes, logical_bytes, modified_ms, descendants)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        )?;
-        statement.execute(params![
-            entry.path,
-            entry.parent_path,
-            entry.name,
-            entry.kind,
-            as_i64(entry.size),
-            as_i64(entry.logical),
-            entry.modified,
-            as_i64(entry.descendants)
-        ])?;
+       (path, parent_path, name, kind, size_bytes, logical_bytes, modified_ms, descendants)
+       VALUES {placeholders}"
+        );
+        let mut values = Vec::with_capacity(self.pending_entries.len() * 8);
+        for entry in self.pending_entries.drain(..) {
+            values.push(SqlValue::Text(entry.path));
+            values.push(entry.parent_path.map_or(SqlValue::Null, SqlValue::Text));
+            values.push(SqlValue::Text(entry.name));
+            values.push(SqlValue::Text(entry.kind.into()));
+            values.push(SqlValue::Integer(as_i64(entry.size)));
+            values.push(SqlValue::Integer(as_i64(entry.logical)));
+            values.push(SqlValue::Integer(entry.modified));
+            values.push(SqlValue::Integer(as_i64(entry.descendants)));
+        }
+        self.database
+            .execute(&sql, params_from_iter(values.iter()))?;
         Ok(())
     }
 
@@ -275,31 +290,63 @@ fn scan_disk(root: &Path, database_path: &Path, control: Arc<Control>) -> Result
         .with_context(|| format!("cannot open {}", database_path.display()))?;
     database.execute_batch(SCHEMA)?;
     database.execute_batch("BEGIN")?;
-    let mut scanner = Scanner::new(&database, control, root.to_path_buf());
-    let result = scanner.visit(root, None);
+    let mut scanner = Scanner::new(&database, control.clone(), root.to_path_buf());
+    let result = (|| -> Result<()> {
+        scanner.visit(root, None)?;
+        scanner.flush_entries()?;
+        create_indexes(&database, control.clone())?;
+        let completed_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let hostname = env::var("HOSTNAME").unwrap_or_default();
+        for (key, value) in [
+            ("rootPath", root.to_string_lossy().into_owned()),
+            ("completedAt", completed_at.to_string()),
+            ("hostname", hostname),
+            ("issues", scanner.counters.issues.to_string()),
+        ] {
+            database.execute(
+                "INSERT INTO metadata (key, value) VALUES (?, ?)",
+                params![key, value],
+            )?;
+        }
+        database.execute_batch("COMMIT")?;
+        Ok(())
+    })();
     if let Err(error) = result {
         let _ = database.execute_batch("ROLLBACK");
+        if control.cancelled.load(Ordering::Relaxed) {
+            return Err(anyhow!(SCAN_CANCELLED));
+        }
         return Err(error);
     }
-    let completed_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis();
-    let hostname = env::var("HOSTNAME").unwrap_or_default();
-    for (key, value) in [
-        ("rootPath", root.to_string_lossy().into_owned()),
-        ("completedAt", completed_at.to_string()),
-        ("hostname", hostname),
-        ("issues", scanner.counters.issues.to_string()),
-    ] {
-        database.execute(
-            "INSERT INTO metadata (key, value) VALUES (?, ?)",
-            params![key, value],
-        )?;
-    }
-    database.execute_batch("COMMIT")?;
     emit(json!({ "type": "progress", "progress": scanner.counters.json(root) }));
     Ok(scanner.counters)
+}
+
+fn create_indexes(database: &Connection, control: Arc<Control>) -> Result<()> {
+    if wait_for_control(&control) {
+        return Err(anyhow!(SCAN_CANCELLED));
+    }
+    let handler_control = control.clone();
+    database.progress_handler(1000, Some(move || wait_for_control(&handler_control)))?;
+    let result = database.execute_batch(INDEX_SCHEMA);
+    database.progress_handler(0, None::<fn() -> bool>)?;
+    if control.cancelled.load(Ordering::Relaxed) {
+        return Err(anyhow!(SCAN_CANCELLED));
+    }
+    result.map_err(Into::into)
+}
+
+fn wait_for_control(control: &Control) -> bool {
+    while control.paused.load(Ordering::Relaxed) {
+        if control.cancelled.load(Ordering::Relaxed) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    control.cancelled.load(Ordering::Relaxed)
 }
 
 fn listen_for_control(control: Arc<Control>) {
@@ -496,6 +543,37 @@ mod tests {
             .unwrap();
         assert_eq!(metadata_root, root_path);
         assert_eq!(metadata_issues, "0");
+        let indexes: i64 = database
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_index_list('entries')
+         WHERE name IN ('entries_path', 'entries_parent', 'entries_size', 'entries_modified')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(indexes, 4);
+        drop(database);
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn writes_complete_batches_and_the_final_partial_batch() {
+        let directory = temp_directory();
+        let root = directory.join("root");
+        let database_path = directory.join("scan.sqlite");
+        fs::create_dir_all(&root).unwrap();
+        for index in 0..=INSERT_BATCH_SIZE {
+            fs::write(root.join(format!("file-{index}")), b"x").unwrap();
+        }
+
+        let counters = scan_disk(&root, &database_path, Arc::new(Control::default())).unwrap();
+        assert_eq!(counters.entries, INSERT_BATCH_SIZE as u64 + 2);
+
+        let database = Connection::open(&database_path).unwrap();
+        let entries: i64 = database
+            .query_row("SELECT COUNT(*) FROM entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(entries, INSERT_BATCH_SIZE as i64 + 2);
         drop(database);
         fs::remove_dir_all(directory).unwrap();
     }
@@ -524,6 +602,25 @@ mod tests {
         assert_eq!(metadata, 0);
         drop(database);
         fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn cancellation_skips_deferred_index_creation() {
+        let database = Connection::open_in_memory().unwrap();
+        database.execute_batch(SCHEMA).unwrap();
+        let control = Arc::new(Control::default());
+        control.cancelled.store(true, Ordering::Relaxed);
+
+        let error = create_indexes(&database, control).unwrap_err();
+        assert_eq!(error.to_string(), SCAN_CANCELLED);
+        let indexes: i64 = database
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_index_list('entries')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(indexes, 0);
     }
 
     #[test]

--- a/product/akbun-macdiskviewer/workspace/scanner/src/main.rs
+++ b/product/akbun-macdiskviewer/workspace/scanner/src/main.rs
@@ -245,6 +245,9 @@ impl<'a> Scanner<'a> {
         if self.pending_entries.is_empty() {
             return Ok(());
         }
+        if wait_for_control(&self.control) {
+            return Err(anyhow!(SCAN_CANCELLED));
+        }
         let placeholders =
             std::iter::repeat_n("(?, ?, ?, ?, ?, ?, ?, ?)", self.pending_entries.len())
                 .collect::<Vec<_>>()
@@ -265,8 +268,10 @@ impl<'a> Scanner<'a> {
             values.push(SqlValue::Integer(entry.modified));
             values.push(SqlValue::Integer(as_i64(entry.descendants)));
         }
-        self.database
-            .execute(&sql, params_from_iter(values.iter()))?;
+        let database = self.database;
+        execute_with_control(database, self.control.clone(), || {
+            database.execute(&sql, params_from_iter(values.iter()))
+        })?;
         Ok(())
     }
 
@@ -326,12 +331,20 @@ fn scan_disk(root: &Path, database_path: &Path, control: Arc<Control>) -> Result
 }
 
 fn create_indexes(database: &Connection, control: Arc<Control>) -> Result<()> {
+    execute_with_control(database, control, || database.execute_batch(INDEX_SCHEMA))
+}
+
+fn execute_with_control<T>(
+    database: &Connection,
+    control: Arc<Control>,
+    operation: impl FnOnce() -> rusqlite::Result<T>,
+) -> Result<T> {
     if wait_for_control(&control) {
         return Err(anyhow!(SCAN_CANCELLED));
     }
     let handler_control = control.clone();
     database.progress_handler(1000, Some(move || wait_for_control(&handler_control)))?;
-    let result = database.execute_batch(INDEX_SCHEMA);
+    let result = operation();
     database.progress_handler(0, None::<fn() -> bool>)?;
     if control.cancelled.load(Ordering::Relaxed) {
         return Err(anyhow!(SCAN_CANCELLED));
@@ -621,6 +634,34 @@ mod tests {
             )
             .unwrap();
         assert_eq!(indexes, 0);
+    }
+
+    #[test]
+    fn cancellation_skips_a_pending_insert_batch() {
+        let database = Connection::open_in_memory().unwrap();
+        database.execute_batch(SCHEMA).unwrap();
+        let control = Arc::new(Control::default());
+        let mut scanner = Scanner::new(&database, control.clone(), PathBuf::from("/root"));
+        scanner
+            .insert_entry(EntryRow {
+                path: "/root/file".into(),
+                parent_path: Some("/root".into()),
+                name: "file".into(),
+                kind: "file",
+                size: 1,
+                logical: 1,
+                modified: 0,
+                descendants: 0,
+            })
+            .unwrap();
+        control.cancelled.store(true, Ordering::Relaxed);
+
+        let error = scanner.flush_entries().unwrap_err();
+        assert_eq!(error.to_string(), SCAN_CANCELLED);
+        let entries: i64 = database
+            .query_row("SELECT COUNT(*) FROM entries", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(entries, 0);
     }
 
     #[test]

--- a/product/akbun-macdiskviewer/workspace/src-tauri/src/scanner.rs
+++ b/product/akbun-macdiskviewer/workspace/src-tauri/src/scanner.rs
@@ -130,17 +130,14 @@ pub fn start(app: AppHandle, backend: Backend) -> Result<bool, String> {
         fs::remove_file(&paths.next).map_err(error_text)?;
     }
     let executable = scanner_executable(&app)?;
-    let mut child = Command::new("/usr/bin/nice")
-        .args(["-n", "10"])
-        .arg(executable)
-        .args(["--root", "/", "--database"])
-        .arg(&paths.next)
+    let mut child = scanner_command(&executable, &paths.next)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(error_text)?;
     let pid = child.id();
+    apply_background_policy(pid);
     let stdin = child
         .stdin
         .take()
@@ -233,6 +230,31 @@ pub fn start(app: AppHandle, backend: Backend) -> Result<bool, String> {
     Ok(true)
 }
 
+fn scanner_command(executable: &Path, database_path: &Path) -> Command {
+    let mut command = Command::new("/usr/bin/nice");
+    command
+        .args(["-n", "10"])
+        .arg(executable)
+        .args(["--root", "/", "--database"])
+        .arg(database_path);
+    command
+}
+
+fn apply_background_policy(pid: u32) {
+    if cfg!(target_os = "macos") {
+        let _ = background_policy_command(pid)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+fn background_policy_command(pid: u32) -> Command {
+    let mut command = Command::new("/usr/sbin/taskpolicy");
+    command.args(["-b", "-p", &pid.to_string()]);
+    command
+}
+
 fn handle_message(
     app: &AppHandle,
     backend: &Backend,
@@ -316,6 +338,35 @@ fn error_text(error: impl std::fmt::Display) -> String {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn scanner_runs_with_background_io_and_low_cpu_priority() {
+        let command = scanner_command(Path::new("/scanner"), Path::new("/catalog.sqlite"));
+        let program = command.get_program().to_string_lossy();
+        let arguments = command
+            .get_args()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(program, "/usr/bin/nice");
+        assert_eq!(&arguments[..3], ["-n", "10", "/scanner"]);
+        assert!(arguments.ends_with(&[
+            "--root".into(),
+            "/".into(),
+            "--database".into(),
+            "/catalog.sqlite".into(),
+        ]));
+
+        let background = background_policy_command(42);
+        assert_eq!(background.get_program(), "/usr/sbin/taskpolicy");
+        assert_eq!(
+            background
+                .get_args()
+                .map(|argument| argument.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            ["-b", "-p", "42"]
+        );
+    }
 
     #[test]
     fn recovers_backup_and_removes_incomplete_scan() {

--- a/product/akbun-macdiskviewer/workspace/src-tauri/src/worktrees.rs
+++ b/product/akbun-macdiskviewer/workspace/src-tauri/src/worktrees.rs
@@ -24,7 +24,8 @@ pub struct WorktreeCatalog {
 }
 
 struct Candidate {
-    git_file: String,
+    git_marker: String,
+    marker_kind: String,
     root: String,
     size_bytes: i64,
     modified_ms: i64,
@@ -43,20 +44,22 @@ pub fn discover(database_path: &Path) -> Result<WorktreeCatalog, String> {
         .map_err(error_text)?;
     let mut statement = database
         .prepare(
-            "SELECT marker.path, root.path, root.size_bytes, root.modified_ms, root.descendants
+            "SELECT marker.path, marker.kind, root.path, root.size_bytes, root.modified_ms,
+                    root.descendants
        FROM entries marker
        JOIN entries root ON root.path = marker.parent_path
-       WHERE marker.name = '.git' AND marker.kind = 'file'",
+       WHERE marker.name = '.git' AND marker.kind IN ('file', 'directory')",
         )
         .map_err(error_text)?;
     let candidates = statement
         .query_map([], |row| {
             Ok(Candidate {
-                git_file: row.get(0)?,
-                root: row.get(1)?,
-                size_bytes: row.get(2)?,
-                modified_ms: row.get(3)?,
-                descendants: row.get(4)?,
+                git_marker: row.get(0)?,
+                marker_kind: row.get(1)?,
+                root: row.get(2)?,
+                size_bytes: row.get(3)?,
+                modified_ms: row.get(4)?,
+                descendants: row.get(5)?,
             })
         })
         .map_err(error_text)?
@@ -85,12 +88,21 @@ pub fn discover(database_path: &Path) -> Result<WorktreeCatalog, String> {
 
 fn read_candidate(candidate: &Candidate) -> Option<WorktreeEntry> {
     let root = Path::new(&candidate.root);
-    let git_dir = parse_git_dir(Path::new(&candidate.git_file), root)?;
-    let common_dir = common_directory(&git_dir)?;
-    let repository_path = if common_dir.file_name().is_some_and(|name| name == ".git") {
-        common_dir.parent()?.to_path_buf()
+    let marker = Path::new(&candidate.git_marker);
+    let (git_dir, repository_path) = if candidate.marker_kind == "directory" {
+        if !marker.is_dir() || !root.is_dir() {
+            return None;
+        }
+        (marker.to_path_buf(), root.to_path_buf())
     } else {
-        common_dir
+        let git_dir = parse_git_dir(marker, root)?;
+        let common_dir = common_directory(&git_dir)?;
+        let repository_path = if common_dir.file_name().is_some_and(|name| name == ".git") {
+            common_dir.parent()?.to_path_buf()
+        } else {
+            common_dir
+        };
+        (git_dir, repository_path)
     };
     let repository = repository_path.file_name().map_or_else(
         || repository_path.to_string_lossy().into_owned(),
@@ -203,7 +215,52 @@ mod tests {
     }
 
     #[test]
-    fn ignores_regular_git_directories_and_invalid_markers() {
+    fn discovers_regular_git_repositories_from_the_disk_index() {
+        let directory = tempdir().unwrap();
+        let repository = directory.path().join("projects/sample-repository");
+        let git_dir = repository.join(".git");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let database_path = directory.path().join("catalog.sqlite");
+        let database = Connection::open(&database_path).unwrap();
+        database
+            .execute_batch(
+                "CREATE TABLE entries (
+        path TEXT PRIMARY KEY, parent_path TEXT, name TEXT NOT NULL, kind TEXT NOT NULL,
+        size_bytes INTEGER NOT NULL, logical_bytes INTEGER NOT NULL,
+        modified_ms INTEGER NOT NULL, descendants INTEGER NOT NULL DEFAULT 0
+      );",
+            )
+            .unwrap();
+        database
+            .execute(
+                "INSERT INTO entries VALUES (?, NULL, ?, 'directory', 8192, 8192, 5678, 30)",
+                params![repository.to_string_lossy(), "sample-repository"],
+            )
+            .unwrap();
+        database
+            .execute(
+                "INSERT INTO entries VALUES (?, ?, '.git', 'directory', 1024, 1024, 5678, 5)",
+                params![git_dir.to_string_lossy(), repository.to_string_lossy()],
+            )
+            .unwrap();
+        drop(database);
+
+        let catalog = discover(&database_path).unwrap();
+        assert_eq!(catalog.count, 1);
+        assert_eq!(catalog.total_size_bytes, 8192);
+        assert_eq!(catalog.items[0].repository, "sample-repository");
+        assert_eq!(catalog.items[0].branch, "main");
+        assert_eq!(catalog.items[0].path, repository.to_string_lossy());
+        assert_eq!(
+            catalog.items[0].repository_path,
+            repository.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn ignores_git_markers_missing_from_the_filesystem() {
         let directory = tempdir().unwrap();
         let database_path = directory.path().join("catalog.sqlite");
         let database = Connection::open(&database_path).unwrap();

--- a/product/akbun-macdiskviewer/workspace/src/renderer/index.html
+++ b/product/akbun-macdiskviewer/workspace/src/renderer/index.html
@@ -25,7 +25,7 @@
         </button>
         <button class="nav-item" id="worktreeNav">
           <span class="nav-icon">⑂</span>
-          Worktrees
+          Git storage
         </button>
         <button class="nav-item" id="largestButton">
           <span class="nav-icon">⇣</span>
@@ -156,9 +156,9 @@
       <div class="hidden" id="worktreeView">
         <section class="worktree-summary">
           <div>
-            <span class="eyebrow">AI AGENT WORKTREES</span>
+            <span class="eyebrow">GIT STORAGE</span>
             <strong id="worktreeSize">0 B</strong>
-            <p>Disk space used by linked Git worktrees</p>
+            <p>Disk space used by Git repositories and linked worktrees</p>
           </div>
           <div class="worktree-stat">
             <span>Detected</span>
@@ -169,8 +169,8 @@
         <section class="browser-card worktree-card">
           <div class="browser-toolbar">
             <div>
-              <strong>Linked worktrees</strong>
-              <p class="toolbar-copy">Detected from <code>.git</code> pointer files in the latest disk index.</p>
+              <strong>Repositories and worktrees</strong>
+              <p class="toolbar-copy">Detected from <code>.git</code> directories and pointer files in the latest disk index.</p>
             </div>
             <div class="filters">
               <label class="search-box compact">
@@ -199,12 +199,12 @@
             </table>
             <div class="empty-state hidden" id="worktreeEmpty">
               <div>⑂</div>
-              <strong>No linked worktrees found</strong>
-              <span>Run a disk scan after an AI agent creates worktrees.</span>
+              <strong>No Git repositories found</strong>
+              <span>Run a disk scan to find repositories and linked worktrees.</span>
             </div>
           </div>
           <footer class="pagination">
-            <span id="worktreeResultCount">0 worktrees</span>
+            <span id="worktreeResultCount">0 Git directories</span>
             <span>Right click a row for Finder and terminal actions</span>
           </footer>
         </section>

--- a/product/akbun-macdiskviewer/workspace/src/renderer/preview.js
+++ b/product/akbun-macdiskviewer/workspace/src/renderer/preview.js
@@ -14,6 +14,7 @@ if (!window.diskViewer && new URLSearchParams(window.location.search).has('previ
     { path: '/cores', parent_path: '/', name: 'cores', kind: 'directory', size_bytes: 0, logical_bytes: 0, modified_ms: now - 60_000_000, descendants: 0 },
   ];
   const worktrees = [
+    { path: '/Users/akbun/git/portfolio', repository: 'portfolio', repositoryPath: '/Users/akbun/git/portfolio', branch: 'main', sizeBytes: 24.1 * gib, modifiedMs: now - 60_000, descendants: 62014 },
     { path: '/Users/akbun/.codex/worktrees/portfolio/agent-42', repository: 'portfolio', repositoryPath: '/Users/akbun/git/portfolio', branch: 'codex/worktree-storage', sizeBytes: 18.4 * gib, modifiedMs: now - 180_000, descendants: 48122 },
     { path: '/Users/akbun/.claude/worktrees/docs/review', repository: 'docs', repositoryPath: '/Users/akbun/git/docs', branch: 'claude/review', sizeBytes: 7.8 * gib, modifiedMs: now - 8_600_000, descendants: 18043 },
     { path: '/Users/akbun/.codex/worktrees/api/test', repository: 'api', repositoryPath: '/Users/akbun/git/api', branch: 'codex/test', sizeBytes: 3.2 * gib, modifiedMs: now - 86_000_000, descendants: 9241 },

--- a/product/akbun-macdiskviewer/workspace/src/renderer/renderer.js
+++ b/product/akbun-macdiskviewer/workspace/src/renderer/renderer.js
@@ -251,7 +251,7 @@ function renderWorktrees() {
   const sorted = sortWorktrees(filtered, elements.worktreeSort.value);
   elements.worktreeRows.replaceChildren(...sorted.map(worktreeRow));
   elements.worktreeEmpty.classList.toggle('hidden', sorted.length !== 0);
-  elements.worktreeResultCount.textContent = `${formatCount(sorted.length)} of ${formatCount(state.worktrees.length)} worktrees`;
+  elements.worktreeResultCount.textContent = `${formatCount(sorted.length)} of ${formatCount(state.worktrees.length)} Git directories`;
 }
 
 async function loadWorktrees() {
@@ -270,7 +270,7 @@ function showView(view) {
   elements.diskSearchBox.classList.toggle('hidden', worktrees);
   elements.diskNav.classList.toggle('active', !worktrees);
   elements.worktreeNav.classList.toggle('active', worktrees);
-  elements.viewTitle.textContent = worktrees ? 'Worktree storage' : 'Macintosh HD';
+  elements.viewTitle.textContent = worktrees ? 'Git storage' : 'Macintosh HD';
   if (worktrees) void loadWorktrees();
 }
 

--- a/product/products.json
+++ b/product/products.json
@@ -1,11 +1,11 @@
 {
   "repoBase": "https://github.com/choisungwook/portfolio/tree/master/product",
-  "updated": "2026-08-22",
+  "updated": "2026-08-23",
   "products": [
     {
       "id": "akbun-macdiskviewer",
       "name": "akbun-macdiskviewer",
-      "description": "macOS 전체 디스크와 AI Agent가 만든 Git worktree의 실제 용량을 낮은 부하로 추적하는 데스크톱 앱",
+      "description": "macOS 전체 디스크와 Git 저장소·AI Agent worktree의 실제 용량을 낮은 부하로 추적하는 데스크톱 앱",
       "kind": "desktop",
       "tags": ["tauri", "rust", "macos", "storage", "git-worktree"],
       "download": "https://github.com/choisungwook/portfolio/releases?q=akbun-macdiskviewer",


### PR DESCRIPTION
# 구현

일반 Git 저장소 탐지와 순차 스캐너 SQLite 배치 최적화
- 로컬 약 45,000개 항목 기준 3.48초에서 0.39~1.03초, 전체 테스트 24개와 Clippy 통과

# 어려웠던 점

강제 지연 제거 후 낮은 자원 사용 정책 보존
- 파일 탐색은 순차 유지, taskpolicy 실패 시 스캐너 시작을 막지 않도록 PID 적용 분리

# 리스크

인덱스를 스캔 완료 후 생성하므로 완료 직전 작업 집중
- SQLite progress handler로 pause와 cancel 응답 유지, 인덱스 작업 스레드 최대 2개와 캐시 32 MiB 제한

Issue #1056