### PR TITLE
docs: SearXNG limiter와 검색 엔진 운영 기준 보강

### DIFF
--- a/computer_science/ai/searxng-production/README.md
+++ b/computer_science/ai/searxng-production/README.md
@@ -3,3 +3,8 @@
 - [프로덕션에서 먼저 확인할 것](./docs/1-production.md)
 - [실습 환경](./docs/2-setup.md)
 - [인증, HA, 봇 탐지 재현](./docs/3-hands-on.md)
+- [Limiter 설정과 봇 차단](./docs/limiter.md)
+- [검색 엔진을 Google과 Naver로 제한](./docs/limit-searchengine.md)
+- [Valkey 역할](./docs/redis-role.md)
+- [검색 엔진의 언어, 지역, 유해물 필터](./docs/engine.md)
+- [검색 테스트 시나리오](./docs/search-test-scenarios.md)

--- a/computer_science/ai/searxng-production/docs/engine.md
+++ b/computer_science/ai/searxng-production/docs/engine.md
@@ -1,0 +1,99 @@
+# 검색 엔진의 언어, 지역, 유해물 필터
+
+SearXNG의 기본 검색 지역이 미국으로 고정되는 것은 아니다. 현재 `default_lang`이 비어 있어 browser의 `Accept-Language`를 사용하고, header가 없으면 `en`으로 fallback한다.
+
+## 현재 locale 결정 순서
+
+검색 locale은 먼저 발견한 값으로 결정한다.
+
+1. 관리자가 lock한 language
+2. query의 `:ko-KR` 같은 language prefix
+3. 요청 parameter `language=ko-KR`
+4. 사용자 preference cookie
+5. browser의 `Accept-Language`
+6. 인식할 header가 없으면 `en`
+
+`en` fallback은 미국 지역을 강제한다는 뜻이 아니다. 언어만 영어로 지정하고 국가 code가 없으므로 Origin은 SearXNG의 NAT Gateway EIP 위치와 자체 정책을 추가로 사용할 수 있다.
+
+## Google
+
+Google engine은 SearXNG locale을 Google 요청 parameter와 domain으로 변환한다.
+
+| SearXNG locale | Google 요청의 주요 효과 |
+| --- | --- |
+| `en` | 영어 결과 제한, 국가 제한 없음, 보통 `www.google.com` 사용 |
+| `en-US` | 영어와 미국 지역을 지정 |
+| `ko` | 한국어 결과 제한, 국가 제한 없음 |
+| `ko-KR` | 한국어와 한국 지역을 지정하고 `www.google.co.kr` 사용 |
+| `all` | 언어·국가 제한을 최소화하고 기본 Google domain 사용 |
+
+Google은 locale 외에도 NAT Gateway EIP의 geolocation과 Origin의 정책에 따라 결과를 달리할 수 있다. 같은 `ko-KR` 요청도 Google 웹 UI와 결과가 완전히 같다고 보장할 수 없다.
+
+## Naver
+
+Naver engine은 `language = "ko"`로 고정된 한국어 전용 engine이다.
+
+- 요청 대상은 `https://search.naver.com/search.naver`다.
+- `language=ko-KR`을 별도 지역 parameter로 변환하지 않는다.
+- SearXNG의 locale 지원 목록에서도 Naver는 locale 미지원으로 표시된다.
+- Naver 결과의 지역·개인화는 Naver의 서버 정책에 따른다.
+
+## 한국 사용자용 설정
+
+모든 요청의 기본 locale을 한국으로 지정하려면 `settings.yml`에 다음 값을 추가한다.
+
+```yaml
+search:
+  default_lang: ko-KR
+```
+
+사용자가 preference나 request parameter로 바꾸지 못하게 하려면 language도 lock한다.
+
+```yaml
+preferences:
+  lock:
+    - language
+```
+
+다국어 검색이 필요하면 lock하지 않고 client가 `language`를 명시하게 한다.
+
+## SafeSearch와 유해물 차단
+
+SearXNG의 `safe_search`는 중앙 콘텐츠 검사기가 아니다. 설정값을 지원하는 Origin에 전달하는 집계 옵션이다.
+
+| 값 | 의미 |
+| --- | --- |
+| `0` | 필터 없음 |
+| `1` | 보통 |
+| `2` | 엄격 |
+
+현재 local 설정에는 `safe_search`가 없으므로 upstream 기본값 `0`을 사용한다.
+
+Google 일반 web engine은 SafeSearch를 지원한다. Naver 일반 web engine은 SearXNG의 SafeSearch 지원 대상으로 표시되지 않으므로 같은 보장을 할 수 없다.
+
+엄격 모드를 기본값으로 지정하는 설정은 다음과 같다.
+
+```yaml
+search:
+  safe_search: 2
+
+preferences:
+  lock:
+    - safesearch
+```
+
+이 설정도 유해물 차단을 보장하지 않는다.
+
+- Origin이 분류한 결과만 필터링한다.
+- Naver처럼 해당 기능을 지원하지 않는 engine에는 적용되지 않는다.
+- URL, snippet, 본문을 SearXNG가 자체 정책으로 분류하지 않는다.
+- 불법정보, 개인정보, 사내 금칙어, 악성코드 URL 같은 조직별 정책을 처리하지 않는다.
+
+강제 차단이 요구되면 gateway의 query 정책, 결과 URL allow/block list, 별도 콘텐츠 분류기를 사용한다. Naver 결과까지 같은 SafeSearch 수준이 필수라면 Naver를 제외하거나 별도 필터를 둔다.
+
+## 참고자료
+
+- [SearXNG search settings](https://docs.searxng.org/admin/settings/settings_search.html)
+- [SearXNG engine settings](https://docs.searxng.org/admin/settings/settings_engines.html)
+- [Configured Engines](https://docs.searxng.org/user/configured_engines.html)
+- [Google engine locale 처리](https://docs.searxng.org/dev/engines/online/google.html)

--- a/computer_science/ai/searxng-production/docs/limit-searchengine.md
+++ b/computer_science/ai/searxng-production/docs/limit-searchengine.md
@@ -66,7 +66,7 @@ JSON 검색 결과에서 실제 응답 engine을 확인한다.
 curl -sS --compressed \
   -u lab:production-lab \
   -A 'Mozilla/5.0' \
-  -H 'Accept: text/html' \
+  -H 'Accept: text/html,application/json' \
   -H 'Accept-Language: ko-KR,ko;q=0.9' \
   'http://localhost:8088/search?q=SearXNG&format=json&language=ko-KR' \
   | jq '{engines: [.results[].engine] | unique, unresponsive_engines}'

--- a/computer_science/ai/searxng-production/docs/limit-searchengine.md
+++ b/computer_science/ai/searxng-production/docs/limit-searchengine.md
@@ -1,0 +1,81 @@
+# 검색 엔진을 Google과 Naver로 제한
+
+외부 Origin은 Google과 Naver만 사용한다. 로컬 `mock success`, `mock upstream`은 `lab` category에 남겨 장애 재현 테스트에만 사용한다.
+
+## 설정
+
+`searxng/settings.yml`에서 upstream 기본 엔진을 두 개만 유지한다.
+
+```yaml
+use_default_settings:
+  engines:
+    keep_only:
+      - google
+      - naver
+
+engines:
+  - name: google
+    inactive: false
+
+  - name: naver
+    disabled: false
+```
+
+- `keep_only`: upstream 기본 엔진 목록에서 Google과 Naver 외의 엔진을 제거한다.
+- `google.inactive: false`: upstream에서 inactive인 Google engine을 registry에 포함한다.
+- `naver.disabled: false`: upstream에서 기본 비활성화된 Naver engine을 기본 검색에 포함한다.
+- `keep_only` 뒤에 선언한 custom mock engine은 제거되지 않는다.
+- mock engine의 category는 `lab`이므로 일반 `general` 검색에는 참여하지 않는다.
+
+Google Images, Google News, Naver Images, Naver News처럼 이름이 다른 engine은 포함하지 않는다. 현재 범위는 두 engine의 일반 web 검색이다.
+
+## 재배포
+
+설정 디렉터리는 read-only bind mount다. 파일 변경은 container 안에 보이지만 SearXNG process가 자동으로 reload하지 않으므로 container를 재생성한다.
+
+```bash
+docker compose up -d --force-recreate --wait
+```
+
+전체 서비스를 내리지 않고 SearXNG와 gateway만 재생성하려면 다음 순서로 실행한다.
+
+```bash
+docker compose up -d --force-recreate --wait searxng-a searxng-b
+docker compose up -d --force-recreate --wait gateway
+```
+
+gateway도 재생성해 새 SearXNG container 주소를 다시 resolve한다.
+
+## 검증
+
+일반 검색에 참여하는 engine 설정을 확인한다.
+
+```bash
+curl -sS \
+  -u lab:production-lab \
+  -A 'Mozilla/5.0' \
+  http://localhost:8088/config \
+  | jq -r '.engines[] | select(.enabled and (.categories | index("general"))) | .name'
+```
+
+출력은 `google`, `naver` 두 개여야 한다. `mock success`, `mock upstream`은 registry에는 있지만 `general` category가 아니므로 명시적으로 engine을 선택한 실습에서만 사용한다.
+
+JSON 검색 결과에서 실제 응답 engine을 확인한다.
+
+```bash
+curl -sS --compressed \
+  -u lab:production-lab \
+  -A 'Mozilla/5.0' \
+  -H 'Accept: text/html' \
+  -H 'Accept-Language: ko-KR,ko;q=0.9' \
+  'http://localhost:8088/search?q=SearXNG&format=json&language=ko-KR' \
+  | jq '{engines: [.results[].engine] | unique, unresponsive_engines}'
+```
+
+실제 Origin 요청은 낮은 빈도로 실행한다. 반복 검증은 [검색 테스트 시나리오](./search-test-scenarios.md)의 mock 테스트를 우선한다.
+
+## 참고자료
+
+- [SearXNG settings.yml과 keep_only](https://docs.searxng.org/admin/settings/settings.html#use-default-settings)
+- [SearXNG engine settings](https://docs.searxng.org/admin/settings/settings_engines.html)
+- [Configured Engines](https://docs.searxng.org/user/configured_engines.html)

--- a/computer_science/ai/searxng-production/docs/limiter.md
+++ b/computer_science/ai/searxng-production/docs/limiter.md
@@ -1,0 +1,144 @@
+# SearXNG limiter 설정
+
+이 구성의 limiter는 클라이언트 요청을 IP 단위로 제한한다. 외부 검색 엔진의 차단을 직접 해제하지는 않지만, 과도한 요청이 Google과 Naver로 전달되는 것을 줄인다.
+
+## 인증과 limiter
+
+Origin 보호 관점에서는 limiter가 핵심이다. 인증된 사용자도 과도한 검색을 만들 수 있으므로 인증만으로 Google과 Naver의 차단을 예방할 수 없다.
+
+- 인증: 허용된 사용자와 service만 SearXNG에 접근하게 한다.
+- Gateway quota: 사용자·tenant·service별 사용량을 제한한다.
+- SearXNG limiter: client IP별 비정상 요청을 마지막 단계에서 제한한다.
+- Origin budget: NAT Gateway EIP별 Google·Naver 요청량과 오류율을 관리한다.
+
+Private 프로덕션에서는 네 가지를 함께 사용한다. Limiter가 중요하다는 이유로 인증을 제거하면 익명 사용자가 제한 범위까지 Origin budget을 계속 소비할 수 있다.
+
+## 활성화 조건
+
+`settings.yml`에서 limiter와 Valkey 연결을 활성화한다.
+
+```yaml
+server:
+  limiter: true
+
+valkey:
+  url: valkey://valkey:6379/0
+```
+
+- `server.limiter`: SearXNG의 요청 전처리 단계에서 봇 탐지를 실행한다.
+- `valkey.url`: replica가 공유할 IP별 sliding window를 저장한다.
+- 둘 중 하나가 빠지면 rate limit이 정상 동작하지 않는다.
+
+## 현재 `limiter.toml`
+
+현재 파일에 명시한 값은 다음과 같다.
+
+```toml
+[botdetection]
+trusted_proxies = ["172.28.240.0/24"]
+
+[botdetection.ip_limit]
+filter_link_local = true
+link_token = false
+
+[botdetection.ip_lists]
+pass_searxng_org = false
+```
+
+로컬 파일에 없는 값은 SearXNG 이미지의 기본 `limiter.toml`과 소스 코드 값을 상속한다.
+
+| 설정 | 현재 값 | 의미 |
+| --- | --- | --- |
+| `trusted_proxies` | `172.28.240.0/24` | 이 Docker network에서 온 요청의 `X-Forwarded-For`를 신뢰한다. gateway가 전달한 실제 client IP를 limiter 기준으로 사용한다. |
+| `filter_link_local` | `true` | link-local client 주소도 `ip_limit` 검사 대상에 포함한다. |
+| `link_token` | `false` | 브라우저가 token이 포함된 CSS를 다시 요청했는지 검사하지 않는다. API client도 일반 rate limit으로 처리한다. |
+| `pass_searxng_org` | `false` | `check.searx.space` 등 SearXNG 조직의 고정 pass list를 사용하지 않는다. private instance에 불필요한 예외를 만들지 않는다. |
+
+`trusted_proxies`에는 실제 reverse proxy와 load balancer CIDR만 넣는다. 인터넷 전체나 VPC 전체를 신뢰하면 client가 위조한 `X-Forwarded-For`로 제한을 우회할 수 있다.
+
+## 상속하는 기본값
+
+현재 이미지 `2026.8.16-b2da6b90f`의 limiter 기본값이다. 이 임계값은 `limiter.toml`로 조정하는 항목이 아니라 SearXNG 소스 코드 상수다.
+
+| 구간 | 정상 요청 한도 | `link_token` 사용 시 의심 요청 한도 |
+| --- | --- | --- |
+| 20초 burst | 15회 | 2회 |
+| 10분 long window | 150회 | 10회 |
+| 1시간 API 요청 | 4회 | 동일 |
+| 30일 suspicious IP window | 사용하지 않음 | 3회 |
+
+- API 요청은 `format`이 `html`이 아닌 JSON, CSV, RSS 요청이다.
+- 한도를 초과한 요청부터 `429 Too Many Requests`를 반환한다.
+- IPv4는 기본 `/32`, IPv6는 `/48` network 단위로 집계한다.
+- 현재 `link_token=false`이므로 의심 요청용 2회, 10회, 30일 window는 사용하지 않는다.
+
+## Header 검사
+
+`/search` 요청은 rate limit 전에 HTTP header 검사도 통과해야 한다.
+
+| Header | 봇으로 처리되는 대표 조건 |
+| --- | --- |
+| `User-Agent` | 값이 없거나 `curl`, `wget`, `python-requests`, `HeadlessChrome` 등 기본 bot 패턴과 일치 |
+| `Accept` | `text/html`이 없음 |
+| `Accept-Encoding` | 압축 지원 header가 브라우저 형태가 아님 |
+| `Accept-Language` | 값이 없음 |
+| `Sec-Fetch-*` | 지원 브라우저가 보낸 값이 유효하지 않음 |
+
+Header 검사는 봇을 확정하는 정교한 판별기가 아니다. 일반 HTTP client도 브라우저 header를 보내지 않으면 차단될 수 있고, 봇도 header를 모방할 수 있다.
+
+## 정상 사용자도 차단되는 조건
+
+정상 사용자도 다음 조건에서는 SearXNG limiter의 `429`를 받을 수 있다.
+
+- 같은 client IP에서 20초 동안 검색을 16회 이상 실행한다.
+- 같은 client IP에서 10분 동안 검색을 151회 이상 실행한다.
+- JSON API를 같은 client IP에서 1시간 동안 5회 이상 호출한다.
+- 회사 NAT 뒤의 여러 사용자가 하나의 공인 IP로 보인다.
+- gateway가 실제 client IP를 전달하지 않아 모든 사용자가 gateway IP로 합쳐진다.
+- 브라우저가 아닌 사내 agent가 필수 header 없이 `/search`를 호출한다.
+
+인증된 사용자도 같은 조건으로 차단된다. 인증은 신원 확인이고 limiter는 요청 속도 제한이므로 서로 대체하지 않는다.
+
+## AWS NAT Gateway 구조
+
+AWS NAT Gateway는 보통 SearXNG에서 Origin으로 나가는 요청에 영향을 준다.
+
+```text
+Client IP -> ALB 또는 gateway -> SearXNG -> NAT Gateway EIP -> Google 또는 Naver
+```
+
+- SearXNG limiter: gateway가 보존한 client IP를 본다.
+- Google과 Naver: NAT Gateway의 EIP만 본다.
+- 여러 사용자와 SearXNG replica의 요청이 Origin에서는 하나의 EIP 트래픽으로 합쳐진다.
+- replica를 늘려도 NAT Gateway EIP가 같으면 Origin이 보는 source IP는 늘지 않는다.
+
+ALB 또는 gateway가 `X-Forwarded-For`를 잘못 구성하면 inbound 요청도 하나의 proxy IP로 합쳐진다. NAT Gateway 자체는 inbound client IP를 결정하지 않는다.
+
+## Origin별 차단 가능성
+
+Google과 Naver의 정확한 anti-bot 임계값은 공개되어 있지 않다. 다음 조건은 공개된 고정 규칙이 아니라 운영 시 관찰해야 할 위험 신호다.
+
+| Origin | SearXNG 구현 | 차단 위험이 커지는 조건 | 관찰 결과 |
+| --- | --- | --- | --- |
+| Google | 공식 API가 아닌 Google HTML 검색 결과를 파싱 | NAT EIP의 높은 요청량·동시성, 짧은 간격의 반복 query, datacenter IP 평판, cookie·HTTP fingerprint의 자동화 패턴 | CAPTCHA 또는 `/sorry` 응답, `403`, `429`, `unresponsive_engines` |
+| Naver | 공식 API가 아닌 `search.naver.com` HTML을 파싱 | NAT EIP의 높은 요청량·동시성, 반복 query, datacenter IP 평판, 자동화된 요청 패턴 | `403`, `429`, 빈 결과, HTML 변경에 따른 parsing 실패 |
+
+Google engine에는 CAPTCHA 응답을 식별하는 전용 처리가 있다. Naver engine에는 같은 형태의 전용 CAPTCHA detector가 없으므로 HTTP 오류, 빈 결과, parser 오류를 함께 감시한다.
+
+SearXNG 응답이 `200`이어도 일부 Origin만 실패할 수 있다. JSON 응답의 `unresponsive_engines`, engine별 결과 수, `403`·`429` 로그를 함께 확인한다.
+
+## 운영 기준
+
+- Gateway에서 identity별 quota와 동시 검색 수를 제한한다.
+- SearXNG limiter를 공통 IP 기반 마지막 방어선으로 유지한다.
+- Google과 Naver의 요청량·성공률·CAPTCHA·`403`·`429`를 분리해 측정한다.
+- NAT Gateway EIP별 전체 요청 budget을 정한다.
+- 실제 Origin을 차단 상태로 만들기 위한 부하 테스트는 하지 않는다.
+- 공식 API가 필요한 트래픽 규모라면 Google Custom Search JSON API나 Naver 검색 API 사용을 별도로 검토한다.
+
+## 참고자료
+
+- [SearXNG Limiter](https://docs.searxng.org/admin/searx.limiter.html)
+- [SearXNG Bot Detection](https://docs.searxng.org/src/searx.botdetection.html)
+- [Configured Engines](https://docs.searxng.org/user/configured_engines.html)
+- [Google engine](https://docs.searxng.org/dev/engines/online/google.html)

--- a/computer_science/ai/searxng-production/docs/redis-role.md
+++ b/computer_science/ai/searxng-production/docs/redis-role.md
@@ -1,0 +1,57 @@
+# Valkey 역할
+
+이 구성의 Valkey는 SearXNG limiter 상태 공유에만 사용한다. 검색 결과를 캐시하지 않는다.
+
+## 이름
+
+- 현재 SearXNG 설정 이름과 URL scheme은 `valkey`, `valkey://`다.
+- `redis` 설정은 이전 호환용이며 deprecated 상태다.
+- 파일명은 질문 범위와 기존 용어를 찾기 쉽도록 `redis-role.md`로 둔다.
+
+## 현재 저장 데이터
+
+| 데이터 | 현재 사용 | 설명 |
+| --- | --- | --- |
+| IP별 burst counter | 사용 | 20초 sliding window |
+| IP별 long counter | 사용 | 10분 sliding window |
+| IP별 API counter | 사용 | non-HTML 요청의 1시간 sliding window |
+| Link token과 browser ping | 판정에 사용 안 함 | UI가 관련 key를 만들 수 있지만 `link_token=false`이므로 현재 rate limit 판정에는 사용하지 않음 |
+| 검색 결과 | 사용 안 함 | 같은 query도 Google과 Naver에 다시 요청 |
+| 사용자 session·인증 | 사용 안 함 | 인증은 gateway가 담당 |
+| Origin engine suspend 상태 | 사용 안 함 | SearXNG process와 replica별 상태 |
+
+Limiter key에는 원본 IP 대신 IP network에서 만든 hash가 사용된다. 두 SearXNG replica가 같은 Valkey DB를 사용하므로 어느 replica가 처리해도 요청 횟수가 합산된다.
+
+## 검색 관련 cache
+
+SearXNG는 일반 검색 결과를 Valkey에 저장하는 response cache를 제공하지 않는다.
+
+- 일부 engine의 token·session 같은 내부 데이터는 `/var/cache/searxng`의 SQLite engine cache를 사용할 수 있다.
+- favicon cache도 별도 SQLite cache다.
+- 현재 활성화한 Google과 Naver의 일반 검색 결과는 이 cache에 저장되지 않는다.
+- `searxng-a-cache`, `searxng-b-cache` volume은 replica별로 분리한다.
+
+검색 결과 cache가 필요하면 gateway 앞단에 임의로 추가하지 않는다. 검색어가 민감정보일 수 있고, 사용자 locale·SafeSearch·engine 상태에 따라 결과가 달라져 cache key와 보존 정책을 별도로 설계해야 한다.
+
+## 장애 영향
+
+- Valkey 연결이 없으면 limiter가 설치되지 않는다.
+- replica 간 rate limit 합산이 사라진다.
+- 검색 결과 cache miss가 아니라 bot protection 장애로 취급한다.
+- 프로덕션에서는 HA Valkey endpoint, 접근 제어, 암호화, memory와 latency 감시가 필요하다.
+
+현재 Compose는 `--save 30 1`과 `valkey-data` volume으로 limiter 상태를 snapshot한다. 로컬 실습 편의를 위한 설정이며 프로덕션 HA를 제공하지 않는다.
+
+## 전용 DB 원칙
+
+- DB `0`은 limiter 전용으로 사용한다.
+- 다른 application cache와 섞지 않는다.
+- 운영 중 `FLUSHDB`를 실행하지 않는다.
+- 실습의 limiter 초기화에서만 `FLUSHDB`를 사용한다.
+- memory eviction으로 limiter key가 사라지지 않도록 별도 capacity를 정한다.
+
+## 참고자료
+
+- [SearXNG Valkey settings](https://docs.searxng.org/admin/settings/settings_valkey.html)
+- [SearXNG Valkey library](https://docs.searxng.org/src/searx.valkeylib.html)
+- [SearXNG Redis migration notice](https://docs.searxng.org/admin/settings/settings_redis.html)

--- a/computer_science/ai/searxng-production/docs/search-test-scenarios.md
+++ b/computer_science/ai/searxng-production/docs/search-test-scenarios.md
@@ -1,0 +1,120 @@
+# 검색 테스트 시나리오
+
+검색 테스트는 기능, 한국어 품질, 제한 정책, 장애 대응을 분리한다. 실제 Google과 Naver에는 낮은 빈도의 smoke test만 실행하고 반복·부하 테스트는 mock engine을 사용한다.
+
+## 공통 판정 항목
+
+- HTTP status
+- 검색 latency
+- 결과 개수
+- 결과를 반환한 engine
+- `unresponsive_engines`
+- CAPTCHA, `403`, `429`
+- 한국어 제목과 snippet 깨짐 여부
+- 중복 URL 비율
+
+HTTP `200`만으로 성공 처리하지 않는다. 최소 결과 개수와 engine별 오류를 함께 판정한다.
+
+## 기능 테스트
+
+| 시나리오 | 입력 | 기대 결과 |
+| --- | --- | --- |
+| 인증 없음 | `/search?q=test` | gateway `401` |
+| HTML 검색 | `q=SearXNG`, `language=ko-KR` | `200`, HTML 결과 표시 |
+| JSON 검색 | `q=SearXNG`, `format=json` | `200`, JSON schema와 결과 확인 |
+| Engine 제한 | 일반 web 검색 | 외부 engine은 Google과 Naver만 사용 |
+| Engine 직접 선택 | `engines=google` 또는 `engines=naver` | 선택한 engine만 결과 반환 |
+| 잘못된 engine | 존재하지 않는 engine 지정 | 정상 결과로 오인하지 않고 오류 확인 |
+| Paging | `pageno=2` | 1페이지와 다른 결과, 중복률 확인 |
+| Timeout | mock에서 지연 응답 | timeout과 `unresponsive_engines` 확인 |
+| Origin `429` | `mock upstream` | 전체 응답과 engine 오류를 분리해 확인 |
+
+## 한국어 검색 품질
+
+고정된 query set과 기대 domain 또는 topic을 version 관리한다.
+
+| 유형 | 예시 | 확인 항목 |
+| --- | --- | --- |
+| 일반 한국어 | `서울 지하철 노선도` | 한국어 결과와 국내 domain 비중 |
+| 공공 정보 | `site:go.kr 주민등록등본 발급` | 공식 공공기관 domain 상위 노출 |
+| 기술 용어 | `쿠버네티스 인그레스 설정` | 한글·영문 혼합 query 처리 |
+| 띄어쓰기 | `근로 장려금 신청` | 띄어쓰기 차이에 따른 품질 |
+| 오탈자 | 사전에 정한 경미한 오탈자 | suggestion 또는 유효 결과 |
+| 고유명사 | `경복궁 관람 시간` | 국내 장소 정보의 관련성 |
+| 최신성 | 날짜가 포함된 공개 보도자료 | `time_range`와 최신 결과 확인 |
+| 영문 query | `SearXNG limiter` | 한국 locale에서도 영문 결과 확인 |
+
+뉴스, 날씨, 환율처럼 값이 변하는 query는 결과 문자열 전체를 assertion으로 사용하지 않는다. 공식 domain 포함 여부, 결과 존재, 날짜 범위로 판정한다.
+
+## Locale 테스트
+
+같은 query를 다음 조건으로 비교한다.
+
+- `language=ko-KR`
+- `language=ko`
+- `language=en-US`
+- `Accept-Language: ko-KR,ko;q=0.9`
+- language parameter와 `Accept-Language`가 모두 없음
+
+Google은 언어와 지역에 따라 결과와 domain이 달라질 수 있다. Naver는 한국어 전용이므로 locale 변화에 같은 방식으로 반응하지 않는다.
+
+## Limiter 테스트
+
+외부 Origin을 호출하지 않고 `mock success`를 지정한다.
+
+- HTML burst: 20초 안에 16번째 요청이 `429`인지 확인한다.
+- HTML long window: 10분 안에 151번째 요청이 `429`인지 확인한다.
+- JSON API: 1시간 안에 5번째 요청이 `429`인지 확인한다.
+- 두 replica 교차 호출: 공유 Valkey에서 합산되는지 확인한다.
+- 서로 다른 client IP: `X-Forwarded-For`별 counter가 분리되는지 확인한다.
+- 잘못된 header: bot header probe가 `429`를 반환하는지 확인한다.
+
+실습 시작 전 `FLUSHDB`는 local Valkey에서만 실행한다. 프로덕션 Valkey에는 실행하지 않는다.
+
+## 검색하면 안 되는 내용 테스트
+
+현재 SearXNG 구성은 query 자체를 금지하지 않는다. `safe_search`도 Origin이 지원하는 결과 필터일 뿐 query 차단 기능이 아니다.
+
+조직 정책상 금지 검색이 있다면 먼저 gateway에 명시적인 정책을 구현하고 다음을 테스트한다.
+
+| 정책 유형 | 테스트 방식 | 기대 결과 |
+| --- | --- | --- |
+| 금칙어 | 실제 불법 자료명 대신 synthetic 금칙어 fixture 사용 | Origin 호출 전 `403` |
+| 금지 domain | 내부 test domain을 block list에 등록 | 결과에서 제거되고 audit event 기록 |
+| 성인물 | 통제된 fixture 결과에 policy label 부여 | strict 정책에서 결과 제거 |
+| 개인정보 | 가짜 주민번호·가짜 email fixture 사용 | query log에 원문을 남기지 않고 차단 |
+| 악성 URL | 무해한 test domain 또는 보안 vendor test URL 사용 | 클릭 전 차단 또는 경고 |
+
+실제 아동 성착취물, 불법 개인정보, 악성코드 배포 URL을 검색하거나 수집하지 않는다. 차단 로직은 mock engine과 synthetic fixture로 검증한다.
+
+SafeSearch smoke test가 필요하면 Google에서 `safesearch=0`과 `safesearch=2`의 결과 차이만 낮은 빈도로 확인한다. 특정 유해 결과가 반드시 사라진다는 assertion은 Origin 결과 변화 때문에 회귀 테스트로 사용하지 않는다.
+
+## Origin smoke test
+
+배포 직후 engine별로 대표 query 한 건씩 실행한다.
+
+```bash
+curl -sS --compressed \
+  -u lab:production-lab \
+  -A 'Mozilla/5.0' \
+  -H 'Accept: text/html' \
+  -H 'Accept-Language: ko-KR,ko;q=0.9' \
+  'http://localhost:8088/search?q=서울%20지하철&format=json&language=ko-KR&engines=google' \
+  | jq '{result_count: (.results | length), unresponsive_engines}'
+```
+
+Naver smoke test는 `engines=naver`로 바꿔 한 번 더 실행한다. 자동화 주기를 짧게 두지 않고 engine별 budget에 포함한다.
+
+## 배포 판정
+
+- Google과 Naver 중 필수 engine이 최소 결과 기준을 충족한다.
+- `unresponsive_engines`에 CAPTCHA, `403`, `429`가 없다.
+- 한국어 query와 UTF-8 결과가 깨지지 않는다.
+- limiter와 gateway 인증 테스트가 통과한다.
+- 금지 검색 정책이 요구되면 synthetic policy test가 통과한다.
+
+## 참고자료
+
+- [SearXNG Search API](https://docs.searxng.org/dev/search_api.html)
+- [Configured Engines](https://docs.searxng.org/user/configured_engines.html)
+- [SearXNG search settings](https://docs.searxng.org/admin/settings/settings_search.html)

--- a/computer_science/ai/searxng-production/docs/search-test-scenarios.md
+++ b/computer_science/ai/searxng-production/docs/search-test-scenarios.md
@@ -97,7 +97,7 @@ SafeSearch smoke test가 필요하면 Google에서 `safesearch=0`과 `safesearch
 curl -sS --compressed \
   -u lab:production-lab \
   -A 'Mozilla/5.0' \
-  -H 'Accept: text/html' \
+  -H 'Accept: text/html,application/json' \
   -H 'Accept-Language: ko-KR,ko;q=0.9' \
   'http://localhost:8088/search?q=서울%20지하철&format=json&language=ko-KR&engines=google' \
   | jq '{result_count: (.results | length), unresponsive_engines}'

--- a/computer_science/ai/searxng-production/searxng/settings.yml
+++ b/computer_science/ai/searxng-production/searxng/settings.yml
@@ -1,6 +1,8 @@
 use_default_settings:
   engines:
-    keep_only: []
+    keep_only:
+      - google
+      - naver
 
 general:
   debug: false
@@ -27,10 +29,16 @@ outgoing:
   request_timeout: 2.0
 
 engines:
+  - name: google
+    inactive: false
+
+  - name: naver
+    disabled: false
+
   - name: mock success
     engine: xpath
     shortcut: mockok
-    categories: general
+    categories: lab
     disabled: false
     enable_http: true
     search_url: http://mock-engine/ok?q={query}
@@ -42,7 +50,7 @@ engines:
   - name: mock upstream
     engine: xpath
     shortcut: mock
-    categories: general
+    categories: lab
     disabled: false
     enable_http: true
     search_url: http://mock-engine/search?q={query}


### PR DESCRIPTION
# 구현

SearXNG limiter·Valkey·engine·locale·SafeSearch·검색 테스트 문서와 Google·Naver Origin 제한 추가
- make verify 통과, 일반 검색 engine google·naver 확인, 공식 문서 링크 응답 확인

# 어려웠던 점

Upstream engine 활성 상태와 로컬 장애 재현용 mock engine의 동시 유지
- Google inactive 해제, Naver disabled 해제, mock engine의 lab category 분리

# 리스크

HTML parsing 기반 Origin의 anti-bot과 SafeSearch 결과 비보장
- NAT EIP 트래픽 합산과 비공개 차단 기준으로 운영 지표 및 별도 정책 필터 필요

Issue #1062
