### PR TITLE
feat: LLM serving endpoint를 같은 Wi-Fi에 노출

### DIFF
--- a/computer_science/ai/study-llmserving/ch5-6/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/README.md
@@ -18,6 +18,7 @@ Chapter 5는 hardware 용어 모음이 아닙니다. Chapter 6의 optimization�
 ## GPU에서 가설을 검증합니다
 
 - 환경 준비: [Ubuntu GPU 환경 준비](./docs/01-setup-ubuntu.md)
+- LAN 접속: [같은 Wi-Fi에서 관측·추론 endpoint 접속](./docs/03-setup-lan-access.md)
 - 전체 실습 순서: [LLM serving이 느린 이유를 GPU에서 직접 확인하는 순서](./docs/handson/)
 - 관측 기준: [GPU 사용률이 높은데 LLM이 느릴 때 무엇을 봐야 할까](./docs/prometheus.md)
 

--- a/computer_science/ai/study-llmserving/ch5-6/docker-compose.yml
+++ b/computer_science/ai/study-llmserving/ch5-6/docker-compose.yml
@@ -22,7 +22,7 @@ x-vllm: &vllm
   <<: [*runtime, *gpu]
   ipc: host
   ports:
-    - "127.0.0.1:8000:8000"
+    - "${LAN_BIND_ADDRESS:-0.0.0.0}:8000:8000"
   networks:
     default:
       aliases:
@@ -115,7 +115,7 @@ services:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus
     ports:
-      - "127.0.0.1:9090:9090"
+      - "${LAN_BIND_ADDRESS:-0.0.0.0}:9090:9090"
 
   grafana:
     image: grafana/grafana:12.1.0
@@ -129,7 +129,7 @@ services:
       - ./observability/grafana/dashboards:/etc/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     ports:
-      - "127.0.0.1:3000:3000"
+      - "${LAN_BIND_ADDRESS:-0.0.0.0}:3000:3000"
 
   dcgm-exporter:
     image: nvidia/dcgm-exporter:4.8.3
@@ -138,7 +138,7 @@ services:
     cap_add:
       - SYS_ADMIN
     ports:
-      - "127.0.0.1:9400:9400"
+      - "${LAN_BIND_ADDRESS:-0.0.0.0}:9400:9400"
 
 volumes:
   hf-cache:

--- a/computer_science/ai/study-llmserving/ch5-6/docs/01-setup-ubuntu.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/01-setup-ubuntu.md
@@ -157,6 +157,8 @@ docker compose ps
 - Prometheus: `http://127.0.0.1:9090`
 - model endpoint: `http://127.0.0.1:8000`
 - dashboard: `LLM serving / LLM Serving Chapter 5-6`
+- 기본 bind: `0.0.0.0`, 같은 LAN에서도 접근 가능
+- 로컬 전용 bind: 실행 전에 `export LAN_BIND_ADDRESS=127.0.0.1`
 - 같은 Wi-Fi의 다른 기기에서 접속: [LAN endpoint 설정](./03-setup-lan-access.md)
 
 ### Compose profile

--- a/computer_science/ai/study-llmserving/ch5-6/docs/01-setup-ubuntu.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/01-setup-ubuntu.md
@@ -157,6 +157,7 @@ docker compose ps
 - Prometheus: `http://127.0.0.1:9090`
 - model endpoint: `http://127.0.0.1:8000`
 - dashboard: `LLM serving / LLM Serving Chapter 5-6`
+- 같은 Wi-Fi의 다른 기기에서 접속: [LAN endpoint 설정](./03-setup-lan-access.md)
 
 ### Compose profile
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/03-setup-lan-access.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/03-setup-lan-access.md
@@ -1,0 +1,105 @@
+# 같은 Wi-Fi에서 LLM serving endpoint 접속
+
+## Up
+
+### 노출 endpoint
+
+Compose는 기본적으로 모든 host interface인 `0.0.0.0`에 port를 publish함.
+
+| 서비스 | URL | 용도 |
+| --- | --- | --- |
+| Grafana | `http://<Ubuntu-IP>:3000` | dashboard 확인 |
+| vLLM | `http://<Ubuntu-IP>:8000/v1` | OpenAI 호환 API 호출 |
+| Prometheus | `http://<Ubuntu-IP>:9090` | target·metric query |
+| DCGM Exporter | `http://<Ubuntu-IP>:9400/metrics` | GPU metric 확인 |
+
+- 외부 인증과 TLS 없음
+- 신뢰할 수 있는 LAN에서만 사용
+- router의 port forwarding 설정 금지
+- Grafana 최초 로그인 후 기본 비밀번호 변경
+
+### 1. Ubuntu IP 확인
+
+기본 route에 사용하는 interface와 IPv4 주소를 확인함.
+
+```bash
+LAN_INTERFACE="$(ip -4 route get 1.1.1.1 | awk '{for (i=1; i<=NF; i++) if ($i == "dev") print $(i+1)}')"
+LAN_IP="$(ip -4 route get 1.1.1.1 | awk '{for (i=1; i<=NF; i++) if ($i == "src") print $(i+1)}')"
+echo "$LAN_INTERFACE $LAN_IP"
+```
+
+- Wi-Fi interface와 사설 IPv4 주소인지 확인
+- 사설 IPv4 예시: `192.168.0.10`, `10.0.0.10`
+- DHCP로 주소가 바뀌면 새 주소로 접속
+
+### 2. LAN 주소에 service bind
+
+현재 shell에서 Compose bind 주소를 Ubuntu LAN IP로 제한함.
+
+```bash
+export LAN_BIND_ADDRESS="$LAN_IP"
+```
+
+관측 stack을 기동함.
+
+```bash
+make observability-up
+docker compose ps
+```
+
+필요한 vLLM server 하나를 기동함.
+
+```bash
+make vllm-bf16
+```
+
+- `LAN_BIND_ADDRESS` 미지정 시 `0.0.0.0`에 bind
+- 같은 shell에서 이후 `docker compose`와 `make` 명령 실행
+- 다른 shell에서는 `LAN_BIND_ADDRESS`를 다시 설정
+
+### 3. Ubuntu에서 확인
+
+모든 endpoint가 응답하는지 확인함.
+
+```bash
+curl --fail "http://$LAN_IP:3000/api/health"
+curl --fail "http://$LAN_IP:8000/health"
+curl --fail "http://$LAN_IP:9090/-/healthy"
+curl --fail "http://$LAN_IP:9400/metrics"
+```
+
+### 4. 같은 Wi-Fi 기기에서 확인
+
+Ubuntu와 같은 Wi-Fi에 연결된 기기에서 접속함.
+
+```bash
+curl --fail "http://<Ubuntu-IP>:8000/v1/models"
+curl --fail "http://<Ubuntu-IP>:9090/-/healthy"
+curl --fail "http://<Ubuntu-IP>:9400/metrics"
+```
+
+browser에서 Grafana에 접속함.
+
+```text
+http://<Ubuntu-IP>:3000
+```
+
+- 기본 계정: `admin` / `admin`
+- dashboard: `LLM serving / LLM Serving Chapter 5-6`
+
+### 접속 실패 확인
+
+- `docker compose ps`: published address와 container 상태 확인
+- `ip -4 addr show "$LAN_INTERFACE"`: Ubuntu IP 유지 여부 확인
+- client와 Ubuntu의 Wi-Fi SSID가 같은지 확인
+- guest Wi-Fi의 client isolation 활성 여부 확인
+- Ubuntu firewall에서 TCP `3000`, `8000`, `9090`, `9400` 허용 여부 확인
+- Docker published port는 UFW 규칙을 우회할 수 있으므로 UFW만으로 외부 접근 차단을 보장하지 않음
+
+## Down
+
+container와 network만 종료함.
+
+```bash
+make down
+```

--- a/computer_science/ai/study-llmserving/ch5-6/docs/03-setup-lan-access.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/03-setup-lan-access.md
@@ -32,15 +32,9 @@ echo "$LAN_INTERFACE $LAN_IP"
 - 사설 IPv4 예시: `192.168.0.10`, `10.0.0.10`
 - DHCP로 주소가 바뀌면 새 주소로 접속
 
-### 2. LAN 주소에 service bind
+### 2. 모든 host interface에 service bind
 
-현재 shell에서 Compose bind 주소를 Ubuntu LAN IP로 제한함.
-
-```bash
-export LAN_BIND_ADDRESS="$LAN_IP"
-```
-
-관측 stack을 기동함.
+`LAN_BIND_ADDRESS`를 지정하지 않고 관측 stack을 기동함.
 
 ```bash
 make observability-up
@@ -53,9 +47,11 @@ docker compose ps
 make vllm-bf16
 ```
 
-- `LAN_BIND_ADDRESS` 미지정 시 `0.0.0.0`에 bind
-- 같은 shell에서 이후 `docker compose`와 `make` 명령 실행
-- 다른 shell에서는 `LAN_BIND_ADDRESS`를 다시 설정
+- 기본값 `0.0.0.0`: LAN IP와 `127.0.0.1`에서 모두 접속 가능
+- 기존 handson 문서와 script의 `127.0.0.1` 호출 유지
+- 로컬 전용 실행: `export LAN_BIND_ADDRESS=127.0.0.1`
+- 특정 interface 실행: `export LAN_BIND_ADDRESS="$LAN_IP"`
+- 특정 interface 실행 시 host의 health check도 `127.0.0.1` 대신 `$LAN_IP` 사용
 
 ### 3. Ubuntu에서 확인
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
@@ -49,6 +49,8 @@ curl http://127.0.0.1:9400/metrics
 - Prometheus: `http://127.0.0.1:9090`
 - Grafana: `http://127.0.0.1:3000`
 - Grafana 계정: `admin` / `admin`
+- 기본 bind: `0.0.0.0`, 같은 LAN에서도 접근 가능
+- 로컬 전용 bind: 실행 전에 `export LAN_BIND_ADDRESS=127.0.0.1`
 - 같은 Wi-Fi의 다른 기기에서 접속: [LAN endpoint 설정](./03-setup-lan-access.md)
 
 ## Queue, prefill, decode를 먼저 분리합니다

--- a/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
@@ -49,6 +49,7 @@ curl http://127.0.0.1:9400/metrics
 - Prometheus: `http://127.0.0.1:9090`
 - Grafana: `http://127.0.0.1:3000`
 - Grafana 계정: `admin` / `admin`
+- 같은 Wi-Fi의 다른 기기에서 접속: [LAN endpoint 설정](./03-setup-lan-access.md)
 
 ## Queue, prefill, decode를 먼저 분리합니다
 


### PR DESCRIPTION
# 구현

vLLM·Grafana·Prometheus·DCGM Exporter LAN bind와 접속 절차 추가
- Compose profile config 검증, pytest 9개·Ruff 통과

# 리스크

인증 없는 endpoint가 지정한 host interface에 공개됨
- 신뢰 LAN 전용, port forwarding 금지와 Docker·UFW 주의사항 문서화

Issue #1058