### PR TITLE
akbun-rendermermaid: PNG 클립보드 복사

### DIFF
--- a/product/akbun-rendermermaid/README.md
+++ b/product/akbun-rendermermaid/README.md
@@ -13,6 +13,7 @@ Deployed at [mermaid.akbun.com](https://mermaid.akbun.com).
 | Zoom | The preview zooms with its own buttons, with Ctrl or Cmd and +, - or 0, and with Ctrl or Cmd and the wheel. Fit re-fits it to the pane |
 | Errors | A failed parse leaves the last good diagram on screen and prints the mermaid message, with its line and caret, under the editor. Nothing flashes away while you are mid-edit |
 | Save PNG | Rasterizes the rendered SVG at 2x onto a white background and downloads it as `mermaid-<type>-<date>-<time>.png`. The export is the diagram's own size whatever the preview zoom is, and a diagram too wide for a canvas is exported at a lower scale instead of failing |
+| Copy PNG | Rasterizes the diagram through the same path as Save PNG and writes the image to the system clipboard |
 | Large view | Opens the diagram full screen, scaled to fill the window rather than left at its original size. Zoom with the buttons, +/-/0, or Ctrl and the wheel; drag to pan; Escape closes |
 | Dots | A 22 px dot grid behind the preview, for lining diagrams up by eye. It is a background of the pane, so it never appears in an exported PNG. The setting is remembered |
 | Restore | The code is kept in `localStorage`, so a reload or a closed tab does not lose the diagram |

--- a/product/akbun-rendermermaid/adr/2026-08-png-export-through-canvas.md
+++ b/product/akbun-rendermermaid/adr/2026-08-png-export-through-canvas.md
@@ -2,7 +2,7 @@
 
 ## Decision
 
-Export by serializing the rendered SVG, loading it through an `<img>`, and drawing it onto a canvas at 2x over a white fill. To make that path produce a correct image, turn `htmlLabels` off in mermaid and give it a system font stack instead of the page's webfont. Cap the export scale so the long edge never passes 8192 px.
+Export by serializing the rendered SVG, loading it through an `<img>`, and drawing it onto a canvas at 2x over a white fill. Use the resulting PNG blob for both file download and clipboard copy. To make that path produce a correct image, turn `htmlLabels` off in mermaid and give it a system font stack instead of the page's webfont. Cap the export scale so the long edge never passes 8192 px.
 
 ## Reason
 

--- a/product/akbun-rendermermaid/wiki/architecture.md
+++ b/product/akbun-rendermermaid/wiki/architecture.md
@@ -47,7 +47,10 @@ The browser will rasterize an SVG for you, but only through an `<img>`, and the 
 2. Pin the pixel size and strip `max-width`, or the image draws at the clamped size and the PNG comes out small.
 3. Choose a scale. 2x by default, lowered when the long edge would pass 8192 px, which is the smallest canvas limit still in the field. A 7500 px flowchart exports at 1.08x rather than failing.
 4. Fill white first. PNG keeps transparency and a transparent diagram is unreadable anywhere dark.
-5. Draw, `toBlob`, download through an object URL.
+5. Draw and encode with `toBlob`.
+6. Download through an object URL or write the PNG blob with the Clipboard API.
+
+Save and Copy share this rasterization function, so the downloaded and copied images have the same scale, white background and canvas limit. Copy constructs the `ClipboardItem` before rasterization finishes and gives it the pending PNG blob. This keeps the write attached to the button click in browsers that enforce transient user activation.
 
 Two mermaid settings exist for this path alone: `htmlLabels: false`, because HTML labels are drawn inside a `foreignObject` that canvas renders as blank space, and a system font stack, because a webfont is not fetched while an SVG is being rasterized. Both make the preview slightly plainer so that the export matches it.
 

--- a/product/akbun-rendermermaid/workspace/package-lock.json
+++ b/product/akbun-rendermermaid/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-rendermermaid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-rendermermaid",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "astro": "^7.1.6",
         "mermaid": "^11.16.0"

--- a/product/akbun-rendermermaid/workspace/package.json
+++ b/product/akbun-rendermermaid/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-rendermermaid",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-rendermermaid/workspace/src/pages/index.astro
+++ b/product/akbun-rendermermaid/workspace/src/pages/index.astro
@@ -8,7 +8,7 @@ import '../styles/global.css';
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>akbun mermaid render</title>
-  <meta name="description" content="Write mermaid code on the left, see the diagram on the right. Zoom it, save it as PNG, open it large. Runs entirely in the browser.">
+  <meta name="description" content="Write mermaid code on the left, see the diagram on the right. Zoom it, save or copy it as PNG, open it large. Runs entirely in the browser.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700&family=Outfit:wght@400;500;600&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
@@ -35,6 +35,7 @@ import '../styles/global.css';
         <button id="render" type="button" title="Render now (Ctrl/Cmd + Enter)">Render</button>
         <button id="refresh" class="ghost" type="button" title="Clear the preview and draw it again">Refresh</button>
         <button id="save-png" class="ghost" type="button" disabled>Save PNG</button>
+        <button id="copy-png" class="ghost" type="button" disabled>Copy PNG</button>
         <button id="large" class="ghost" type="button" disabled>Large view</button>
         <button id="dots" class="ghost" type="button" aria-pressed="true">Dots</button>
 

--- a/product/akbun-rendermermaid/workspace/src/scripts/main.js
+++ b/product/akbun-rendermermaid/workspace/src/scripts/main.js
@@ -26,7 +26,8 @@ const SAMPLE = `flowchart LR
   B -- yes --> C[Render]
   B -- no --> D[Show the error]
   C --> E[Save PNG]
-  C --> F[Large view]`;
+  C --> F[Copy PNG]
+  C --> G[Large view]`;
 
 const codeEl = document.querySelector('#code');
 const diagramEl = document.querySelector('#diagram');
@@ -35,6 +36,7 @@ const statusEl = document.querySelector('#status');
 const renderBtn = document.querySelector('#render');
 const refreshBtn = document.querySelector('#refresh');
 const pngBtn = document.querySelector('#save-png');
+const copyPngBtn = document.querySelector('#copy-png');
 const largeBtn = document.querySelector('#large');
 const dotsBtn = document.querySelector('#dots');
 const previewZoomLabel = document.querySelector('#preview-zoom-level');
@@ -84,8 +86,13 @@ function reportError(error) {
 }
 
 function setDiagramActions(enabled) {
-  pngBtn.disabled = !enabled;
+  setExportActions(enabled);
   largeBtn.disabled = !enabled;
+}
+
+function setExportActions(enabled) {
+  pngBtn.disabled = !enabled;
+  copyPngBtn.disabled = !enabled;
 }
 
 function showEmpty() {
@@ -217,11 +224,7 @@ function exportableMarkup(svg) {
   return new XMLSerializer().serializeToString(copy);
 }
 
-async function savePng() {
-  const svg = diagramEl.querySelector('svg');
-  if (!svg) return;
-
-  pngBtn.disabled = true;
+async function rasterizePng(svg) {
   const markup = exportableMarkup(svg);
   const { width, height } = readSvgSize(markup);
   const scale = exportScale(width, height);
@@ -248,13 +251,50 @@ async function savePng() {
     const blob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
     if (!blob) throw new Error('The PNG could not be encoded.');
 
-    download(blob, pngFileName(codeEl.value, new Date()));
-    setStatus(`Saved PNG at ${canvas.width}x${canvas.height}.`);
+    return { blob, width: canvas.width, height: canvas.height };
+  } finally {
+    URL.revokeObjectURL(source);
+  }
+}
+
+async function savePng() {
+  const svg = diagramEl.querySelector('svg');
+  if (!svg) return;
+
+  setExportActions(false);
+
+  try {
+    const png = await rasterizePng(svg);
+    download(png.blob, pngFileName(codeEl.value, new Date()));
+    setStatus(`Saved PNG at ${png.width}x${png.height}.`);
   } catch (error) {
     reportError(error);
   } finally {
-    URL.revokeObjectURL(source);
-    pngBtn.disabled = false;
+    setExportActions(Boolean(diagramEl.querySelector('svg')));
+  }
+}
+
+async function copyPng() {
+  const svg = diagramEl.querySelector('svg');
+  if (!svg) return;
+
+  if (!navigator.clipboard?.write || typeof ClipboardItem === 'undefined') {
+    reportError(new Error('Copying PNG images is not supported by this browser.'));
+    return;
+  }
+
+  setExportActions(false);
+
+  try {
+    const pngPromise = rasterizePng(svg);
+    const blobPromise = pngPromise.then((png) => png.blob);
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blobPromise })]);
+    const png = await pngPromise;
+    setStatus(`Copied PNG at ${png.width}x${png.height}.`);
+  } catch (error) {
+    reportError(error);
+  } finally {
+    setExportActions(Boolean(diagramEl.querySelector('svg')));
   }
 }
 
@@ -361,6 +401,7 @@ codeEl.addEventListener('keydown', (event) => {
 renderBtn.addEventListener('click', renderNow);
 refreshBtn.addEventListener('click', refresh);
 pngBtn.addEventListener('click', savePng);
+copyPngBtn.addEventListener('click', copyPng);
 largeBtn.addEventListener('click', openLargeView);
 
 dotsBtn.addEventListener('click', () => {

--- a/product/akbun-rendermermaid/workspace/wrangler.json
+++ b/product/akbun-rendermermaid/workspace/wrangler.json
@@ -1,5 +1,5 @@
 {
-  "name": "rendermermaid",
+  "name": "mermaid",
   "compatibility_date": "2026-08-04",
   "assets": {
     "directory": "./dist"


### PR DESCRIPTION
# 구현

PNG 생성 경로 공유와 클립보드 복사 버튼 추가
- 단위 테스트 30개와 Astro 빌드 통과, 내장 브라우저에서 1501x526 PNG 복사 확인

# 어려웠던 점

비동기 래스터화 중 브라우저의 일시적 사용자 활성화 유지
- 대기 전 ClipboardItem을 만들고 미완료 PNG Blob 전달

# 리스크

이미지 Clipboard API 미지원 브라우저에서 복사 불가
- 지원 여부 감지 후 상태 영역에 오류 표시, PNG 저장 기능은 계속 사용 가능

Issue #1074