### PR TITLE
feat: improve akbun-caculatorllm heading hierarchy

### DIFF
--- a/product/akbun-caculatorllm/RELEASE_NOTES.md
+++ b/product/akbun-caculatorllm/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 0.4.0
+
+- Reworked the heading hierarchy around the estimator, model, stages, and results.
+- Placed each desktop memory visualization and result side by side.
+- Kept the stage content stacked on mobile screens.
+
 ## 0.3.0
 
 - Split the estimator into Load Model and Run a Workload calculations.

--- a/product/akbun-caculatorllm/workspace/index.html
+++ b/product/akbun-caculatorllm/workspace/index.html
@@ -20,15 +20,14 @@
 
   <main>
     <section class="intro" aria-labelledby="page-title">
-      <p class="eyebrow">SINGLE-GPU LLM VRAM ESTIMATOR</p>
-      <h1 id="page-title">Will it fit?</h1>
+      <h1 id="page-title">SINGLE-GPU LLM VRAM ESTIMATOR</h1>
+      <h2>Will it fit?</h2>
     </section>
 
     <form id="calculator-form" novalidate>
       <section class="page-section model-information" aria-labelledby="model-information-title">
         <div class="section-heading">
-          <p class="section-number">MODEL</p>
-          <h2 id="model-information-title">Model information</h2>
+          <h1 id="model-information-title">Model information</h1>
         </div>
 
         <div class="model-information-grid">
@@ -118,9 +117,9 @@
       </section>
 
       <section class="page-section memory-panel" aria-labelledby="load-model-title">
-        <div class="section-heading">
-          <p class="section-number">01 · MODEL WEIGHTS ONLY</p>
-          <h2 id="load-model-title">Load Model</h2>
+        <div class="section-heading stage-heading">
+          <h1 id="load-model-title">01 · MODEL WEIGHTS ONLY</h1>
+          <h2>Load Model</h2>
         </div>
 
         <div class="result-layout">
@@ -143,7 +142,7 @@
           </div>
 
           <div class="status-column">
-            <p class="result-kicker">LOAD RESULT</p>
+            <h2 class="result-kicker">LOAD RESULT</h2>
             <h3 id="load-fit-status">Fits</h3>
             <dl class="result-totals">
               <div><dt>Needed</dt><dd id="load-total-needed">0 GiB</dd></div>
@@ -156,9 +155,9 @@
       </section>
 
       <section class="page-section memory-panel workload-panel" aria-labelledby="workload-title">
-        <div class="section-heading">
-          <p class="section-number">02 · MODEL + WORKLOAD MEMORY</p>
-          <h2 id="workload-title">Run a Workload</h2>
+        <div class="section-heading stage-heading">
+          <h1 id="workload-title">02 · MODEL + WORKLOAD MEMORY</h1>
+          <h2>Run a Workload</h2>
         </div>
 
         <div class="workload-layout">
@@ -218,7 +217,7 @@
           </div>
 
           <div class="status-column">
-            <p class="result-kicker">WORKLOAD RESULT</p>
+            <h2 class="result-kicker">WORKLOAD RESULT</h2>
             <h3 id="workload-fit-status">Out of memory</h3>
             <dl class="result-totals">
               <div><dt>Needed</dt><dd id="workload-total-needed">0 GiB</dd></div>

--- a/product/akbun-caculatorllm/workspace/index.html
+++ b/product/akbun-caculatorllm/workspace/index.html
@@ -116,10 +116,10 @@
         </details>
       </section>
 
-      <section class="page-section memory-panel" aria-labelledby="load-model-title">
+      <section class="page-section memory-panel" aria-labelledby="load-model-title load-model-action-title">
         <div class="section-heading stage-heading">
           <h1 id="load-model-title">01 · MODEL WEIGHTS ONLY</h1>
-          <h2>Load Model</h2>
+          <h2 id="load-model-action-title">Load Model</h2>
         </div>
 
         <div class="result-layout">
@@ -154,10 +154,10 @@
         </div>
       </section>
 
-      <section class="page-section memory-panel workload-panel" aria-labelledby="workload-title">
+      <section class="page-section memory-panel workload-panel" aria-labelledby="workload-title workload-action-title">
         <div class="section-heading stage-heading">
           <h1 id="workload-title">02 · MODEL + WORKLOAD MEMORY</h1>
-          <h2>Run a Workload</h2>
+          <h2 id="workload-action-title">Run a Workload</h2>
         </div>
 
         <div class="workload-layout">

--- a/product/akbun-caculatorllm/workspace/package-lock.json
+++ b/product/akbun-caculatorllm/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-caculatorllm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-caculatorllm",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "vite": "^8.2.1",
         "wrangler": "^4.124.0"

--- a/product/akbun-caculatorllm/workspace/package.json
+++ b/product/akbun-caculatorllm/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-caculatorllm",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-caculatorllm/workspace/src/styles.css
+++ b/product/akbun-caculatorllm/workspace/src/styles.css
@@ -49,7 +49,7 @@ main { width: min(1500px, 100%); margin: 0 auto; }
   padding: clamp(38px, 5vw, 76px) clamp(18px, 5vw, 76px) clamp(34px, 4vw, 62px);
 }
 
-.eyebrow, .section-number {
+.section-number {
   margin: 0 0 12px;
   font: 500 .66rem 'DM Mono', monospace;
   letter-spacing: .14em;
@@ -57,10 +57,19 @@ main { width: min(1500px, 100%); margin: 0 auto; }
 
 .intro h1 {
   margin: 0;
-  font-size: clamp(3.3rem, 7vw, 6.7rem);
+  max-width: 1200px;
+  font-size: clamp(3rem, 6.5vw, 6.2rem);
   font-weight: 800;
-  line-height: .86;
-  letter-spacing: -.08em;
+  line-height: .9;
+  letter-spacing: -.07em;
+}
+
+.intro h2 {
+  margin: 18px 0 0;
+  font-size: clamp(1.45rem, 2.4vw, 2.35rem);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -.045em;
 }
 
 .page-section {
@@ -70,13 +79,39 @@ main { width: min(1500px, 100%); margin: 0 auto; }
 
 .page-section:nth-child(even) { background: var(--surface); }
 .section-heading { margin-bottom: clamp(32px, 5vw, 62px); }
-.section-heading h2 {
+.model-information .section-heading h1,
+.calculation-ledger .section-heading h2 {
   max-width: 1100px;
   margin: 0;
   font-size: clamp(2.9rem, 6.5vw, 6.2rem);
   font-weight: 800;
   line-height: .9;
   letter-spacing: -.07em;
+}
+
+.stage-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 28px;
+}
+
+.stage-heading h1 {
+  max-width: 1000px;
+  margin: 0;
+  font-size: clamp(2.45rem, 5.2vw, 5rem);
+  font-weight: 800;
+  line-height: .92;
+  letter-spacing: -.065em;
+}
+
+.stage-heading h2 {
+  margin: 0 0 .18em;
+  font-size: clamp(1.35rem, 2.2vw, 2.15rem);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: -.045em;
+  text-align: right;
 }
 
 .model-information-grid {
@@ -192,14 +227,16 @@ main { width: min(1500px, 100%); margin: 0 auto; }
 .model-shape { padding-bottom: 14px; color: var(--muted); font: 400 .63rem/1.6 'DM Mono', monospace; }
 
 .result-layout, .workload-layout {
-  max-width: 940px;
+  max-width: 1220px;
   margin: 0 auto;
   display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(360px, .9fr);
+  align-items: center;
   justify-items: stretch;
   gap: clamp(34px, 5vw, 64px);
 }
 
-.workload-settings { width: min(700px, 100%); margin: 0 auto; }
+.workload-settings { width: min(700px, 100%); margin: 0 auto; grid-column: 1 / -1; }
 .workload-settings > h3 {
   margin: 0 0 24px;
   font-size: clamp(1.5rem, 2.5vw, 2.2rem);
@@ -346,7 +383,13 @@ main { width: min(1500px, 100%); margin: 0 auto; }
 .extra-swatch { background: var(--extra); }
 
 .status-column { width: min(760px, 100%); margin: 0 auto; text-align: center; }
-.result-kicker { margin: 0 0 12px; font: 500 .66rem 'DM Mono', monospace; letter-spacing: .14em; }
+.result-kicker {
+  margin: 0 0 14px;
+  font-size: clamp(1.35rem, 2.2vw, 2rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -.04em;
+}
 .status-column h3 {
   margin: 0 0 28px;
   font-size: clamp(2.5rem, 5vw, 4.4rem);
@@ -404,6 +447,13 @@ main { width: min(1500px, 100%); margin: 0 auto; }
   .model-information-grid { grid-template-columns: 1fr; }
   .advanced-body { grid-template-columns: 1fr; align-items: start; }
   .model-shape { padding-bottom: 0; }
+}
+
+@media (max-width: 900px) {
+  .stage-heading, .result-layout, .workload-layout { grid-template-columns: 1fr; }
+  .stage-heading { align-items: start; gap: 14px; }
+  .stage-heading h2 { margin: 0; text-align: left; }
+  .workload-settings { grid-column: auto; }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
# 구현

계산기 제목 계층 재구성, 데스크톱 결과 2열 및 모바일 1열 배치
- 계산 테스트 11개, Vite 빌드, 1440px과 390px 브라우저 검증 통과

# 리스크

900px 단일 breakpoint 기준으로 태블릿 가로 화면도 세로 배치
- 900px 이하에서 단계 제목, 시각화, 결과 모두 한 열로 전환

Issue #1103