### PR TITLE
feat: simplify akbun-caculatorllm heading hierarchy

### DIFF
--- a/product/akbun-caculatorllm/RELEASE_NOTES.md
+++ b/product/akbun-caculatorllm/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 0.5.0
+
+- Kept a single H1 for the page title and shifted section headings down one level.
+- Removed redundant action, formula, and tagline labels.
+- Kept the highlighted page title on one line at every responsive size.
+
 ## 0.4.0
 
 - Reworked the heading hierarchy around the estimator, model, stages, and results.

--- a/product/akbun-caculatorllm/workspace/index.html
+++ b/product/akbun-caculatorllm/workspace/index.html
@@ -21,13 +21,12 @@
   <main>
     <section class="intro" aria-labelledby="page-title">
       <h1 id="page-title">SINGLE-GPU LLM VRAM ESTIMATOR</h1>
-      <h2>Will it fit?</h2>
     </section>
 
     <form id="calculator-form" novalidate>
       <section class="page-section model-information" aria-labelledby="model-information-title">
         <div class="section-heading">
-          <h1 id="model-information-title">Model information</h1>
+          <h2 id="model-information-title">Model information</h2>
         </div>
 
         <div class="model-information-grid">
@@ -116,10 +115,9 @@
         </details>
       </section>
 
-      <section class="page-section memory-panel" aria-labelledby="load-model-title load-model-action-title">
+      <section class="page-section memory-panel" aria-labelledby="load-model-title">
         <div class="section-heading stage-heading">
-          <h1 id="load-model-title">01 · MODEL WEIGHTS ONLY</h1>
-          <h2 id="load-model-action-title">Load Model</h2>
+          <h2 id="load-model-title">01 · MODEL WEIGHTS ONLY</h2>
         </div>
 
         <div class="result-layout">
@@ -142,8 +140,8 @@
           </div>
 
           <div class="status-column">
-            <h2 class="result-kicker">LOAD RESULT</h2>
-            <h3 id="load-fit-status">Fits</h3>
+            <h3 class="result-kicker">LOAD RESULT</h3>
+            <h4 id="load-fit-status">Fits</h4>
             <dl class="result-totals">
               <div><dt>Needed</dt><dd id="load-total-needed">0 GiB</dd></div>
               <div><dt>Available</dt><dd id="load-total-available">16 GiB</dd></div>
@@ -154,10 +152,9 @@
         </div>
       </section>
 
-      <section class="page-section memory-panel workload-panel" aria-labelledby="workload-title workload-action-title">
+      <section class="page-section memory-panel workload-panel" aria-labelledby="workload-title">
         <div class="section-heading stage-heading">
-          <h1 id="workload-title">02 · MODEL + WORKLOAD MEMORY</h1>
-          <h2 id="workload-action-title">Run a Workload</h2>
+          <h2 id="workload-title">02 · MODEL + WORKLOAD MEMORY</h2>
         </div>
 
         <div class="workload-layout">
@@ -217,8 +214,8 @@
           </div>
 
           <div class="status-column">
-            <h2 class="result-kicker">WORKLOAD RESULT</h2>
-            <h3 id="workload-fit-status">Out of memory</h3>
+            <h3 class="result-kicker">WORKLOAD RESULT</h3>
+            <h4 id="workload-fit-status">Out of memory</h4>
             <dl class="result-totals">
               <div><dt>Needed</dt><dd id="workload-total-needed">0 GiB</dd></div>
               <div><dt>Available</dt><dd id="workload-total-available">16 GiB</dd></div>
@@ -231,7 +228,6 @@
 
       <section class="page-section calculation-ledger" aria-labelledby="calculation-title">
         <div class="section-heading">
-          <p class="section-number">FORMULAS</p>
           <h2 id="calculation-title">How It Is Calculated</h2>
         </div>
 

--- a/product/akbun-caculatorllm/workspace/package-lock.json
+++ b/product/akbun-caculatorllm/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-caculatorllm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-caculatorllm",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "vite": "^8.2.1",
         "wrangler": "^4.124.0"

--- a/product/akbun-caculatorllm/workspace/package.json
+++ b/product/akbun-caculatorllm/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-caculatorllm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/product/akbun-caculatorllm/workspace/src/styles.css
+++ b/product/akbun-caculatorllm/workspace/src/styles.css
@@ -49,27 +49,17 @@ main { width: min(1500px, 100%); margin: 0 auto; }
   padding: clamp(38px, 5vw, 76px) clamp(18px, 5vw, 76px) clamp(34px, 4vw, 62px);
 }
 
-.section-number {
-  margin: 0 0 12px;
-  font: 500 .66rem 'DM Mono', monospace;
-  letter-spacing: .14em;
-}
-
 .intro h1 {
+  width: fit-content;
   margin: 0;
-  max-width: 1200px;
-  font-size: clamp(3rem, 6.5vw, 6.2rem);
+  padding: .1em .14em .14em;
+  border: 1px solid var(--ink);
+  background: var(--acid);
+  font-size: clamp(1rem, 5.2vw, 4.8rem);
   font-weight: 800;
   line-height: .9;
   letter-spacing: -.07em;
-}
-
-.intro h2 {
-  margin: 18px 0 0;
-  font-size: clamp(1.45rem, 2.4vw, 2.35rem);
-  font-weight: 600;
-  line-height: 1;
-  letter-spacing: -.045em;
+  white-space: nowrap;
 }
 
 .page-section {
@@ -79,7 +69,7 @@ main { width: min(1500px, 100%); margin: 0 auto; }
 
 .page-section:nth-child(even) { background: var(--surface); }
 .section-heading { margin-bottom: clamp(32px, 5vw, 62px); }
-.model-information .section-heading h1,
+.model-information .section-heading h2,
 .calculation-ledger .section-heading h2 {
   max-width: 1100px;
   margin: 0;
@@ -89,29 +79,13 @@ main { width: min(1500px, 100%); margin: 0 auto; }
   letter-spacing: -.07em;
 }
 
-.stage-heading {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
-  gap: 28px;
-}
-
-.stage-heading h1 {
+.stage-heading h2 {
   max-width: 1000px;
   margin: 0;
   font-size: clamp(2.45rem, 5.2vw, 5rem);
   font-weight: 800;
   line-height: .92;
   letter-spacing: -.065em;
-}
-
-.stage-heading h2 {
-  margin: 0 0 .18em;
-  font-size: clamp(1.35rem, 2.2vw, 2.15rem);
-  font-weight: 600;
-  line-height: 1;
-  letter-spacing: -.045em;
-  text-align: right;
 }
 
 .model-information-grid {
@@ -390,15 +364,15 @@ main { width: min(1500px, 100%); margin: 0 auto; }
   line-height: 1;
   letter-spacing: -.04em;
 }
-.status-column h3 {
+.status-column h4 {
   margin: 0 0 28px;
   font-size: clamp(2.5rem, 5vw, 4.4rem);
   line-height: .95;
   letter-spacing: -.06em;
   white-space: nowrap;
 }
-.status-column h3.fits { color: var(--success); }
-.status-column h3.oom { color: var(--danger); }
+.status-column h4.fits { color: var(--success); }
+.status-column h4.oom { color: var(--danger); }
 .result-totals {
   margin: 0;
   display: grid;
@@ -450,9 +424,7 @@ main { width: min(1500px, 100%); margin: 0 auto; }
 }
 
 @media (max-width: 900px) {
-  .stage-heading, .result-layout, .workload-layout { grid-template-columns: 1fr; }
-  .stage-heading { align-items: start; gap: 14px; }
-  .stage-heading h2 { margin: 0; text-align: left; }
+  .result-layout, .workload-layout { grid-template-columns: 1fr; }
   .workload-settings { grid-column: auto; }
 }
 
@@ -467,7 +439,7 @@ main { width: min(1500px, 100%); margin: 0 auto; }
   .jar-stage { width: min(112%, 430px); margin-left: 50%; transform: translateX(-50%); }
   .capacity-title { font-size: .63rem; }
   .capacity-title strong { font-size: .9rem; }
-  .status-column h3 { font-size: clamp(2.1rem, 11vw, 3.1rem); white-space: normal; }
+  .status-column h4 { font-size: clamp(2.1rem, 11vw, 3.1rem); white-space: normal; }
   .memory-legend > div { padding: 10px 7px; gap: 3px 6px; }
   .memory-legend strong { font-size: .58rem; }
   .memory-legend output { font-size: .64rem; }


### PR DESCRIPTION
# 구현

페이지 제목 단일 H1 구성, 중복 라벨 제거, 하위 제목 계층 재정렬
- 계산 테스트 11개, Vite 빌드, 1440px과 390px 및 320px 브라우저 검증 통과

# 어려웠던 점

최소 320px 화면에서 초기 제목 너비가 viewport보다 약 34px 초과
- 유동 글자 크기의 최소값을 낮춰 한 줄 유지와 가로 overflow 제거

# 리스크

320px 화면에서 제목 크기가 데스크톱보다 크게 축소
- acid 배경과 테두리로 작은 크기에서도 페이지 제목 강조 유지

Issue #1105