### PR TITLE
docs: LLM serving 실행 명령을 Docker Compose로 명시

### DIFF
--- a/computer_science/ai/study-llmserving/ch5-6/AGENTS.md
+++ b/computer_science/ai/study-llmserving/ch5-6/AGENTS.md
@@ -44,7 +44,7 @@
 ## GPU 초기화 안전선
 
 - 실습 기준은 VRAM `0 MiB`가 아니라 **실습 compute process가 없는 baseline**이다.
-- `make gpu-reset`은 이 workspace의 Compose resource만 내린다.
+- 문서의 `docker compose --profile "*" down --remove-orphans`는 이 workspace의 Compose resource만 내린다.
 - 다른 workspace나 container orchestrator의 GPU process가 남으면 목록을 출력하고 실패해야 한다.
 - 소유권을 확인하지 않은 PID, Xorg, desktop session을 자동 종료하지 않는다.
 - 외부 process를 직접 kill하는 기능을 `gpu-reset`에 추가하지 않는다.
@@ -66,7 +66,7 @@
 - `docs/prometheus.md`
 - `docs/troubleshooting.md`
 
-`make observability-check`는 다음 경로를 검증한다.
+`bash scripts/check_observability.sh`는 다음 경로를 검증한다.
 
 ```text
 nvidia-smi → DCGM Exporter → Prometheus → Grafana datasource
@@ -103,14 +103,25 @@ git diff --check
 GPU 동작을 바꾸면 가능한 환경에서 다음 순서로 추가 검증한다.
 
 ```bash
-make gpu-reset
-make observability-check
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
 docker compose --profile oom run --rm vllm-7b-bf16-expect-failure
 ```
 
 - expected OOM 명령의 non-zero exit는 정상 결과다.
 - OOM 전후 `dcgm-exporter UP`과 Prometheus의 VRAM peak를 확인한다.
 - 검증용 GPU server의 주소, hostname, 사용자명, SSH alias, 절대 경로를 저장소에 기록하지 않는다.
+
+## 핸즈온 명령 표기
+
+- `docs/handson/`에서는 Make target으로 실행 단계를 숨기지 않는다.
+- Service 기동·종료·benchmark는 실제 `docker compose` 명령을 적는다.
+- GPU process 확인과 HTTP health check처럼 Compose 밖의 검증만 `nvidia-smi`, `bash`, `curl`을 직접 사용한다.
+- Makefile은 개발자 편의용으로 유지할 수 있지만 핸즈온의 유일한 실행 경로로 삼지 않는다.
 
 ## 공개 저장소 개인정보 규칙
 

--- a/computer_science/ai/study-llmserving/ch5-6/Makefile
+++ b/computer_science/ai/study-llmserving/ch5-6/Makefile
@@ -31,7 +31,7 @@ ch5-calculate:
 
 ch5-roofline: build
 	$(COMPOSE) --profile tools run --rm gpu-probe
-	uv run --group viz python -m calculators.plot_roofline
+	$(COMPOSE) --profile tools run --rm benchmark python3 -m calculators.plot_roofline
 
 ch5-kv-probe: build observability-up
 	$(COMPOSE) --profile tools run --rm benchmark python3 -m benchmark.kv_cache_probe

--- a/computer_science/ai/study-llmserving/ch5-6/docker/Dockerfile
+++ b/computer_science/ai/study-llmserving/ch5-6/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG VLLM_IMAGE=vllm/vllm-openai:v0.27.1-cu129
 FROM ${VLLM_IMAGE}
 
-RUN uv pip install --system "httpx>=0.28"
+RUN python3 -m pip install --no-cache-dir "httpx>=0.28" "matplotlib>=3.10"
 
 WORKDIR /workspace
 ENTRYPOINT []

--- a/computer_science/ai/study-llmserving/ch5-6/docs/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/README.md
@@ -11,7 +11,7 @@
 | 2 | [03 KV cache 배치·시퀀스](./handson/03-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
 | 3 | [04 roofline과 병목 재현](./handson/04-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
 
-메모리 이야기(02 → 03)를 끝내고 속도 이야기(04)로 넘어가는 순서입니다. 03과 04는 `make ch5-kv-probe`, `make ch5-roofline`, `make ch5-bottleneck`으로 직접 측정합니다.
+메모리 이야기(02 → 03)를 끝내고 속도 이야기(04)로 넘어가는 순서입니다. 03과 04는 문서에 적힌 Docker Compose 명령으로 KV cache, roofline, bottleneck을 직접 측정합니다.
 
 ## Chapter 6 — 병목마다 어떤 optimization이 붙는가
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
@@ -21,10 +21,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리하고 desktop baseline을 확인합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 VRAM이 0MiB가 아니어도 compute process가 없으면 정상입니다.
 
@@ -71,7 +74,8 @@ docker compose --profile tools build benchmark
 Prometheus, Grafana, DCGM Exporter를 실행하고 수집 경로를 자동 점검합니다.
 
 ```bash
-make observability-check
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
 docker compose ps
 ```
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
@@ -20,10 +20,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 다른 process가 VRAM을 사용하면 OOM 원인이 7B model인지 기존 workload인지 구분할 수 없습니다. Workspace container를 정리하고 남은 GPU compute process를 확인합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-`GPU compute processes remain`이 출력되면 각 PID의 실행 주체를 확인합니다.
+두 번째 명령이 process를 출력하면 각 PID의 실행 주체를 확인합니다.
 
 ```bash
 nvidia-smi \
@@ -49,11 +52,15 @@ kubectl scale deployment/<WORKLOAD> --replicas=0 -n <NAMESPACE>
 소유자를 모르는 process, Xorg, desktop session은 종료하지 않습니다. 종료 후 기준 상태와 OOM 순간의 hardware metric 수집 경로를 다시 확인합니다.
 
 ```bash
-make gpu-reset
-make observability-check
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
 ```
 
-`make gpu-reset`이 성공하고 compute process 목록이 비어 있어야 실습을 시작합니다. Desktop baseline VRAM과 Grafana 값이 예상과 다르면 [GPU 실습 troubleshooting](../troubleshooting.md)을 확인합니다.
+Compute process 목록이 비어 있고 관측 경로 점검이 성공해야 실습을 시작합니다. Desktop baseline VRAM과 Grafana 값이 예상과 다르면 [GPU 실습 troubleshooting](../troubleshooting.md)을 확인합니다.
 
 ## 먼저 OOM 가설을 계산합니다
 
@@ -140,7 +147,7 @@ docker compose --profile tools run --rm model-loader python3 -m model_loader.loa
 같은 serving 설정에서 model만 3B로 바꿔 API server와 KV pool이 준비되는지 확인합니다.
 
 ```bash
-make vllm-bf16
+docker compose --profile bf16 up -d vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
 ```

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
@@ -20,10 +20,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 1. 먼저 token 하나의 비용을 구합니다
 
@@ -42,7 +45,9 @@ Qwen2.5-3B-Instruct는 layers 36, KV heads 2, head dimension 128, BF16입니다.
 책 예제의 Llama-2-7B는 같은 계산으로 **512 KiB**가 나옵니다. 14배 차이입니다. parameter 수가 2배 차이인데 KV는 14배 차이가 나는 이유는 KV head 수에 있습니다. Llama-2-7B는 attention head 32개마다 KV head도 32개인 MHA이고, Qwen2.5-3B는 attention head 16개가 KV head 2개를 나눠 쓰는 GQA입니다.
 
 ```bash
-make ch5-calculate
+docker compose --profile tools build benchmark
+docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
+docker compose --profile tools run --rm benchmark python3 -m calculators.roofline
 ```
 
 | Model | attention | KV heads | KV/token | 같은 16GB에서 4096-token 요청 |
@@ -59,7 +64,7 @@ vLLM은 기동할 때 KV pool을 미리 잡고 그 크기를 log에 남깁니다
 02번에서 실행한 3B BF16 server가 내려갔다면 다시 기동하고 health check를 확인합니다.
 
 ```bash
-make vllm-bf16
+docker compose --profile bf16 up -d vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 ```
 
@@ -104,7 +109,9 @@ VRAM 전체가 어떻게 갈라지는지도 여기서 맞춰볼 수 있습니다
 동시 요청 수와 prompt 길이를 바꿔가며, 공식이 예측한 pool 점유율과 서버가 보고하는 실제 점유율을 나란히 놓습니다.
 
 ```bash
-make ch5-kv-probe
+docker compose --profile tools build benchmark
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_probe
 ```
 
 `max_num_seqs 8` 기본 설정에서의 결과입니다.
@@ -155,7 +162,7 @@ TTFT가 300배 흔들리는 동안 TPOT는 15.9 ms에서 28.3 ms로 완만하게
 
 ```bash
 VLLM_MAX_NUM_SEQS=64 docker compose --profile bf16 up -d --force-recreate vllm-bf16
-make ch5-kv-probe
+docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_probe
 ```
 
 이 설정에서는 `gpu-memory-utilization`이 0.85라 pool이 173,328 tokens(5.95 GiB)로 조금 작아집니다. 예측값은 그 pool 기준입니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
@@ -20,10 +20,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 1. 축이 무엇인지부터 고정합니다
 
@@ -47,7 +50,9 @@ crossover = peak FLOPS ÷ memory bandwidth
 사양표를 믿지 않고 측정합니다. 큰 정사각 행렬 곱으로 peak 연산 성능을, 큰 device 복사로 memory bandwidth를 잽니다.
 
 ```bash
-make ch5-roofline
+docker compose --profile tools build benchmark
+docker compose --profile tools run --rm gpu-probe
+docker compose --profile tools run --rm benchmark python3 -m calculators.plot_roofline
 ```
 
 측정 결과입니다.
@@ -67,7 +72,8 @@ crossover가 131이라는 것은 이 카드가 연산 성능 대비 대역폭이
 Projection 연산을 `[s, h] × [h, h]`로 두고 계산기를 돌립니다.
 
 ```bash
-make ch5-calculate
+docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
+docker compose --profile tools run --rm benchmark python3 -m calculators.roofline
 ```
 
 책 예제와 맞추기 위해 hidden size 4096으로 계산한 값입니다. [이론 문서](../02-ch5-theory.md)의 표는 이 workspace가 실제로 서빙하는 Qwen2.5-3B의 2048 기준이라 같은 sequence 길이라도 값이 다릅니다.
@@ -118,8 +124,12 @@ Qwen2.5-3B BF16의 weight는 vLLM이 보고한 값으로 5.79 GiB입니다.
 vLLM을 띄우고 서로 반대쪽에 있는 workload를 던집니다.
 
 ```bash
-make vllm-bf16
-make ch5-bottleneck
+docker compose --profile bf16 up -d vllm-bf16
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+docker compose --profile tools build benchmark
+docker compose --profile tools run --rm \
+  -e MEASURED_BANDWIDTH_GBPS=384 \
+  benchmark python3 -m benchmark.bottleneck_probe
 ```
 
 실험이 만드는 네 상황입니다.

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
@@ -21,10 +21,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 무엇을 바꾸고 무엇을 고정할까
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
@@ -22,10 +22,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 먼저 비교 범위를 구분합니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
@@ -21,10 +21,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 두 workload가 다른 metric을 움직인다는 가설
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
@@ -22,10 +22,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 세 model이 노리는 병목이 다릅니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
@@ -22,10 +22,13 @@ cd computer_science/ai/study-llmserving/ch5-6
 이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-명령이 남은 process를 출력하고 실패하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
 
 ## 세 request가 확인하는 조건
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
@@ -7,13 +7,17 @@
 Workspace의 이전 model process를 정리하고 hardware metric 수집 경로를 확인합니다.
 
 ```bash
-make gpu-reset
-make observability-check
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
 ```
 
 Desktop GPU는 화면 출력 때문에 baseline VRAM이 0MiB가 아닙니다. 초기화 기준과 metric 불일치 판별은 [GPU 실습 troubleshooting](../troubleshooting.md)을 따릅니다.
 
-`make gpu-reset`이 남은 compute process를 출력하고 실패하면 실습을 진행하지 않습니다. [process 실행 주체 확인과 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 `make gpu-reset`부터 다시 실행합니다.
+`nvidia-smi`가 compute process를 출력하면 실습을 진행하지 않습니다. [process 실행 주체 확인과 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 초기화 명령부터 다시 실행합니다.
 
 ## Chapter 5만 볼 때
 
@@ -26,7 +30,7 @@ Chapter 5는 "이 GPU에 이 model이 들어가는가, 느리다면 연산인가
 | 2 | [03 KV cache 배치·시퀀스](./03-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
 | 3 | [04 roofline과 병목 재현](./04-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
 
-03과 04는 `make ch5-kv-probe`, `make ch5-roofline`, `make ch5-bottleneck`으로 직접 측정합니다. 실행 전에 [01 GPU 환경](./01-gpu-environment.md)이 필요합니다.
+03과 04는 문서에 적힌 Docker Compose 명령으로 KV cache, roofline, bottleneck을 직접 측정합니다. 실행 전에 [01 GPU 환경](./01-gpu-environment.md)이 필요합니다.
 
 ## Chapter 6만 볼 때
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/troubleshooting.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/troubleshooting.md
@@ -7,7 +7,10 @@ GPU 실습 결과가 예상과 다르면 model option보다 먼저 GPU 기준 �
 Workspace container를 모두 내리고 남은 GPU compute process를 확인합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
 - workspace의 container와 network만 정리
@@ -59,10 +62,13 @@ kubectl scale deployment/<WORKLOAD> --replicas=0 -n <NAMESPACE>
 종료 후 다시 초기화합니다.
 
 ```bash
-make gpu-reset
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
 ```
 
-`No GPU compute process remains`가 출력되면 GPU 실습을 시작합니다. 계속 process가 출력되면 같은 확인 절차를 반복하되 `kill -KILL`, 전체 PID 일괄 종료, container runtime 전체 중지는 사용하지 않습니다.
+Compute process 목록이 비어 있으면 GPU 실습을 시작합니다. 계속 process가 출력되면 같은 확인 절차를 반복하되 `kill -KILL`, 전체 PID 일괄 종료, container runtime 전체 중지는 사용하지 않습니다.
 
 ## 관측 경로가 유효한지 한 번에 확인합니다
 
@@ -75,7 +81,8 @@ nvidia-smi → DCGM Exporter → Prometheus → Grafana datasource
 자동 점검을 실행합니다.
 
 ```bash
-make observability-check
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
 ```
 
 성공 조건:
@@ -130,8 +137,12 @@ curl -s http://127.0.0.1:9090/api/v1/targets | \
 실행 중인 Prometheus와 DCGM Exporter는 Git pull만으로 설정을 다시 읽지 않을 수 있습니다. 기준 상태부터 다시 만듭니다.
 
 ```bash
-make gpu-reset
-make observability-check
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
 ```
 
 Prometheus volume은 유지되므로 이전 시계열도 남습니다. Grafana time range를 실습 실행 시각 전후로 좁혀 새 결과만 확인합니다.

--- a/computer_science/ai/study-llmserving/ch5-6/tests/test_observability_config.py
+++ b/computer_science/ai/study-llmserving/ch5-6/tests/test_observability_config.py
@@ -32,3 +32,16 @@ def test_gpu_utilization_panel_uses_rolling_peak() -> None:
   """Keep brief GPU busy samples visible in Grafana."""
   panel = dashboard_panel(12)
   assert panel["targets"][0]["expr"] == "max(max_over_time(DCGM_FI_DEV_GPU_UTIL[5s]))"
+
+
+def test_handson_exposes_compose_commands_without_make_targets() -> None:
+  """Keep environment and benchmark commands visible in every hands-on document."""
+  for document_path in (ROOT / "docs/handson").glob("*.md"):
+    document = document_path.read_text(encoding="utf-8")
+    assert "make " not in document
+
+
+def test_runtime_image_can_render_roofline_plot() -> None:
+  """Install the plotting dependency used by the documented Compose command."""
+  dockerfile = (ROOT / "docker/Dockerfile").read_text(encoding="utf-8")
+  assert '"matplotlib>=3.10"' in dockerfile


### PR DESCRIPTION
# 구현

모든 핸즈온의 Make target를 실제 Docker Compose profile·service·module 명령으로 전개
- 전체 14개 test와 lint 통과, Compose image build·matplotlib import·calculator 실행 확인

# 어려웠던 점

Roofline 그림 생성만 host visualization dependency에 의존
- 공용 실습 image에 matplotlib을 포함해 probe와 plot을 같은 Compose 경계로 통일

# 리스크

Matplotlib dependency 추가에 따른 실습 image build 크기와 시간 증가
- Roofline 그림의 container 재현성을 위한 의도된 비용

Issue #1111