### PR TITLE
docs: LLM serving 핸즈온 시나리오 재구성

### DIFF
--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
@@ -1,77 +1,97 @@
-# GPU가 보여도 container에서 못 쓰는 이유부터 확인합니다
+# Host부터 Grafana까지 GPU 관측 경로 확인
 
-Host의 `nvidia-smi`가 성공해도 vLLM container가 GPU를 사용할 수 있다는 뜻은 아닙니다. Driver, NVIDIA Container Toolkit, container CUDA runtime까지 이어져야 model 실행 문제와 환경 문제를 분리할 수 있습니다.
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. Host GPU의 기준 상태 확인
+2. Container의 GPU 연결 확인
+3. Prometheus와 Grafana의 GPU metric 수집 경로 확인
+
+공통 환경:
 
 - 환경 준비: [Ubuntu GPU 환경 준비](../01-setup-ubuntu.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
 - OS: Ubuntu 24.04 LTS
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. Host GPU의 기준 상태를 확인합니다
+
+### 이론
+
+Host의 GPU 이름, driver, VRAM, power limit은 이후 OOM과 성능 결과를 해석하는 기준입니다. Desktop GPU는 화면 출력에 VRAM을 사용하므로 `0 MiB`보다 실습 compute process가 없는 상태를 기준으로 삼습니다.
+
+### 실습
+
+Repository root에서 workspace로 이동하고 기존 workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리하고 desktop baseline을 확인합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-VRAM이 0MiB가 아니어도 compute process가 없으면 정상입니다.
-
-## 먼저 host의 기준값을 고정합니다
-
-이 값은 이후 OOM과 성능 결과를 해석할 hardware 기준입니다.
+Hardware 기준값을 확인합니다.
 
 ```bash
-nvidia-smi --query-gpu=name,driver_version,memory.total,memory.free,power.limit --format=csv
+nvidia-smi \
+  --query-gpu=name,driver_version,memory.total,memory.free,power.limit \
+  --format=csv
 ```
 
 | 항목 | 기준값 |
 | --- | --- |
 | GPU | NVIDIA GeForce RTX 5060 Ti |
-| VRAM | 16311MiB, nominal 16GB |
+| VRAM | 16311 MiB, nominal 16GB |
 | Driver | 595.71.05 |
 | CUDA compatibility | 13.2 |
 | Power limit | 180W |
 
-여기서 CUDA 13.2는 driver가 지원하는 compatibility 상한입니다. 실습 container의 CUDA 12.9 runtime과 같은 값일 필요는 없습니다.
+`nvidia-smi`의 CUDA 값은 driver가 지원하는 compatibility 상한입니다. Container CUDA runtime과 같은 값일 필요는 없습니다.
 
-## Container 경계에서 GPU 연결을 검증합니다
+## 시나리오 2. Container의 GPU 연결을 확인합니다
 
-다음 명령은 model을 받기 전에 Docker가 GPU device와 driver library를 전달하는지 확인합니다.
+### 이론
+
+Host의 `nvidia-smi` 성공은 container가 GPU device와 driver library를 전달받았다는 뜻이 아닙니다. Model을 받기 전에 container 경계를 검증해야 환경 문제와 model 문제를 분리할 수 있습니다.
+
+### 실습
+
+CUDA base image에서 GPU를 조회합니다.
 
 ```bash
 docker run --rm --gpus all nvidia/cuda:12.9.1-base-ubuntu24.04 nvidia-smi
 ```
 
-- host와 같은 GPU 확인: container runtime 연결 정상
+- Host와 같은 GPU 확인: container runtime 연결 정상
 - `could not select device driver`: NVIDIA Container Toolkit 구성 확인
-- driver compatibility 오류: host driver와 container CUDA 조합 확인
+- Driver compatibility 오류: host driver와 container CUDA 조합 확인
 
-여기서 model load까지 바로 시도할 수도 있습니다. 하지만 실패하면 network, model format, CUDA kernel, VRAM이 한꺼번에 후보가 됩니다. `nvidia-smi`부터 확인하면 환경 문제를 먼저 제외할 수 있습니다.
+Model load부터 시도하면 network, model format, CUDA kernel, VRAM 문제가 한 번에 후보가 됩니다. 이 단계에서는 GPU 전달 경로만 확인합니다.
 
-## 관측이 가능한 실습 기반을 만듭니다
+## 시나리오 3. GPU metric 수집 경로를 확인합니다
 
-공통 vLLM image와 benchmark client를 build합니다.
+### 이론
+
+관측 경로는 다음 순서입니다.
+
+```text
+nvidia-smi → DCGM Exporter → Prometheus → Grafana
+```
+
+어느 구간이 끊겼는지 분리하려면 DCGM 원본 metric, Prometheus target, Grafana datasource를 순서대로 확인합니다.
+
+### 실습
+
+Benchmark image를 build합니다.
 
 ```bash
 docker compose --profile tools build benchmark
 ```
 
-Prometheus, Grafana, DCGM Exporter를 실행하고 수집 경로를 자동 점검합니다.
+관측 stack을 기동하고 수집 경로를 자동 점검합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
@@ -79,28 +99,30 @@ bash scripts/check_observability.sh
 docker compose ps
 ```
 
+접속 정보:
+
 - Prometheus: `http://127.0.0.1:9090`
 - Grafana: `http://127.0.0.1:3000`
 - Grafana 계정: `admin` / `admin`
-- dashboard: `LLM serving / LLM Serving Chapter 5-6`
+- Dashboard: provisioned LLM serving dashboard
 
-원본 metric을 직접 확인할 때만 다음 명령을 사용합니다.
+원본 metric과 target을 직접 확인합니다.
 
 ```bash
-curl http://127.0.0.1:9090/api/v1/targets
 curl http://127.0.0.1:9400/metrics
+curl http://127.0.0.1:9090/api/v1/targets
 ```
 
-## 판단
+완료 조건:
 
-- host와 container에서 같은 GPU가 보임
-- VRAM 16311MiB 확인
-- Prometheus에서 DCGM Exporter target이 `UP`
+- Host와 container에서 같은 GPU 확인
+- VRAM 16311 MiB 확인
+- Prometheus에서 DCGM Exporter target `UP`
 - Grafana dashboard 접근 가능
 
-이 네 조건을 만족하면 이후 실패를 GPU 연결이 아니라 model·memory·scheduler 문제로 좁힐 수 있습니다.
+이 조건을 만족하면 이후 실패를 GPU 연결이 아니라 model, memory, scheduler 문제로 좁힐 수 있습니다.
 
-## 참고자료
+참고자료:
 
 - [Ubuntu GPU 환경 준비](../01-setup-ubuntu.md)
 - [GPU 실습 troubleshooting](../troubleshooting.md)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
@@ -1,150 +1,122 @@
-# 16GB GPU에서 7B BF16이 OOM 나는 이유를 직접 확인합니다
+# 16GB GPU에서 7B BF16 serving이 실패하는 이유
 
-7B BF16 weight는 약 14.2GiB라서 16GB GPU에 들어갈 것처럼 보입니다. 실제 model load에는 runtime overhead가 필요하고, serving에는 KV cache까지 필요합니다. 이 실습은 계산상 여유가 왜 실제 여유가 아닌지 확인합니다.
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. Weight와 runtime을 포함한 memory budget 계산
+2. 7B BF16 model load OOM 재현
+3. 7B BF16 vLLM 초기화 실패 재현
+4. 3B BF16에서 model load와 KV cache pool 확인
 
-- 선행 실습: [GPU가 보여도 container에서 못 쓰는 이유](./01-gpu-environment.md)
+공통 환경:
+
+- 선행 실습: [Host부터 Grafana까지 GPU 관측 경로 확인](./01-gpu-environment.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. 7B BF16의 memory budget을 계산합니다
 
-```bash
-cd computer_science/ai/study-llmserving/ch5-6
-```
+### 이론
 
-## GPU를 사용하는 기존 process를 먼저 종료합니다
+7B BF16 weight는 약 14.2 GiB입니다. 16GB GPU에 남는 약 1.7 GiB는 CUDA context, allocator, temporary tensor, activation, KV cache에 충분하지 않습니다.
 
-다른 process가 VRAM을 사용하면 OOM 원인이 7B model인지 기존 workload인지 구분할 수 없습니다. Workspace container를 정리하고 남은 GPU compute process를 확인합니다.
-
-```bash
-docker compose --profile "*" down --remove-orphans
-nvidia-smi \
-  --query-compute-apps=pid,process_name,used_gpu_memory \
-  --format=csv,noheader
-```
-
-두 번째 명령이 process를 출력하면 각 PID의 실행 주체를 확인합니다.
-
-```bash
-nvidia-smi \
-  --query-compute-apps=pid,process_name,used_gpu_memory \
-  --format=csv,noheader
-ps -fp <PID>
-cat /proc/<PID>/cgroup
-```
-
-본인이 실행한 일반 process만 정상 종료 신호를 보냅니다.
-
-```bash
-kill -TERM <PID>
-```
-
-Container나 Kubernetes가 관리하는 process는 PID를 직접 종료하지 않습니다. 본인이 실행한 workload를 해당 도구로 종료합니다.
-
-```bash
-docker stop <CONTAINER>
-kubectl scale deployment/<WORKLOAD> --replicas=0 -n <NAMESPACE>
-```
-
-소유자를 모르는 process, Xorg, desktop session은 종료하지 않습니다. 종료 후 기준 상태와 OOM 순간의 hardware metric 수집 경로를 다시 확인합니다.
-
-```bash
-docker compose --profile "*" down --remove-orphans
-nvidia-smi \
-  --query-compute-apps=pid,process_name,used_gpu_memory \
-  --format=csv,noheader
-docker compose --profile observability up -d prometheus grafana dcgm-exporter
-bash scripts/check_observability.sh
-```
-
-Compute process 목록이 비어 있고 관측 경로 점검이 성공해야 실습을 시작합니다. Desktop baseline VRAM과 Grafana 값이 예상과 다르면 [GPU 실습 troubleshooting](../troubleshooting.md)을 확인합니다.
-
-## 먼저 OOM 가설을 계산합니다
-
-Memory budget과 roofline calculator로 실행 전 가설을 만듭니다.
-
-```bash
-docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
-docker compose --profile tools run --rm benchmark python3 -m calculators.roofline
-```
-
-| Precision | 7B weight 근사 | 16GB GPU에서의 가설 |
+| Precision | 7B weight 근사 | 16GB GPU 가설 |
 | --- | ---: | --- |
-| BF16 | 약 14.2GiB | runtime·KV cache 여유 부족 |
-| FP8·INT8 | 약 7.1GiB | 실행 가능하나 KV cache 검증 필요 |
-| INT4 | 약 3.5GiB | batch·context 확장 여유 증가 |
+| BF16 | 약 14.2 GiB | Runtime·KV cache 여유 부족 |
+| FP8·INT8 | 약 7.1 GiB | 실행 가능, KV cache 검증 필요 |
+| INT4 | 약 3.5 GiB | Batch·context 확장 여유 증가 |
 
-여기서 “14.2GiB가 16GB보다 작으니 조금은 남지 않나”라고 묻기 쉽습니다. 남은 공간은 약 1.7GiB뿐이며 CUDA context, allocator, temporary tensor가 먼저 사용합니다. Model이 올라가더라도 request capacity는 거의 남지 않습니다.
+같은 parameter 수라도 KV head 수에 따라 request capacity가 달라집니다.
 
-같은 명령이 attention 구조별 KV 비용도 함께 출력합니다. 같은 16GB에서 4096-token 요청을 몇 개나 받을 수 있는지가 여기서 갈립니다.
-
-| Model | attention | KV heads | KV/token | 요청 수 |
+| Model | Attention | KV heads | KV/token | 4096-token 요청 수 |
 | --- | --- | ---: | ---: | ---: |
 | Llama-2-7B | MHA | 32 | 512 KiB | 0 |
 | Qwen2.5-7B | GQA | 4 | 56 KiB | 1 |
 | Qwen2.5-3B | GQA | 2 | 36 KiB | 61 |
 
-**KV 용량은 parameter 수가 아니라 KV head 수가 정합니다.** 이 계산을 실제 vLLM이 잡는 KV pool과 맞춰보는 것은 [배치와 시퀀스 스윕](./03-kv-cache-batch-sequence.md)에서 합니다.
+### 실습
 
-`calculators.roofline`은 같은 workload가 카드에 따라 compute-bound인지 bandwidth-bound인지 다르게 판정되는 것을 보여줍니다. 축을 읽는 법과 이 카드의 실측 crossover는 [roofline과 병목 재현](./04-roofline-bottleneck.md)에 있습니다.
+Repository root에서 workspace로 이동하고 기존 GPU workload를 정리합니다.
 
-## 7B BF16의 실패를 확인합니다
+```bash
+cd computer_science/ai/study-llmserving/ch5-6
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+```
 
-OOM 시점의 GPU memory를 함께 보기 위해 관측 stack을 실행합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
+
+관측 stack을 실행하고 계산기로 가설을 만듭니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
+bash scripts/check_observability.sh
+docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
+docker compose --profile tools run --rm benchmark python3 -m calculators.roofline
 ```
 
-의도적으로 7B BF16 model load를 시도합니다.
+## 시나리오 2. 7B BF16 model load OOM을 재현합니다
+
+### 이론
+
+Model weight가 nominal VRAM보다 작아도 실제 load에는 CUDA context와 allocator가 필요합니다. OOM 순간의 process allocator 값과 DCGM의 GPU 전체 framebuffer 값은 측정 범위가 다르므로 숫자가 같지 않아도 됩니다.
+
+### 실습
+
+7B BF16 model을 CUDA로 이동합니다.
 
 ```bash
-docker compose --profile tools run --rm model-loader python3 -m model_loader.load_7b_expect_oom
+docker compose --profile tools run --rm \
+  model-loader python3 -m model_loader.load_7b_expect_oom
 ```
 
 - 기대 결과: CUDA OOM
 - 저장 결과: `results/ch5-7b-bf16-oom.json`
-- OOM이 아닌 오류: network·model format·kernel 문제부터 해결
+- OOM이 아닌 오류: network, model format, kernel 문제 확인
+- Grafana: GPU VRAM panel의 최근 5초 최대값 확인
 
-실패 자체가 목적은 아닙니다. 계산한 weight와 실제 GPU memory 사이에 runtime 비용이 존재한다는 가설이 맞는지 확인하는 단계입니다.
+실패 자체보다 계산한 weight와 실제 GPU memory 사이의 runtime 비용을 확인하는 것이 목적입니다.
 
-## 같은 7B BF16을 vLLM으로 기동합니다
+## 시나리오 3. 7B BF16 vLLM 초기화 실패를 재현합니다
 
-앞의 실험은 model을 CUDA로 옮기는 데 필요한 memory만 확인했습니다. Serving engine은 model 외에도 activation을 profiling하고 KV cache pool을 확보해야 합니다.
+### 이론
 
-동시 sequence를 하나로 제한한 가장 작은 serving 설정으로 vLLM 기동을 시도합니다.
+Serving engine은 model load 뒤 activation을 profiling하고 KV cache pool을 확보합니다. vLLM은 기동 시 pool을 미리 만들므로 실행 중 요청으로 KV cache를 채우기 전에 실패할 수 있습니다.
+
+### 실습
+
+동시 sequence를 하나로 제한한 설정으로 vLLM을 기동합니다.
 
 ```bash
 docker compose --profile oom run --rm vllm-7b-bf16-expect-failure
 ```
 
-- 기대 결과: API server가 준비되기 전에 GPU memory 부족으로 종료
-- memory 부족의 형태: CUDA OOM 또는 KV cache pool을 만들 수 없다는 초기화 오류
-- OOM이 아닌 오류: network·model format·kernel 문제부터 해결
+- 기대 결과: API server 준비 전 GPU memory 부족으로 종료
+- 실패 형태: CUDA OOM 또는 KV cache pool 초기화 오류
+- OOM이 아닌 오류: network, model format, kernel 문제 확인
 
-요청을 보내 KV cache를 채운 뒤 OOM을 만드는 실험이 아닙니다. vLLM은 기동할 때 KV pool을 미리 확보하고, 실행 중에는 pool을 넘는 요청을 대기시키거나 preemption합니다. **7B BF16은 요청을 받기 전에 serving 작업 공간부터 확보하지 못한다는 것이 이 단계의 결론입니다.**
+7B BF16은 request를 받기 전에 serving 작업 공간을 확보하지 못합니다.
 
-## 3B BF16에서 남는 공간을 확인합니다
+## 시나리오 4. 3B BF16에서 KV cache pool을 확인합니다
 
-같은 GPU에 더 작은 model을 올려 비교합니다.
+### 이론
+
+Model load 성공과 serving 가능은 다른 조건입니다. Weight와 runtime을 제외한 VRAM에 0보다 큰 KV cache pool을 만들 수 있어야 request를 처리할 수 있습니다.
+
+### 실습
+
+3B BF16 model을 CUDA로 이동합니다.
 
 ```bash
 docker compose --profile tools run --rm model-loader python3 -m model_loader.load_3b
 ```
 
-- 기대 결과: model의 CUDA 이동 성공
+- 기대 결과: CUDA 이동 성공
 - 저장 결과: `results/ch5-3b-bf16-load.json`
 - 확인값: elapsed time, peak allocated VRAM, peak reserved VRAM
-- Grafana: GPU VRAM panel
 
-3B model이 올라갔다는 사실만으로 serving capacity가 결정되지는 않습니다. 남은 VRAM이 KV cache budget이 되고, batch size와 sequence length가 그 budget을 소비합니다.
-
-## 3B BF16은 vLLM serving까지 기동합니다
-
-같은 serving 설정에서 model만 3B로 바꿔 API server와 KV pool이 준비되는지 확인합니다.
+같은 model을 vLLM으로 기동하고 KV cache pool을 확인합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
@@ -152,23 +124,15 @@ bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
 ```
 
-- 기대 결과: health check 성공
-- vLLM log: 0보다 큰 `Available KV cache memory`와 `GPU KV cache size`
-- 의미: weight와 runtime을 제외하고도 실제 요청을 저장할 KV pool 확보
+완료 조건:
 
-여기까지는 KV pool이 생겼다는 사실만 확인합니다. 다음 [KV cache 배치·시퀀스 실습](./03-kv-cache-batch-sequence.md)에서 token당 KV 비용을 계산하고, 동시 요청 수와 prompt 길이로 pool을 직접 채웁니다.
+- Health check 성공
+- `Available KV cache memory`가 0보다 큼
+- `GPU KV cache size`가 0보다 큼
 
-## 판단
+다음 [KV cache 배치·시퀀스 실습](./03-kv-cache-batch-sequence.md)에서 pool 사용률을 metric으로 확인하고 동시 요청과 prompt 길이로 pool을 채웁니다.
 
-- 7B BF16 OOM: weight 외 runtime 공간까지 포함하면 16GB 초과
-- 7B BF16 vLLM 실패: KV pool을 포함한 serving 작업 공간 확보 불가
-- 3B BF16 load 성공: request를 위한 KV cache 여유 확보
-- 3B BF16 vLLM 성공: API server와 KV pool 준비 완료
-- Roofline 결과: long-prefill과 batch 1 decode의 병목 가설 분리
+참고자료:
 
-정리하면, “모델이 들어가는가”와 “요청을 처리할 수 있는가”는 다른 질문입니다. Serving에서는 weight를 뺀 나머지 VRAM이 실제 request capacity이고, vLLM은 그 공간을 기동할 때 KV pool로 확보합니다.
-
-## 참고자료
-
-- [16GB GPU에 7B 모델이 올라가도 serving이 어려운 이유](../02-ch5-theory.md)
+- [Memory와 KV cache 이론](../02-ch5-theory.md)
 - [GPU 실습 troubleshooting](../troubleshooting.md)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
@@ -1,36 +1,25 @@
-# 배치와 시퀀스를 흔들어 KV cache가 실제로 어떻게 차는지 봅니다
+# 배치와 시퀀스에 따라 KV cache가 차는 과정
 
-Chapter 5는 KV cache 크기를 `token당 bytes × 최대 배치 × 최대 시퀀스`로 추정합니다. 이 실습은 그 공식이 얼마나 맞는지 실제 서버에서 확인하고, 어디서부터 어긋나는지, 어긋나는 이유가 무엇인지 봅니다. 결론부터 말하면 공식은 정확하지만 **적용 범위가 따로 있습니다.**
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. Attention 구조로 token당 KV cache 크기 계산
+2. vLLM metric으로 KV cache pool과 사용률 확인
+3. 동시 요청 수와 prompt 길이를 늘려 scheduler 제한 확인
+4. `max_num_seqs`를 높여 KV cache 제한 확인
+5. GPU memory 예산과 context 길이로 동시성 조정
+
+공통 환경:
 
 - 선행 실습: [16GB GPU에서 7B BF16이 OOM 나는 이유](./02-memory-budget-oom.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 - Model: Qwen2.5-3B-Instruct BF16, `max-model-len 4096`
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. Attention 구조로 token당 KV cache 크기를 계산합니다
 
-```bash
-cd computer_science/ai/study-llmserving/ch5-6
-```
+### 이론
 
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
-docker compose --profile "*" down --remove-orphans
-nvidia-smi \
-  --query-compute-apps=pid,process_name,used_gpu_memory \
-  --format=csv,noheader
-```
-
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
-
-## 1. 먼저 token 하나의 비용을 구합니다
-
-Model config에서 네 값만 있으면 됩니다.
+KV cache의 token당 크기는 parameter 수가 아니라 layer 수, KV head 수, head dimension, dtype으로 결정됩니다.
 
 ```text
 KV bytes/token = 2 × layers × KV heads × head dimension × dtype bytes
@@ -42,37 +31,88 @@ Qwen2.5-3B-Instruct는 layers 36, KV heads 2, head dimension 128, BF16입니다.
 2 × 36 × 2 × 128 × 2 = 36,864 bytes = 36 KiB
 ```
 
-책 예제의 Llama-2-7B는 같은 계산으로 **512 KiB**가 나옵니다. 14배 차이입니다. parameter 수가 2배 차이인데 KV는 14배 차이가 나는 이유는 KV head 수에 있습니다. Llama-2-7B는 attention head 32개마다 KV head도 32개인 MHA이고, Qwen2.5-3B는 attention head 16개가 KV head 2개를 나눠 쓰는 GQA입니다.
+MHA는 attention head마다 KV head를 두고, GQA는 여러 attention head가 적은 KV head를 공유합니다. 따라서 비슷한 parameter 수라도 attention 구조에 따라 KV cache 크기가 크게 달라집니다.
 
-```bash
-docker compose --profile tools build benchmark
-docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
-docker compose --profile tools run --rm benchmark python3 -m calculators.roofline
-```
-
-| Model | attention | KV heads | KV/token | 같은 16GB에서 4096-token 요청 |
+| Model | Attention | KV heads | KV/token | 같은 16GB에서 4096-token 요청 |
 | --- | --- | ---: | ---: | ---: |
 | Llama-2-7B | MHA | 32 | 512 KiB | 0개 |
 | Qwen2.5-3B | GQA | 2 | 36 KiB | 약 61개 |
 
-**KV cache 용량은 모델 크기가 아니라 attention 구조가 결정합니다.**
+### 실습
 
-## 2. 공식을 뒤집으면 vLLM의 자체 계산과 맞습니다
+Repository root에서 workspace로 이동하고 기존 GPU workload를 정리합니다.
 
-vLLM은 기동할 때 KV pool을 미리 잡고 그 크기를 log에 남깁니다.
+```bash
+cd computer_science/ai/study-llmserving/ch5-6
+docker compose --profile "*" down --remove-orphans
+nvidia-smi \
+  --query-compute-apps=pid,process_name,used_gpu_memory \
+  --format=csv,noheader
+```
 
-02번에서 실행한 3B BF16 server가 내려갔다면 다시 기동하고 health check를 확인합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
+
+계산기를 실행해 model별 KV 비용을 비교합니다.
+
+```bash
+docker compose --profile tools build benchmark
+docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
+```
+
+## 시나리오 2. vLLM metric으로 KV cache를 확인합니다
+
+### 이론
+
+vLLM은 기동할 때 KV cache pool을 미리 확보합니다. 요청이 사용하는 block 비율과 pool 구조를 `/metrics`에서 확인할 수 있습니다.
+
+| Metric | 확인값 | 해석 |
+| --- | --- | --- |
+| `vllm:kv_cache_usage_perc` | 사용 중인 block 비율, `1`이 100% | 현재 pool 점유율 |
+| `vllm:cache_config_info` | `num_gpu_blocks`, `block_size` label | pool이 담는 전체 token 수 계산 |
+| `vllm:num_requests_running` | 실행 중인 request 수 | KV block을 할당받은 request 확인 |
+| `vllm:num_requests_waiting` | 대기 request 수 | scheduler 또는 memory 제한 확인 |
+| `DCGM_FI_DEV_FB_USED` | GPU 전체 framebuffer 사용량 | weight·runtime·KV cache를 합친 VRAM 확인 |
+
+`vllm:kv_cache_usage_perc`는 KV cache pool의 block 점유율입니다. KV cache가 차지한 VRAM byte나 request별 사용량을 직접 반환하지는 않습니다.
+
+Pool token 수와 이론상 byte는 다음처럼 계산합니다.
+
+```text
+pool tokens = num_gpu_blocks × block_size
+pool bytes = pool tokens × KV bytes/token
+```
+
+### 실습
+
+Server와 관측 stack을 기동합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
+docker compose --profile observability up -d prometheus grafana dcgm-exporter
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 ```
+
+vLLM 원본 metric을 확인합니다.
+
+```bash
+curl -s http://127.0.0.1:8000/metrics \
+  | grep -E 'vllm:(kv_cache_usage_perc|cache_config_info|num_requests_(running|waiting))'
+```
+
+Prometheus에서 현재 KV cache 사용률을 percent로 조회합니다.
+
+```bash
+curl -sG http://127.0.0.1:9090/api/v1/query \
+  --data-urlencode 'query=max(vllm:kv_cache_usage_perc) * 100'
+```
+
+vLLM log의 pool 계산도 확인합니다.
 
 ```bash
 docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
 ```
 
-실제 출력입니다.
+실측 예시입니다.
 
 ```text
 Available KV cache memory: 6.76 GiB
@@ -80,43 +120,36 @@ GPU KV cache size: 196,896 tokens
 Maximum concurrency for 4,096 tokens per request: 48.07x
 ```
 
-여기에 1절의 36,864 bytes를 곱해 봅니다.
+위 값은 token당 36,864 bytes 계산과 일치합니다.
 
 ```text
-196,896 tokens × 36,864 B = 6.76 GiB      (vLLM: 6.76 GiB)
-196,896 ÷ 4,096            = 48.07         (vLLM: 48.07x)
+196,896 tokens × 36,864 B = 6.76 GiB
+196,896 ÷ 4,096            = 48.07
 ```
 
-소수점까지 같습니다. 책의 공식과 vLLM이 같은 산수를 하고 있고, 방향만 반대입니다. 책은 "이만큼 필요하다"를 구하고, vLLM은 "이만큼 잡았으니 이만큼 담긴다"를 구합니다.
+## 시나리오 3. Scheduler 제한이 KV cache 사용률을 멈추는지 확인합니다
 
-VRAM 전체가 어떻게 갈라지는지도 여기서 맞춰볼 수 있습니다.
+### 이론
 
-| 항목 | `utilization 0.9` | `utilization 0.85` |
-| --- | ---: | ---: |
-| GPU 전체 | 15.93 GiB | 15.93 GiB |
-| 적용 예산 | 14.34 GiB | 13.54 GiB |
-| model weight | 5.79 GiB | 5.79 GiB |
-| KV pool | 6.76 GiB | 5.95 GiB |
-| 나머지 (activation, CUDA graph, allocator) | 약 1.79 GiB | 약 1.80 GiB |
-| 4096-token 요청 최대 동시성 | 48.07 | 42.32 |
+KV cache 공식은 scheduler에 admit되어 block을 할당받은 request에만 적용됩니다. 대기 request는 KV cache를 사용하지 않습니다.
 
-`gpu-memory-utilization`을 0.05만 내렸는데 KV pool이 0.81 GiB 줄고 최대 동시성이 6 감소합니다. weight와 나머지는 고정이라 **줄어든 예산이 통째로 KV pool에서 빠지기 때문입니다.** 이 workspace의 기본값은 0.85인데, 이유는 아래 6절에 있습니다.
+```text
+실제 최대 동시 request = min(max_num_seqs, KV pool이 수용하는 request 수)
+```
 
-계산기가 예측한 batch 61과 vLLM의 48 차이가 바로 이 "나머지"와 10% 여유분입니다. **weight만 계산하면 안 되는 이유가 이 표에 다 있습니다.**
+KV cache 사용률이 낮은데 `running`이 고정되고 `waiting`이 증가하면 memory가 아니라 `max_num_seqs`가 제한입니다.
 
-## 3. 배치와 시퀀스를 흔듭니다
+### 실습
 
-동시 요청 수와 prompt 길이를 바꿔가며, 공식이 예측한 pool 점유율과 서버가 보고하는 실제 점유율을 나란히 놓습니다.
+`max_num_seqs 8`에서 동시성과 prompt 길이를 변경합니다.
 
 ```bash
-docker compose --profile tools build benchmark
-docker compose --profile observability up -d prometheus grafana dcgm-exporter
 docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_probe
 ```
 
-`max_num_seqs 8` 기본 설정에서의 결과입니다.
+실측 예시입니다.
 
-| 동시성 | prompt | running | waiting | 예측 KV% | 실측 KV% | TTFT p95 | TPOT p50 | Output TPS |
+| 동시성 | Prompt | Running | Waiting | 예측 KV% | 실측 KV% | TTFT p95 | TPOT p50 | Output TPS |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 | 1 | 256 | 1 | 0 | 0.20% | 0.21% | 74 ms | 15.9 ms | 60 |
 | 4 | 256 | 4 | 0 | 0.78% | 0.81% | 184 ms | 15.9 ms | 229 |
@@ -126,124 +159,90 @@ docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_
 | 32 | 2048 | 8 | 27 | 35.36% | **8.93%** | 15,584 ms | 26.3 ms | 229 |
 | 48 | 2048 | 8 | 43 | 53.05% | **8.93%** | 23,908 ms | 28.3 ms | 229 |
 
-## 4. 위 표에서 읽어야 할 네 가지
+확인할 패턴:
 
-### 공식은 맞습니다, 단 admit된 요청에만
+- 동시성 8까지 예측과 실측 KV 사용률이 일치
+- 동시성 8 이후 `running`과 KV 사용률이 고정
+- 추가 request는 `waiting`과 TTFT를 증가시킴
+- Output TPS는 거의 고정되고 TPOT는 완만하게 증가
 
-위 네 줄에서 예측과 실측이 소수점 둘째 자리까지 붙습니다. 아래 세 줄에서 예측만 계속 올라가고 실측은 8.9%에 멈춥니다. **대기 중인 요청은 KV cache를 한 byte도 쓰지 않기 때문입니다.** scheduler에 admit되어야 block이 할당됩니다.
+Grafana의 `KV pool occupancy vs admitted requests` panel에서 KV pool used %, running, waiting을 같은 시간축으로 확인합니다.
 
-그래서 실측 점유율이 예측보다 낮을 때 "메모리가 남는다"고 읽으면 안 됩니다. 오히려 **scheduler가 막고 있다**는 신호입니다.
+## 시나리오 4. Scheduler 제한을 높여 KV cache 제한에 접근합니다
 
-### 최대 배치 크기는 둘 중 낮은 쪽입니다
+### 이론
 
-`running`이 8에서 더 올라가지 않습니다. `max_num_seqs 8`이 천장이기 때문입니다. KV pool은 8.9%밖에 안 찼으니 메모리는 한참 남았습니다.
+`max_num_seqs`를 높이면 더 많은 request가 KV block을 할당받습니다. 같은 weight 읽기를 여러 request가 공유해 처리량은 늘지만, request별 token 간격과 KV cache 사용량도 증가할 수 있습니다.
 
-```text
-실제 최대 배치 = min(max_num_seqs, KV pool이 담을 수 있는 요청 수)
-```
+### 실습
 
-이 설정에서는 앞쪽이, `max_num_seqs`를 충분히 올리면 뒤쪽이 천장이 됩니다. **어느 쪽이 천장인지 모르면 엉뚱한 knob을 돌리게 됩니다.**
-
-### 늘어난 부하는 전부 TTFT로 갑니다
-
-동시성을 8에서 48로 6배 올렸는데 Output TPS는 229에서 그대로입니다. 처리량이 1도 늘지 않았습니다. 대신 TTFT p95가 2.2초에서 **23.9초**가 됐습니다.
-
-`waiting`이 43이라는 것은 43개 요청이 아무 일도 못 하고 줄 서 있다는 뜻이고, 그 대기 시간이 통째로 TTFT에 들어갑니다. 이것이 TTFT를 latency SLO의 대표로 쓰는 이유입니다. 사용자가 겪는 것은 GPU 사용률이 아니라 이 24초입니다.
-
-### TPOT는 거의 움직이지 않습니다
-
-TTFT가 300배 흔들리는 동안 TPOT는 15.9 ms에서 28.3 ms로 완만하게만 늘었습니다. 두 지표는 서로 다른 것을 재고 있습니다. TTFT는 prefill과 queue를, TPOT는 token 하나를 만드는 비용을 잽니다.
-
-짧은 prompt에서 TPOT 15.9 ms는 초당 62.9 token이고, 이 값은 [04번 실습](./04-roofline-bottleneck.md)에서 memory bandwidth로 계산한 이론 상한 62.1 token/s와 거의 같습니다. **decode가 대역폭에 붙어 있다는 증거입니다.**
-
-## 5. 천장을 옮기면 공식이 다시 맞습니다
-
-앞의 어긋남이 정말 scheduler 때문이었는지 확인하려면 천장만 옮겨 보면 됩니다. `max_num_seqs`를 64로 올리고 같은 스윕을 돌립니다.
+`max_num_seqs`를 64로 높이고 같은 sweep을 실행합니다.
 
 ```bash
 VLLM_MAX_NUM_SEQS=64 docker compose --profile bf16 up -d --force-recreate vllm-bf16
 docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_probe
 ```
 
-이 설정에서는 `gpu-memory-utilization`이 0.85라 pool이 173,328 tokens(5.95 GiB)로 조금 작아집니다. 예측값은 그 pool 기준입니다.
+실측 예시입니다.
 
-| 동시성 | prompt | running | 예측 KV% | 실측 KV% | TTFT p95 | TPOT p50 | Output TPS |
+| 동시성 | Prompt | Running | 예측 KV% | 실측 KV% | TTFT p95 | TPOT p50 | Output TPS |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 1 | 256 | 1 | 0.22% | 0.23% | 346 ms | 16.0 ms | 53 |
-| 4 | 256 | 4 | 0.89% | 0.92% | 193 ms | 15.8 ms | 229 |
-| 8 | 256 | 8 | 1.77% | 1.85% | 353 ms | 16.0 ms | 423 |
 | 8 | 2048 | 8 | 10.04% | 10.12% | 2,268 ms | 21.9 ms | 227 |
-| 16 | 2048 | **16** | 20.09% | **20.25%** | 4,547 ms | 32.2 ms | 293 |
-| 32 | 2048 | **32** | 40.17% | **40.29%** | 8,923 ms | 53.9 ms | 340 |
-| 48 | 2048 | **48** | 60.26% | **60.34%** | 13,493 ms | 78.2 ms | 351 |
+| 16 | 2048 | 16 | 20.09% | 20.25% | 4,547 ms | 32.2 ms | 293 |
+| 32 | 2048 | 32 | 40.17% | 40.29% | 8,923 ms | 53.9 ms | 340 |
+| 48 | 2048 | 48 | 60.26% | 60.34% | 13,493 ms | 78.2 ms | 351 |
 
-`running`이 이제 동시성을 그대로 따라가고, **예측과 실측이 모든 행에서 다시 붙습니다.** 앞 절의 어긋남은 공식이 틀려서가 아니라 admit되지 않은 요청을 세었기 때문이라는 것이 확인됩니다.
+동시성 48, prompt 2048 조건을 비교합니다.
 
-### 같은 부하, 다른 설정의 대가
-
-두 설정을 같은 부하(동시성 48, prompt 2048)에서 비교합니다.
-
-| | `max_num_seqs 8` | `max_num_seqs 64` |
+| Metric | `max_num_seqs 8` | `max_num_seqs 64` |
 | --- | ---: | ---: |
-| Output TPS | 229 | **351** (+53%) |
-| TPOT p50 | 28.3 ms | **78.2 ms** (2.8배) |
+| Output TPS | 229 | **351** |
+| TPOT p50 | 28.3 ms | **78.2 ms** |
 | TTFT p95 | 23.9 s | **13.5 s** |
-| KV pool 점유 | 8.9% | 60.3% |
+| KV pool 점유율 | 8.9% | **60.3%** |
 
-batch를 크게 잡으면 같은 weight 읽기를 더 많은 요청이 나눠 쓰므로 처리량이 오릅니다. 대신 한 요청이 GPU를 독점하는 시간이 줄어 **token 하나가 나오는 간격이 2.8배로 늘어납니다.**
+Throughput과 token latency는 같은 scheduler 설정의 trade-off입니다. Latency SLO를 만족하는 범위에서 동시성을 선택합니다.
 
-**처리량과 token 지연은 같은 knob의 양쪽 끝입니다.** 어느 쪽을 고를지는 SLO가 정합니다. 채팅처럼 사람이 읽는 속도가 중요하면 TPOT를, 배치 처리처럼 총량이 중요하면 Output TPS를 지킵니다.
+## 시나리오 5. GPU memory 예산과 context 길이로 동시성을 조정합니다
 
-## 6. gpu-memory-utilization은 전체 VRAM 기준입니다
+### 이론
 
-이 실습을 desktop이 떠 있는 machine에서 하면 이 오류를 만날 수 있습니다.
+`gpu-memory-utilization`은 현재 여유 VRAM이 아니라 전체 VRAM에 적용됩니다. 값을 낮추면 model weight와 runtime 영역보다 KV pool이 먼저 줄어듭니다.
 
-```text
-ValueError: Free memory on device cuda:0 (13.83/15.45 GiB) on startup is less
-than desired GPU memory utilization (0.9, 13.9 GiB).
-```
+| 항목 | `utilization 0.9` | `utilization 0.85` |
+| --- | ---: | ---: |
+| 적용 예산 | 14.34 GiB | 13.54 GiB |
+| Model weight | 5.79 GiB | 5.79 GiB |
+| KV pool | 6.76 GiB | 5.95 GiB |
+| 4096-token 최대 동시성 | 48.07 | 42.32 |
 
-Xorg와 gnome-shell이 VRAM을 약 1.6 GiB 쓰고 있어 여유가 13.83 GiB인데, `0.9`는 여유가 아니라 **전체 15.45 GiB에 곱해져** 13.9 GiB를 요구합니다. 0.07 GiB 차이로 기동이 실패합니다.
+Context 길이는 request 하나가 pool을 소비하는 속도를 정합니다. 같은 동시성 8에서도 prompt가 256에서 2048로 늘면 실측 KV 사용률이 1.56%에서 8.91%로 증가합니다.
 
-이 workspace는 값을 환경변수로 받고 기본값을 `0.85`로 둡니다.
+### 실습
+
+Desktop process 때문에 기본 설정으로 기동할 수 없으면 전체 VRAM 기준 예산을 낮춥니다.
 
 ```bash
-VLLM_GPU_MEMORY_UTILIZATION=0.85 docker compose --profile bf16 up -d vllm-bf16
+VLLM_GPU_MEMORY_UTILIZATION=0.85 docker compose --profile bf16 up -d --force-recreate vllm-bf16
 ```
 
-같은 값을 headless server에 쓰면 KV pool이 그만큼 작아지므로, 결과를 비교할 때는 이 값을 반드시 함께 적어야 합니다. **"GPU 사용률을 100%로 올리면 되지 않나"에 대한 실물 답이 이 오류입니다.**
+다음 세 값을 함께 기록합니다.
 
-## 7. 시퀀스 길이는 pool을 쓰는 속도를 바꿉니다
+- `VLLM_GPU_MEMORY_UTILIZATION`
+- `max-model-len`
+- `vllm:cache_config_info`의 `num_gpu_blocks`, `block_size`
 
-동시성 8을 고정하고 prompt만 256에서 2048로 늘리면 실측 KV가 1.56%에서 8.91%로 늘어납니다. 요청 수는 그대로인데 각 요청이 차지하는 자리가 길어졌기 때문입니다.
+정리:
 
-`--max-model-len`은 이 자리의 상한을 정합니다. 이 값을 올리면 요청 하나가 최악의 경우 차지할 수 있는 자리가 커지고, vLLM이 계산하는 최대 동시성이 그만큼 줄어듭니다. 위 log의 `Maximum concurrency ... 48.07x`가 4,096을 기준으로 나온 값이라, `max-model-len`을 2,048로 줄이면 96배로 늘어납니다.
+- KV/token은 attention 구조가 결정합니다.
+- KV cache 사용률은 `vllm:kv_cache_usage_perc`로 직접 확인할 수 있습니다.
+- Pool 크기는 `vllm:cache_config_info`와 token당 KV byte로 계산할 수 있습니다.
+- 대기 request는 KV cache를 사용하지 않습니다.
+- 최대 동시성은 scheduler 제한과 KV pool 제한 중 작은 값입니다.
+- Context 길이와 동시성을 늘리면 KV cache 사용률과 latency가 함께 변합니다.
 
-**긴 context를 지원하는 비용은 GPU 메모리가 아니라 동시 사용자 수로 지불됩니다.**
+참고자료:
 
-## 8. Grafana에서 같은 장면을 봅니다
-
-`KV pool occupancy vs admitted requests` panel이 세 선을 한 화면에 그립니다.
-
-| 선 | 무엇을 보나 |
-| --- | --- |
-| KV pool used % | 실제로 캐시된 양 |
-| running | admit되어 GPU를 쓰는 요청 수 |
-| waiting | 줄 서 있는 요청 수 |
-
-`running`이 평평해지고 `waiting`이 올라가기 시작하는 지점이 이 workload의 실제 최대 배치 크기입니다. 그때 KV pool used %가 낮으면 `max_num_seqs`가, 높으면 메모리가 천장입니다.
-
-## 정리
-
-- KV/token은 attention 구조가 정한다. GQA와 MHA는 같은 GPU에서 용량이 십수 배 다르다.
-- 책의 공식과 vLLM의 pool 계산은 같은 산수이고 방향만 반대다.
-- 공식은 admit된 요청에만 적용된다. 대기 요청은 KV를 쓰지 않는다.
-- 최대 배치는 `max_num_seqs`와 pool 용량 중 낮은 쪽이다.
-- 천장을 넘은 부하는 처리량이 아니라 TTFT로 나타난다.
-- 천장을 올리면 처리량이 오르는 대신 token 지연이 늘어난다. 어느 쪽을 지킬지는 SLO가 정한다.
-
-## 참고자료
-
-- *Hands-On LLM Serving and Optimization*, Chapter 5
-- [Chapter 5 이론](../02-ch5-theory.md)
-- [metric 해석](../prometheus.md)
+- [Memory와 KV cache 이론](../02-ch5-theory.md)
+- [Metric 해석](../prometheus.md)
+- [vLLM v0.27.1 metrics](https://docs.vllm.ai/en/v0.27.1/usage/metrics/)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
@@ -1,53 +1,51 @@
-# 내 GPU의 crossover를 직접 재고 병목을 일부러 만들어 봅니다
+# GPU roofline을 측정하고 병목 재현
 
-책은 L40S의 사양표로 roofline을 그립니다. 사양표는 카드마다 다르고, 실제로 나오는 값은 사양표보다 낮습니다. 이 실습은 지금 꽂혀 있는 카드에서 peak 연산 성능과 memory bandwidth를 **직접 재서** roofline을 그리고, 그 위에 prefill과 decode를 올려놓습니다. 그다음 대역폭 병목과 연산 병목을 일부러 만들어 두 상황을 구분하는 방법을 확인합니다.
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. GPU의 peak BF16 성능과 memory bandwidth 측정
+2. Arithmetic intensity와 crossover로 workload 분류
+3. Decode와 prefill 병목 재현
+4. GPU metric의 병목 판별 한계 확인
 
-- 선행 실습: [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./03-kv-cache-batch-sequence.md)
+공통 환경:
+
+- 선행 실습: [KV cache 배치·시퀀스 실습](./03-kv-cache-batch-sequence.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
-- 이론: [16GB GPU에 7B 모델이 올라가도 serving이 어려운 이유](../02-ch5-theory.md)
+- 이론: [Memory와 roofline 이론](../02-ch5-theory.md)
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. GPU의 roofline 천장을 측정합니다
+
+### 이론
+
+Roofline은 workload의 arithmetic intensity와 hardware 상한을 겹쳐 병목 방향을 찾습니다.
+
+| 축 | 단위 | 의미 |
+| --- | --- | --- |
+| x | FLOPS/Byte | 1 byte를 옮길 때 수행하는 연산 수 |
+| y | TFLOPS | 해당 intensity에서 hardware가 낼 수 있는 연산 속도 |
+
+Roofline이 꺾이는 crossover는 다음처럼 계산합니다.
+
+```text
+crossover = peak FLOPS ÷ memory bandwidth
+```
+
+### 실습
+
+Workspace로 이동하고 기존 GPU workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-## 1. 축이 무엇인지부터 고정합니다
-
-Roofline 그래프를 처음 보면 축을 읽는 것부터 막힙니다. 두 축은 서로 다른 것을 잽니다.
-
-| 축 | 단위 | 무엇인가 |
-| --- | --- | --- |
-| x | FLOPS/Byte | **workload의 성질**. 1 byte를 옮길 때 연산을 몇 번 하는가 |
-| y | TFLOPS | **hardware의 상한**. 그 x에서 최대로 낼 수 있는 연산 속도 |
-
-x는 GPU를 바꿔도 변하지 않습니다. 행렬 크기가 정하기 때문입니다. y의 천장만 GPU에 따라 달라집니다. 그래서 "이 workload는 x가 얼마인가"와 "이 카드의 천장은 어디서 꺾이는가"를 따로 구한 뒤 겹쳐 보는 것이 roofline입니다.
-
-꺾이는 지점이 crossover이고 계산은 나눗셈 하나입니다.
-
-```text
-crossover = peak FLOPS ÷ memory bandwidth
-```
-
-## 2. 이 카드의 천장을 잽니다
-
-사양표를 믿지 않고 측정합니다. 큰 정사각 행렬 곱으로 peak 연산 성능을, 큰 device 복사로 memory bandwidth를 잽니다.
+큰 행렬 곱으로 peak BF16 성능을, device 복사로 memory bandwidth를 측정합니다.
 
 ```bash
 docker compose --profile tools build benchmark
@@ -55,132 +53,126 @@ docker compose --profile tools run --rm gpu-probe
 docker compose --profile tools run --rm benchmark python3 -m calculators.plot_roofline
 ```
 
-측정 결과입니다.
+실측 예시:
 
-| 항목 | L40S (책 사양표) | RTX 5060 Ti (실측) |
-| --- | ---: | ---: |
-| peak BF16 | 362 TFLOPS | 50.3 TFLOPS |
-| memory bandwidth | 864 GB/s | 384 GB/s |
-| **crossover** | **419 FLOPS/B** | **131 FLOPS/B** |
+| 항목 | RTX 5060 Ti 실측 |
+| --- | ---: |
+| Peak BF16 | 50.3 TFLOPS |
+| Memory bandwidth | 384 GB/s |
+| Crossover | 131 FLOPS/B |
 
-crossover가 131이라는 것은 이 카드가 연산 성능 대비 대역폭이 상대적으로 덜 부족하다는 뜻입니다. 결과적으로 **책보다 짧은 prompt에서도 compute-bound로 넘어갑니다.**
+그래프는 `results/roofline.png`에 저장됩니다.
 
-`results/roofline.png`에 그래프가 저장됩니다. 검은 선이 천장이고 점이 실제 측정값입니다.
+## 시나리오 2. Workload를 compute-bound와 bandwidth-bound로 분류합니다
 
-## 3. 같은 workload가 카드에 따라 다르게 판정됩니다
+### 이론
 
-Projection 연산을 `[s, h] × [h, h]`로 두고 계산기를 돌립니다.
+Arithmetic intensity는 행렬 크기가 정하고, crossover는 GPU가 정합니다. 같은 workload도 GPU의 crossover에 따라 판정이 달라질 수 있습니다.
+
+Decode는 token 하나를 생성할 때 `[1, h] × [h, h]` projection을 반복하므로 intensity가 낮습니다. 긴 prompt의 prefill은 큰 행렬 연산으로 intensity가 올라갑니다.
+
+Roofline은 상한 모델입니다. Kernel launch, cache hit, scheduler, thermal 상태를 포함한 latency 예측기는 아닙니다.
+
+### 실습
+
+Projection workload의 intensity를 계산합니다.
 
 ```bash
 docker compose --profile tools run --rm benchmark python3 -m calculators.memory_budget
 docker compose --profile tools run --rm benchmark python3 -m calculators.roofline
 ```
 
-책 예제와 맞추기 위해 hidden size 4096으로 계산한 값입니다. [이론 문서](../02-ch5-theory.md)의 표는 이 workspace가 실제로 서빙하는 Qwen2.5-3B의 2048 기준이라 같은 sequence 길이라도 값이 다릅니다.
+Hidden size 4096 기준 예시입니다.
 
-| sequence 길이 | intensity | L40S 판정 | RTX 5060 Ti 판정 |
-| ---: | ---: | --- | --- |
-| 1 (decode) | 1.0 | memory bandwidth-bound | memory bandwidth-bound |
-| 64 | 62.1 | memory bandwidth-bound | memory bandwidth-bound |
-| 512 | 409.6 | memory bandwidth-bound | **compute-bound** |
-| 4096 | 1365.3 | compute-bound | compute-bound |
+| Sequence 길이 | Intensity | Crossover 131 기준 판정 |
+| ---: | ---: | --- |
+| 1 | 1.0 | Memory bandwidth-bound |
+| 64 | 62.1 | Memory bandwidth-bound |
+| 512 | 409.6 | Compute-bound |
+| 4096 | 1365.3 | Compute-bound |
 
-`s=512` 행에서 판정이 뒤집힙니다. intensity는 두 카드에서 똑같이 409.6인데 천장의 위치가 다르기 때문입니다. **"prefill은 compute-bound"라는 문장은 카드를 말하지 않으면 반쪽짜리입니다.**
+작은 행렬이 roofline 상한보다 느린 것은 kernel launch overhead가 상대적으로 크기 때문입니다.
 
-decode 행이 sequence 길이와 무관하게 1.0으로 고정되는 것이 이 장의 결론입니다. 몇 번째 token을 만들든 그 순간의 행렬은 항상 `[1, h] × [h, h]`입니다.
+## 시나리오 3. Decode와 prefill 병목을 재현합니다
 
-## 4. Roofline이 맞히지 못하는 것도 봅니다
+### 이론
 
-그래프에서 작은 행렬(64, 128, 256)은 천장에서 한참 아래에 찍힙니다.
-
-| 행렬 크기 | intensity | 천장이 허용하는 값 | 실측 |
-| ---: | ---: | ---: | ---: |
-| 64 | 21.3 | 8.2 TFLOPS | 0.02 TFLOPS |
-| 512 | 170.7 | 50.3 TFLOPS | 9.36 TFLOPS |
-| 4096 | 1365.3 | 50.3 TFLOPS | 46.16 TFLOPS |
-
-작은 행렬은 계산 자체가 수십 마이크로초라 kernel을 띄우는 비용이 전부를 차지합니다. 대역폭 때문에 느린 것이 아닙니다. **Roofline은 상한선이지 latency 예측기가 아닙니다.** 이 구분을 놓치면 "roofline이 틀렸다"는 결론으로 갑니다.
-
-## 5. Decode의 이론 상한을 계산합니다
-
-병목을 지표로 추측하는 대신 산수로 못박을 수 있는 지점이 하나 있습니다. batch 1에서 token 하나를 만들려면 **model weight 전체를 한 번 읽어야** 합니다. 그러면 상한이 나옵니다.
+Batch 1 decode에서 token 하나를 만들려면 model weight 전체를 읽어야 합니다. 따라서 memory bandwidth로 token 생성 상한을 근사할 수 있습니다.
 
 ```text
 batch 1 decode 상한(token/s) = memory bandwidth ÷ weight bytes
 ```
 
-Qwen2.5-3B BF16의 weight는 vLLM이 보고한 값으로 5.79 GiB입니다.
+Qwen2.5-3B BF16의 weight가 5.79 GiB이면 다음 값이 나옵니다.
 
 ```text
 384 GB/s ÷ 6.18 GB = 약 62 token/s
 ```
 
-이 숫자가 중요한 이유는, 실측 token 생성 속도가 여기에 가깝게 붙으면 **대역폭 병목이라는 것이 추측이 아니라 증명**이 되기 때문입니다. 연산을 아무리 빠르게 만들어도 이 선을 넘을 수 없습니다.
+Batching은 한 번 읽은 weight를 여러 request가 공유해 전체 처리량을 높입니다.
 
-넘는 방법은 하나뿐입니다. weight를 한 번 읽어서 여러 요청이 나눠 쓰는 것, 곧 batching입니다. Chapter 6가 여기서 시작합니다.
+### 실습
 
-## 6. 병목 두 개를 일부러 만듭니다
-
-vLLM을 띄우고 서로 반대쪽에 있는 workload를 던집니다.
+Server와 관측 stack을 기동하고 네 workload를 실행합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
-docker compose --profile tools build benchmark
 docker compose --profile tools run --rm \
   -e MEASURED_BANDWIDTH_GBPS=384 \
   benchmark python3 -m benchmark.bottleneck_probe
 ```
 
-실험이 만드는 네 상황입니다.
-
-| 시나리오 | 동시성 | prompt | 생성 | 노리는 것 |
+| 시나리오 | 동시성 | Prompt | 생성 | 목표 |
 | --- | ---: | ---: | ---: | --- |
-| decode-bound | 1 | 32 | 512 | 시간 대부분이 decode. 대역폭 병목 |
-| decode-bound-batched | 16 | 32 | 512 | 같은 decode를 batch로 나눠 쓰기 |
-| prefill-bound | 8 | 3584 | 1 | 시간 대부분이 prefill. 연산 병목 |
-| mixed | 8 | 512 | 128 | 실제 chat에 가까운 혼합 |
+| Decode-bound | 1 | 32 | 512 | Batch 1 bandwidth 상한 확인 |
+| Batched decode | 16 | 32 | 512 | Weight read 공유 확인 |
+| Prefill-bound | 8 | 3584 | 1 | Compute pressure 확인 |
+| Mixed | 8 | 512 | 128 | 혼합 workload 확인 |
 
-실측 결과입니다.
+실측 예시:
 
-| 시나리오 | 요청당 token/s | 이론 상한 대비 | 전체 Output TPS | GPU util | Memory util |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| decode-bound (동시성 1) | 62.5 | **1.01** | 62 | – | – |
-| decode-bound-batched (동시성 16) | 59.7 | 0.96 | **955** | 25% | 24% |
-| prefill-bound (prompt 3584) | – | – | – | 100% | 96% |
-| mixed | 48.1 | 0.77 | 385 | 100% | 96% |
+| 시나리오 | 요청당 token/s | 이론 상한 대비 | 전체 Output TPS |
+| --- | ---: | ---: | ---: |
+| Decode-bound | 62.5 | 1.01 | 62 |
+| Batched decode | 59.7 | 0.96 | 955 |
 
-첫 두 줄이 이 실습의 핵심입니다. **동시성을 1에서 16으로 올려도 요청 하나의 속도는 62.5에서 59.7로 거의 그대로인데, 전체 처리량은 62에서 955로 15배가 됩니다.** 같은 weight 읽기를 16개 요청이 나눠 썼기 때문입니다. 대역폭 병목을 우회하는 방법이 batching이라는 것이 이 두 줄에 있습니다.
+요청당 속도는 비슷하지만 전체 처리량은 약 15배 증가합니다. 상한과 1% 정도 차이는 L2 cache 재사용과 bandwidth 측정 방식에서 생길 수 있습니다.
 
-상한 대비 1.01은 측정값이 이론값을 1% 넘었다는 뜻입니다. 일부 weight가 L2에 남아 재사용되거나, 복사로 잰 대역폭이 순수 읽기 대역폭을 조금 낮게 잡았기 때문으로 볼 수 있습니다. **이 상한은 법칙이 아니라 근사 모델입니다.** 다만 1% 오차로 맞는 근사라면 병목을 지목하는 근거로는 충분합니다.
+## 시나리오 4. GPU metric만으로 병목을 구분할 수 있는지 확인합니다
 
-## 7. MEM_COPY_UTIL로 구분하려 했지만 실패했습니다
+### 이론
 
-`DCGM_FI_DEV_GPU_UTIL`은 "SM에 할 일이 배정된 시간 비율"이라 데이터를 기다리며 멈춰 있어도 올라갑니다. 그래서 `DCGM_FI_DEV_MEM_COPY_UTIL`을 겹치면 방향이 보일 것이라 기대했습니다. 위 표의 오른쪽 두 열이 그 결과입니다.
+`DCGM_FI_DEV_GPU_UTIL`과 `DCGM_FI_DEV_MEM_COPY_UTIL`은 바쁜 시간 비율을 나타냅니다. 실제 DRAM bandwidth 사용률이나 compute 효율을 직접 뜻하지 않습니다.
 
-**두 값이 거의 같이 움직입니다.** 연산 병목을 노리고 만든 prefill 시나리오에서도 memory util이 96%로 높습니다. 이 카드에서 이 조합만으로는 병목이 갈리지 않습니다.
+GeForce GPU에서는 `DCGM_FI_PROF_DRAM_ACTIVE` 같은 profiling metric이 노출되지 않을 수 있습니다. 이 경우 두 utilization metric만으로 compute와 bandwidth 병목을 구분할 수 없습니다.
 
-이유는 정의에 있습니다. 두 지표 모두 "그 시간 동안 바빴는가"를 재는 시간 비율이지 "대역폭의 몇 퍼센트를 썼는가"가 아닙니다. 후자를 재려면 `DCGM_FI_PROF_DRAM_ACTIVE` 같은 profiling 지표가 필요한데, GeForce 계열에는 노출되지 않습니다. 이 workspace의 DCGM exporter가 내보내는 지표 목록으로 직접 확인할 수 있습니다.
+### 실습
+
+DCGM Exporter가 profiling metric을 노출하는지 확인합니다.
 
 ```bash
 curl -s localhost:9400/metrics | grep "^# HELP" | grep PROF
 ```
 
-아무것도 나오지 않습니다.
+아무것도 출력되지 않으면 다음 근거를 함께 사용합니다.
 
-**그래서 판별은 지표가 아니라 5절의 산수로 합니다.** Grafana의 `Compute vs Bandwidth pressure` panel은 여전히 유용한데, 두 값이 함께 낮은 세 번째 경우 곧 GPU가 노는 상황을 잡아주기 때문입니다. 그때는 client 동시성이나 queue를 봐야 합니다.
+- Roofline의 crossover와 workload intensity
+- Batch 1 decode의 bandwidth 기반 token/s 상한
+- 실측 token/s와 이론 상한의 거리
+- Running, waiting, queue metric
 
-## 정리
+Grafana의 `Compute vs Bandwidth pressure` panel은 두 값이 함께 낮아 GPU가 쉬는 상황을 찾는 용도로 사용합니다.
 
-- crossover는 카드마다 다르므로 병목을 말하기 전에 자기 카드에서 먼저 잰다.
-- x축은 workload가, y축의 천장은 hardware가 정한다.
-- decode의 intensity는 sequence 길이와 무관하게 고정이라 구조적으로 대역폭 병목이다.
-- GPU utilization과 memory utilization을 겹쳐도 이 카드에서는 두 병목이 갈리지 않았다.
-- 대신 대역폭에서 나온 이론 상한과 실측 token 속도를 비교하면 1% 오차로 판별된다.
-- batching은 요청당 속도를 거의 그대로 두면서 전체 처리량만 15배로 올린다.
+정리:
 
-## 참고자료
+- Crossover는 GPU마다 직접 측정합니다.
+- Decode는 구조적으로 arithmetic intensity가 낮습니다.
+- Batch 1 decode 실측이 bandwidth 상한에 가까우면 bandwidth 병목 근거가 됩니다.
+- GPU utilization과 memory copy utilization만으로 병목을 단정하지 않습니다.
+- Batching은 weight read를 공유해 전체 decode 처리량을 높입니다.
 
-- *Hands-On LLM Serving and Optimization*, Chapter 5
-- [Chapter 5 이론](../02-ch5-theory.md)
-- [metric 해석](../prometheus.md)
+참고자료:
+
+- [Memory와 roofline 이론](../02-ch5-theory.md)
+- [Metric 해석](../prometheus.md)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
@@ -1,105 +1,129 @@
-# Batch를 키우면 throughput은 오르지만 latency도 좋아질까
+# Latency SLO를 만족하는 vLLM batch 설정 찾기
 
-Batch를 크게 잡으면 GPU가 여러 request를 함께 처리할 수 있습니다. 하지만 scheduler가 감당할 수 있는 token budget을 넘으면 waiting request와 TTFT가 늘어납니다. 이 실습은 가장 큰 batch가 아니라 latency SLO를 만족하는 가장 높은 throughput 설정을 찾습니다.
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. Latency 우선 설정 측정
+2. 균형 설정 측정
+3. Throughput 우선 설정 측정
+4. 세 결과에서 SLO를 만족하는 설정 선택
 
-- 선행 실습: [내 GPU의 crossover를 직접 재고 병목을 일부러 만들기](./04-roofline-bottleneck.md)
+공통 환경:
+
+- 선행 실습: [GPU roofline과 병목 재현](./04-roofline-bottleneck.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
-- runtime: vLLM `v0.27.1`
-- model: `Qwen/Qwen2.5-3B-Instruct`
+- Runtime: vLLM `v0.27.1`
+- Model: `Qwen/Qwen2.5-3B-Instruct`
+- 고정 조건: model, prompt, output limit, concurrency 1·4·8
 
-Repository root에서 workspace로 이동합니다.
+비교 설정:
+
+| 설정 | `max_num_seqs` | `max_num_batched_tokens` | 예상 trade-off |
+| --- | ---: | ---: | --- |
+| Latency 우선 | 1 | 512 | Queue 감소, throughput 제한 |
+| 균형 | 4 | 2048 | 작은 concurrency와 token budget 수용 |
+| Throughput 우선 | 8 | 4096 | 동시 처리 증가, queue·VRAM 증가 가능 |
+
+## 시나리오 1. Latency 우선 설정을 측정합니다
+
+### 이론
+
+`max_num_seqs`는 iteration에서 처리하는 sequence 상한이고, `max_num_batched_tokens`는 iteration의 token budget입니다. Sequence를 하나로 제한하면 경쟁은 줄지만 weight read를 공유하지 못해 처리량이 제한됩니다.
+
+vLLM `v0.27.1`에는 고정 `max_delay_ms` serve option이 없습니다. Batch 대기는 Queue time, TTFT, E2E latency로 측정합니다.
+
+### 실습
+
+Workspace로 이동하고 기존 GPU workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-## 무엇을 바꾸고 무엇을 고정할까
-
-vLLM continuous batching의 두 scheduler 제한값만 변경합니다.
-
-| 설정 | `max_num_seqs` | `max_num_batched_tokens` | 예상 trade-off |
-| --- | ---: | ---: | --- |
-| Latency 우선 | 1 | 512 | queue 감소, throughput 제한 |
-| 균형 | 4 | 2048 | 작은 concurrency와 token budget 수용 |
-| Throughput 우선 | 8 | 4096 | 동시 처리 증가, queue·VRAM 증가 가능 |
-
-- `max_num_seqs`: iteration에서 처리할 sequence 수의 상한
-- `max_num_batched_tokens`: iteration 전체 token 수의 상한
-- 고정 조건: model, prompt, output limit, concurrency 1·4·8
-
-vLLM `v0.27.1`에는 고정 `max_delay_ms` serve option이 없습니다. 따라서 batch latency를 설정값으로 가정하지 않고 Queue time, TTFT, E2E latency로 측정합니다.
-
-## 관측부터 시작합니다
-
-세 설정을 같은 시간축에서 비교하기 위해 관측 stack을 먼저 실행합니다.
+관측 stack과 latency 우선 server를 실행합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
-```
-
-## Latency 우선: sequence를 하나로 제한합니다
-
-동시 실행을 제한한 기준점을 만듭니다.
-
-```bash
-VLLM_MAX_NUM_SEQS=1 VLLM_MAX_NUM_BATCHED_TOKENS=512 docker compose --profile bf16 up -d --force-recreate vllm-bf16
+VLLM_MAX_NUM_SEQS=1 VLLM_MAX_NUM_BATCHED_TOKENS=512 \
+  docker compose --profile bf16 up -d --force-recreate vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
-```
-
-설정값을 결과 JSON에도 기록하며 동일 workload를 실행합니다.
-
-```bash
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16-seq1-tokens512 -e PRECISION=BF16 -e VLLM_MAX_NUM_SEQS=1 -e VLLM_MAX_NUM_BATCHED_TOKENS=512 benchmark python3 -m benchmark.benchmark_vllm_batching
-```
-
-다음 설정과 port·metric target이 겹치지 않도록 server를 종료합니다.
-
-```bash
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16-seq1-tokens512 \
+  -e PRECISION=BF16 \
+  -e VLLM_MAX_NUM_SEQS=1 \
+  -e VLLM_MAX_NUM_BATCHED_TOKENS=512 \
+  benchmark python3 -m benchmark.benchmark_vllm_batching
 docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-## 균형: sequence 4와 token budget 2048을 허용합니다
+## 시나리오 2. 균형 설정을 측정합니다
 
-같은 workload를 실행해 동시 처리 이득과 queue 증가를 비교합니다.
+### 이론
+
+Sequence 4와 token budget 2048은 일부 data reuse를 허용하면서 과도한 queue 증가를 피하려는 중간값입니다.
+
+### 실습
+
+같은 workload를 균형 설정에서 실행합니다.
 
 ```bash
-VLLM_MAX_NUM_SEQS=4 VLLM_MAX_NUM_BATCHED_TOKENS=2048 docker compose --profile bf16 up -d --force-recreate vllm-bf16
+VLLM_MAX_NUM_SEQS=4 VLLM_MAX_NUM_BATCHED_TOKENS=2048 \
+  docker compose --profile bf16 up -d --force-recreate vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16-seq4-tokens2048 -e PRECISION=BF16 -e VLLM_MAX_NUM_SEQS=4 -e VLLM_MAX_NUM_BATCHED_TOKENS=2048 benchmark python3 -m benchmark.benchmark_vllm_batching
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16-seq4-tokens2048 \
+  -e PRECISION=BF16 \
+  -e VLLM_MAX_NUM_SEQS=4 \
+  -e VLLM_MAX_NUM_BATCHED_TOKENS=2048 \
+  benchmark python3 -m benchmark.benchmark_vllm_batching
 docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-## Throughput 우선: sequence 8과 token budget 4096을 허용합니다
+## 시나리오 3. Throughput 우선 설정을 측정합니다
 
-가장 큰 설정에서 throughput이 실제로 증가하는지 확인합니다.
+### 이론
+
+더 큰 sequence와 token budget은 GPU data reuse를 늘릴 수 있습니다. Capacity를 넘으면 waiting request, KV cache 사용률, TTFT가 함께 증가합니다.
+
+### 실습
+
+가장 큰 설정에서 동일 workload를 실행합니다.
 
 ```bash
-VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 docker compose --profile bf16 up -d --force-recreate vllm-bf16
+VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  docker compose --profile bf16 up -d --force-recreate vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16-seq8-tokens4096 -e PRECISION=BF16 -e VLLM_MAX_NUM_SEQS=8 -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 benchmark python3 -m benchmark.benchmark_vllm_batching
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16-seq8-tokens4096 \
+  -e PRECISION=BF16 \
+  -e VLLM_MAX_NUM_SEQS=8 \
+  -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  benchmark python3 -m benchmark.benchmark_vllm_batching
 docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-## 큰 설정이 좋은 설정인지 판정합니다
+## 시나리오 4. Latency SLO를 만족하는 설정을 선택합니다
+
+### 이론
+
+가장 큰 batch가 항상 운영 capacity를 높이지는 않습니다. Queue와 E2E p95가 SLO를 넘으면 높은 throughput은 사용자 대기 증가의 결과일 수 있습니다.
+
+| 관찰 | 해석 |
+| --- | --- |
+| Output TPS 증가, Queue p95 허용 범위 | Batching 이득 있음 |
+| Queue·E2E p95 증가, throughput 정체 | 설정이 너무 큼 |
+| Waiting과 GPU utilization 증가 | GPU capacity 포화 가능 |
+| Waiting 증가, GPU utilization 낮음 | Scheduler·runtime 추가 확인 |
+
+### 실습
 
 세 JSON을 하나의 표로 결합합니다.
 
@@ -108,25 +132,13 @@ ls results/performance-bf16-seq*-vllm-batching.json
 docker compose --profile tools run --rm benchmark python3 -m benchmark.summary
 ```
 
-| 관찰 | 의미 |
-| --- | --- |
-| Output TPS 증가 + Queue p95 허용 범위 | batching 이득 있음 |
-| Queue·E2E p95 증가 + throughput 정체 | 설정이 너무 큼 |
-| waiting request + GPU utilization 증가 | GPU capacity 포화 가능 |
-| waiting request 증가 + GPU utilization 낮음 | scheduler·runtime 추가 확인 |
+선택 기준:
 
-여기서 보통 “RPS가 가장 높은 설정을 고르면 되지 않나”라고 묻습니다. 사용자는 throughput이 아니라 자신의 latency를 경험합니다. TTFT·E2E SLO를 넘긴 throughput은 운영 capacity가 아니라 queue를 늘린 결과일 수 있습니다.
+1. TTFT와 E2E p95가 SLO를 만족하는 설정만 남김
+2. 남은 설정 중 Output TPS가 가장 높은 값 선택
+3. `results/summary.md`에서 scheduler 설정과 결과 연결 확인
 
-## 판단
+참고자료:
 
-- 세 설정의 JSON 생성
-- concurrency 1·4·8의 p95 latency와 throughput 비교
-- `results/summary.md`에서 scheduler 설정과 결과 연결
-- latency SLO를 만족하는 설정 중 Output TPS가 가장 높은 값 선택
-
-정리하면, batch를 키우는 목적은 request를 더 오래 기다리게 하는 것이 아니라 GPU data reuse를 높이는 것입니다. Queue 증가보다 throughput 이득이 클 때만 더 큰 설정이 의미가 있습니다.
-
-## 참고자료
-
-- [vLLM serve options](https://docs.vllm.ai/en/v0.27.0/cli/serve/)
-- [vLLM Metrics](https://docs.vllm.ai/en/stable/usage/metrics/)
+- [vLLM v0.27.1 serve options](https://docs.vllm.ai/en/v0.27.1/cli/serve/)
+- [vLLM v0.27.1 metrics](https://docs.vllm.ai/en/v0.27.1/usage/metrics/)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
@@ -1,103 +1,117 @@
-# Static·dynamic·continuous batching은 어디에서 성능 차이가 날까
+# Static·dynamic·continuous admission 전략 비교
 
-Output 길이가 다른 request를 고정 batch로 묶으면 짧은 request가 끝나도 다음 batch는 시작하지 못합니다. Dynamic batching은 batch가 차거나 대기 시간이 끝날 때 보내고, continuous batching은 빈 sequence slot을 바로 채웁니다. 이 차이가 admission delay, TTFT, throughput을 어떻게 바꾸는지 확인합니다.
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. Client admission과 vLLM scheduler의 범위 구분
+2. Running·waiting metric으로 continuous scheduling 관찰
+3. 같은 arrival stream으로 세 admission 전략 비교
+4. Client 대기와 server 대기를 분리해 결과 해석
 
-- 선행 실습: [vLLM scheduler 제한값 비교](./05-vllm-batching.md)
+공통 환경:
+
+- 선행 실습: [vLLM batch 설정 비교](./05-vllm-batching.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
-- runtime: vLLM `v0.27.1`
-- model: `Qwen/Qwen2.5-3B-Instruct`
-- workload: output limit 32~256 token의 request 24개
+- Runtime: vLLM `v0.27.1`
+- Model: `Qwen/Qwen2.5-3B-Instruct`
+- Workload: output limit 32~256 token의 request 24개
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. Client admission과 vLLM scheduler를 구분합니다
+
+### 이론
+
+vLLM online server는 iteration마다 running request와 waiting request에 token budget을 배분하는 continuous batching을 사용합니다. Static과 dynamic batching은 이 실습의 client-side admission 전략이며 vLLM serve option이 아닙니다.
+
+| 전략 | Client admission | vLLM 내부 실행 | 예상 결과 |
+| --- | --- | --- | --- |
+| Static | 8개 전송 후 모두 끝날 때까지 다음 cohort 대기 | Continuous | 긴 request가 cohort barrier 지배 |
+| Dynamic | 최대 8개 또는 20 ms 후 전송 | Continuous | 무한 대기 방지, admission delay 추가 |
+| Continuous | 도착 즉시 전송하고 빈 slot 보충 | Continuous | Barrier 감소, slot 활용 증가 |
+
+### 실습
+
+Workspace로 이동하고 기존 GPU workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
-
-## 먼저 비교 범위를 구분합니다
-
-vLLM online server의 내부 scheduler는 iteration마다 running request와 waiting request에 token budget을 배분하는 continuous batching 방식입니다. Static batching과 dynamic batching은 vLLM의 serve option이 아닙니다.
-
-따라서 이 실습은 같은 vLLM server 앞에서 request admission 시점만 바꿉니다.
-
-| 전략 | Client admission | vLLM 내부 실행 | 예상 결과 |
-| --- | --- | --- | --- |
-| Static | 8개가 모이면 전송하고 모두 끝날 때까지 다음 cohort 대기 | Continuous | 긴 request가 cohort barrier를 지배 |
-| Dynamic | 최대 8개 또는 20ms가 되면 전송 | Continuous | 낮은 traffic의 무한 대기를 막지만 queue delay 추가 |
-| Continuous | request 도착 즉시 전송하고 빈 slot을 보충 | Continuous | barrier 감소와 높은 slot 활용 |
-
-이 결과를 “vLLM에 세 scheduler를 설치한 비교”로 해석하면 안 됩니다. 세 전략은 client-side admission 차이를 비교하고, 실제 GPU scheduling은 모두 같은 vLLM continuous scheduler가 수행합니다.
-
-## vLLM의 batch 전략과 제한값을 확인합니다
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
 Compose가 vLLM에 전달하는 scheduler option을 확인합니다.
 
 ```bash
-VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 docker compose --profile bf16 config vllm-bf16
+VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  docker compose --profile bf16 config vllm-bf16
 ```
 
-확인할 command argument입니다.
+확인값:
 
-- `--max-num-seqs 8`: 한 iteration에서 처리할 sequence 상한
-- `--max-num-batched-tokens 4096`: 한 iteration의 token budget
+- `--max-num-seqs 8`: iteration의 sequence 상한
+- `--max-num-batched-tokens 4096`: iteration의 token budget
 - `--enable-chunked-prefill`: 긴 prefill을 token budget에 맞춰 분할
 
-여기서 `batch_size=8`은 benchmark admission cohort 크기이고, `max_num_seqs=8`은 vLLM 내부 running sequence 상한입니다. 이름은 비슷하지만 적용 위치가 다릅니다.
+Benchmark의 `batch_size=8`은 client cohort 크기이고 `max_num_seqs=8`은 server의 running sequence 상한입니다.
 
-## Running·waiting request로 continuous scheduling을 관찰합니다
+## 시나리오 2. Continuous scheduling을 metric으로 관찰합니다
 
-관측 stack과 BF16 server를 실행합니다.
+### 이론
+
+짧은 request가 완료된 뒤 `num_requests_running`이 다시 채워지면 고정 cohort 전체를 기다리지 않고 빈 slot을 재사용한 것입니다. `num_requests_waiting`과 queue time은 admission이 server capacity를 넘었는지 보여 줍니다.
+
+### 실습
+
+관측 stack과 server를 기동합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
-VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 docker compose --profile bf16 up -d --force-recreate vllm-bf16
+VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  docker compose --profile bf16 up -d --force-recreate vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 ```
 
-vLLM이 scheduler metric을 노출하는지 확인합니다.
+Scheduler metric을 확인합니다.
 
 ```bash
-curl http://127.0.0.1:8000/metrics | grep -E 'vllm:num_requests_(running|waiting)|vllm:request_queue_time_seconds'
+curl -s http://127.0.0.1:8000/metrics \
+  | grep -E 'vllm:num_requests_(running|waiting)|vllm:request_queue_time_seconds'
 ```
 
-- `num_requests_running`: 현재 iteration에서 실행 가능한 request
-- `num_requests_waiting`: sequence·token·KV cache budget을 기다리는 request
-- `request_queue_time_seconds`: vLLM 내부 admission 대기 시간
+| Metric | 의미 |
+| --- | --- |
+| `vllm:num_requests_running` | 현재 실행 batch에 포함된 request 수 |
+| `vllm:num_requests_waiting` | Sequence·token·KV cache budget을 기다리는 request 수 |
+| `vllm:request_queue_time_seconds` | vLLM 내부 admission 대기 시간 |
 
-Benchmark 중 짧은 request가 완료된 뒤 running 수가 다시 채워지면 고정 cohort 전체를 기다리지 않고 빈 slot을 재사용하는 continuous scheduling을 관찰할 수 있습니다.
+## 시나리오 3. 같은 arrival stream으로 세 전략을 비교합니다
 
-## 같은 arrival stream으로 세 전략을 비교합니다
+### 이론
 
-Benchmark는 다음 조건을 고정합니다.
+Output 길이가 다른 request를 사용해야 cohort barrier와 slot 재사용 차이가 드러납니다. Request 수가 적거나 길이가 비슷하면 전략 차이가 작을 수 있습니다.
 
-- logical arrival interval: 5ms
-- request count: 24
-- output limit: 32·48·64·96·128·192·224·256 token 반복
-- static batch size: 8
-- dynamic max batch size: 8
-- dynamic max delay: 20ms
-- continuous max in-flight: vLLM `max_num_seqs`와 같은 8
+고정 조건:
 
-세 admission 전략을 한 번에 순서대로 실행합니다.
+- Logical arrival interval: 5 ms
+- Request count: 24
+- Output limit: 32·48·64·96·128·192·224·256 token 반복
+- Static batch size: 8
+- Dynamic max batch size: 8
+- Dynamic max delay: 20 ms
+- Continuous max in-flight: 8
+
+### 실습
+
+세 admission 전략을 같은 server에서 순서대로 실행합니다.
 
 ```bash
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16 -e VLLM_MAX_NUM_SEQS=8 -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 benchmark python3 -m benchmark.benchmark_batch_strategies
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16 \
+  -e VLLM_MAX_NUM_SEQS=8 \
+  -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  benchmark python3 -m benchmark.benchmark_batch_strategies
 ```
 
 결과를 확인합니다.
@@ -107,60 +121,43 @@ cat results/batch-strategies-bf16.md
 cat results/batch-strategies-bf16.json
 ```
 
-- Markdown: 전략별 핵심 성능 지표를 한 표로 비교
-- JSON: dynamic dispatch plan, request별 arrival·admission·completion 순서 확인
+- Markdown: 전략별 핵심 지표 비교
+- JSON: dispatch plan, request별 arrival·admission·completion 순서
 
-## 어떤 숫자가 전략 차이를 설명할까
+## 시나리오 4. Client 대기와 server 대기를 분리합니다
 
-| 지표 | 질문 |
+### 이론
+
+`admission_p95_ms`는 client가 request를 보내기 전에 기다린 시간입니다. vLLM Queue p95는 server에 도착한 뒤 scheduler에서 기다린 시간입니다. 두 값을 분리해야 전략 차이와 server capacity 문제를 혼동하지 않습니다.
+
+| 지표 | 확인 질문 |
 | --- | --- |
-| `admission_p95_ms` | client 전략 때문에 request가 전송 전 얼마나 기다렸는가 |
-| `ttft_p95_ms` | admission과 vLLM queue·prefill을 합쳐 첫 token이 언제 나왔는가 |
-| `e2e_p95_ms` | 짧은 request가 긴 request의 barrier에 얼마나 영향받았는가 |
-| `rps` | 전체 request를 초당 몇 개 완료했는가 |
-| `output_tps` | output 길이가 다른 workload에서 token 처리량이 얼마인가 |
-| `peak_vram_mib` | 동시 running request가 KV cache를 얼마나 사용했는가 |
-| `completion_order` | 짧은 request 완료 뒤 새 request가 cohort barrier 없이 진행했는가 |
+| `admission_p95_ms` | Client batch가 전송을 얼마나 지연했는가 |
+| `ttft_p95_ms` | Admission, queue, prefill을 거쳐 첫 token이 언제 나왔는가 |
+| `e2e_p95_ms` | 긴 request의 barrier가 완료 시간에 영향을 줬는가 |
+| `output_tps` | Barrier 감소가 token 처리량으로 이어졌는가 |
+| `peak_vram_mib` | 동시 running request가 memory pressure를 높였는가 |
+| `completion_order` | 빈 slot을 cohort barrier 없이 재사용했는가 |
 
-예상하는 상대적 패턴입니다.
+### 실습
 
-- Static
-  - cohort 안의 가장 긴 request가 다음 cohort 시작을 지연
-  - admission p95와 E2E p95 증가 가능
-- Dynamic
-  - batch가 차지 않는 traffic도 20ms 뒤 dispatch
-  - static barrier는 줄지만 max delay만큼 admission latency 추가
-- Continuous
-  - arrival 즉시 전송하고 완료 slot을 바로 보충
-  - heterogeneous output에서 RPS·Output TPS 개선 가능
-  - 부하가 capacity를 넘으면 vLLM queue time 증가
+Grafana와 결과 JSON을 같은 시간 구간에서 비교합니다.
 
-여기서 보통 “continuous 결과가 항상 가장 좋아야 하지 않나”라고 묻습니다. Request 수가 적거나 길이가 거의 같으면 static barrier 비용이 작습니다. 반대로 continuous admission은 concurrency와 KV cache usage를 높일 수 있습니다. 전략 차이는 반드시 heterogeneous workload와 실제 traffic arrival에서 측정해야 합니다.
+- Scheduler: 빈 running slot이 다시 채워지는지 확인
+- Queue p95: server scheduler 대기 확인
+- TTFT·E2E p95: 사용자 latency 확인
+- KV Cache·GPU VRAM: concurrency의 memory 영향 확인
+- GPU Utilization·Power: strategy별 idle 차이 확인
 
-## Grafana로 JSON의 원인을 확인합니다
-
-- Scheduler: running slot이 비는 즉시 다시 채워지는지
-- Queue p95: dynamic burst와 continuous admission이 server queue를 만드는지
-- TTFT·E2E p95: client admission과 server queue가 사용자 latency로 이어지는지
-- Output TPS: barrier 감소가 GPU throughput으로 이어지는지
-- KV Cache·GPU VRAM: 더 높은 concurrency가 memory pressure를 만드는지
-- GPU Utilization·Power: strategy별 GPU idle 차이
-
-`admission_p95_ms`는 benchmark client가 기록하고, vLLM Queue p95는 Prometheus가 기록합니다. 두 값을 구분해야 client batch 대기와 server scheduler 대기를 혼동하지 않습니다.
-
-## 정리
-
-실험이 끝나면 model server만 종료합니다.
+실험 후 model server를 종료합니다.
 
 ```bash
 docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-Static·dynamic·continuous batching의 차이는 batch라는 이름보다 request를 언제 admit하고 언제 빈 slot을 재사용하는지에 있습니다. **vLLM의 continuous batching은 고정 cohort의 가장 긴 request를 기다리지 않지만, 더 높은 concurrency가 queue와 KV cache pressure를 만들 수 있으므로 latency와 throughput을 함께 판단해야 합니다.**
+참고자료:
 
-## 참고자료
-
-- [vLLM scheduler source documentation](https://docs.vllm.ai/en/v0.27.0/api/vllm/v1/core/sched/scheduler/)
-- [vLLM serve options](https://docs.vllm.ai/en/v0.27.0/cli/serve/)
-- [vLLM Metrics](https://docs.vllm.ai/en/stable/usage/metrics/)
+- [vLLM v0.27.1 scheduler](https://docs.vllm.ai/en/v0.27.1/api/vllm/v1/core/sched/scheduler/)
+- [vLLM v0.27.1 serve options](https://docs.vllm.ai/en/v0.27.1/cli/serve/)
+- [vLLM v0.27.1 metrics](https://docs.vllm.ai/en/v0.27.1/usage/metrics/)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
@@ -1,135 +1,146 @@
-# TTFT와 TPOT만으로 prefill·decode 병목을 구분할 수 있을까
+# Prefill과 decode 병목을 metric으로 구분
 
-TTFT가 느리면 prefill 문제처럼 보이지만 scheduler queue가 원인일 수 있습니다. TPOT가 느려도 decode compute보다 KV cache pressure가 원인일 수 있습니다. 이 실습은 사용자 지표와 vLLM 내부 metric, GPU metric을 연결해 병목을 한 단계씩 좁힙니다.
+다음 시나리오를 순서대로 진행합니다.
 
-## 실습 환경
+1. Long-prefill workload에서 첫 token 지연 분석
+2. Long-decode workload에서 token 생성 지연 분석
+3. 같은 E2E latency의 원인을 lifecycle metric으로 구분
 
-- 선행 실습: [Static·dynamic·continuous 전략 비교](./06-batch-strategies.md)
+공통 환경:
+
+- 선행 실습: [Admission 전략 비교](./06-batch-strategies.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
-- runtime: vLLM `v0.27.1`
-- model: `Qwen/Qwen2.5-3B-Instruct`
+- Runtime: vLLM `v0.27.1`
+- Model: `Qwen/Qwen2.5-3B-Instruct`
+- Scheduler: `max_num_seqs 8`, `max_num_batched_tokens 4096`
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. Long-prefill의 첫 token 지연을 분석합니다
+
+### 이론
+
+긴 input과 짧은 output은 prefill 비중이 큽니다. TTFT가 증가해도 queue time이 함께 증가하면 prompt 계산만의 문제로 단정할 수 없습니다.
+
+가설:
+
+- Queue p95 안정, Prefill p95·TTFT 증가: 긴 prompt 계산 비용
+- Queue p95·TTFT 동반 증가: scheduler 대기 포함
+- Peak VRAM 증가: 긴 context의 memory 영향
+
+### 실습
+
+Workspace로 이동하고 기존 GPU workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-## 두 workload가 다른 metric을 움직인다는 가설
-
-- long-prefill
-  - 조건: 긴 input, 짧은 output
-  - 가설: Prefill p95와 TTFT 증가
-- long-decode
-  - 조건: 짧은 input, 긴 output
-  - 가설: Decode p95, TPOT, KV cache usage 증가
-- 고정 조건
-  - 같은 BF16 model
-  - 같은 scheduler 설정
-  - 같은 GPU
-
-Workload 외 조건을 고정해야 metric 차이를 prefill과 decode의 차이로 해석할 수 있습니다.
-
-## Server와 metric target을 준비합니다
-
-관측 stack과 BF16 server를 실행합니다.
+관측 stack과 server를 기동합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
-VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 docker compose --profile bf16 up -d --force-recreate vllm-bf16
+VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  docker compose --profile bf16 up -d --force-recreate vllm-bf16
 bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
-```
-
-Benchmark 전에 metric endpoint와 Prometheus target을 확인합니다.
-
-```bash
 curl http://127.0.0.1:8000/metrics
 curl http://127.0.0.1:9090/api/v1/targets
 ```
 
-## Long-prefill은 첫 token이 늦어진 이유를 보여줍니다
-
-긴 input과 짧은 output workload를 실행합니다.
+Long-prefill workload를 실행합니다.
 
 ```bash
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16 -e PRECISION=BF16 -e VLLM_MAX_NUM_SEQS=8 -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 benchmark python3 -m benchmark.benchmark_long_prefill
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16 \
+  -e PRECISION=BF16 \
+  -e VLLM_MAX_NUM_SEQS=8 \
+  -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  benchmark python3 -m benchmark.benchmark_long_prefill
 ```
 
-Grafana에서 다음 순서로 봅니다.
+Grafana 확인 순서:
 
-1. Queue p95로 scheduler 대기를 제외합니다.
-2. Prefill p95로 prompt 계산 시간을 확인합니다.
-3. TTFT p95로 사용자 첫 응답 지연과 연결합니다.
-4. GPU utilization·power로 workload 강도를 확인합니다.
-5. Peak VRAM으로 context가 memory에 미친 영향을 확인합니다.
+1. Queue p95
+2. Prefill p95
+3. TTFT p95
+4. GPU utilization·power
+5. Peak VRAM
 
-TTFT만 증가하고 Queue p95가 안정적이라면 prefill 계산이 유력합니다. Queue와 TTFT가 함께 증가한다면 prompt 계산만의 문제로 단정할 수 없습니다.
+## 시나리오 2. Long-decode의 token 생성 지연을 분석합니다
 
-## Long-decode는 token 생성 비용을 보여줍니다
+### 이론
 
-짧은 input과 긴 output workload를 실행합니다.
+짧은 input과 긴 output은 decode 비중이 큽니다. 낮은 concurrency에서 TPOT가 좋아도 request가 늘면 waiting queue와 KV cache 사용률이 증가할 수 있습니다.
+
+가설:
+
+- Decode p95·TPOT 증가: output 생성 비용 증가
+- Output TPS 정체·waiting 증가: serving capacity 포화
+- TPOT·KV cache 사용률 동반 증가: decode concurrency와 memory pressure
+
+### 실습
+
+Long-decode workload를 실행합니다.
 
 ```bash
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16 -e PRECISION=BF16 -e VLLM_MAX_NUM_SEQS=8 -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 benchmark python3 -m benchmark.benchmark_long_decode
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16 \
+  -e PRECISION=BF16 \
+  -e VLLM_MAX_NUM_SEQS=8 \
+  -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
+  benchmark python3 -m benchmark.benchmark_long_decode
 ```
 
-이번에는 다음 순서로 봅니다.
+Grafana 확인 순서:
 
-1. Decode p95로 output 생성 구간을 확인합니다.
-2. TPOT p95로 token 사이 사용자 체감 속도를 확인합니다.
-3. Output TPS로 GPU 전체 decode 처리량을 확인합니다.
-4. running·waiting request로 scheduler 포화를 확인합니다.
-5. KV cache usage와 VRAM으로 memory pressure를 확인합니다.
+1. Decode p95
+2. TPOT p95
+3. Output TPS
+4. Running·waiting request
+5. KV cache 사용률·VRAM
 
-여기서 “TPOT가 낮으면 decode가 해결된 것 아닌가”라고 묻습니다. Concurrency가 낮을 때 TPOT가 좋아도 요청이 늘어 waiting queue가 쌓일 수 있습니다. TPOT와 Output TPS, waiting request를 함께 봐야 합니다.
+## 시나리오 3. 같은 E2E latency의 원인을 구분합니다
 
-## 같은 E2E latency라도 원인은 다릅니다
+### 이론
 
-두 결과를 확인합니다.
+TTFT와 TPOT는 사용자가 겪은 결과입니다. Queue, prefill, decode, KV cache metric은 지연이 발생한 단계를 보여 줍니다.
+
+| Workload | 우선 확인 metric | 병목 가설 |
+| --- | --- | --- |
+| Long-prefill | Queue·Prefill·TTFT p95 | Scheduler 대기 또는 prompt 계산 |
+| Long-decode | Decode·TPOT·Output TPS | Weight·KV cache data movement |
+
+Lifecycle metric은 느린 단계를 좁히지만 compute와 memory bandwidth 원인을 직접 판정하지는 못합니다. 그 판정은 [roofline과 병목 재현](./04-roofline-bottleneck.md)의 이론 상한과 실측 token 속도를 사용합니다.
+
+### 실습
+
+두 결과 파일을 확인합니다.
 
 ```bash
 ls results/performance-bf16-long-*.json
 ```
 
-| Workload | 우선 확인 metric | 병목 가설 |
-| --- | --- | --- |
-| long-prefill | Queue·Prefill·TTFT p95 | scheduler 대기 또는 prompt 계산 |
-| long-decode | Decode·TPOT·Output TPS | weight·KV cache data movement |
+판단 순서:
 
-- Prefill p95와 TTFT 동반 증가: 긴 prompt 계산 비용
-- Decode p95와 TPOT 동반 증가: 긴 output 생성 비용
-- waiting request와 GPU utilization 동반 증가: serving capacity 포화 가능
-- waiting request만 증가: scheduler·runtime 병목 추가 확인
-- TPOT와 KV cache usage 동반 증가: decode concurrency와 memory pressure 확인
+1. Queue 증가 여부 확인
+2. Prefill 또는 decode 시간 증가 확인
+3. TTFT 또는 TPOT와 연결
+4. Running·waiting으로 scheduler 포화 확인
+5. KV cache와 VRAM으로 memory pressure 확인
+6. Roofline과 token/s 상한으로 compute·bandwidth 방향 확인
 
-이 목록은 어느 **단계**가 느린지까지 좁혀줍니다. 그 단계가 연산 때문인지 memory bandwidth 때문인지는 metric만으로 갈리지 않습니다. 실측에서 `DCGM_FI_DEV_GPU_UTIL`과 `DCGM_FI_DEV_MEM_COPY_UTIL`이 거의 같이 움직였기 때문입니다. 그 판별은 대역폭에서 계산한 이론 상한과 실측 token 속도를 대조하는 방법으로 하고, 절차는 [roofline과 병목 재현](./04-roofline-bottleneck.md)에 있습니다.
-
-## 정리
-
-실험이 끝나면 model server만 종료해 metric과 model cache를 유지합니다.
+실험 후 model server를 종료합니다.
 
 ```bash
 docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-TTFT와 TPOT는 사용자가 겪은 결과를 알려 줍니다. Queue, prefill, decode, KV cache metric은 그 결과가 생긴 단계를 알려 줍니다. **병목은 단일 숫자가 아니라 서로 연결된 metric의 움직임으로 판단해야 합니다.**
+참고자료:
 
-## 참고자료
-
-- [GPU 사용률이 높은데 LLM이 느릴 때 무엇을 봐야 할까](../prometheus.md)
-- [vLLM Metrics](https://docs.vllm.ai/en/stable/usage/metrics/)
+- [LLM serving metric 해석](../prometheus.md)
+- [vLLM v0.27.1 metrics](https://docs.vllm.ai/en/v0.27.1/usage/metrics/)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
@@ -1,53 +1,50 @@
-# VRAM이 가장 적은 quantization model이 가장 빠를까
+# BF16·W4A16·W8A8의 성능과 품질 비교
 
-W4A16은 weight를 크게 줄이고, W8A8은 activation compute까지 줄일 수 있습니다. 그렇다고 W4A16이 모든 decode에서, W8A8이 모든 prefill에서 빠르다고 단정할 수는 없습니다. Hardware kernel과 dequantization overhead, accuracy가 실제 선택을 바꿉니다.
+다음 시나리오를 순서대로 진행합니다.
 
-이 실습은 BF16·W4A16·W8A8을 같은 workload에서 비교하고, 성능과 quality를 동시에 통과한 model만 선택합니다.
+1. BF16 기준점 측정
+2. W4A16의 decode·VRAM 변화 측정
+3. W8A8의 prefill 변화 측정
+4. 성능과 quality gate를 통과한 model 선택
 
-## 실습 환경
+공통 환경:
 
-- 선행 실습: [Prefill·decode 병목 관찰](./07-prefill-decode-observability.md)
+- 선행 실습: [Prefill·decode 병목 관측](./07-prefill-decode-observability.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
+- 성능 workload: long-prefill, long-decode
+- Quality gate: smoke 20문항, GSM8K 앞 20문항
+- 비교 지표: TTFT, TPOT, RPS, Output TPS, Peak VRAM, accuracy
 
-Repository root에서 workspace로 이동합니다.
+비교 model:
+
+| Label | Model | Precision | 가설 |
+| --- | --- | --- | --- |
+| `bf16` | `Qwen/Qwen2.5-3B-Instruct` | BF16 | Quality·성능 기준점 |
+| `gptq-int4` | `Qwen/Qwen2.5-3B-Instruct-GPTQ-Int4` | W4A16 | Weight bandwidth·VRAM 감소 |
+| `fp8` | `RedHatAI/Qwen2.5-3B-Instruct-FP8-dynamic` | W8A8 | Long-prefill compute 감소 |
+
+## 시나리오 1. BF16 기준점을 측정합니다
+
+### 이론
+
+Quantization 효과는 같은 model family, workload, scheduler, GPU memory budget에서 BF16과 비교해야 합니다. `VLLM_GPU_MEMORY_UTILIZATION`이 다르면 quantization이 아니라 KV pool 설정 차이를 측정하게 됩니다.
+
+### 실습
+
+Workspace로 이동하고 기존 GPU workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-## 세 model이 노리는 병목이 다릅니다
-
-| Label | Model | Precision | 가설 |
-| --- | --- | --- | --- |
-| `bf16` | `Qwen/Qwen2.5-3B-Instruct` | BF16 | quality·성능 기준점 |
-| `gptq-int4` | `Qwen/Qwen2.5-3B-Instruct-GPTQ-Int4` | W4A16 | weight bandwidth와 VRAM 감소 |
-| `fp8` | `RedHatAI/Qwen2.5-3B-Instruct-FP8-dynamic` | W8A8 | long-prefill compute 감소 |
-
-- 성능 workload: long-prefill·long-decode
-- 빠른 quality gate: smoke 20문항
-- reasoning quality gate: GSM8K 앞 20문항
-- 비교 지표: TTFT·TPOT·RPS·Output TPS·Peak VRAM·accuracy
-
-Peak VRAM을 비교하려면 `VLLM_GPU_MEMORY_UTILIZATION`을 세 설정에서 같게 두어야 합니다. 이 값이 KV pool 크기를 직접 정하기 때문에, 값이 다르면 quantization이 아니라 설정 차이를 재게 됩니다. 기본값 `0.85`를 그대로 쓰고 결과에 함께 기록합니다.
-
-## BF16으로 기준점을 만듭니다
-
-Quantization 결과를 해석하려면 같은 model family의 BF16 결과가 먼저 필요합니다.
+기본값 `VLLM_GPU_MEMORY_UTILIZATION=0.85`에서 BF16을 측정합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
@@ -60,7 +57,13 @@ docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-## W4A16이 decode와 VRAM에 주는 이득을 확인합니다
+## 시나리오 2. W4A16의 decode와 VRAM 변화를 측정합니다
+
+### 이론
+
+W4A16은 weight를 줄여 VRAM과 decode의 weight bandwidth를 낮추는 것이 목표입니다. Kernel 또는 dequantization overhead가 크면 VRAM만 줄고 TPOT는 개선되지 않을 수 있습니다.
+
+### 실습
 
 같은 workload와 quality gate를 GPTQ model에 적용합니다.
 
@@ -75,11 +78,21 @@ docker compose stop vllm-gptq
 docker compose rm -f vllm-gptq
 ```
 
-W4A16의 우선 확인값은 Peak VRAM, long-decode TPOT, Output TPS입니다. VRAM만 줄고 TPOT가 개선되지 않으면 kernel 또는 dequantization overhead를 확인해야 합니다.
+우선 확인값:
 
-## W8A8이 prefill compute에 주는 이득을 확인합니다
+- Peak VRAM
+- Long-decode TPOT
+- Output TPS
 
-FP8 model에도 같은 조건을 적용합니다.
+## 시나리오 3. W8A8의 prefill 변화를 측정합니다
+
+### 이론
+
+W8A8은 weight와 activation compute를 줄여 long-prefill을 개선하는 것이 목표입니다. GPU가 FP8 path를 효율적으로 지원하지 않으면 낮은 precision이 속도 향상으로 이어지지 않습니다.
+
+### 실습
+
+같은 조건을 FP8 model에 적용합니다.
 
 ```bash
 docker compose --profile fp8 up -d vllm-fp8
@@ -92,30 +105,43 @@ docker compose stop vllm-fp8
 docker compose rm -f vllm-fp8
 ```
 
-W8A8의 우선 확인값은 long-prefill TTFT와 RPS입니다. Hardware가 FP8 path를 효율적으로 지원하지 않으면 낮은 precision이 성능 향상으로 이어지지 않을 수 있습니다.
+우선 확인값:
 
-## 가장 빠른 결과가 아니라 채택 가능한 결과를 고릅니다
+- Long-prefill TTFT
+- RPS
+- Peak VRAM
 
-성능과 quality 결과를 한 표로 결합합니다.
+## 시나리오 4. 성능과 quality gate로 model을 선택합니다
 
-```bash
-docker compose --profile tools run --rm benchmark python3 -m benchmark.summary
-```
+### 이론
+
+VRAM이 가장 작은 model이 반드시 가장 빠르지는 않습니다. W4A16과 W8A8은 줄이는 data와 유리한 workload가 다릅니다.
 
 | 질문 | 판단 지표 |
 | --- | --- |
 | Long-prefill이 빨라졌는가 | TTFT·RPS |
 | Long-decode가 빨라졌는가 | TPOT·Output TPS |
-| 더 많은 request를 받을 여유가 생겼는가 | Peak VRAM |
+| Request capacity가 늘었는가 | Peak VRAM·KV cache pool |
 | 출력 quality를 유지했는가 | Smoke·GSM8K-20 accuracy |
 
-여기서 “accuracy가 같고 VRAM이 작으면 quantized model이 정답 아닌가”라고 묻습니다. 20문항 accuracy는 큰 regression을 찾는 quick gate일 뿐입니다. Production 채택에는 full evaluation과 domain dataset이 추가로 필요합니다.
+20문항 accuracy는 큰 regression을 찾는 quick gate입니다. 실제 채택에는 full evaluation과 domain dataset이 필요합니다.
 
-## 정리
+### 실습
 
-VRAM이 가장 적은 model이 반드시 가장 빠르지는 않습니다. W4A16과 W8A8은 줄이는 data와 유리한 workload가 다르고, 실제 speedup은 GPU kernel에 의존합니다. **Quantization은 precision 순위가 아니라 workload별 성능, memory, accuracy를 함께 통과시키는 선택입니다.**
+성능과 quality 결과를 하나의 표로 결합합니다.
 
-## 참고자료
+```bash
+docker compose --profile tools run --rm benchmark python3 -m benchmark.summary
+```
 
-- [LLM serving optimization은 왜 하나의 옵션으로 끝나지 않을까](../04-ch6-theory.md)
+선택 순서:
+
+1. Quality gate를 통과한 model만 남김
+2. 목표 workload의 TTFT 또는 TPOT 비교
+3. Output TPS와 Peak VRAM trade-off 확인
+4. GPU kernel 지원과 운영 SLO를 포함해 최종 선택
+
+참고자료:
+
+- [LLM serving optimization 이론](../04-ch6-theory.md)
 - [GSM8K 20문항 점수의 한계](../06-gsm8k-deep-dive.md)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
@@ -1,51 +1,46 @@
-# 같은 내용인데 prefix cache가 빗나가는 이유
+# Prefix cache가 hit하거나 빗나가는 조건
 
-System prompt와 document 내용이 같아도 순서나 whitespace가 달라지면 prefix cache hit가 사라질 수 있습니다. Prefix caching은 의미가 같은 문장을 찾는 기능이 아니라 앞부분의 동일한 token sequence를 재사용하기 때문입니다.
+다음 시나리오를 순서대로 진행합니다.
 
-이 실습은 cold, warm, reordered request를 비교해 TTFT가 언제 줄어드는지 확인합니다.
+1. Cold·warm·reordered request의 prefix cache hit와 TTFT 비교
+2. Cache hit rate와 tenant isolation의 trade-off 판단
 
-## 실습 환경
+공통 환경:
 
-- 선행 실습: [Prefill·decode 병목 관찰](./07-prefill-decode-observability.md)
+- 선행 실습: [Prefill·decode 병목 관측](./07-prefill-decode-observability.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
-- 이후 모든 명령: 위 workspace에서 실행
-- model: `Qwen/Qwen2.5-3B-Instruct`
+- Model: `Qwen/Qwen2.5-3B-Instruct`
+- Prefix caching: 활성화
 
-Repository root에서 workspace로 이동합니다.
+## 시나리오 1. Token 순서가 cache hit와 TTFT를 바꾸는지 확인합니다
+
+### 이론
+
+Prefix caching은 의미가 같은 문장을 찾는 기능이 아닙니다. 앞에서부터 동일한 token sequence의 KV cache block을 재사용합니다.
+
+| Request | 조건 | 예상 결과 |
+| --- | --- | --- |
+| Cold | 긴 static prefix를 처음 계산 | Cache miss, 높은 TTFT |
+| Warm | 같은 token prefix를 다시 요청 | Cache hit, 낮은 TTFT |
+| Reordered | 같은 내용을 다른 순서로 요청 | 공통 prefix 단절, TTFT 재증가 |
+
+Whitespace나 document 순서가 달라져 token sequence가 바뀌면 뒤의 동일 내용도 재사용하지 못할 수 있습니다.
+
+### 실습
+
+Workspace로 이동하고 기존 GPU workload를 정리합니다.
 
 ```bash
 cd computer_science/ai/study-llmserving/ch5-6
-```
-
-## 실습 전 GPU process를 정리합니다
-
-이전 실습과 다른 workload가 사용하는 GPU compute process를 정리합니다.
-
-```bash
 docker compose --profile "*" down --remove-orphans
 nvidia-smi \
   --query-compute-apps=pid,process_name,used_gpu_memory \
   --format=csv,noheader
 ```
 
-두 번째 명령이 process를 출력하면 실습을 진행하지 않습니다. [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 두 명령을 다시 실행합니다.
+두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-## 세 request가 확인하는 조건
-
-1. Cold request
-   - 긴 static prefix를 처음 계산
-2. Warm request
-   - 같은 token prefix를 다시 요청
-   - KV cache 재사용 예상
-3. Reordered request
-   - 같은 내용을 다른 순서로 요청
-   - token prefix 연속성 상실 예상
-
-Semantic similarity가 아니라 token prefix가 비교 기준이라는 가설을 검증합니다.
-
-## Prefix hit와 TTFT를 함께 측정합니다
-
-관측 stack과 prefix caching이 활성화된 BF16 server를 실행합니다.
+관측 stack과 prefix caching이 활성화된 server를 기동합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
@@ -56,48 +51,53 @@ bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 Cold, warm, reordered request를 순서대로 실행합니다.
 
 ```bash
-docker compose --profile tools run --rm -e MODEL_LABEL=bf16 benchmark python3 -m benchmark.benchmark_prefix_cache
+docker compose --profile tools run --rm \
+  -e MODEL_LABEL=bf16 \
+  benchmark python3 -m benchmark.benchmark_prefix_cache
 ```
 
-Request별 TTFT 결과를 확인합니다.
+Request별 결과를 확인합니다.
 
 ```bash
 cat results/prefix-cache-bf16.json
 ```
 
-Grafana에서는 다음 값을 같은 시간 구간에서 확인합니다.
+Grafana 확인값:
 
 - Prefix Cache Hit Rate: warm request의 hit 증가
 - TTFT p95: cold와 warm의 첫 token 지연 차이
-- KV Cache Usage: cache가 GPU memory에 미친 영향
+- KV Cache Usage: cache block 점유율 변화
 
-여기서 “reordered request도 내용이 같으니 일부는 재사용하지 않나”라고 묻습니다. 앞에서부터 이어지는 공통 token까지만 재사용할 수 있습니다. 문서 순서가 초반에 달라지면 뒤의 동일 내용까지 prefix가 끊깁니다.
+Warm TTFT가 줄고 reordered TTFT가 다시 늘면 token ordering 의존성을 확인한 것입니다.
 
-## Hit rate와 isolation 사이의 trade-off
+## 시나리오 2. Cache hit rate와 tenant isolation을 함께 판단합니다
 
-- static content를 앞에 고정
-  - 얻는 것: 긴 공통 prefix와 높은 hit 가능성
-  - 주의점: dynamic content가 중간에 들어가면 이후 prefix 재사용 중단
-- cache-aware routing
-  - 얻는 것: 같은 cache가 있는 replica로 요청 전달
-  - 주의점: replica load imbalance 가능
-- tenant namespace 분리
-  - 얻는 것: tenant 간 cache 정보 노출 방지
-  - 잃는 것: shared cache hit 감소
+### 이론
+
+| 설계 | 얻는 것 | 주의점 |
+| --- | --- | --- |
+| Static content를 앞에 고정 | 긴 공통 prefix, 높은 hit 가능성 | 중간의 dynamic content 뒤는 재사용 중단 |
+| Cache-aware routing | Cache가 있는 replica에서 높은 hit | Replica load imbalance 가능 |
+| Tenant namespace 분리 | Tenant 간 cache 정보 노출 방지 | Shared cache hit 감소 |
 
 Multi-tenant 환경에서는 hit rate보다 isolation이 우선입니다. Shared prefix의 latency 차이가 cache 존재 여부를 추정하는 side channel이 될 수 있습니다.
 
-## 정리
+### 실습
 
-실험이 끝나면 model server를 종료합니다.
+Prompt template과 routing 정책을 검토합니다.
+
+- System prompt와 static document를 앞에 배치
+- Request별 dynamic content를 뒤에 배치
+- Tenant namespace 또는 cache key 분리 확인
+- Cache-aware routing의 replica 편중 확인
+
+실험 후 model server를 종료합니다.
 
 ```bash
 docker compose stop vllm-bf16
 docker compose rm -f vllm-bf16
 ```
 
-Warm TTFT가 줄고 reordered TTFT가 다시 늘면 prefix caching이 token ordering에 의존한다는 가설을 확인한 것입니다. **Cache hit를 높이려면 같은 의미보다 같은 prompt 구조를 유지해야 합니다.**
+참고자료:
 
-## 참고자료
-
-- [vLLM Automatic Prefix Caching](https://docs.vllm.ai/en/stable/features/automatic_prefix_caching.html)
+- [vLLM Automatic Prefix Caching](https://docs.vllm.ai/en/v0.27.1/features/automatic_prefix_caching/)

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
@@ -1,74 +1,124 @@
-# LLM serving이 느린 이유를 GPU에서 직접 확인하는 순서
+# LLM serving 병목을 재현하는 시나리오
 
-옵션을 먼저 바꾸면 숫자는 달라져도 원인을 설명하기 어렵습니다. 이 핸즈온은 GPU 확인부터 시작해 memory, KV cache, roofline, scheduling, prefill·decode, quantization, cache 순서로 병목을 좁힙니다. 파일 번호가 학습 순서입니다.
+다음 시나리오를 번호 순서대로 진행합니다.
 
-## 모든 GPU 실습 전에 기준 상태를 만듭니다
+1. Host부터 Grafana까지 GPU 관측 경로 확인
+2. 7B BF16의 memory budget과 OOM 확인
+3. Batch·sequence에 따른 KV cache 변화 확인
+4. GPU roofline 측정과 병목 재현
+5. Latency SLO를 만족하는 vLLM batch 설정 선택
+6. Static·dynamic·continuous admission 전략 비교
+7. Prefill·decode 병목 구분
+8. BF16·W4A16·W8A8 비교
+9. Prefix cache hit 조건 확인
 
-Workspace의 이전 model process를 정리하고 hardware metric 수집 경로를 확인합니다.
+모든 GPU 실습은 [Ubuntu GPU 환경 준비](../01-setup-ubuntu.md)를 완료한 뒤 실행합니다. GPU 기준 상태와 metric 불일치 판별은 [GPU 실습 troubleshooting](../troubleshooting.md)을 따릅니다.
 
-```bash
-docker compose --profile "*" down --remove-orphans
-nvidia-smi \
-  --query-compute-apps=pid,process_name,used_gpu_memory \
-  --format=csv,noheader
-docker compose --profile observability up -d prometheus grafana dcgm-exporter
-bash scripts/check_observability.sh
-```
+## 시나리오 1. GPU 실행 경로와 metric 수집 경로를 확인합니다
 
-Desktop GPU는 화면 출력 때문에 baseline VRAM이 0MiB가 아닙니다. 초기화 기준과 metric 불일치 판별은 [GPU 실습 troubleshooting](../troubleshooting.md)을 따릅니다.
+### 이론
 
-`nvidia-smi`가 compute process를 출력하면 실습을 진행하지 않습니다. [process 실행 주체 확인과 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행한 뒤 초기화 명령부터 다시 실행합니다.
+- Host driver, container runtime, DCGM Exporter, Prometheus, Grafana의 역할 구분
+- 이후 OOM과 성능 결과를 해석할 hardware baseline 설정
 
-## Chapter 5만 볼 때
+### 실습
 
-Chapter 5는 "이 GPU에 이 model이 들어가는가, 느리다면 연산인가 대역폭인가"를 다룹니다. 이론을 먼저 읽고 세 실습을 순서대로 합니다.
+- [Host부터 Grafana까지 GPU 관측 경로 확인](./01-gpu-environment.md)
 
-| 순서 | 문서 | 답하는 질문 |
-| ---: | --- | --- |
-| 0 | [Chapter 5 이론](../02-ch5-theory.md) | weight 말고 무엇이 VRAM을 쓰는가 |
-| 1 | [02 메모리 예산과 OOM](./02-memory-budget-oom.md) | 계산상 들어가는데 왜 OOM이 나는가 |
-| 2 | [03 KV cache 배치·시퀀스](./03-kv-cache-batch-sequence.md) | 캐시할 토큰 개수를 어떻게 세고, 최대 배치는 무엇이 정하는가 |
-| 3 | [04 roofline과 병목 재현](./04-roofline-bottleneck.md) | 연산집약도 축은 무엇이고, 병목이 연산인가 대역폭인가 |
+## 시나리오 2. Model load와 serving memory budget의 차이를 확인합니다
 
-03과 04는 문서에 적힌 Docker Compose 명령으로 KV cache, roofline, bottleneck을 직접 측정합니다. 실행 전에 [01 GPU 환경](./01-gpu-environment.md)이 필요합니다.
+### 이론
 
-## Chapter 6만 볼 때
+- Weight 외 CUDA runtime, activation, allocator, KV cache가 사용하는 VRAM 확인
+- Model load 성공과 API serving 가능 조건 구분
 
-Chapter 6는 "Chapter 5에서 찾은 병목마다 어떤 optimization이 붙는가"를 다룹니다.
+### 실습
 
-| 순서 | 문서 | 답하는 질문 |
-| ---: | --- | --- |
-| 0 | [Chapter 6 이론](../04-ch6-theory.md) | optimization을 무엇을 기준으로 고르는가 |
-| 1 | [05 batching](./05-vllm-batching.md) | batch를 키우면 latency도 좋아지는가 |
-| 2 | [06 batching 전략](./06-batch-strategies.md) | static·dynamic·continuous는 어디서 갈리는가 |
-| 3 | [07 prefill·decode 관측](./07-prefill-decode-observability.md) | 느린 단계가 prefill인가 decode인가 |
-| 4 | [08 quantization](./08-quantization.md) | VRAM이 가장 적은 model이 가장 빠른가 |
-| 5 | [09 prefix caching](./09-prefix-caching.md) | 같은 내용인데 cache가 왜 빗나가는가 |
+- [16GB GPU에서 7B BF16 serving이 실패하는 이유](./02-memory-budget-oom.md)
 
-품질 검증의 한계는 [GSM8K 20문항의 범위](../06-gsm8k-deep-dive.md)에 있습니다.
+## 시나리오 3. Batch와 sequence가 KV cache를 채우는 과정을 확인합니다
 
-07은 Chapter 5의 병목 개념을 metric으로 관측해 Chapter 6 optimization과 연결합니다.
+### 이론
 
-## 전체 순서
+- Attention 구조로 token당 KV cache 크기 계산
+- Scheduler 제한과 KV cache 제한으로 최대 동시성 계산
+- KV cache metric과 전체 GPU VRAM metric의 범위 구분
 
-환경부터 순서대로 다 할 때의 번호 순입니다.
+### 실습
 
-| # | 문서 | Chapter |
-| ---: | --- | --- |
-| 1 | [GPU가 보여도 container에서 못 쓰는 이유](./01-gpu-environment.md) | 환경 |
-| 2 | [16GB GPU에서 7B BF16이 OOM 나는 이유](./02-memory-budget-oom.md) | 5 |
-| 3 | [배치와 시퀀스를 흔들어 KV cache가 차는 과정](./03-kv-cache-batch-sequence.md) | 5 |
-| 4 | [내 GPU의 crossover를 직접 재고 병목을 만들기](./04-roofline-bottleneck.md) | 5 |
-| 5 | [Batch를 키우면 throughput과 latency가 어떻게 바뀌는가](./05-vllm-batching.md) | 6 |
-| 6 | [Static·dynamic·continuous batching의 성능 차이](./06-batch-strategies.md) | 6 |
-| 7 | [TTFT와 TPOT만으로 부족한 prefill·decode 병목](./07-prefill-decode-observability.md) | 5→6 |
-| 8 | [VRAM이 줄었다고 빠른 model이 아닌 quantization](./08-quantization.md) | 6 |
-| 9 | [같은 내용이어도 prefix cache가 빗나가는 조건](./09-prefix-caching.md) | 6 |
+- [배치와 시퀀스에 따라 KV cache가 차는 과정](./03-kv-cache-batch-sequence.md)
 
-공통 metric의 수집 이유와 해석은 [GPU 사용률이 높은데 LLM이 느릴 때 무엇을 봐야 할까](../prometheus.md)에서 설명합니다.
+## 시나리오 4. Compute와 memory bandwidth 병목을 구분합니다
 
-## 참고자료
+### 이론
 
-- [Chapter 5 이론](../02-ch5-theory.md)
-- [Chapter 6 이론](../04-ch6-theory.md)
+- Arithmetic intensity와 hardware crossover 계산
+- Batch 1 decode의 bandwidth 기반 token/s 상한 계산
+- GPU utilization metric만으로 병목을 단정할 수 없는 이유 확인
+
+### 실습
+
+- [GPU roofline을 측정하고 병목 재현](./04-roofline-bottleneck.md)
+
+## 시나리오 5. Latency SLO를 만족하는 batch 설정을 찾습니다
+
+### 이론
+
+- `max_num_seqs`와 `max_num_batched_tokens`의 역할 확인
+- Throughput, Queue, TTFT, E2E latency의 trade-off 판단
+
+### 실습
+
+- [Latency SLO를 만족하는 vLLM batch 설정 찾기](./05-vllm-batching.md)
+
+## 시나리오 6. Request admission 전략을 비교합니다
+
+### 이론
+
+- Client-side static·dynamic·continuous admission 구분
+- vLLM 내부 continuous scheduler와 client admission의 범위 구분
+
+### 실습
+
+- [Static·dynamic·continuous admission 전략 비교](./06-batch-strategies.md)
+
+## 시나리오 7. Prefill과 decode 지연 원인을 분리합니다
+
+### 이론
+
+- Queue·prefill·decode lifecycle metric 구분
+- TTFT·TPOT와 server 내부 metric 연결
+
+### 실습
+
+- [Prefill과 decode 병목을 metric으로 구분](./07-prefill-decode-observability.md)
+
+## 시나리오 8. Quantization을 성능과 품질로 평가합니다
+
+### 이론
+
+- W4A16과 W8A8이 줄이는 data와 유리한 workload 구분
+- VRAM, latency, throughput, accuracy를 함께 사용한 선택 기준 설정
+
+### 실습
+
+- [BF16·W4A16·W8A8의 성능과 품질 비교](./08-quantization.md)
+
+## 시나리오 9. Prefix cache hit 조건을 확인합니다
+
+### 이론
+
+- Semantic similarity와 동일 token prefix 구분
+- Cache hit rate와 tenant isolation trade-off 확인
+
+### 실습
+
+- [Prefix cache가 hit하거나 빗나가는 조건](./09-prefix-caching.md)
+
+관련 문서:
+
+- [Memory와 roofline 이론](../02-ch5-theory.md)
+- [LLM serving optimization 이론](../04-ch6-theory.md)
+- [LLM serving metric 해석](../prometheus.md)
+- [GSM8K 20문항 점수의 한계](../06-gsm8k-deep-dive.md)
 - [Quiz](../quiz.md)


### PR DESCRIPTION
# 구현

핸즈온 10개 문서를 시나리오 중심의 이론·실습 구조로 통일
- KV cache metric 직접 조회와 Prometheus 해석 추가, Markdown 구조·링크·diff 검증 통과

# 리스크

H2 재구성에 따른 기존 문서 anchor 변경
- 외부에서 기존 섹션 anchor를 직접 참조한 경우 링크 갱신 필요

Issue #1113