### PR TITLE
fix: LLM serving OOM 관측 신뢰성 개선

### DIFF
--- a/computer_science/ai/study-llmserving/ch5-6/.env.example
+++ b/computer_science/ai/study-llmserving/ch5-6/.env.example
@@ -10,6 +10,10 @@ VLLM_MAX_NUM_BATCHED_TOKENS=4096
 # a desktop, 0.9 fails to start because Xorg already holds ~1.6 GiB.
 VLLM_GPU_MEMORY_UTILIZATION=0.85
 
+# DCGM hardware sampling interval in milliseconds. One second captures short
+# model-load peaks while keeping exporter polling suitable for this lab.
+DCGM_EXPORTER_INTERVAL_MS=1000
+
 # Measured device bandwidth used by benchmark.bottleneck_probe to compute the
 # batch-1 decode ceiling. Get it from `make ch5-roofline`.
 MEASURED_BANDWIDTH_GBPS=384

--- a/computer_science/ai/study-llmserving/ch5-6/AGENTS.md
+++ b/computer_science/ai/study-llmserving/ch5-6/AGENTS.md
@@ -1,0 +1,120 @@
+# LLM serving Chapter 5·6 — agent memory
+
+이 파일은 이 workspace를 수정하는 agent를 위한 영구 맥락이다. 저장소 공통 규칙은 루트 [AGENTS.md](../../../../AGENTS.md)를 우선 적용한다.
+
+## 목적
+
+- 단일 NVIDIA GPU에서 LLM serving의 memory·bandwidth·scheduling 병목을 재현한다.
+- Chapter 5의 hardware 한계를 확인한 뒤 Chapter 6의 optimization으로 이어 간다.
+- 문서는 핸즈온 절차와 결과를 설명하는 데 필요한 이론만 담는다.
+- production serving framework가 아니라 원인을 관측하고 설명하는 학습 workspace다.
+
+## 학습 흐름은 파일 번호를 따른다
+
+1. GPU 환경과 metric 수집 경로 확인
+2. model weight 외 memory budget과 7B BF16 expected OOM 재현
+3. batch·sequence length에 따라 증가하는 KV cache 확인
+4. roofline으로 compute·memory bandwidth 병목 구분
+5. vLLM continuous batching 관측
+6. batch 전략 비교
+7. prefill·decode 분리 관측
+8. quantization의 memory·latency·quality 비교
+9. prefix caching 효과 확인
+
+`docs/handson/`의 번호는 설명 순서가 아니라 인과관계다. 파일을 추가·삭제·이동하면 모든 README 목차와 문서 링크를 함께 갱신한다.
+
+## 유지해야 할 학습 시나리오
+
+### 7B BF16 expected OOM
+
+- `vllm-7b-bf16-expect-failure`는 API server 준비 전에 실패해야 하는 의도된 시나리오다.
+- model weight가 GPU에 들어갈 것처럼 보여도 runtime overhead와 KV cache 공간까지 확보되는 것은 아니라는 점을 보여 준다.
+- 시나리오를 통과시키기 위해 model 크기, dtype, memory utilization을 임의로 낮추지 않는다.
+- 성공 종료로 바꾸면 02에서 03으로 이어지는 학습 흐름이 깨진다.
+- OOM 중 `model-server` Prometheus target은 `DOWN`이어도 정상이다. `dcgm-exporter` target은 `UP`이어야 한다.
+
+### OOM log와 GPU metric의 범위
+
+- vLLM OOM log: 실패 순간 해당 process allocator의 memory
+- `DCGM_FI_DEV_FB_USED`: GPU 전체 framebuffer memory의 sampled value
+- Grafana GPU VRAM panel: DCGM sample의 최근 5초 최대값
+- process memory와 GPU 전체 memory는 측정 범위가 다르므로 숫자가 같아야 한다고 가정하지 않는다.
+- DCGM metric은 MiB다. Grafana unit은 `mbytes`를 유지한다.
+
+## GPU 초기화 안전선
+
+- 실습 기준은 VRAM `0 MiB`가 아니라 **실습 compute process가 없는 baseline**이다.
+- `make gpu-reset`은 이 workspace의 Compose resource만 내린다.
+- 다른 workspace나 container orchestrator의 GPU process가 남으면 목록을 출력하고 실패해야 한다.
+- 소유권을 확인하지 않은 PID, Xorg, desktop session을 자동 종료하지 않는다.
+- 외부 process를 직접 kill하는 기능을 `gpu-reset`에 추가하지 않는다.
+- 자세한 판단과 복구 절차는 [docs/troubleshooting.md](docs/troubleshooting.md) 한 곳에서 관리한다.
+
+## 관측 설정 불변 조건
+
+- DCGM collection interval: 1초
+- Prometheus `dcgm-exporter` scrape interval: 1초
+- Grafana GPU panel: 최근 5초 rolling maximum
+- VRAM panel unit: MiB
+
+7B model load의 짧은 peak는 DCGM 기본 30초와 Prometheus 5초 설정에서 누락될 수 있다. 간격을 변경하면 다음 파일을 한 변경으로 맞춘다.
+
+- `docker-compose.yml`
+- `observability/prometheus.yml`
+- `observability/grafana/dashboards/llm-serving.json`
+- `tests/test_observability_config.py`
+- `docs/prometheus.md`
+- `docs/troubleshooting.md`
+
+`make observability-check`는 다음 경로를 검증한다.
+
+```text
+nvidia-smi → DCGM Exporter → Prometheus → Grafana datasource
+```
+
+GPU utilization은 서로 다른 sample 시점의 값이므로 세 구간의 숫자 일치를 요구하지 않는다. 값의 범위, sample freshness, target·datasource health를 확인한다.
+
+## 주요 파일 역할
+
+- `README.md`: workspace 문서 링크 허브와 전체 학습 흐름
+- `docs/handson/`: 번호 순서대로 실행하는 핸즈온
+- `docs/troubleshooting.md`: GPU baseline과 관측 장애의 단일 troubleshooting 문서
+- `calculators/`: 실행 전 memory budget·roofline 가설 계산
+- `model_loader/`: weight load 성공·실패 경계 재현
+- `benchmark/`: KV cache, batching, prefill·decode, quantization 실험
+- `observability/`: Prometheus와 provisioned Grafana dashboard
+- `scripts/`: 반복 실행과 검증 절차
+- `tests/`: 계산기·benchmark·관측 설정 회귀 테스트
+
+## 변경 검증
+
+GPU가 없어도 다음 검증은 모두 실행한다.
+
+```bash
+uv run --group dev --group client pytest
+uv run --group dev ruff format --check .
+uv run --group dev ruff check .
+bash -n scripts/*.sh
+docker compose --profile observability --profile oom config
+jq empty observability/grafana/dashboards/llm-serving.json
+git diff --check
+```
+
+GPU 동작을 바꾸면 가능한 환경에서 다음 순서로 추가 검증한다.
+
+```bash
+make gpu-reset
+make observability-check
+docker compose --profile oom run --rm vllm-7b-bf16-expect-failure
+```
+
+- expected OOM 명령의 non-zero exit는 정상 결과다.
+- OOM 전후 `dcgm-exporter UP`과 Prometheus의 VRAM peak를 확인한다.
+- 검증용 GPU server의 주소, hostname, 사용자명, SSH alias, 절대 경로를 저장소에 기록하지 않는다.
+
+## 공개 저장소 개인정보 규칙
+
+- 문서, 코드, 주석, test fixture, commit, Issue, PR에 개인 환경 정보를 쓰지 않는다.
+- 금지 대상: IP 주소, hostname, 사용자명, SSH 접속 정보, 개인 절대 경로, 장비 고유 ID.
+- 명령 예시는 repository 상대 경로, localhost, placeholder, 환경 변수만 사용한다.
+- 실제 검증 결과를 기록할 때는 학습에 필요한 metric과 일반화된 원인만 남긴다.

--- a/computer_science/ai/study-llmserving/ch5-6/Makefile
+++ b/computer_science/ai/study-llmserving/ch5-6/Makefile
@@ -2,7 +2,7 @@ COMPOSE := docker compose
 MODEL_LABEL ?= bf16
 MEASURED_BANDWIDTH_GBPS ?= 384
 
-.PHONY: setup build gpu-check observability-up ch5-calculate ch5-roofline ch5-kv-probe \
+.PHONY: setup build gpu-check gpu-reset observability-up observability-check ch5-calculate ch5-roofline ch5-kv-probe \
 	ch5-bottleneck ch5-oom ch5-load \
 	vllm-bf16 vllm-gptq vllm-fp8 \
 	quant-benchmark accuracy smoke gsm8k prefix-test summary down clean test lint format
@@ -16,8 +16,14 @@ build:
 gpu-check:
 	docker run --rm --gpus all nvidia/cuda:12.9.1-base-ubuntu24.04 nvidia-smi
 
+gpu-reset:
+	bash scripts/reset_gpu.sh
+
 observability-up:
 	$(COMPOSE) --profile observability up -d prometheus grafana dcgm-exporter
+
+observability-check: observability-up
+	bash scripts/check_observability.sh
 
 ch5-calculate:
 	uv run python -m calculators.memory_budget

--- a/computer_science/ai/study-llmserving/ch5-6/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/README.md
@@ -36,6 +36,7 @@ Chapter 5는 hardware 용어 모음이 아닙니다. Chapter 6의 optimization�
 - LAN 접속: [같은 Wi-Fi에서 관측·추론 endpoint 접속](./docs/03-setup-lan-access.md)
 - 전체 실습 순서: [LLM serving이 느린 이유를 GPU에서 직접 확인하는 순서](./docs/handson/)
 - 관측 기준: [GPU 사용률이 높은데 LLM이 느릴 때 무엇을 봐야 할까](./docs/prometheus.md)
+- 문제 해결: [GPU 실습 troubleshooting](./docs/troubleshooting.md)
 
 | 순서 | Ch | 질문 | 확인할 결과 |
 | ---: | :-: | --- | --- |

--- a/computer_science/ai/study-llmserving/ch5-6/docker-compose.yml
+++ b/computer_science/ai/study-llmserving/ch5-6/docker-compose.yml
@@ -160,6 +160,8 @@ services:
     image: nvidia/dcgm-exporter:4.8.3
     profiles: [observability]
     <<: *gpu
+    environment:
+      DCGM_EXPORTER_INTERVAL: "${DCGM_EXPORTER_INTERVAL_MS:-1000}"
     cap_add:
       - SYS_ADMIN
     ports:

--- a/computer_science/ai/study-llmserving/ch5-6/docs/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/README.md
@@ -39,6 +39,7 @@
 | 문서 | 하는 일 |
 | --- | --- |
 | [metric 해석](./prometheus.md) | 어떤 지표를 왜 모으고 어떻게 읽는가 |
+| [GPU 실습 troubleshooting](./troubleshooting.md) | VRAM 초기화와 DCGM·Prometheus·Grafana 수집 검증 |
 | [GSM8K 20문항의 범위](./06-gsm8k-deep-dive.md) | 빠른 quality gate로 판단해도 되는 선 |
 | [Quiz](./quiz.md) | Chapter 5·6 핵심 개념 복습 |
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
@@ -16,6 +16,14 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+이전 실습의 model process를 정리하고 desktop baseline을 확인합니다.
+
+```bash
+make gpu-reset
+```
+
+VRAM이 0MiB가 아니어도 compute process가 없으면 정상입니다. 상세 판정은 [GPU 실습 troubleshooting](../troubleshooting.md)에 있습니다.
+
 ## 먼저 host의 기준값을 고정합니다
 
 이 값은 이후 OOM과 성능 결과를 해석할 hardware 기준입니다.
@@ -56,10 +64,10 @@ docker run --rm --gpus all nvidia/cuda:12.9.1-base-ubuntu24.04 nvidia-smi
 docker compose --profile tools build benchmark
 ```
 
-Prometheus, Grafana, DCGM Exporter를 실행합니다.
+Prometheus, Grafana, DCGM Exporter를 실행하고 수집 경로를 자동 점검합니다.
 
 ```bash
-docker compose --profile observability up -d prometheus grafana dcgm-exporter
+make observability-check
 docker compose ps
 ```
 
@@ -68,7 +76,7 @@ docker compose ps
 - Grafana 계정: `admin` / `admin`
 - dashboard: `LLM serving / LLM Serving Chapter 5-6`
 
-Prometheus와 GPU exporter 연결을 확인합니다.
+원본 metric을 직접 확인할 때만 다음 명령을 사용합니다.
 
 ```bash
 curl http://127.0.0.1:9090/api/v1/targets
@@ -87,4 +95,5 @@ curl http://127.0.0.1:9400/metrics
 ## 참고자료
 
 - [Ubuntu GPU 환경 준비](../01-setup-ubuntu.md)
+- [GPU 실습 troubleshooting](../troubleshooting.md)
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
@@ -15,6 +15,15 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+이전 model process를 정리하고 OOM 순간의 hardware metric이 수집되는지 확인합니다.
+
+```bash
+make gpu-reset
+make observability-check
+```
+
+Desktop baseline VRAM과 Grafana 값이 예상과 다르면 [GPU 실습 troubleshooting](../troubleshooting.md)부터 확인합니다.
+
 ## 먼저 OOM 가설을 계산합니다
 
 Memory budget과 roofline calculator로 실행 전 가설을 만듭니다.
@@ -124,3 +133,4 @@ docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
 ## 참고자료
 
 - [16GB GPU에 7B 모델이 올라가도 serving이 어려운 이유](../02-ch5-theory.md)
+- [GPU 실습 troubleshooting](../troubleshooting.md)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
@@ -2,6 +2,17 @@
 
 옵션을 먼저 바꾸면 숫자는 달라져도 원인을 설명하기 어렵습니다. 이 핸즈온은 GPU 확인부터 시작해 memory, KV cache, roofline, scheduling, prefill·decode, quantization, cache 순서로 병목을 좁힙니다. 파일 번호가 학습 순서입니다.
 
+## 모든 GPU 실습 전에 기준 상태를 만듭니다
+
+Workspace의 이전 model process를 정리하고 hardware metric 수집 경로를 확인합니다.
+
+```bash
+make gpu-reset
+make observability-check
+```
+
+Desktop GPU는 화면 출력 때문에 baseline VRAM이 0MiB가 아닙니다. 초기화 기준과 metric 불일치 판별은 [GPU 실습 troubleshooting](../troubleshooting.md)을 따릅니다.
+
 ## Chapter 5만 볼 때
 
 Chapter 5는 "이 GPU에 이 model이 들어가는가, 느리다면 연산인가 대역폭인가"를 다룹니다. 이론을 먼저 읽고 세 실습을 순서대로 합니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/prometheus.md
@@ -210,8 +210,10 @@ Benchmark는 측정 시작부터 종료까지 Prometheus `/api/v1/query_range`�
 
 ## 관측의 한계
 
-- scrape interval: 5초
-  - 더 짧은 VRAM·utilization spike 누락 가능
+- DCGM·Prometheus GPU interval: 1초
+  - 1초보다 짧은 VRAM·utilization spike 누락 가능
+- Grafana GPU panel: 최근 5초 최대값
+  - 짧은 spike를 보존하지만 vLLM process allocator와 같은 순간값은 아님
 - rate window: 1분
   - 짧은 benchmark에서 지연되거나 흔들리는 값
 - Prometheus metric: aggregate
@@ -227,6 +229,7 @@ GPU 사용률이 높다는 사실은 LLM이 왜 느린지 답하지 못합니다
 
 ## 참고자료
 
+- [GPU 실습 troubleshooting](./troubleshooting.md)
 - [vLLM Metrics](https://docs.vllm.ai/en/stable/usage/metrics/)
 - [Prometheus metric types](https://prometheus.io/docs/concepts/metric_types/)
 - [NVIDIA DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/troubleshooting.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/troubleshooting.md
@@ -1,0 +1,117 @@
+# LLM serving GPU 실습 troubleshooting
+
+GPU 실습 결과가 예상과 다르면 model option보다 먼저 GPU 기준 상태와 metric 수집 경로를 확인합니다. VRAM을 0MiB로 만드는 것이 아니라 **실습 compute process가 없는 desktop baseline**에서 시작하는 것이 기준입니다.
+
+## 실습 전 GPU 기준 상태를 만듭니다
+
+Workspace container를 모두 내리고 남은 GPU compute process를 확인합니다.
+
+```bash
+make gpu-reset
+```
+
+- workspace의 container와 network만 정리
+- Prometheus·Grafana volume과 model cache는 유지
+- 다른 workspace의 GPU process는 종료하지 않고 목록을 출력한 뒤 실패
+- Xorg·gnome-shell 같은 desktop process의 VRAM은 유지
+
+Desktop GPU는 화면 출력만으로도 VRAM을 사용하므로 `memory.used=0 MiB`가 되지 않습니다. Xorg나 desktop session을 강제로 종료하면 사용자 화면을 끊으므로 초기화 대상으로 삼지 않습니다.
+
+남은 process를 직접 확인할 때는 compute application만 조회합니다.
+
+```bash
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+```
+
+소유한 process인지 확인한 뒤 해당 service나 process만 종료합니다. PID 전체를 일괄 종료하지 않습니다.
+
+출력된 PID의 실행 주체를 확인합니다.
+
+```bash
+ps -fp <PID>
+cat /proc/<PID>/cgroup
+```
+
+- 일반 process: 실행한 shell이나 service에서 정상 종료
+- container·Kubernetes process: process를 직접 kill하지 않고 소유한 workload에서 종료
+- 소유자를 모르는 process: 종료하지 않고 실습 관리자에게 확인
+
+## 관측 경로가 유효한지 한 번에 확인합니다
+
+관측 stack을 기동하고 네 구간을 대조합니다.
+
+```text
+nvidia-smi → DCGM Exporter → Prometheus → Grafana datasource
+```
+
+자동 점검을 실행합니다.
+
+```bash
+make observability-check
+```
+
+성공 조건:
+
+- Prometheus의 `dcgm-exporter` target이 `UP`
+- `nvidia-smi`와 DCGM의 idle VRAM 차이가 256MiB 이내
+- DCGM과 Prometheus의 VRAM 차이가 256MiB 이내
+- Prometheus GPU sample이 10초보다 오래되지 않음
+- Grafana의 Prometheus datasource health가 `OK`
+
+GPU utilization은 같은 순간을 재지 않으므로 세 숫자가 정확히 같을 필요가 없습니다. 값이 0~100 범위이고 Prometheus sample이 최신인지만 확인합니다.
+
+## Grafana VRAM이 OOM log보다 낮습니다
+
+vLLM OOM log는 allocation이 실패한 순간의 process memory를 출력합니다. DCGM은 host GPU 전체를 일정 간격으로 sample하고 Prometheus는 그 값을 다시 scrape합니다. 측정 시점과 범위가 다릅니다.
+
+```text
+vLLM OOM log       process allocator의 실패 순간
+DCGM_FI_DEV_FB_USED host GPU 전체의 sampled VRAM
+Grafana GPU VRAM    DCGM sample의 최근 5초 최대값
+```
+
+이 workspace의 수집 간격:
+
+| 구간 | 간격 |
+| --- | ---: |
+| DCGM GPU 수집 | 1초 |
+| Prometheus DCGM scrape | 1초 |
+| Grafana GPU panel | 최근 5초 최대값 |
+
+이전 기본값은 DCGM 30초, Prometheus 5초였습니다. 7B OOM처럼 model load peak가 수 초 안에 끝나면 정상 연결이어도 peak를 통째로 놓칠 수 있었습니다. 1초로 줄여 가능성을 낮췄지만 1초보다 짧은 spike까지 보장하지는 않습니다.
+
+Grafana panel은 `DCGM_FI_DEV_FB_USED`의 MiB를 표시합니다. vLLM log의 GiB와 비교할 때는 `GiB × 1024 = MiB`로 단위를 맞춥니다.
+
+## Expected OOM에서 model-server target이 DOWN입니다
+
+`vllm-7b-bf16-expect-failure`는 API server가 준비되기 전에 종료됩니다. 따라서 Prometheus의 `model-server` target이 `DOWN`이고 vLLM application panel이 비어 있는 것이 정상입니다.
+
+Expected OOM에서 확인할 target은 `dcgm-exporter`입니다.
+
+```bash
+curl -s http://127.0.0.1:9090/api/v1/targets | \
+  jq -r '.data.activeTargets[] | [.labels.job, .health, .lastError] | @tsv'
+```
+
+- `dcgm-exporter UP`: OOM 중 hardware metric 수집 가능
+- `model-server DOWN`: vLLM 초기화 실패 시 정상
+- 둘 다 `DOWN`: 관측 stack 문제부터 해결
+
+## 변경한 수집 간격이 적용되지 않습니다
+
+실행 중인 Prometheus와 DCGM Exporter는 Git pull만으로 설정을 다시 읽지 않을 수 있습니다. 기준 상태부터 다시 만듭니다.
+
+```bash
+make gpu-reset
+make observability-check
+```
+
+Prometheus volume은 유지되므로 이전 시계열도 남습니다. Grafana time range를 실습 실행 시각 전후로 좁혀 새 결과만 확인합니다.
+
+## 참고자료
+
+- [관측 metric과 panel 해석](./prometheus.md)
+- [GPU 환경 확인](./handson/01-gpu-environment.md)
+- [NVIDIA DCGM Exporter collect interval](https://github.com/NVIDIA/dcgm-exporter/blob/4.6.0-4.8.3/pkg/cmd/app.go)

--- a/computer_science/ai/study-llmserving/ch5-6/observability/grafana/dashboards/llm-serving.json
+++ b/computer_science/ai/study-llmserving/ch5-6/observability/grafana/dashboards/llm-serving.json
@@ -284,7 +284,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "decmbytes"
+          "unit": "mbytes"
         }
       },
       "gridPos": {
@@ -296,11 +296,12 @@
       "id": 11,
       "targets": [
         {
-          "expr": "max(DCGM_FI_DEV_FB_USED)",
+          "expr": "max(max_over_time(DCGM_FI_DEV_FB_USED[5s]))",
           "legendFormat": "VRAM used",
           "refId": "A"
         }
       ],
+      "description": "DCGM reports MiB. The panel keeps each sample visible for 5 seconds so short model-load peaks are less likely to disappear at Grafana query resolution.",
       "title": "GPU VRAM",
       "type": "timeseries"
     },
@@ -325,11 +326,12 @@
       "id": 12,
       "targets": [
         {
-          "expr": "max(DCGM_FI_DEV_GPU_UTIL)",
+          "expr": "max(max_over_time(DCGM_FI_DEV_GPU_UTIL[5s]))",
           "legendFormat": "GPU utilization",
           "refId": "A"
         }
       ],
+      "description": "Rolling 5-second maximum of DCGM samples. It validates that the GPU became busy; it is not expected to equal an nvidia-smi sample taken at a different instant.",
       "title": "GPU Utilization",
       "type": "timeseries"
     },

--- a/computer_science/ai/study-llmserving/ch5-6/observability/prometheus.yml
+++ b/computer_science/ai/study-llmserving/ch5-6/observability/prometheus.yml
@@ -8,5 +8,6 @@ scrape_configs:
       - targets: [model-server:8000]
 
   - job_name: dcgm-exporter
+    scrape_interval: 1s
     static_configs:
       - targets: [dcgm-exporter:9400]

--- a/computer_science/ai/study-llmserving/ch5-6/scripts/check_observability.sh
+++ b/computer_science/ai/study-llmserving/ch5-6/scripts/check_observability.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+prometheus_url="${PROMETHEUS_URL:-http://127.0.0.1:9090}"
+dcgm_url="${DCGM_URL:-http://127.0.0.1:9400}"
+grafana_url="${GRAFANA_URL:-http://127.0.0.1:3000}"
+grafana_user="${GRAFANA_USER:-admin}"
+grafana_password="${GRAFANA_PASSWORD:-admin}"
+vram_tolerance_mib="${VRAM_TOLERANCE_MIB:-256}"
+freshness_seconds="${METRIC_FRESHNESS_SECONDS:-10}"
+
+require_command() {
+  command -v "$1" >/dev/null || {
+    echo "Required command not found: $1" >&2
+    exit 1
+  }
+}
+
+wait_for_url() {
+  local url="$1"
+  for _ in $(seq 1 30); do
+    curl --fail --silent "$url" >/dev/null && return 0
+    sleep 2
+  done
+  echo "Timed out waiting for $url" >&2
+  exit 1
+}
+
+wait_for_prometheus_target() {
+  local health
+  for _ in $(seq 1 30); do
+    health="$(curl --fail --silent "$prometheus_url/api/v1/targets" | jq -r \
+      '.data.activeTargets[] | select(.labels.job == "dcgm-exporter") | .health' || true)"
+    [[ "$health" == "up" ]] && return 0
+    sleep 2
+  done
+  echo "Prometheus dcgm-exporter target is not UP: ${health:-missing}" >&2
+  exit 1
+}
+
+absolute_difference() {
+  awk -v left="$1" -v right="$2" 'BEGIN { diff = left - right; print diff < 0 ? -diff : diff }'
+}
+
+assert_within_tolerance() {
+  local label="$1"
+  local left="$2"
+  local right="$3"
+  local difference
+  difference="$(absolute_difference "$left" "$right")"
+  awk -v diff="$difference" -v tolerance="$vram_tolerance_mib" 'BEGIN { exit !(diff <= tolerance) }' || {
+    echo "$label differs by ${difference}MiB; tolerance is ${vram_tolerance_mib}MiB" >&2
+    exit 1
+  }
+}
+
+assert_percent() {
+  local label="$1"
+  local value="$2"
+  awk -v number="$value" 'BEGIN { exit !(number >= 0 && number <= 100) }' || {
+    echo "$label is outside 0-100: $value" >&2
+    exit 1
+  }
+}
+
+assert_number() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+    echo "$label is not numeric: $value" >&2
+    exit 1
+  fi
+}
+
+prometheus_value() {
+  local metric="$1"
+  curl --fail --silent --get "$prometheus_url/api/v1/query" \
+    --data-urlencode "query=$metric" | jq -r '.data.result[0].value[1] // empty'
+}
+
+prometheus_metric_age() {
+  local metric="$1"
+  curl --fail --silent --get "$prometheus_url/api/v1/query" \
+    --data-urlencode "query=min(time() - timestamp($metric))" | jq -r '.data.result[0].value[1] // empty'
+}
+
+wait_for_grafana_datasource() {
+  local datasource
+  local datasource_uid
+  local datasource_health
+  for _ in $(seq 1 30); do
+    datasource="$(curl --silent --user "$grafana_user:$grafana_password" \
+      "$grafana_url/api/datasources/name/Prometheus" || true)"
+    datasource_uid="$(jq -r '.uid // empty' <<<"$datasource")"
+    if [[ -n "$datasource_uid" ]]; then
+      datasource_health="$(curl --silent --user "$grafana_user:$grafana_password" \
+        "$grafana_url/api/datasources/uid/$datasource_uid/health" | jq -r '.status // empty')"
+      [[ "$datasource_health" == "OK" ]] && return 0
+    fi
+    sleep 2
+  done
+  echo "Grafana Prometheus datasource is not healthy" >&2
+  exit 1
+}
+
+require_command curl
+require_command jq
+require_command nvidia-smi
+require_command awk
+
+wait_for_url "$dcgm_url/metrics"
+wait_for_url "$prometheus_url/-/ready"
+wait_for_url "$grafana_url/api/health"
+wait_for_prometheus_target
+
+dcgm_metrics="$(curl --fail --silent "$dcgm_url/metrics")"
+dcgm_vram="$(awk '/^DCGM_FI_DEV_FB_USED\{/ { print $NF; exit }' <<<"$dcgm_metrics")"
+dcgm_util="$(awk '/^DCGM_FI_DEV_GPU_UTIL\{/ { print $NF; exit }' <<<"$dcgm_metrics")"
+host_vram="$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits | head -1 | tr -d ' ')"
+host_util="$(nvidia-smi --query-gpu=utilization.gpu --format=csv,noheader,nounits | head -1 | tr -d ' ')"
+prometheus_vram="$(prometheus_value "last_over_time(DCGM_FI_DEV_FB_USED[${freshness_seconds}s])")"
+prometheus_util="$(prometheus_value "last_over_time(DCGM_FI_DEV_GPU_UTIL[${freshness_seconds}s])")"
+metric_age="$(prometheus_metric_age DCGM_FI_DEV_FB_USED)"
+
+for value in "$dcgm_vram" "$dcgm_util" "$host_vram" "$host_util" "$prometheus_vram" "$prometheus_util" "$metric_age"; do
+  if [[ -z "$value" ]]; then
+    echo "GPU observability metric is missing" >&2
+    exit 1
+  fi
+done
+
+assert_number "DCGM VRAM" "$dcgm_vram"
+assert_number "DCGM GPU utilization" "$dcgm_util"
+assert_number "nvidia-smi VRAM" "$host_vram"
+assert_number "nvidia-smi GPU utilization" "$host_util"
+assert_number "Prometheus VRAM" "$prometheus_vram"
+assert_number "Prometheus GPU utilization" "$prometheus_util"
+assert_number "Prometheus metric age" "$metric_age"
+assert_within_tolerance "nvidia-smi and DCGM VRAM" "$host_vram" "$dcgm_vram"
+assert_within_tolerance "DCGM and Prometheus VRAM" "$dcgm_vram" "$prometheus_vram"
+assert_percent "nvidia-smi GPU utilization" "$host_util"
+assert_percent "DCGM GPU utilization" "$dcgm_util"
+assert_percent "Prometheus GPU utilization" "$prometheus_util"
+
+awk -v age="$metric_age" -v limit="$freshness_seconds" 'BEGIN { exit !(age >= -2 && age <= limit) }' || {
+  echo "Prometheus GPU metric is stale: ${metric_age}s" >&2
+  exit 1
+}
+
+wait_for_grafana_datasource
+
+echo "Prometheus dcgm-exporter target: UP"
+echo "VRAM MiB: nvidia-smi=$host_vram dcgm=$dcgm_vram prometheus=$prometheus_vram"
+echo "GPU utilization %: nvidia-smi=$host_util dcgm=$dcgm_util prometheus=$prometheus_util"
+echo "Prometheus GPU metric age: ${metric_age}s"
+echo "Grafana Prometheus datasource: OK"

--- a/computer_science/ai/study-llmserving/ch5-6/scripts/reset_gpu.sh
+++ b/computer_science/ai/study-llmserving/ch5-6/scripts/reset_gpu.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+docker compose --profile "*" down --remove-orphans
+
+remaining_processes="$(nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader,nounits 2>/dev/null || true)"
+
+if [[ -n "${remaining_processes//[[:space:]]/}" ]]; then
+  echo "GPU compute processes remain after project cleanup:" >&2
+  echo "$remaining_processes" >&2
+  echo "Stop only the listed process you own, then run make gpu-reset again." >&2
+  exit 1
+fi
+
+echo "No GPU compute process remains. Desktop VRAM can stay allocated."
+nvidia-smi \
+  --query-gpu=name,memory.total,memory.used,memory.free,utilization.gpu \
+  --format=csv

--- a/computer_science/ai/study-llmserving/ch5-6/tests/test_observability_config.py
+++ b/computer_science/ai/study-llmserving/ch5-6/tests/test_observability_config.py
@@ -1,0 +1,34 @@
+"""Verify GPU observability sampling and dashboard units."""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+
+
+def dashboard_panel(panel_id: int) -> dict:
+  """Return one provisioned Grafana panel by numeric ID."""
+  dashboard_path = ROOT / "observability/grafana/dashboards/llm-serving.json"
+  dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+  return next(panel for panel in dashboard["panels"] if panel["id"] == panel_id)
+
+
+def test_gpu_collection_intervals_capture_short_peaks() -> None:
+  """Keep DCGM collection and Prometheus scraping at one second."""
+  compose = (ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+  prometheus = (ROOT / "observability/prometheus.yml").read_text(encoding="utf-8")
+  assert 'DCGM_EXPORTER_INTERVAL: "${DCGM_EXPORTER_INTERVAL_MS:-1000}"' in compose
+  assert "scrape_interval: 1s" in prometheus
+
+
+def test_gpu_vram_panel_uses_mib_and_rolling_peak() -> None:
+  """Display DCGM MiB without losing short model-load peaks."""
+  panel = dashboard_panel(11)
+  assert panel["fieldConfig"]["defaults"]["unit"] == "mbytes"
+  assert panel["targets"][0]["expr"] == "max(max_over_time(DCGM_FI_DEV_FB_USED[5s]))"
+
+
+def test_gpu_utilization_panel_uses_rolling_peak() -> None:
+  """Keep brief GPU busy samples visible in Grafana."""
+  panel = dashboard_panel(12)
+  assert panel["targets"][0]["expr"] == "max(max_over_time(DCGM_FI_DEV_GPU_UTIL[5s]))"


### PR DESCRIPTION
# 구현

GPU baseline 초기화, DCGM·Prometheus·Grafana 수집 검증, troubleshooting과 agent memory 추가
- Expected OOM 재현에서 GPU peak 수집 확인, 전체 test와 lint 통과

# 어려웠던 점

vLLM allocator memory와 DCGM GPU 전체 memory의 범위·sampling 시점 불일치
- DCGM 기본 30초와 Prometheus 5초 간격에서 짧은 model load peak 누락, 1초 수집과 최근 5초 최대값으로 완화

# 리스크

1초 scrape 적용에 따른 GPU metric 시계열과 exporter polling 증가
- 단일 GPU 학습 환경 범위이며 1초보다 짧은 spike 포착은 보장하지 않음

Issue #1107