### PR TITLE
docs: LLM serving 메모리 핸즈온 흐름 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@
 95. LLM serving challenge와 essential optimization Chapter 5-6 핸즈온 (26.8.22) - [링크](./computer_science/ai/study-llmserving/ch5-6/)
   - [문서 인덱스](./computer_science/ai/study-llmserving/ch5-6/docs/) - chapter별로 무엇을 어떤 순서로 볼지
   - [16GB GPU에 7B 모델이 올라가도 serving이 어려운 이유](./computer_science/ai/study-llmserving/ch5-6/docs/02-ch5-theory.md) - weight 외 KV cache·activation 계산
-  - [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./computer_science/ai/study-llmserving/ch5-6/docs/handson/09-kv-cache-batch-sequence.md) - 책 공식과 vLLM 실측 pool 대조
-  - [내 GPU의 crossover를 직접 재고 병목을 만들기](./computer_science/ai/study-llmserving/ch5-6/docs/handson/08-roofline-bottleneck.md) - roofline 실측과 대역폭 병목 증명
+  - [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md) - 책 공식과 vLLM 실측 pool 대조
+  - [내 GPU의 crossover를 직접 재고 병목을 만들기](./computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md) - roofline 실측과 대역폭 병목 증명
 96. SearXNG 프로덕션 주의사항과 봇 탐지 핸즈온 (26.8.23) - [링크](./computer_science/ai/searxng-production/)
 97. Amazon Bedrock Web Search와 AgentCore 핸즈온 (26.8.23) - [링크](./aws/bedrock/agentcore-web-search/)
 98. Amazon Bedrock Web Search 유해콘텐스 검색 테스트 (26.8.23) - [링크](./aws/bedrock/agentcore-web-search/docs/5-safety-test.md)

--- a/computer_science/ai/study-llmserving/ch5-6/.env.example
+++ b/computer_science/ai/study-llmserving/ch5-6/.env.example
@@ -2,7 +2,7 @@
 LAN_BIND_ADDRESS=0.0.0.0
 
 # vLLM scheduler limits. Raising max_num_seqs moves the batch ceiling from the
-# scheduler to the KV pool. See docs/handson/09-kv-cache-batch-sequence.md
+# scheduler to the KV pool. See docs/handson/03-kv-cache-batch-sequence.md
 VLLM_MAX_NUM_SEQS=8
 VLLM_MAX_NUM_BATCHED_TOKENS=4096
 

--- a/computer_science/ai/study-llmserving/ch5-6/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/README.md
@@ -2,7 +2,7 @@
 
 Batching과 quantization option부터 바꾸면 성능 숫자는 달라져도 이유를 설명하기 어렵습니다. Model이 VRAM을 어떻게 쓰고 prefill과 decode가 어디에서 막히는지 먼저 알아야 optimization 결과를 예측할 수 있습니다.
 
-이 workspace는 RTX 5060 Ti 16GB에서 memory budget → scheduling → observability → quantization → caching 순서로 가설을 검증합니다.
+이 workspace는 RTX 5060 Ti 16GB에서 memory budget → KV cache → roofline → scheduling → observability → quantization → caching 순서로 가설을 검증합니다.
 
 ## 문서 인덱스
 
@@ -14,10 +14,10 @@ Batching과 quantization option부터 바꾸면 성능 숫자는 달라져도 �
 | ---: | --- | --- |
 | 0 | [Chapter 5 이론](./docs/02-ch5-theory.md) | weight 말고 무엇이 VRAM을 쓰는가 |
 | 1 | [02 메모리 예산과 OOM](./docs/handson/02-memory-budget-oom.md) | 계산상 들어가는데 왜 OOM이 나는가 |
-| 2 | [09 KV cache 배치·시퀀스](./docs/handson/09-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고 최대 배치는 무엇이 정하는가 |
-| 3 | [08 roofline과 병목 재현](./docs/handson/08-roofline-bottleneck.md) | 연산집약도 축은 무엇이고 병목이 연산인가 대역폭인가 |
+| 2 | [03 KV cache 배치·시퀀스](./docs/handson/03-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고 최대 배치는 무엇이 정하는가 |
+| 3 | [04 roofline과 병목 재현](./docs/handson/04-roofline-bottleneck.md) | 연산집약도 축은 무엇이고 병목이 연산인가 대역폭인가 |
 
-Chapter 6는 [Chapter 6 이론](./docs/04-ch6-theory.md) 다음에 실습 03, 04, 06, 07 순서입니다.
+Chapter 6는 [Chapter 6 이론](./docs/04-ch6-theory.md) 다음에 실습 05부터 09까지 순서대로 진행합니다.
 
 ## 먼저 원리를 이해합니다
 
@@ -40,16 +40,16 @@ Chapter 5는 hardware 용어 모음이 아닙니다. Chapter 6의 optimization�
 | 순서 | Ch | 질문 | 확인할 결과 |
 | ---: | :-: | --- | --- |
 | 1 | 환경 | Host와 container가 같은 GPU를 사용하는가 | GPU·driver·VRAM·Prometheus target |
-| 2 | **5** | 7B BF16은 왜 16GB에서 OOM이 나는가 | weight budget·runtime overhead |
-| 3 | 6 | Batch를 키우면 latency와 throughput이 어떻게 바뀌는가 | Queue·TTFT·E2E·Output TPS |
-| 4 | 6 | Static·dynamic·continuous batching은 어떻게 다른가 | admission delay·TTFT·RPS |
-| 5 | 5→6 | 느린 구간이 prefill인가 decode인가 | Prefill·Decode p95·TPOT·KV cache |
-| 6 | 6 | W4A16과 W8A8 중 무엇이 workload에 맞는가 | 성능·Peak VRAM·accuracy |
-| 7 | 6 | Prefix cache는 언제 TTFT를 줄이는가 | cold·warm·reordered request |
-| 8 | **5** | 내 카드의 crossover는 몇 FLOPS/B인가 | 실측 peak TFLOPS·bandwidth·roofline 그래프 |
-| 9 | **5** | 배치와 시퀀스를 키우면 KV cache가 어떻게 차는가 | 예측 대비 실측 pool 점유율·running·waiting |
+| 2 | **5** | 7B BF16은 왜 16GB에서 serving을 시작하지 못하는가 | weight·runtime·KV pool budget |
+| 3 | **5** | 배치와 시퀀스를 키우면 KV cache가 어떻게 차는가 | 예측 대비 실측 pool 점유율·running·waiting |
+| 4 | **5** | 내 카드의 crossover는 몇 FLOPS/B인가 | 실측 peak TFLOPS·bandwidth·roofline 그래프 |
+| 5 | 6 | Batch를 키우면 latency와 throughput이 어떻게 바뀌는가 | Queue·TTFT·E2E·Output TPS |
+| 6 | 6 | Static·dynamic·continuous batching은 어떻게 다른가 | admission delay·TTFT·RPS |
+| 7 | 5→6 | 느린 구간이 prefill인가 decode인가 | Prefill·Decode p95·TPOT·KV cache |
+| 8 | 6 | W4A16과 W8A8 중 무엇이 workload에 맞는가 | 성능·Peak VRAM·accuracy |
+| 9 | 6 | Prefix cache는 언제 TTFT를 줄이는가 | cold·warm·reordered request |
 
-번호는 만든 순서라 chapter가 섞여 있습니다. **Chapter 5만 보려면 이론 → 2 → 9 → 8 순서**로 읽습니다. chapter별 경로는 [실습 인덱스](./docs/handson/)에 정리돼 있습니다.
+파일 번호가 학습 순서입니다. Chapter별 경로와 선행 실습은 [실습 인덱스](./docs/handson/)에 정리돼 있습니다.
 
 ## 빠른 quality gate의 범위를 구분합니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docker-compose.yml
+++ b/computer_science/ai/study-llmserving/ch5-6/docker-compose.yml
@@ -48,6 +48,26 @@ services:
       SERVED_MODEL_NAME: qwen
     command: ["python3", "-m", "benchmark.summary"]
 
+  vllm-7b-bf16-expect-failure:
+    <<: *vllm
+    profiles: [oom]
+    command:
+      - vllm
+      - serve
+      - Qwen/Qwen2.5-7B-Instruct
+      - --served-model-name
+      - qwen
+      - --dtype
+      - bfloat16
+      - --max-model-len
+      - "4096"
+      - --max-num-seqs
+      - "1"
+      - --max-num-batched-tokens
+      - "4096"
+      - --gpu-memory-utilization
+      - "0.85"
+
   vllm-bf16:
     <<: *vllm
     profiles: [bf16]

--- a/computer_science/ai/study-llmserving/ch5-6/docs/02-ch5-theory.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/02-ch5-theory.md
@@ -161,7 +161,7 @@ Roofline 그래프에서 축을 잘못 읽으면 그림 전체가 의미를 잃�
 | memory bandwidth | 864 GB/s | 384 GB/s |
 | crossover | 419 FLOPS/B | **131 FLOPS/B** |
 
-crossover가 낮다는 것은 연산 성능에 비해 대역폭이 상대적으로 덜 부족하다는 뜻이고, 그만큼 **더 짧은 prompt에서도 compute-bound로 넘어간다**는 뜻입니다. 같은 workload라도 카드가 바뀌면 판정이 뒤집힐 수 있으므로, 병목을 말하기 전에 자기 카드의 crossover를 먼저 구해야 합니다. 구하는 방법은 [roofline과 병목 재현](./handson/08-roofline-bottleneck.md)에 있습니다.
+crossover가 낮다는 것은 연산 성능에 비해 대역폭이 상대적으로 덜 부족하다는 뜻이고, 그만큼 **더 짧은 prompt에서도 compute-bound로 넘어간다**는 뜻입니다. 같은 workload라도 카드가 바뀌면 판정이 뒤집힐 수 있으므로, 병목을 말하기 전에 자기 카드의 crossover를 먼저 구해야 합니다. 구하는 방법은 [roofline과 병목 재현](./handson/04-roofline-bottleneck.md)에 있습니다.
 
 ### decode는 sequence가 길어져도 intensity가 오르지 않습니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/README.md
@@ -1,6 +1,6 @@
 # Chapter 5-6 문서 인덱스
 
-이 디렉터리의 문서는 이론, 실습, 환경, 관측 네 갈래입니다. 파일 번호는 만든 순서라 chapter가 섞여 있으므로, chapter별로 볼 때는 아래 경로를 따릅니다.
+이 디렉터리의 문서는 이론, 실습, 환경, 관측 네 갈래입니다. 실습 파일 번호는 memory budget에서 optimization으로 이어지는 학습 순서입니다.
 
 ## Chapter 5 — 이 GPU에 이 model이 들어가는가, 느리면 무엇 때문인가
 
@@ -8,24 +8,23 @@
 | ---: | --- | --- |
 | 0 | [Chapter 5 이론](./02-ch5-theory.md) | weight 말고 무엇이 VRAM을 쓰는가 |
 | 1 | [02 메모리 예산과 OOM](./handson/02-memory-budget-oom.md) | 계산상 들어가는데 왜 OOM이 나는가 |
-| 2 | [09 KV cache 배치·시퀀스](./handson/09-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
-| 3 | [08 roofline과 병목 재현](./handson/08-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
+| 2 | [03 KV cache 배치·시퀀스](./handson/03-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
+| 3 | [04 roofline과 병목 재현](./handson/04-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
 
-메모리 이야기(02 → 09)를 끝내고 속도 이야기(08)로 넘어가는 순서입니다. 08과 09는 `make ch5-roofline`, `make ch5-kv-probe`, `make ch5-bottleneck`으로 직접 측정합니다.
+메모리 이야기(02 → 03)를 끝내고 속도 이야기(04)로 넘어가는 순서입니다. 03과 04는 `make ch5-kv-probe`, `make ch5-roofline`, `make ch5-bottleneck`으로 직접 측정합니다.
 
 ## Chapter 6 — 병목마다 어떤 optimization이 붙는가
 
 | 순서 | 문서 | 답하는 질문 |
 | ---: | --- | --- |
 | 0 | [Chapter 6 이론](./04-ch6-theory.md) | optimization을 무엇을 기준으로 고르는가 |
-| 1 | [03 batching](./handson/03-vllm-batching.md) | batch를 키우면 latency도 좋아지는가 |
-| 2 | [04 batching 전략](./handson/04-batch-strategies.md) | static·dynamic·continuous는 어디서 갈리는가 |
-| 3 | [06 quantization](./handson/06-quantization.md) | VRAM이 가장 적은 model이 가장 빠른가 |
-| 4 | [07 prefix caching](./handson/07-prefix-caching.md) | 같은 내용인데 cache가 왜 빗나가는가 |
+| 1 | [05 batching](./handson/05-vllm-batching.md) | batch를 키우면 latency도 좋아지는가 |
+| 2 | [06 batching 전략](./handson/06-batch-strategies.md) | static·dynamic·continuous는 어디서 갈리는가 |
+| 3 | [07 prefill·decode 관측](./handson/07-prefill-decode-observability.md) | 느린 단계가 prefill인가 decode인가 |
+| 4 | [08 quantization](./handson/08-quantization.md) | VRAM이 가장 적은 model이 가장 빠른가 |
+| 5 | [09 prefix caching](./handson/09-prefix-caching.md) | 같은 내용인데 cache가 왜 빗나가는가 |
 
-## 두 chapter를 잇는 실습
-
-[05 prefill·decode 관측](./handson/05-prefill-decode-observability.md)은 Chapter 5의 병목 개념을 metric으로 보는 다리입니다. 어느 **단계**가 느린지까지 좁히고, 그 단계가 연산 때문인지 대역폭 때문인지는 08로 넘깁니다.
+07은 Chapter 5에서 구분한 병목을 vLLM metric으로 관측해 Chapter 6 optimization과 연결합니다.
 
 ## 환경 준비
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
@@ -40,9 +40,9 @@ docker compose --profile tools run --rm benchmark python3 -m calculators.rooflin
 | Qwen2.5-7B | GQA | 4 | 56 KiB | 1 |
 | Qwen2.5-3B | GQA | 2 | 36 KiB | 61 |
 
-**KV 용량은 parameter 수가 아니라 KV head 수가 정합니다.** 이 계산을 실제 vLLM이 잡는 KV pool과 맞춰보는 것은 [배치와 시퀀스 스윕](./09-kv-cache-batch-sequence.md)에서 합니다.
+**KV 용량은 parameter 수가 아니라 KV head 수가 정합니다.** 이 계산을 실제 vLLM이 잡는 KV pool과 맞춰보는 것은 [배치와 시퀀스 스윕](./03-kv-cache-batch-sequence.md)에서 합니다.
 
-`calculators.roofline`은 같은 workload가 카드에 따라 compute-bound인지 bandwidth-bound인지 다르게 판정되는 것을 보여줍니다. 축을 읽는 법과 이 카드의 실측 crossover는 [roofline과 병목 재현](./08-roofline-bottleneck.md)에 있습니다.
+`calculators.roofline`은 같은 workload가 카드에 따라 compute-bound인지 bandwidth-bound인지 다르게 판정되는 것을 보여줍니다. 축을 읽는 법과 이 카드의 실측 crossover는 [roofline과 병목 재현](./04-roofline-bottleneck.md)에 있습니다.
 
 ## 7B BF16의 실패를 확인합니다
 
@@ -64,6 +64,22 @@ docker compose --profile tools run --rm model-loader python3 -m model_loader.loa
 
 실패 자체가 목적은 아닙니다. 계산한 weight와 실제 GPU memory 사이에 runtime 비용이 존재한다는 가설이 맞는지 확인하는 단계입니다.
 
+## 같은 7B BF16을 vLLM으로 기동합니다
+
+앞의 실험은 model을 CUDA로 옮기는 데 필요한 memory만 확인했습니다. Serving engine은 model 외에도 activation을 profiling하고 KV cache pool을 확보해야 합니다.
+
+동시 sequence를 하나로 제한한 가장 작은 serving 설정으로 vLLM 기동을 시도합니다.
+
+```bash
+docker compose --profile oom run --rm vllm-7b-bf16-expect-failure
+```
+
+- 기대 결과: API server가 준비되기 전에 GPU memory 부족으로 종료
+- memory 부족의 형태: CUDA OOM 또는 KV cache pool을 만들 수 없다는 초기화 오류
+- OOM이 아닌 오류: network·model format·kernel 문제부터 해결
+
+요청을 보내 KV cache를 채운 뒤 OOM을 만드는 실험이 아닙니다. vLLM은 기동할 때 KV pool을 미리 확보하고, 실행 중에는 pool을 넘는 요청을 대기시키거나 preemption합니다. **7B BF16은 요청을 받기 전에 serving 작업 공간부터 확보하지 못한다는 것이 이 단계의 결론입니다.**
+
 ## 3B BF16에서 남는 공간을 확인합니다
 
 같은 GPU에 더 작은 model을 올려 비교합니다.
@@ -79,13 +95,31 @@ docker compose --profile tools run --rm model-loader python3 -m model_loader.loa
 
 3B model이 올라갔다는 사실만으로 serving capacity가 결정되지는 않습니다. 남은 VRAM이 KV cache budget이 되고, batch size와 sequence length가 그 budget을 소비합니다.
 
+## 3B BF16은 vLLM serving까지 기동합니다
+
+같은 serving 설정에서 model만 3B로 바꿔 API server와 KV pool이 준비되는지 확인합니다.
+
+```bash
+make vllm-bf16
+bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
+```
+
+- 기대 결과: health check 성공
+- vLLM log: 0보다 큰 `Available KV cache memory`와 `GPU KV cache size`
+- 의미: weight와 runtime을 제외하고도 실제 요청을 저장할 KV pool 확보
+
+여기까지는 KV pool이 생겼다는 사실만 확인합니다. 다음 [KV cache 배치·시퀀스 실습](./03-kv-cache-batch-sequence.md)에서 token당 KV 비용을 계산하고, 동시 요청 수와 prompt 길이로 pool을 직접 채웁니다.
+
 ## 판단
 
 - 7B BF16 OOM: weight 외 runtime 공간까지 포함하면 16GB 초과
+- 7B BF16 vLLM 실패: KV pool을 포함한 serving 작업 공간 확보 불가
 - 3B BF16 load 성공: request를 위한 KV cache 여유 확보
+- 3B BF16 vLLM 성공: API server와 KV pool 준비 완료
 - Roofline 결과: long-prefill과 batch 1 decode의 병목 가설 분리
 
-정리하면, “모델이 들어가는가”와 “요청을 처리할 수 있는가”는 다른 질문입니다. Serving에서는 weight를 뺀 나머지 VRAM이 실제 request capacity입니다.
+정리하면, “모델이 들어가는가”와 “요청을 처리할 수 있는가”는 다른 질문입니다. Serving에서는 weight를 뺀 나머지 VRAM이 실제 request capacity이고, vLLM은 그 공간을 기동할 때 KV pool로 확보합니다.
 
 ## 참고자료
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
@@ -4,7 +4,7 @@ Chapter 5는 KV cache 크기를 `token당 bytes × 최대 배치 × 최대 시�
 
 ## 실습 환경
 
-- 선행 실습: [내 GPU의 crossover를 직접 재고 병목을 일부러 만들기](./08-roofline-bottleneck.md)
+- 선행 실습: [16GB GPU에서 7B BF16이 OOM 나는 이유](./02-memory-budget-oom.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 - Model: Qwen2.5-3B-Instruct BF16, `max-model-len 4096`
@@ -45,6 +45,13 @@ make ch5-calculate
 ## 2. 공식을 뒤집으면 vLLM의 자체 계산과 맞습니다
 
 vLLM은 기동할 때 KV pool을 미리 잡고 그 크기를 log에 남깁니다.
+
+02번에서 실행한 3B BF16 server가 내려갔다면 다시 기동하고 health check를 확인합니다.
+
+```bash
+make vllm-bf16
+bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
 
 ```bash
 docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
@@ -130,7 +137,7 @@ make ch5-kv-probe
 
 TTFT가 300배 흔들리는 동안 TPOT는 15.9 ms에서 28.3 ms로 완만하게만 늘었습니다. 두 지표는 서로 다른 것을 재고 있습니다. TTFT는 prefill과 queue를, TPOT는 token 하나를 만드는 비용을 잽니다.
 
-짧은 prompt에서 TPOT 15.9 ms는 초당 62.9 token이고, 이 값은 [08번 실습](./08-roofline-bottleneck.md)에서 memory bandwidth로 계산한 이론 상한 62.1 token/s와 거의 같습니다. **decode가 대역폭에 붙어 있다는 증거입니다.**
+짧은 prompt에서 TPOT 15.9 ms는 초당 62.9 token이고, 이 값은 [04번 실습](./04-roofline-bottleneck.md)에서 memory bandwidth로 계산한 이론 상한 62.1 token/s와 거의 같습니다. **decode가 대역폭에 붙어 있다는 증거입니다.**
 
 ## 5. 천장을 옮기면 공식이 다시 맞습니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
@@ -4,7 +4,7 @@
 
 ## 실습 환경
 
-- 선행 실습: [16GB GPU에서 7B BF16이 OOM 나는 이유](./02-memory-budget-oom.md)
+- 선행 실습: [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./03-kv-cache-batch-sequence.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 - 이론: [16GB GPU에 7B 모델이 올라가도 serving이 어려운 이유](../02-ch5-theory.md)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
@@ -4,7 +4,7 @@ Batch를 크게 잡으면 GPU가 여러 request를 함께 처리할 수 있습�
 
 ## 실습 환경
 
-- 선행 실습: [GPU 환경 확인](./01-gpu-environment.md)
+- 선행 실습: [내 GPU의 crossover를 직접 재고 병목을 일부러 만들기](./04-roofline-bottleneck.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - 이후 모든 명령: 위 workspace에서 실행
 - runtime: vLLM `v0.27.1`

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
@@ -4,7 +4,7 @@ Output 길이가 다른 request를 고정 batch로 묶으면 짧은 request가 �
 
 ## 실습 환경
 
-- 선행 실습: [vLLM scheduler 제한값 비교](./03-vllm-batching.md)
+- 선행 실습: [vLLM scheduler 제한값 비교](./05-vllm-batching.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - 이후 모든 명령: 위 workspace에서 실행
 - runtime: vLLM `v0.27.1`

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
@@ -4,7 +4,7 @@ TTFT가 느리면 prefill 문제처럼 보이지만 scheduler queue가 원인일
 
 ## 실습 환경
 
-- 선행 실습: [Static·dynamic·continuous 전략 비교](./04-batch-strategies.md)
+- 선행 실습: [Static·dynamic·continuous 전략 비교](./06-batch-strategies.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - 이후 모든 명령: 위 workspace에서 실행
 - runtime: vLLM `v0.27.1`
@@ -103,7 +103,7 @@ ls results/performance-bf16-long-*.json
 - waiting request만 증가: scheduler·runtime 병목 추가 확인
 - TPOT와 KV cache usage 동반 증가: decode concurrency와 memory pressure 확인
 
-이 목록은 어느 **단계**가 느린지까지 좁혀줍니다. 그 단계가 연산 때문인지 memory bandwidth 때문인지는 metric만으로 갈리지 않습니다. 실측에서 `DCGM_FI_DEV_GPU_UTIL`과 `DCGM_FI_DEV_MEM_COPY_UTIL`이 거의 같이 움직였기 때문입니다. 그 판별은 대역폭에서 계산한 이론 상한과 실측 token 속도를 대조하는 방법으로 하고, 절차는 [roofline과 병목 재현](./08-roofline-bottleneck.md)에 있습니다.
+이 목록은 어느 **단계**가 느린지까지 좁혀줍니다. 그 단계가 연산 때문인지 memory bandwidth 때문인지는 metric만으로 갈리지 않습니다. 실측에서 `DCGM_FI_DEV_GPU_UTIL`과 `DCGM_FI_DEV_MEM_COPY_UTIL`이 거의 같이 움직였기 때문입니다. 그 판별은 대역폭에서 계산한 이론 상한과 실측 token 속도를 대조하는 방법으로 하고, 절차는 [roofline과 병목 재현](./04-roofline-bottleneck.md)에 있습니다.
 
 ## 정리
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
@@ -6,7 +6,7 @@ W4A16은 weight를 크게 줄이고, W8A8은 activation compute까지 줄일 수
 
 ## 실습 환경
 
-- 선행 실습: [Prefill·decode 병목 관찰](./05-prefill-decode-observability.md)
+- 선행 실습: [Prefill·decode 병목 관찰](./07-prefill-decode-observability.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - 이후 모든 명령: 위 workspace에서 실행
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
@@ -6,7 +6,7 @@ System prompt와 document 내용이 같아도 순서나 whitespace가 달라지�
 
 ## 실습 환경
 
-- 선행 실습: [Prefill·decode 병목 관찰](./05-prefill-decode-observability.md)
+- 선행 실습: [Prefill·decode 병목 관찰](./07-prefill-decode-observability.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - 이후 모든 명령: 위 workspace에서 실행
 - model: `Qwen/Qwen2.5-3B-Instruct`

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
@@ -1,8 +1,6 @@
 # LLM serving이 느린 이유를 GPU에서 직접 확인하는 순서
 
-옵션을 먼저 바꾸면 숫자는 달라져도 원인을 설명하기 어렵습니다. 이 핸즈온은 GPU 확인부터 시작해 memory, scheduling, prefill·decode, quantization, cache 순서로 병목을 좁힙니다.
-
-파일 번호는 **만든 순서**이지 chapter 순서가 아닙니다. 그래서 chapter 별로 어디를 봐야 하는지 아래에 따로 적습니다.
+옵션을 먼저 바꾸면 숫자는 달라져도 원인을 설명하기 어렵습니다. 이 핸즈온은 GPU 확인부터 시작해 memory, KV cache, roofline, scheduling, prefill·decode, quantization, cache 순서로 병목을 좁힙니다. 파일 번호가 학습 순서입니다.
 
 ## Chapter 5만 볼 때
 
@@ -12,10 +10,10 @@ Chapter 5는 "이 GPU에 이 model이 들어가는가, 느리다면 연산인가
 | ---: | --- | --- |
 | 0 | [Chapter 5 이론](../02-ch5-theory.md) | weight 말고 무엇이 VRAM을 쓰는가 |
 | 1 | [02 메모리 예산과 OOM](./02-memory-budget-oom.md) | 계산상 들어가는데 왜 OOM이 나는가 |
-| 2 | [09 KV cache 배치·시퀀스](./09-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
-| 3 | [08 roofline과 병목 재현](./08-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
+| 2 | [03 KV cache 배치·시퀀스](./03-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
+| 3 | [04 roofline과 병목 재현](./04-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
 
-08과 09는 `make ch5-roofline`, `make ch5-kv-probe`, `make ch5-bottleneck`으로 직접 측정합니다. 실행 전에 [01 GPU 환경](./01-gpu-environment.md)이 필요합니다.
+03과 04는 `make ch5-kv-probe`, `make ch5-roofline`, `make ch5-bottleneck`으로 직접 측정합니다. 실행 전에 [01 GPU 환경](./01-gpu-environment.md)이 필요합니다.
 
 ## Chapter 6만 볼 때
 
@@ -24,16 +22,15 @@ Chapter 6는 "Chapter 5에서 찾은 병목마다 어떤 optimization이 붙는�
 | 순서 | 문서 | 답하는 질문 |
 | ---: | --- | --- |
 | 0 | [Chapter 6 이론](../04-ch6-theory.md) | optimization을 무엇을 기준으로 고르는가 |
-| 1 | [03 batching](./03-vllm-batching.md) | batch를 키우면 latency도 좋아지는가 |
-| 2 | [04 batching 전략](./04-batch-strategies.md) | static·dynamic·continuous는 어디서 갈리는가 |
-| 3 | [06 quantization](./06-quantization.md) | VRAM이 가장 적은 model이 가장 빠른가 |
-| 4 | [07 prefix caching](./07-prefix-caching.md) | 같은 내용인데 cache가 왜 빗나가는가 |
+| 1 | [05 batching](./05-vllm-batching.md) | batch를 키우면 latency도 좋아지는가 |
+| 2 | [06 batching 전략](./06-batch-strategies.md) | static·dynamic·continuous는 어디서 갈리는가 |
+| 3 | [07 prefill·decode 관측](./07-prefill-decode-observability.md) | 느린 단계가 prefill인가 decode인가 |
+| 4 | [08 quantization](./08-quantization.md) | VRAM이 가장 적은 model이 가장 빠른가 |
+| 5 | [09 prefix caching](./09-prefix-caching.md) | 같은 내용인데 cache가 왜 빗나가는가 |
 
 품질 검증의 한계는 [GSM8K 20문항의 범위](../06-gsm8k-deep-dive.md)에 있습니다.
 
-## 두 chapter를 잇는 실습
-
-[05 prefill·decode 관측](./05-prefill-decode-observability.md)은 Chapter 5의 병목 개념을 metric으로 보는 다리입니다. 어느 **단계**가 느린지까지 좁히고, 그 단계가 연산 때문인지 대역폭 때문인지는 08로 넘깁니다.
+07은 Chapter 5의 병목 개념을 metric으로 관측해 Chapter 6 optimization과 연결합니다.
 
 ## 전체 순서
 
@@ -43,13 +40,13 @@ Chapter 6는 "Chapter 5에서 찾은 병목마다 어떤 optimization이 붙는�
 | ---: | --- | --- |
 | 1 | [GPU가 보여도 container에서 못 쓰는 이유](./01-gpu-environment.md) | 환경 |
 | 2 | [16GB GPU에서 7B BF16이 OOM 나는 이유](./02-memory-budget-oom.md) | 5 |
-| 3 | [Batch를 키우면 throughput과 latency가 어떻게 바뀌는가](./03-vllm-batching.md) | 6 |
-| 4 | [Static·dynamic·continuous batching의 성능 차이](./04-batch-strategies.md) | 6 |
-| 5 | [TTFT와 TPOT만으로 부족한 prefill·decode 병목](./05-prefill-decode-observability.md) | 5→6 |
-| 6 | [VRAM이 줄었다고 빠른 model이 아닌 quantization](./06-quantization.md) | 6 |
-| 7 | [같은 내용이어도 prefix cache가 빗나가는 조건](./07-prefix-caching.md) | 6 |
-| 8 | [내 GPU의 crossover를 직접 재고 병목을 만들기](./08-roofline-bottleneck.md) | 5 |
-| 9 | [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./09-kv-cache-batch-sequence.md) | 5 |
+| 3 | [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./03-kv-cache-batch-sequence.md) | 5 |
+| 4 | [내 GPU의 crossover를 직접 재고 병목을 만들기](./04-roofline-bottleneck.md) | 5 |
+| 5 | [Batch를 키우면 throughput과 latency가 어떻게 바뀌는가](./05-vllm-batching.md) | 6 |
+| 6 | [Static·dynamic·continuous batching의 성능 차이](./06-batch-strategies.md) | 6 |
+| 7 | [TTFT와 TPOT만으로 부족한 prefill·decode 병목](./07-prefill-decode-observability.md) | 5→6 |
+| 8 | [VRAM이 줄었다고 빠른 model이 아닌 quantization](./08-quantization.md) | 6 |
+| 9 | [같은 내용이어도 prefix cache가 빗나가는 조건](./09-prefix-caching.md) | 6 |
 
 공통 metric의 수집 이유와 해석은 [GPU 사용률이 높은데 LLM이 느릴 때 무엇을 봐야 할까](../prometheus.md)에서 설명합니다.
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
@@ -159,7 +159,7 @@ GPU utilization이 높다고 compute-bound로 단정할 수는 없습니다. Mem
 
 이유는 지표의 정의에 있습니다. 둘 다 **"그 시간 동안 바빴는가"**를 재는 시간 비율이지 "대역폭의 몇 %를 썼는가"가 아닙니다. 후자를 재려면 `DCGM_FI_PROF_DRAM_ACTIVE` 같은 profiling 지표가 필요한데 GeForce 계열에는 노출되지 않습니다.
 
-그래서 판별은 지표가 아니라 산수로 합니다. [roofline과 병목 재현](./handson/08-roofline-bottleneck.md)에서 하듯 **측정한 대역폭에서 나오는 이론 상한과 실제 token 생성 속도를 비교**합니다. 실측에서 batch 1 decode가 상한의 101%, batch 16에서도 96%로 나왔고, 이것이 대역폭 병목의 훨씬 확실한 증거입니다.
+그래서 판별은 지표가 아니라 산수로 합니다. [roofline과 병목 재현](./handson/04-roofline-bottleneck.md)에서 하듯 **측정한 대역폭에서 나오는 이론 상한과 실제 token 생성 속도를 비교**합니다. 실측에서 batch 1 decode가 상한의 101%, batch 16에서도 96%로 나왔고, 이것이 대역폭 병목의 훨씬 확실한 증거입니다.
 
 두 지표를 여전히 대시보드에 두는 이유는 세 번째 경우를 잡기 위해서입니다. 둘 다 낮으면 GPU가 노는 것이고, 그때는 client 동시성이나 queue를 봐야 합니다.
 

--- a/computer_science/ai/study-llmserving/ch5-6/observability/grafana/dashboards/llm-serving.json
+++ b/computer_science/ai/study-llmserving/ch5-6/observability/grafana/dashboards/llm-serving.json
@@ -365,7 +365,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Both are time-busy ratios, not bandwidth ratios. On this GeForce card they were measured moving together even in a compute-bound prefill run (100% vs 96%), so do NOT use the pair to classify compute-bound versus bandwidth-bound. What this panel is good for is the case where both stay low: the GPU is idle and the problem is client concurrency or the queue. For bottleneck classification compare measured token rate against the bandwidth ceiling - see docs/handson/08-roofline-bottleneck.md.",
+      "description": "Both are time-busy ratios, not bandwidth ratios. On this GeForce card they were measured moving together even in a compute-bound prefill run (100% vs 96%), so do NOT use the pair to classify compute-bound versus bandwidth-bound. What this panel is good for is the case where both stay low: the GPU is idle and the problem is client concurrency or the queue. For bottleneck classification compare measured token rate against the bandwidth ceiling - see docs/handson/04-roofline-bottleneck.md.",
       "fieldConfig": {
         "defaults": {
           "unit": "percent"


### PR DESCRIPTION
# 구현

7B vLLM serving 초기화 실패 시나리오 추가와 handson 학습 순서 재정렬
- Compose 구성 정상, pytest 9개 통과, 상대 Markdown 링크와 Grafana JSON 검증 완료

# 어려웠던 점

vLLM의 메모리 부족 관측 시점을 요청 처리 중 OOM이 아닌 KV pool 초기화 단계로 구분
- vLLM이 KV pool을 기동 시 미리 확보하고 실행 중 초과 요청은 대기 또는 preemption으로 처리

# 리스크

7B BF16 expected-failure의 실제 오류 문구가 GPU 사용 상태에 따라 달라질 수 있음
- RTX 5060 Ti 16GB 실측은 별도 GPU 호스트 필요, 문서는 CUDA OOM과 KV pool 초기화 오류를 모두 허용

Issue #1101