### PR TITLE
docs: GPU 실습 전 프로세스 정리 절차 통일

### DIFF
--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
@@ -16,13 +16,17 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
-이전 실습의 model process를 정리하고 desktop baseline을 확인합니다.
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리하고 desktop baseline을 확인합니다.
 
 ```bash
 make gpu-reset
 ```
 
-VRAM이 0MiB가 아니어도 compute process가 없으면 정상입니다. 상세 판정은 [GPU 실습 troubleshooting](../troubleshooting.md)에 있습니다.
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
+VRAM이 0MiB가 아니어도 compute process가 없으면 정상입니다.
 
 ## 먼저 host의 기준값을 고정합니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
@@ -15,14 +15,45 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
-이전 model process를 정리하고 OOM 순간의 hardware metric이 수집되는지 확인합니다.
+## GPU를 사용하는 기존 process를 먼저 종료합니다
+
+다른 process가 VRAM을 사용하면 OOM 원인이 7B model인지 기존 workload인지 구분할 수 없습니다. Workspace container를 정리하고 남은 GPU compute process를 확인합니다.
+
+```bash
+make gpu-reset
+```
+
+`GPU compute processes remain`이 출력되면 각 PID의 실행 주체를 확인합니다.
+
+```bash
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+ps -fp <PID>
+cat /proc/<PID>/cgroup
+```
+
+본인이 실행한 일반 process만 정상 종료 신호를 보냅니다.
+
+```bash
+kill -TERM <PID>
+```
+
+Container나 Kubernetes가 관리하는 process는 PID를 직접 종료하지 않습니다. 본인이 실행한 workload를 해당 도구로 종료합니다.
+
+```bash
+docker stop <CONTAINER>
+kubectl scale deployment/<WORKLOAD> --replicas=0 -n <NAMESPACE>
+```
+
+소유자를 모르는 process, Xorg, desktop session은 종료하지 않습니다. 종료 후 기준 상태와 OOM 순간의 hardware metric 수집 경로를 다시 확인합니다.
 
 ```bash
 make gpu-reset
 make observability-check
 ```
 
-Desktop baseline VRAM과 Grafana 값이 예상과 다르면 [GPU 실습 troubleshooting](../troubleshooting.md)부터 확인합니다.
+`make gpu-reset`이 성공하고 compute process 목록이 비어 있어야 실습을 시작합니다. Desktop baseline VRAM과 Grafana 값이 예상과 다르면 [GPU 실습 troubleshooting](../troubleshooting.md)을 확인합니다.
 
 ## 먼저 OOM 가설을 계산합니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
@@ -15,6 +15,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 1. 먼저 token 하나의 비용을 구합니다
 
 Model config에서 네 값만 있으면 됩니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
@@ -15,6 +15,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 1. 축이 무엇인지부터 고정합니다
 
 Roofline 그래프를 처음 보면 축을 읽는 것부터 막힙니다. 두 축은 서로 다른 것을 잽니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
@@ -16,6 +16,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 무엇을 바꾸고 무엇을 고정할까
 
 vLLM continuous batching의 두 scheduler 제한값만 변경합니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
@@ -17,6 +17,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 먼저 비교 범위를 구분합니다
 
 vLLM online server의 내부 scheduler는 iteration마다 running request와 waiting request에 token budget을 배분하는 continuous batching 방식입니다. Static batching과 dynamic batching은 vLLM의 serve option이 아닙니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
@@ -16,6 +16,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 두 workload가 다른 metric을 움직인다는 가설
 
 - long-prefill

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
@@ -17,6 +17,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 세 model이 노리는 병목이 다릅니다
 
 | Label | Model | Precision | 가설 |

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
@@ -17,6 +17,16 @@ Repository root에서 workspace로 이동합니다.
 cd computer_science/ai/study-llmserving/ch5-6
 ```
 
+## 실습 전 GPU process를 정리합니다
+
+이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
+
+```bash
+make gpu-reset
+```
+
+명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+
 ## 세 request가 확인하는 조건
 
 1. Cold request

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
@@ -13,6 +13,8 @@ make observability-check
 
 Desktop GPU는 화면 출력 때문에 baseline VRAM이 0MiB가 아닙니다. 초기화 기준과 metric 불일치 판별은 [GPU 실습 troubleshooting](../troubleshooting.md)을 따릅니다.
 
+`make gpu-reset`이 남은 compute process를 출력하고 실패하면 실습을 진행하지 않습니다. [process 실행 주체 확인과 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`부터 다시 실행합니다.
+
 ## Chapter 5만 볼 때
 
 Chapter 5는 "이 GPU에 이 model이 들어가는가, 느리다면 연산인가 대역폭인가"를 다룹니다. 이론을 먼저 읽고 세 실습을 순서대로 합니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/troubleshooting.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/troubleshooting.md
@@ -38,6 +38,32 @@ cat /proc/<PID>/cgroup
 - container·Kubernetes process: process를 직접 kill하지 않고 소유한 workload에서 종료
 - 소유자를 모르는 process: 종료하지 않고 실습 관리자에게 확인
 
+본인이 실행한 일반 process에는 정상 종료 신호를 보냅니다.
+
+```bash
+kill -TERM <PID>
+```
+
+본인이 실행한 container는 container runtime에서 종료합니다.
+
+```bash
+docker stop <CONTAINER>
+```
+
+본인이 실행한 Kubernetes workload는 controller의 replica를 0으로 줄입니다. Pod만 삭제하면 controller가 다시 생성할 수 있습니다.
+
+```bash
+kubectl scale deployment/<WORKLOAD> --replicas=0 -n <NAMESPACE>
+```
+
+종료 후 다시 초기화합니다.
+
+```bash
+make gpu-reset
+```
+
+`No GPU compute process remains`가 출력되면 GPU 실습을 시작합니다. 계속 process가 출력되면 같은 확인 절차를 반복하되 `kill -KILL`, 전체 PID 일괄 종료, container runtime 전체 중지는 사용하지 않습니다.
+
 ## 관측 경로가 유효한지 한 번에 확인합니다
 
 관측 stack을 기동하고 네 구간을 대조합니다.


### PR DESCRIPTION
# 구현

모든 LLM serving 핸즈온에 GPU process 확인·정리 사전 조건 추가
- 10개 문서의 make gpu-reset 포함 여부와 Markdown diff 검증 완료

# 어려웠던 점

각 실습의 자기 완결성과 종료 절차의 단일 관리 균형
- 공통 확인 명령은 각 문서에 배치, 소유 주체별 상세 종료 명령은 troubleshooting으로 연결

# 리스크

Container·Kubernetes 종료 예시 실행 전 실제 소유 workload 확인 필요
- 알 수 없는 PID와 desktop process는 종료 대상에서 명시적으로 제외

Issue #1109