### PR TITLE
feat: akbun-gitdesktop 브랜치 다중 선택과 일괄 삭제

### DIFF
--- a/product/akbun-gitdesktop/README.md
+++ b/product/akbun-gitdesktop/README.md
@@ -20,7 +20,7 @@ UI 언어는 영어다.
 - commit 목록 보기 (graph 행에 subject, author, date, hash 표시)
 - commit을 클릭하면 그 commit이 바꾼 파일 목록, 파일을 클릭하면 diff를 오른쪽 drawer에 표시
 - branch를 클릭하면 기본 브랜치와의 3-dot diff 파일 목록과 diff를 표시
-- branch 보기, 생성, 삭제 (미병합 브랜치는 확인 후 강제 삭제)
+- branch 보기, 생성, 다중 선택과 일괄 삭제 (Cmd/Ctrl 개별 선택, Shift 범위 선택, 미병합 강제 삭제 확인)
 - worktree 보기, 생성(새 브랜치와 함께), 삭제
 - GitHub PR과 issue 목록 보기 (state, label, 작성자, 갱신일)
 - 하위 issue가 있으면 issue 목록을 트리로 표시. 부모 아래에 하위 issue를 들여쓰고 세로선으로 상하관계를 그리며, 부모 행에는 하위 개수를 ↳ 배지로 표시

--- a/product/akbun-gitdesktop/src/main/branchDeletion.ts
+++ b/product/akbun-gitdesktop/src/main/branchDeletion.ts
@@ -1,0 +1,35 @@
+import type { BranchDeletionResult } from '../shared/types'
+
+type DeleteBranch = (name: string, force: boolean) => Promise<void>
+type IsBranchMerged = (name: string) => Promise<boolean>
+
+export async function deleteBranchBatch(
+  names: string[],
+  force: boolean,
+  deleteBranch: DeleteBranch,
+  isBranchMerged: IsBranchMerged
+): Promise<BranchDeletionResult> {
+  const result: BranchDeletionResult = { deleted: [], unmerged: [], failed: [] }
+
+  for (const name of names) {
+    try {
+      await deleteBranch(name, force)
+      result.deleted.push(name)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (!force) {
+        try {
+          if (!(await isBranchMerged(name))) {
+            result.unmerged.push(name)
+            continue
+          }
+        } catch {
+          // Keep the original deletion error because it is the actionable failure.
+        }
+      }
+      result.failed.push({ name, error: message })
+    }
+  }
+
+  return result
+}

--- a/product/akbun-gitdesktop/src/main/git.ts
+++ b/product/akbun-gitdesktop/src/main/git.ts
@@ -1,4 +1,5 @@
 import type {
+  BranchDeletionResult,
   BranchInfo,
   CliStatus,
   CliToolStatus,
@@ -6,6 +7,7 @@ import type {
   FileChange,
   WorktreeInfo
 } from '../shared/types'
+import { deleteBranchBatch } from './branchDeletion'
 import { probeCli, runCli } from './cli'
 
 const FIELD_SEP = '\x1f'
@@ -164,6 +166,39 @@ export async function createBranch(repoPath: string, name: string, startPoint: s
 
 export async function deleteBranch(repoPath: string, name: string, force: boolean): Promise<void> {
   await runGit(repoPath, ['branch', force ? '-D' : '-d', name])
+}
+
+async function isBranchMerged(repoPath: string, name: string): Promise<boolean> {
+  const fields = ['%(refname)', '%(upstream)'].join(FIELD_SEP)
+  const ref = (await runGit(repoPath, [
+    'for-each-ref',
+    `--format=${fields}`,
+    `refs/heads/${name}`
+  ])).trim()
+  if (!ref) throw new Error(`Local branch not found: ${name}`)
+
+  const [, upstream] = ref.split(FIELD_SEP)
+  const target = upstream || 'HEAD'
+  const merged = await runGit(repoPath, [
+    'branch',
+    '--merged',
+    target,
+    '--format=%(refname:short)'
+  ])
+  return merged.split('\n').includes(name)
+}
+
+export async function deleteBranches(
+  repoPath: string,
+  names: string[],
+  force: boolean
+): Promise<BranchDeletionResult> {
+  return deleteBranchBatch(
+    names,
+    force,
+    (name, shouldForce) => deleteBranch(repoPath, name, shouldForce),
+    (name) => isBranchMerged(repoPath, name)
+  )
 }
 
 export async function createWorktree(

--- a/product/akbun-gitdesktop/src/main/index.ts
+++ b/product/akbun-gitdesktop/src/main/index.ts
@@ -84,8 +84,8 @@ function registerIpcHandlers(): void {
   ipcMain.handle('git:createBranch', (_event, repoPath: string, name: string, startPoint: string) =>
     wrap(() => git.createBranch(repoPath, name, startPoint))
   )
-  ipcMain.handle('git:deleteBranch', (_event, repoPath: string, name: string, force: boolean) =>
-    wrap(() => git.deleteBranch(repoPath, name, force))
+  ipcMain.handle('git:deleteBranches', (_event, repoPath: string, names: string[], force: boolean) =>
+    wrap(() => git.deleteBranches(repoPath, names, force))
   )
   ipcMain.handle(
     'git:createWorktree',

--- a/product/akbun-gitdesktop/src/preload/index.d.ts
+++ b/product/akbun-gitdesktop/src/preload/index.d.ts
@@ -1,5 +1,6 @@
 import type {
   AppSettings,
+  BranchDeletionResult,
   BranchInfo,
   CliStatus,
   CommitInfo,
@@ -35,7 +36,11 @@ export interface GitDesktopApi {
   getDefaultBranch: (repoPath: string) => Promise<GitResult<string>>
 
   createBranch: (repoPath: string, name: string, startPoint: string) => Promise<GitResult<void>>
-  deleteBranch: (repoPath: string, name: string, force: boolean) => Promise<GitResult<void>>
+  deleteBranches: (
+    repoPath: string,
+    names: string[],
+    force: boolean
+  ) => Promise<GitResult<BranchDeletionResult>>
   createWorktree: (
     repoPath: string,
     worktreePath: string,

--- a/product/akbun-gitdesktop/src/preload/index.ts
+++ b/product/akbun-gitdesktop/src/preload/index.ts
@@ -21,8 +21,8 @@ const api = {
 
   createBranch: (repoPath: string, name: string, startPoint: string) =>
     ipcRenderer.invoke('git:createBranch', repoPath, name, startPoint),
-  deleteBranch: (repoPath: string, name: string, force: boolean) =>
-    ipcRenderer.invoke('git:deleteBranch', repoPath, name, force),
+  deleteBranches: (repoPath: string, names: string[], force: boolean) =>
+    ipcRenderer.invoke('git:deleteBranches', repoPath, names, force),
   createWorktree: (repoPath: string, worktreePath: string, branch: string, createNewBranch: boolean) =>
     ipcRenderer.invoke('git:createWorktree', repoPath, worktreePath, branch, createNewBranch),
   removeWorktree: (repoPath: string, worktreePath: string) =>

--- a/product/akbun-gitdesktop/src/renderer/src/components/BranchPanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/BranchPanel.tsx
@@ -1,13 +1,20 @@
 import {
   useCallback,
   useEffect,
+  useRef,
   useState,
   type JSX,
   type KeyboardEvent,
   type MouseEvent
 } from 'react'
 import type { BranchDeletionFailure, BranchInfo } from '../../../shared/types'
-import { selectBranchNames, type BranchSelectionMode } from '../lib/branchSelection'
+import {
+  clampMenuCoordinate,
+  nextBranchFocusIndex,
+  selectBranchNames,
+  type BranchFocusMove,
+  type BranchSelectionMode
+} from '../lib/branchSelection'
 
 interface Props {
   repoPath: string
@@ -24,6 +31,11 @@ interface SelectionAnchor {
 interface ContextMenuPosition {
   left: number
   top: number
+}
+
+interface FocusedBranches {
+  local: string
+  remote: string
 }
 
 interface SelectionModifiers {
@@ -49,16 +61,24 @@ export default function BranchPanel({
   const [branches, setBranches] = useState<BranchInfo[]>([])
   const [selectedNames, setSelectedNames] = useState<string[]>([])
   const [anchor, setAnchor] = useState<SelectionAnchor | null>(null)
+  const [focusedBranches, setFocusedBranches] = useState<FocusedBranches>({ local: '', remote: '' })
   const [contextMenu, setContextMenu] = useState<ContextMenuPosition | null>(null)
   const [newBranchName, setNewBranchName] = useState('')
   const [startPoint, setStartPoint] = useState('')
+  const branchElements = useRef(new Map<string, HTMLLIElement>())
 
   const refresh = useCallback(async () => {
     const result = await window.gitdesktop.getBranches(repoPath)
     if (result.ok) {
       const available = new Set(result.data.map((branch) => branch.name))
+      const localNames = result.data.filter((branch) => !branch.isRemote).map((branch) => branch.name)
+      const remoteNames = result.data.filter((branch) => branch.isRemote).map((branch) => branch.name)
       setBranches(result.data)
       setSelectedNames((current) => current.filter((name) => available.has(name)))
+      setFocusedBranches((current) => ({
+        local: localNames.includes(current.local) ? current.local : (localNames[0] ?? ''),
+        remote: remoteNames.includes(current.remote) ? current.remote : (remoteNames[0] ?? '')
+      }))
     } else {
       onError(result.error)
     }
@@ -67,6 +87,7 @@ export default function BranchPanel({
   useEffect(() => {
     setSelectedNames([])
     setAnchor(null)
+    setFocusedBranches({ local: '', remote: '' })
     setContextMenu(null)
     refresh()
   }, [refresh])
@@ -197,9 +218,34 @@ export default function BranchPanel({
       onSelectBranch(branch)
     }
     setContextMenu({
-      left: Math.min(event.clientX, window.innerWidth - 240),
-      top: Math.min(event.clientY, window.innerHeight - 64)
+      left: clampMenuCoordinate(event.clientX, window.innerWidth, 240),
+      top: clampMenuCoordinate(event.clientY, window.innerHeight, 64)
     })
+  }
+
+  const moveBranchFocus = (
+    event: KeyboardEvent<HTMLLIElement>,
+    group: 'local' | 'remote',
+    groupBranches: BranchInfo[]
+  ): boolean => {
+    const moves: Partial<Record<string, BranchFocusMove>> = {
+      ArrowUp: 'previous',
+      ArrowDown: 'next',
+      Home: 'first',
+      End: 'last'
+    }
+    const move = moves[event.key]
+    if (!move) return false
+
+    event.preventDefault()
+    const currentIndex = groupBranches.findIndex((branch) => branch.name === focusedBranches[group])
+    const nextIndex = nextBranchFocusIndex(groupBranches.length, currentIndex, move)
+    const nextName = groupBranches[nextIndex]?.name
+    if (!nextName) return true
+
+    setFocusedBranches((current) => ({ ...current, [group]: nextName }))
+    branchElements.current.get(`${group}:${nextName}`)?.focus()
+    return true
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
@@ -222,14 +268,21 @@ export default function BranchPanel({
     return (
       <li
         key={branch.name}
+        ref={(element) => {
+          const key = `${group}:${branch.name}`
+          if (element) branchElements.current.set(key, element)
+          else branchElements.current.delete(key)
+        }}
         className={className}
         role="option"
-        tabIndex={0}
+        tabIndex={focusedBranches[group] === branch.name ? 0 : -1}
         aria-selected={isSelected}
         title={`Show files changed on ${branch.name}`}
         onClick={(event) => selectBranch(branch, group, groupBranches, event)}
         onContextMenu={(event) => openContextMenu(event, branch, group)}
+        onFocus={() => setFocusedBranches((current) => ({ ...current, [group]: branch.name }))}
         onKeyDown={(event) => {
+          if (moveBranchFocus(event, group, groupBranches)) return
           if (event.key !== 'Enter' && event.key !== ' ') return
           event.preventDefault()
           selectBranch(branch, group, groupBranches, event)

--- a/product/akbun-gitdesktop/src/renderer/src/components/BranchPanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/BranchPanel.tsx
@@ -1,12 +1,43 @@
-import { useCallback, useEffect, useState, type JSX } from 'react'
-import type { BranchInfo } from '../../../shared/types'
-import { clickable } from '../lib/clickable'
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type JSX,
+  type KeyboardEvent,
+  type MouseEvent
+} from 'react'
+import type { BranchDeletionFailure, BranchInfo } from '../../../shared/types'
+import { selectBranchNames, type BranchSelectionMode } from '../lib/branchSelection'
 
 interface Props {
   repoPath: string
   selectedBranch: string
   onError: (message: string) => void
   onSelectBranch: (branch: BranchInfo) => void
+}
+
+interface SelectionAnchor {
+  name: string
+  group: 'local' | 'remote'
+}
+
+interface ContextMenuPosition {
+  left: number
+  top: number
+}
+
+interface SelectionModifiers {
+  metaKey: boolean
+  ctrlKey: boolean
+  shiftKey: boolean
+}
+
+function branchLabel(count: number): string {
+  return `${count} local branch${count === 1 ? '' : 'es'}`
+}
+
+function failureMessage(failures: BranchDeletionFailure[]): string {
+  return failures.map((failure) => `${failure.name}: ${failure.error}`).join('\n\n')
 }
 
 export default function BranchPanel({
@@ -16,21 +47,40 @@ export default function BranchPanel({
   onSelectBranch
 }: Props): JSX.Element {
   const [branches, setBranches] = useState<BranchInfo[]>([])
+  const [selectedNames, setSelectedNames] = useState<string[]>([])
+  const [anchor, setAnchor] = useState<SelectionAnchor | null>(null)
+  const [contextMenu, setContextMenu] = useState<ContextMenuPosition | null>(null)
   const [newBranchName, setNewBranchName] = useState('')
   const [startPoint, setStartPoint] = useState('')
 
   const refresh = useCallback(async () => {
     const result = await window.gitdesktop.getBranches(repoPath)
     if (result.ok) {
+      const available = new Set(result.data.map((branch) => branch.name))
       setBranches(result.data)
+      setSelectedNames((current) => current.filter((name) => available.has(name)))
     } else {
       onError(result.error)
     }
   }, [repoPath, onError])
 
   useEffect(() => {
+    setSelectedNames([])
+    setAnchor(null)
+    setContextMenu(null)
     refresh()
   }, [refresh])
+
+  useEffect(() => {
+    if (!contextMenu) return
+    const closeMenu = (): void => setContextMenu(null)
+    window.addEventListener('click', closeMenu)
+    window.addEventListener('blur', closeMenu)
+    return () => {
+      window.removeEventListener('click', closeMenu)
+      window.removeEventListener('blur', closeMenu)
+    }
+  }, [contextMenu])
 
   const createBranch = async (): Promise<void> => {
     if (!newBranchName.trim()) {
@@ -47,53 +97,156 @@ export default function BranchPanel({
     }
   }
 
-  const deleteBranch = async (branch: BranchInfo): Promise<void> => {
-    if (!window.confirm(`Delete this branch?\n${branch.name}`)) return
-    const result = await window.gitdesktop.deleteBranch(repoPath, branch.name, false)
-    if (result.ok) {
-      refresh()
+  const locals = branches.filter((branch) => !branch.isRemote)
+  const remotes = branches.filter((branch) => branch.isRemote)
+  const selectedBranches = selectedNames
+    .map((name) => branches.find((branch) => branch.name === name))
+    .filter((branch): branch is BranchInfo => Boolean(branch))
+  const deletableBranches = selectedBranches.filter((branch) => !branch.isRemote && !branch.isCurrent)
+
+  const selectBranch = (
+    branch: BranchInfo,
+    group: 'local' | 'remote',
+    groupBranches: BranchInfo[],
+    modifiers: SelectionModifiers
+  ): void => {
+    const toggle = modifiers.metaKey || modifiers.ctrlKey
+    const sameGroupAnchor = anchor?.group === group ? anchor.name : ''
+    let mode: BranchSelectionMode = 'single'
+    if (modifiers.shiftKey) mode = toggle ? 'add-range' : 'range'
+    else if (toggle) mode = 'toggle'
+
+    const next = selectBranchNames(
+      groupBranches.map((item) => item.name),
+      selectedNames,
+      sameGroupAnchor,
+      branch.name,
+      mode
+    )
+    setSelectedNames(next)
+
+    if (!modifiers.shiftKey || !sameGroupAnchor) {
+      setAnchor({ name: branch.name, group })
+    }
+
+    if (next.includes(branch.name)) {
+      onSelectBranch(branch)
       return
     }
-    if (window.confirm(`The branch is not fully merged. Delete it anyway?\n\n${result.error}`)) {
-      const forced = await window.gitdesktop.deleteBranch(repoPath, branch.name, true)
-      forced.ok ? refresh() : onError(forced.error)
+
+    if (selectedBranch === branch.name && next.length > 0) {
+      const nextActive = branches.find((item) => item.name === next[next.length - 1])
+      if (nextActive) onSelectBranch(nextActive)
     }
   }
 
-  const locals = branches.filter((branch) => !branch.isRemote)
-  const remotes = branches.filter((branch) => branch.isRemote)
+  const deleteSelectedBranches = async (): Promise<void> => {
+    if (deletableBranches.length === 0) return
 
-  const renderBranch = (branch: BranchInfo, deletable: boolean): JSX.Element => (
-    <li
-      key={branch.name}
-      className={branch.name === selectedBranch ? 'selected' : ''}
-      {...clickable(() => onSelectBranch(branch))}
-      title={`Show files changed on ${branch.name}`}
-    >
-      <span className={branch.isCurrent ? 'branch-name current' : 'branch-name'}>
-        {branch.isCurrent && '● '}
-        {branch.name}
-      </span>
-      <span className="branch-hash">{branch.shortHash}</span>
-      <span className="branch-upstream">{branch.upstream}</span>
-      {deletable && (
-        <button
-          className="icon-button"
-          title="Delete branch"
-          aria-label={`Delete branch ${branch.name}`}
-          onClick={(event) => {
-            event.stopPropagation()
-            deleteBranch(branch)
-          }}
-        >
-          ✕
-        </button>
-      )}
-    </li>
-  )
+    const excluded = selectedBranches.filter((branch) => branch.isRemote || branch.isCurrent)
+    const excludedDetail = excluded.length > 0
+      ? `\n\nExcluded from deletion:\n${excluded.map((branch) => branch.name).join('\n')}`
+      : ''
+    const names = deletableBranches.map((branch) => branch.name)
+    if (!window.confirm(`Delete ${branchLabel(names.length)}?\n\n${names.join('\n')}${excludedDetail}`)) return
+
+    const safelyDeleted = await window.gitdesktop.deleteBranches(repoPath, names, false)
+    if (!safelyDeleted.ok) {
+      onError(safelyDeleted.error)
+      return
+    }
+
+    const deleted = [...safelyDeleted.data.deleted]
+    const failures = [...safelyDeleted.data.failed]
+    const unmerged = safelyDeleted.data.unmerged
+    if (
+      unmerged.length > 0 &&
+      window.confirm(`Force delete ${branchLabel(unmerged.length)} not fully merged?\n\n${unmerged.join('\n')}`)
+    ) {
+      const forciblyDeleted = await window.gitdesktop.deleteBranches(repoPath, unmerged, true)
+      if (forciblyDeleted.ok) {
+        deleted.push(...forciblyDeleted.data.deleted)
+        failures.push(...forciblyDeleted.data.failed)
+      } else {
+        failures.push(...unmerged.map((name) => ({ name, error: forciblyDeleted.error })))
+      }
+    }
+
+    const deletedSet = new Set(deleted)
+    const remaining = selectedNames.filter((name) => !deletedSet.has(name))
+    setSelectedNames(remaining)
+    setContextMenu(null)
+    await refresh()
+
+    if (deletedSet.has(selectedBranch) && remaining.length > 0) {
+      const nextActive = branches.find((branch) => branch.name === remaining[remaining.length - 1])
+      if (nextActive) onSelectBranch(nextActive)
+    }
+    if (failures.length > 0) onError(`Some branches could not be deleted.\n\n${failureMessage(failures)}`)
+  }
+
+  const openContextMenu = (
+    event: MouseEvent<HTMLLIElement>,
+    branch: BranchInfo,
+    group: 'local' | 'remote'
+  ): void => {
+    event.preventDefault()
+    if (!selectedNames.includes(branch.name)) {
+      setSelectedNames([branch.name])
+      setAnchor({ name: branch.name, group })
+      onSelectBranch(branch)
+    }
+    setContextMenu({
+      left: Math.min(event.clientX, window.innerWidth - 240),
+      top: Math.min(event.clientY, window.innerHeight - 64)
+    })
+  }
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    const target = event.target as HTMLElement
+    if (target.matches('input, button')) return
+    if (event.key !== 'Delete' && event.key !== 'Backspace') return
+    if (deletableBranches.length === 0) return
+    event.preventDefault()
+    deleteSelectedBranches()
+  }
+
+  const renderBranch = (
+    branch: BranchInfo,
+    group: 'local' | 'remote',
+    groupBranches: BranchInfo[]
+  ): JSX.Element => {
+    const isSelected = selectedNames.includes(branch.name)
+    const isActive = isSelected && branch.name === selectedBranch
+    const className = [isSelected ? 'selected' : '', isActive ? 'active' : ''].filter(Boolean).join(' ')
+    return (
+      <li
+        key={branch.name}
+        className={className}
+        role="option"
+        tabIndex={0}
+        aria-selected={isSelected}
+        title={`Show files changed on ${branch.name}`}
+        onClick={(event) => selectBranch(branch, group, groupBranches, event)}
+        onContextMenu={(event) => openContextMenu(event, branch, group)}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') return
+          event.preventDefault()
+          selectBranch(branch, group, groupBranches, event)
+        }}
+      >
+        <span className={branch.isCurrent ? 'branch-name current' : 'branch-name'}>
+          {branch.isCurrent && '● '}
+          {branch.name}
+        </span>
+        <span className="branch-hash">{branch.shortHash}</span>
+        <span className="branch-upstream">{branch.upstream}</span>
+      </li>
+    )
+  }
 
   return (
-    <div className="branch-panel">
+    <div className="branch-panel" onKeyDown={handleKeyDown}>
       <div className="branch-create">
         <input
           type="text"
@@ -111,11 +264,33 @@ export default function BranchPanel({
           + Create branch
         </button>
       </div>
-      <p className="branch-hint">Click a branch to see the files it changed, then click a file for its diff.</p>
+      <p className="branch-hint">
+        Click for a diff. Cmd/Ctrl-click selects branches individually; Shift-click selects a range.
+      </p>
       <h3>Local branches</h3>
-      <ul className="branch-list">{locals.map((branch) => renderBranch(branch, !branch.isCurrent))}</ul>
+      <ul className="branch-list" role="listbox" aria-label="Local branches" aria-multiselectable="true">
+        {locals.map((branch) => renderBranch(branch, 'local', locals))}
+      </ul>
       <h3>Remote branches</h3>
-      <ul className="branch-list">{remotes.map((branch) => renderBranch(branch, false))}</ul>
+      <ul className="branch-list" role="listbox" aria-label="Remote branches" aria-multiselectable="true">
+        {remotes.map((branch) => renderBranch(branch, 'remote', remotes))}
+      </ul>
+      {contextMenu && (
+        <div
+          className="branch-context-menu"
+          role="menu"
+          style={{ left: contextMenu.left, top: contextMenu.top }}
+          onContextMenu={(event) => event.preventDefault()}
+        >
+          <button
+            role="menuitem"
+            disabled={deletableBranches.length === 0}
+            onClick={deleteSelectedBranches}
+          >
+            Delete {branchLabel(deletableBranches.length)}…
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/product/akbun-gitdesktop/src/renderer/src/lib/branchSelection.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/lib/branchSelection.ts
@@ -1,5 +1,23 @@
 export type BranchSelectionMode = 'single' | 'toggle' | 'range' | 'add-range'
 
+export type BranchFocusMove = 'previous' | 'next' | 'first' | 'last'
+
+export function clampMenuCoordinate(pointer: number, viewport: number, menuSize: number): number {
+  return Math.max(0, Math.min(pointer, viewport - menuSize))
+}
+
+export function nextBranchFocusIndex(
+  itemCount: number,
+  currentIndex: number,
+  move: BranchFocusMove
+): number {
+  if (itemCount === 0) return -1
+  if (move === 'first') return 0
+  if (move === 'last') return itemCount - 1
+  if (move === 'previous') return Math.max(0, currentIndex - 1)
+  return Math.min(itemCount - 1, currentIndex + 1)
+}
+
 export function selectBranchNames(
   groupNames: string[],
   selectedNames: string[],

--- a/product/akbun-gitdesktop/src/renderer/src/lib/branchSelection.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/lib/branchSelection.ts
@@ -1,0 +1,27 @@
+export type BranchSelectionMode = 'single' | 'toggle' | 'range' | 'add-range'
+
+export function selectBranchNames(
+  groupNames: string[],
+  selectedNames: string[],
+  anchorName: string,
+  clickedName: string,
+  mode: BranchSelectionMode
+): string[] {
+  if (mode === 'single') return [clickedName]
+
+  if (mode === 'toggle') {
+    return selectedNames.includes(clickedName)
+      ? selectedNames.filter((name) => name !== clickedName)
+      : [...selectedNames, clickedName]
+  }
+
+  const anchorIndex = groupNames.indexOf(anchorName)
+  const clickedIndex = groupNames.indexOf(clickedName)
+  if (anchorIndex < 0 || clickedIndex < 0) return [clickedName]
+
+  const start = Math.min(anchorIndex, clickedIndex)
+  const end = Math.max(anchorIndex, clickedIndex)
+  const range = groupNames.slice(start, end + 1)
+  if (mode === 'range') return range
+  return [...selectedNames, ...range.filter((name) => !selectedNames.includes(name))]
+}

--- a/product/akbun-gitdesktop/src/renderer/src/styles.css
+++ b/product/akbun-gitdesktop/src/renderer/src/styles.css
@@ -621,6 +621,11 @@ button:focus-visible,
   border-left-color: var(--accent);
 }
 
+.branch-list li.active {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
 .branch-name {
   flex: 1;
   overflow: hidden;
@@ -642,6 +647,36 @@ button:focus-visible,
 .branch-upstream {
   color: var(--text-dim);
   font-size: 11px;
+}
+
+.branch-context-menu {
+  position: fixed;
+  z-index: 40;
+  min-width: 220px;
+  padding: 5px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.branch-context-menu button {
+  width: 100%;
+  padding: 7px 9px;
+  border: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.branch-context-menu button:hover:not(:disabled) {
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+
+.branch-context-menu button:disabled {
+  color: var(--text-dim);
+  cursor: default;
+  opacity: 0.6;
 }
 
 /* Pull requests and issues */

--- a/product/akbun-gitdesktop/src/shared/types.ts
+++ b/product/akbun-gitdesktop/src/shared/types.ts
@@ -25,6 +25,17 @@ export interface BranchInfo {
   isRemote: boolean
 }
 
+export interface BranchDeletionFailure {
+  name: string
+  error: string
+}
+
+export interface BranchDeletionResult {
+  deleted: string[]
+  unmerged: string[]
+  failed: BranchDeletionFailure[]
+}
+
 export interface WorktreeInfo {
   path: string
   head: string

--- a/product/akbun-gitdesktop/test/branch-deletion.test.js
+++ b/product/akbun-gitdesktop/test/branch-deletion.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test')
+const assert = require('node:assert')
+
+test('안전 삭제는 성공, 미병합, 일반 실패를 분리한다', async () => {
+  const { deleteBranchBatch } = await import('../src/main/branchDeletion.ts')
+  const merged = new Set(['merged', 'locked'])
+  const deleteBranch = async (name, force) => {
+    assert.strictEqual(force, false)
+    if (name === 'merged') return
+    throw new Error(name === 'locked' ? 'checked out in a worktree' : 'not fully merged')
+  }
+
+  const result = await deleteBranchBatch(
+    ['merged', 'unmerged', 'locked'],
+    false,
+    deleteBranch,
+    async (name) => merged.has(name)
+  )
+
+  assert.deepStrictEqual(result, {
+    deleted: ['merged'],
+    unmerged: ['unmerged'],
+    failed: [{ name: 'locked', error: 'checked out in a worktree' }]
+  })
+})
+
+test('강제 삭제 실패는 미병합 후보가 아니라 실패로 남긴다', async () => {
+  const { deleteBranchBatch } = await import('../src/main/branchDeletion.ts')
+  let mergeCheckCalled = false
+
+  const result = await deleteBranchBatch(
+    ['feature'],
+    true,
+    async () => { throw new Error('checked out in a worktree') },
+    async () => {
+      mergeCheckCalled = true
+      return false
+    }
+  )
+
+  assert.strictEqual(mergeCheckCalled, false)
+  assert.deepStrictEqual(result, {
+    deleted: [],
+    unmerged: [],
+    failed: [{ name: 'feature', error: 'checked out in a worktree' }]
+  })
+})

--- a/product/akbun-gitdesktop/test/renderer-utils.test.js
+++ b/product/akbun-gitdesktop/test/renderer-utils.test.js
@@ -51,3 +51,19 @@ test('다른 그룹의 기준점으로 범위 선택하면 클릭한 브랜치�
     ['origin/dev']
   )
 })
+
+test('컨텍스트 메뉴 좌표는 작은 화면에서도 음수가 되지 않는다', async () => {
+  const { clampMenuCoordinate } = await import('../src/renderer/src/lib/branchSelection.ts')
+
+  assert.strictEqual(clampMenuCoordinate(700, 800, 240), 560)
+  assert.strictEqual(clampMenuCoordinate(20, 200, 240), 0)
+})
+
+test('브랜치 포커스는 목록 경계를 넘지 않는다', async () => {
+  const { nextBranchFocusIndex } = await import('../src/renderer/src/lib/branchSelection.ts')
+
+  assert.strictEqual(nextBranchFocusIndex(4, 0, 'previous'), 0)
+  assert.strictEqual(nextBranchFocusIndex(4, 1, 'next'), 2)
+  assert.strictEqual(nextBranchFocusIndex(4, 2, 'first'), 0)
+  assert.strictEqual(nextBranchFocusIndex(4, 2, 'last'), 3)
+})

--- a/product/akbun-gitdesktop/test/renderer-utils.test.js
+++ b/product/akbun-gitdesktop/test/renderer-utils.test.js
@@ -17,3 +17,37 @@ test('clampPanelWidth는 패널 너비를 허용 범위에 둔다', async () => 
   assert.strictEqual(clampPanelWidth(240, 160, 420), 240)
   assert.strictEqual(clampPanelWidth(600, 160, 420), 420)
 })
+
+test('브랜치 선택은 단일, 토글, 범위 선택을 구분한다', async () => {
+  const { selectBranchNames } = await import('../src/renderer/src/lib/branchSelection.ts')
+  const branches = ['main', 'feature-a', 'feature-b', 'feature-c']
+
+  assert.deepStrictEqual(selectBranchNames(branches, ['main'], 'main', 'feature-a', 'single'), ['feature-a'])
+  assert.deepStrictEqual(selectBranchNames(branches, ['main'], 'main', 'feature-b', 'toggle'), [
+    'main',
+    'feature-b'
+  ])
+  assert.deepStrictEqual(selectBranchNames(branches, ['main', 'feature-b'], 'main', 'main', 'toggle'), [
+    'feature-b'
+  ])
+  assert.deepStrictEqual(selectBranchNames(branches, ['feature-c'], 'feature-a', 'feature-c', 'range'), [
+    'feature-a',
+    'feature-b',
+    'feature-c'
+  ])
+  assert.deepStrictEqual(selectBranchNames(branches, ['main'], 'feature-a', 'feature-c', 'add-range'), [
+    'main',
+    'feature-a',
+    'feature-b',
+    'feature-c'
+  ])
+})
+
+test('다른 그룹의 기준점으로 범위 선택하면 클릭한 브랜치만 선택한다', async () => {
+  const { selectBranchNames } = await import('../src/renderer/src/lib/branchSelection.ts')
+
+  assert.deepStrictEqual(
+    selectBranchNames(['origin/main', 'origin/dev'], ['main'], '', 'origin/dev', 'range'),
+    ['origin/dev']
+  )
+})


### PR DESCRIPTION
# 구현

Branches 목록 Finder식 다중 선택과 우클릭·키보드 일괄 삭제 추가
- 타입 검사, 14개 테스트, production build, 내장 브라우저 상호작용 검증 통과

# 어려웠던 점

미병합과 worktree 사용 중 오류의 안정적 분리
- Git 오류 문자열 대신 upstream 또는 HEAD의 도달 가능성과 실제 안전 삭제 결과 조합

# 리스크

여러 브랜치 삭제의 비원자적 처리
- 중간 실패 시 이미 삭제한 브랜치는 복구하지 않고 실패·제외 항목 선택 유지

Issue #1066