### PR TITLE
docs: LLM serving 원격 GPU endpoint 명시

### DIFF
--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/01-gpu-environment.md
@@ -9,6 +9,7 @@
 공통 환경:
 
 - 환경 준비: [Ubuntu GPU 환경 준비](../01-setup-ubuntu.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - OS: Ubuntu 24.04 LTS
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
@@ -85,13 +86,13 @@ nvidia-smi → DCGM Exporter → Prometheus → Grafana
 
 ### 실습
 
-Benchmark image를 build합니다.
+GPU server에서 benchmark image를 build합니다.
 
 ```bash
 docker compose --profile tools build benchmark
 ```
 
-관측 stack을 기동하고 수집 경로를 자동 점검합니다.
+GPU server에서 관측 stack을 기동하고 수집 경로를 자동 점검합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
@@ -99,18 +100,24 @@ bash scripts/check_observability.sh
 docker compose ps
 ```
 
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
+
 접속 정보:
 
-- Prometheus: `http://127.0.0.1:9090`
-- Grafana: `http://127.0.0.1:3000`
+- Prometheus: `http://${GPU_SERVER_IP}:9090`
+- Grafana: `http://${GPU_SERVER_IP}:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6`
 - Grafana 계정: `admin` / `admin`
 - Dashboard: provisioned LLM serving dashboard
 
-원본 metric과 target을 직접 확인합니다.
+Local client에서 원본 metric과 target을 직접 확인합니다.
 
 ```bash
-curl http://127.0.0.1:9400/metrics
-curl http://127.0.0.1:9090/api/v1/targets
+curl "http://${GPU_SERVER_IP}:9400/metrics"
+curl "http://${GPU_SERVER_IP}:9090/api/v1/targets"
 ```
 
 완료 조건:

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/02-memory-budget-oom.md
@@ -10,8 +10,15 @@
 공통 환경:
 
 - 선행 실습: [Host부터 Grafana까지 GPU 관측 경로 확인](./01-gpu-environment.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 ## 시나리오 1. 7B BF16의 memory budget을 계산합니다
 
@@ -74,7 +81,8 @@ docker compose --profile tools run --rm \
 - 기대 결과: CUDA OOM
 - 저장 결과: `results/ch5-7b-bf16-oom.json`
 - OOM이 아닌 오류: network, model format, kernel 문제 확인
-- Grafana: GPU VRAM panel의 최근 5초 최대값 확인
+- Grafana: `http://${GPU_SERVER_IP}:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6`
+- Grafana GPU VRAM panel의 최근 5초 최대값 확인
 
 실패 자체보다 계산한 weight와 실제 GPU memory 사이의 runtime 비용을 확인하는 것이 목적입니다.
 
@@ -116,11 +124,21 @@ docker compose --profile tools run --rm model-loader python3 -m model_loader.loa
 - 저장 결과: `results/ch5-3b-bf16-load.json`
 - 확인값: elapsed time, peak allocated VRAM, peak reserved VRAM
 
-같은 model을 vLLM으로 기동하고 KV cache pool을 확인합니다.
+GPU server에서 같은 model을 vLLM으로 기동합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 KV cache pool log를 확인합니다.
+
+```bash
 docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
 ```
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/03-kv-cache-batch-sequence.md
@@ -11,9 +11,17 @@
 공통 환경:
 
 - 선행 실습: [16GB GPU에서 7B BF16이 OOM 나는 이유](./02-memory-budget-oom.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 - Model: Qwen2.5-3B-Instruct BF16, `max-model-len 4096`
+
+명령 실행 위치를 구분합니다.
+
+- GPU server: Docker Compose 기동과 log 확인
+- Local client: `<GPU-SERVER-IP>`를 사용한 health·metric 확인과 Grafana 접속
+- `0.0.0.0`은 server의 listen address이므로 client URL로 사용하지 않음
+- `127.0.0.1`은 명령을 실행한 host 자신을 가리키므로 GPU server 내부 확인에만 사용
 
 ## 시나리오 1. Attention 구조로 token당 KV cache 크기를 계산합니다
 
@@ -84,29 +92,46 @@ pool bytes = pool tokens × KV bytes/token
 
 ### 실습
 
-Server와 관측 stack을 기동합니다.
+GPU server에서 server와 관측 stack을 기동합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 ```
 
-vLLM 원본 metric을 확인합니다.
+Local client에서 GPU server의 API가 준비될 때까지 기다립니다.
 
 ```bash
-curl -s http://127.0.0.1:8000/metrics \
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+최초 기동은 model load, compile, CUDA graph capture 때문에 수 분 걸릴 수 있습니다. 준비 전에는 Prometheus의 `model-server` target이 `DOWN`이고 Grafana의 vLLM panel에 새 sample이 없습니다.
+
+Local client에서 vLLM 원본 metric을 확인합니다.
+
+```bash
+curl -s "http://${GPU_SERVER_IP}:8000/metrics" \
   | grep -E 'vllm:(kv_cache_usage_perc|cache_config_info|num_requests_(running|waiting))'
 ```
 
-Prometheus에서 현재 KV cache 사용률을 percent로 조회합니다.
+Prometheus target과 현재 KV cache 사용률을 확인합니다.
 
 ```bash
-curl -sG http://127.0.0.1:9090/api/v1/query \
+curl -sG "http://${GPU_SERVER_IP}:9090/api/v1/query" \
+  --data-urlencode 'query=up{job="model-server"}'
+
+curl -sG "http://${GPU_SERVER_IP}:9090/api/v1/query" \
   --data-urlencode 'query=max(vllm:kv_cache_usage_perc) * 100'
 ```
 
-vLLM log의 pool 계산도 확인합니다.
+- `up{job="model-server"}`가 `1`이면 vLLM metric 수집 정상
+- 실행 중인 요청이 없을 때 active block 사용률인 `vllm:kv_cache_usage_perc`는 `0`이 정상
+- 완료된 요청의 block은 free queue로 반환되지만 prefix cache의 내용과 hash는 eviction 전까지 재사용될 수 있음
+- Startup dummy workload는 실제 KV block을 할당하지 않으므로 이 metric에 나타나지 않음
+- 실제 변화는 시나리오 3의 benchmark를 실행하는 동안 Grafana에서 확인
+
+GPU server에서 vLLM log의 pool 계산도 확인합니다.
 
 ```bash
 docker compose --profile bf16 logs vllm-bf16 | grep -i "KV cache"
@@ -141,7 +166,7 @@ KV cache 사용률이 낮은데 `running`이 고정되고 `waiting`이 증가하
 
 ### 실습
 
-`max_num_seqs 8`에서 동시성과 prompt 길이를 변경합니다.
+GPU server에서 `max_num_seqs 8`로 동시성과 prompt 길이를 변경합니다.
 
 ```bash
 docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_probe
@@ -167,6 +192,16 @@ docker compose --profile tools run --rm benchmark python3 -m benchmark.kv_cache_
 - Output TPS는 거의 고정되고 TPOT는 완만하게 증가
 
 Grafana의 `KV pool occupancy vs admitted requests` panel에서 KV pool used %, running, waiting을 같은 시간축으로 확인합니다.
+
+Local client browser에서 dashboard를 엽니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
+```
+
+- 시간 범위: `Last 15 minutes`
+- 새로 고침: `5s`
+- benchmark가 끝난 뒤에는 KV cache가 해제되므로 실행 시간 구간을 확인
 
 ## 시나리오 4. Scheduler 제한을 높여 KV cache 제한에 접근합니다
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/04-roofline-bottleneck.md
@@ -10,9 +10,16 @@
 공통 환경:
 
 - 선행 실습: [KV cache 배치·시퀀스 실습](./03-kv-cache-batch-sequence.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 - 이론: [Memory와 roofline 이론](../02-ch5-theory.md)
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 ## 시나리오 1. GPU의 roofline 천장을 측정합니다
 
@@ -149,10 +156,10 @@ GeForce GPU에서는 `DCGM_FI_PROF_DRAM_ACTIVE` 같은 profiling metric이 노�
 
 ### 실습
 
-DCGM Exporter가 profiling metric을 노출하는지 확인합니다.
+Local client에서 DCGM Exporter가 profiling metric을 노출하는지 확인합니다.
 
 ```bash
-curl -s localhost:9400/metrics | grep "^# HELP" | grep PROF
+curl -s "http://${GPU_SERVER_IP}:9400/metrics" | grep "^# HELP" | grep PROF
 ```
 
 아무것도 출력되지 않으면 다음 근거를 함께 사용합니다.
@@ -162,7 +169,13 @@ curl -s localhost:9400/metrics | grep "^# HELP" | grep PROF
 - 실측 token/s와 이론 상한의 거리
 - Running, waiting, queue metric
 
-Grafana의 `Compute vs Bandwidth pressure` panel은 두 값이 함께 낮아 GPU가 쉬는 상황을 찾는 용도로 사용합니다.
+Local client에서 Grafana dashboard를 엽니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
+```
+
+`Compute vs Bandwidth pressure` panel은 두 값이 함께 낮아 GPU가 쉬는 상황을 찾는 용도로 사용합니다.
 
 정리:
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/05-vllm-batching.md
@@ -10,10 +10,17 @@
 공통 환경:
 
 - 선행 실습: [GPU roofline과 병목 재현](./04-roofline-bottleneck.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - Runtime: vLLM `v0.27.1`
 - Model: `Qwen/Qwen2.5-3B-Instruct`
 - 고정 조건: model, prompt, output limit, concurrency 1·4·8
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 비교 설정:
 
@@ -45,13 +52,23 @@ nvidia-smi \
 
 두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-관측 stack과 latency 우선 server를 실행합니다.
+GPU server에서 관측 stack과 latency 우선 server를 실행합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
 VLLM_MAX_NUM_SEQS=1 VLLM_MAX_NUM_BATCHED_TOKENS=512 \
   docker compose --profile bf16 up -d --force-recreate vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 benchmark를 실행하고 server를 종료합니다.
+
+```bash
 docker compose --profile tools run --rm \
   -e MODEL_LABEL=bf16-seq1-tokens512 \
   -e PRECISION=BF16 \
@@ -70,12 +87,22 @@ Sequence 4와 token budget 2048은 일부 data reuse를 허용하면서 과도�
 
 ### 실습
 
-같은 workload를 균형 설정에서 실행합니다.
+GPU server에서 균형 설정을 기동합니다.
 
 ```bash
 VLLM_MAX_NUM_SEQS=4 VLLM_MAX_NUM_BATCHED_TOKENS=2048 \
   docker compose --profile bf16 up -d --force-recreate vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 같은 workload를 실행하고 server를 종료합니다.
+
+```bash
 docker compose --profile tools run --rm \
   -e MODEL_LABEL=bf16-seq4-tokens2048 \
   -e PRECISION=BF16 \
@@ -94,12 +121,22 @@ docker compose rm -f vllm-bf16
 
 ### 실습
 
-가장 큰 설정에서 동일 workload를 실행합니다.
+GPU server에서 가장 큰 설정을 기동합니다.
 
 ```bash
 VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
   docker compose --profile bf16 up -d --force-recreate vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 동일 workload를 실행하고 server를 종료합니다.
+
+```bash
 docker compose --profile tools run --rm \
   -e MODEL_LABEL=bf16-seq8-tokens4096 \
   -e PRECISION=BF16 \
@@ -137,6 +174,12 @@ docker compose --profile tools run --rm benchmark python3 -m benchmark.summary
 1. TTFT와 E2E p95가 SLO를 만족하는 설정만 남김
 2. 남은 설정 중 Output TPS가 가장 높은 값 선택
 3. `results/summary.md`에서 scheduler 설정과 결과 연결 확인
+
+Local client에서 같은 시간 구간의 Grafana metric을 확인합니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
+```
 
 참고자료:
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/06-batch-strategies.md
@@ -10,10 +10,17 @@
 공통 환경:
 
 - 선행 실습: [vLLM batch 설정 비교](./05-vllm-batching.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - Runtime: vLLM `v0.27.1`
 - Model: `Qwen/Qwen2.5-3B-Instruct`
 - Workload: output limit 32~256 token의 request 24개
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 ## 시나리오 1. Client admission과 vLLM scheduler를 구분합니다
 
@@ -64,19 +71,19 @@ Benchmark의 `batch_size=8`은 client cohort 크기이고 `max_num_seqs=8`은 se
 
 ### 실습
 
-관측 stack과 server를 기동합니다.
+GPU server에서 관측 stack과 server를 기동합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
 VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
   docker compose --profile bf16 up -d --force-recreate vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
 ```
 
-Scheduler metric을 확인합니다.
+Local client에서 준비 상태와 scheduler metric을 확인합니다.
 
 ```bash
-curl -s http://127.0.0.1:8000/metrics \
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+curl -s "http://${GPU_SERVER_IP}:8000/metrics" \
   | grep -E 'vllm:num_requests_(running|waiting)|vllm:request_queue_time_seconds'
 ```
 
@@ -141,7 +148,11 @@ cat results/batch-strategies-bf16.json
 
 ### 실습
 
-Grafana와 결과 JSON을 같은 시간 구간에서 비교합니다.
+Local client에서 Grafana를 열고 결과 JSON과 같은 시간 구간을 비교합니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
+```
 
 - Scheduler: 빈 running slot이 다시 채워지는지 확인
 - Queue p95: server scheduler 대기 확인

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/07-prefill-decode-observability.md
@@ -9,10 +9,17 @@
 공통 환경:
 
 - 선행 실습: [Admission 전략 비교](./06-batch-strategies.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - Runtime: vLLM `v0.27.1`
 - Model: `Qwen/Qwen2.5-3B-Instruct`
 - Scheduler: `max_num_seqs 8`, `max_num_batched_tokens 4096`
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 ## 시나리오 1. Long-prefill의 첫 token 지연을 분석합니다
 
@@ -40,15 +47,20 @@ nvidia-smi \
 
 두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-관측 stack과 server를 기동합니다.
+GPU server에서 관측 stack과 server를 기동합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
 VLLM_MAX_NUM_SEQS=8 VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
   docker compose --profile bf16 up -d --force-recreate vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
-curl http://127.0.0.1:8000/metrics
-curl http://127.0.0.1:9090/api/v1/targets
+```
+
+Local client에서 준비 상태와 metric 수집을 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+curl "http://${GPU_SERVER_IP}:8000/metrics"
+curl "http://${GPU_SERVER_IP}:9090/api/v1/targets"
 ```
 
 Long-prefill workload를 실행합니다.
@@ -60,6 +72,12 @@ docker compose --profile tools run --rm \
   -e VLLM_MAX_NUM_SEQS=8 \
   -e VLLM_MAX_NUM_BATCHED_TOKENS=4096 \
   benchmark python3 -m benchmark.benchmark_long_prefill
+```
+
+Local client에서 Grafana dashboard를 엽니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
 ```
 
 Grafana 확인 순서:

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/08-quantization.md
@@ -10,11 +10,18 @@
 공통 환경:
 
 - 선행 실습: [Prefill·decode 병목 관측](./07-prefill-decode-observability.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - GPU: NVIDIA GeForce RTX 5060 Ti 16GB
 - 성능 workload: long-prefill, long-decode
 - Quality gate: smoke 20문항, GSM8K 앞 20문항
 - 비교 지표: TTFT, TPOT, RPS, Output TPS, Peak VRAM, accuracy
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 비교 model:
 
@@ -44,11 +51,21 @@ nvidia-smi \
 
 두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-기본값 `VLLM_GPU_MEMORY_UTILIZATION=0.85`에서 BF16을 측정합니다.
+GPU server에서 기본값 `VLLM_GPU_MEMORY_UTILIZATION=0.85`로 BF16 server를 기동합니다.
 
 ```bash
 docker compose --profile bf16 up -d vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 BF16을 측정하고 server를 종료합니다.
+
+```bash
 docker compose --profile tools run --rm -e MODEL_LABEL=bf16 -e PRECISION=BF16 benchmark python3 -m benchmark.benchmark_long_prefill
 docker compose --profile tools run --rm -e MODEL_LABEL=bf16 -e PRECISION=BF16 benchmark python3 -m benchmark.benchmark_long_decode
 docker compose --profile tools run --rm -e MODEL_LABEL=bf16 benchmark python3 -m benchmark.accuracy_smoke
@@ -65,11 +82,21 @@ W4A16은 weight를 줄여 VRAM과 decode의 weight bandwidth를 낮추는 것이
 
 ### 실습
 
-같은 workload와 quality gate를 GPTQ model에 적용합니다.
+GPU server에서 GPTQ model을 기동합니다.
 
 ```bash
 docker compose --profile gptq up -d vllm-gptq
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 같은 workload와 quality gate를 적용하고 server를 종료합니다.
+
+```bash
 docker compose --profile tools run --rm -e MODEL_LABEL=gptq-int4 -e PRECISION=W4A16 benchmark python3 -m benchmark.benchmark_long_prefill
 docker compose --profile tools run --rm -e MODEL_LABEL=gptq-int4 -e PRECISION=W4A16 benchmark python3 -m benchmark.benchmark_long_decode
 docker compose --profile tools run --rm -e MODEL_LABEL=gptq-int4 benchmark python3 -m benchmark.accuracy_smoke
@@ -92,11 +119,21 @@ W8A8은 weight와 activation compute를 줄여 long-prefill을 개선하는 것�
 
 ### 실습
 
-같은 조건을 FP8 model에 적용합니다.
+GPU server에서 FP8 model을 기동합니다.
 
 ```bash
 docker compose --profile fp8 up -d vllm-fp8
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
+```
+
+GPU server에서 같은 조건을 적용하고 server를 종료합니다.
+
+```bash
 docker compose --profile tools run --rm -e MODEL_LABEL=fp8 -e PRECISION=W8A8 benchmark python3 -m benchmark.benchmark_long_prefill
 docker compose --profile tools run --rm -e MODEL_LABEL=fp8 -e PRECISION=W8A8 benchmark python3 -m benchmark.benchmark_long_decode
 docker compose --profile tools run --rm -e MODEL_LABEL=fp8 benchmark python3 -m benchmark.accuracy_smoke
@@ -140,6 +177,12 @@ docker compose --profile tools run --rm benchmark python3 -m benchmark.summary
 2. 목표 workload의 TTFT 또는 TPOT 비교
 3. Output TPS와 Peak VRAM trade-off 확인
 4. GPU kernel 지원과 운영 SLO를 포함해 최종 선택
+
+Local client에서 model별 실행 시간 구간의 Grafana metric을 비교합니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
+```
 
 참고자료:
 

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/09-prefix-caching.md
@@ -8,9 +8,16 @@
 공통 환경:
 
 - 선행 실습: [Prefill·decode 병목 관측](./07-prefill-decode-observability.md)
+- LAN 접속 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
 - 실행 workspace: `computer_science/ai/study-llmserving/ch5-6`
 - Model: `Qwen/Qwen2.5-3B-Instruct`
 - Prefix caching: 활성화
+
+Local client에서 GPU server 주소를 지정합니다.
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
 
 ## 시나리오 1. Token 순서가 cache hit와 TTFT를 바꾸는지 확인합니다
 
@@ -40,12 +47,17 @@ nvidia-smi \
 
 두 번째 명령이 process를 출력하면 [실행 주체 확인과 안전한 종료 절차](../troubleshooting.md#실습-전-gpu-기준-상태를-만듭니다)를 수행합니다.
 
-관측 stack과 prefix caching이 활성화된 server를 기동합니다.
+GPU server에서 관측 stack과 prefix caching이 활성화된 server를 기동합니다.
 
 ```bash
 docker compose --profile observability up -d prometheus grafana dcgm-exporter
 docker compose --profile bf16 up -d vllm-bf16
-bash scripts/wait_for_health.sh http://127.0.0.1:8000/health
+```
+
+Local client에서 준비 완료를 확인합니다.
+
+```bash
+bash scripts/wait_for_health.sh "http://${GPU_SERVER_IP}:8000/health"
 ```
 
 Cold, warm, reordered request를 순서대로 실행합니다.
@@ -60,6 +72,12 @@ Request별 결과를 확인합니다.
 
 ```bash
 cat results/prefix-cache-bf16.json
+```
+
+Local client에서 Grafana dashboard를 엽니다.
+
+```text
+http://<GPU-SERVER-IP>:3000/d/llm-serving-ch5-6/llm-serving-chapter-5-6
 ```
 
 Grafana 확인값:

--- a/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
+++ b/computer_science/ai/study-llmserving/ch5-6/docs/handson/README.md
@@ -14,6 +14,20 @@
 
 모든 GPU 실습은 [Ubuntu GPU 환경 준비](../01-setup-ubuntu.md)를 완료한 뒤 실행합니다. GPU 기준 상태와 metric 불일치 판별은 [GPU 실습 troubleshooting](../troubleshooting.md)을 따릅니다.
 
+## 실행 위치
+
+- GPU server: Docker Compose, benchmark, log, `nvidia-smi` 실행
+- Local client: health·metric API 확인과 Grafana 접속
+- Local client에서 endpoint 확인 전에 GPU server 주소 설정
+
+```bash
+export GPU_SERVER_IP="<GPU-SERVER-IP>"
+```
+
+- LAN 준비: [같은 Wi-Fi에서 LLM serving endpoint 접속](../03-setup-lan-access.md)
+- `127.0.0.1`은 명령을 실행한 host 자신이므로 원격 접속에 사용하지 않음
+- `0.0.0.0`은 server listen address이므로 client URL에 사용하지 않음
+
 ## 시나리오 1. GPU 실행 경로와 metric 수집 경로를 확인합니다
 
 ### 이론


### PR DESCRIPTION
# 구현

LLM serving handson 원격 endpoint를 GPU server IP 기준으로 통일
- handson 01~09와 README의 실행 위치 구분, 14개 테스트와 정적 검증 통과

# 어려웠던 점

KV cache active 사용률과 재사용 가능한 prefix cache 상태 구분
- 동일한 1,200-token prompt 재요청에서 active 사용률 0과 cache hit 1,200 동시 확인

# 리스크

GPU server와 Local client의 두 shell 전환 필요
- Local client health 확인 후 GPU server benchmark를 이어서 실행해야 함

Issue #1115