### PR TITLE
fix: akbun-gitdesktop 브랜치 강제 삭제

### DIFF
--- a/product/akbun-gitdesktop/package-lock.json
+++ b/product/akbun-gitdesktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-gitdesktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-gitdesktop",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/product/akbun-gitdesktop/package.json
+++ b/product/akbun-gitdesktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-gitdesktop",
   "productName": "akbun-gitdesktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Git graph desktop viewer for local repositories and worktrees",
   "author": "akbun",
   "license": "MIT",

--- a/product/akbun-gitdesktop/src-tauri/crates/gitdesktop-core/src/lib.rs
+++ b/product/akbun-gitdesktop/src-tauri/crates/gitdesktop-core/src/lib.rs
@@ -49,7 +49,6 @@ pub struct BranchDeletionFailure {
 #[serde(rename_all = "camelCase")]
 pub struct BranchDeletionResult {
   pub deleted: Vec<String>,
-  pub unmerged: Vec<String>,
   pub failed: Vec<BranchDeletionFailure>,
 }
 

--- a/product/akbun-gitdesktop/src-tauri/src/commands.rs
+++ b/product/akbun-gitdesktop/src-tauri/src/commands.rs
@@ -337,57 +337,14 @@ pub fn create_branch(repo_path: String, name: String, start_point: String) -> Re
     run_git(&repo_path, &args).map(|_| ())
 }
 
-fn is_branch_merged(repo_path: &str, name: &str) -> Result<bool, String> {
-    let reference = run_git(
-        repo_path,
-        &[
-            "for-each-ref".into(),
-            format!("--format=%(refname){FIELD_SEPARATOR}%(upstream)"),
-            format!("refs/heads/{name}"),
-        ],
-    )?;
-    if reference.trim().is_empty() {
-        return Err(format!("Local branch not found: {name}"));
-    }
-    let upstream = reference.trim().split(FIELD_SEPARATOR).nth(1).unwrap_or("");
-    let target = if upstream.is_empty() {
-        "HEAD"
-    } else {
-        upstream
-    };
-    let merged = run_git(
-        repo_path,
-        &[
-            "branch".into(),
-            "--merged".into(),
-            target.into(),
-            "--format=%(refname:short)".into(),
-        ],
-    )?;
-    Ok(merged.lines().any(|branch| branch == name))
-}
-
 #[tauri::command]
-pub fn delete_branches(repo_path: String, names: Vec<String>, force: bool) -> BranchDeletionResult {
+pub fn delete_branches(repo_path: String, names: Vec<String>) -> BranchDeletionResult {
     let mut result = BranchDeletionResult::default();
     for name in names {
-        let deletion = run_git(
-            &repo_path,
-            &[
-                "branch".into(),
-                if force { "-D" } else { "-d" }.into(),
-                name.clone(),
-            ],
-        );
+        let deletion = run_git(&repo_path, &["branch".into(), "-D".into(), name.clone()]);
         match deletion {
             Ok(_) => result.deleted.push(name),
-            Err(error) => {
-                if !force && is_branch_merged(&repo_path, &name).is_ok_and(|merged| !merged) {
-                    result.unmerged.push(name);
-                } else {
-                    result.failed.push(BranchDeletionFailure { name, error });
-                }
-            }
+            Err(error) => result.failed.push(BranchDeletionFailure { name, error }),
         }
     }
     result

--- a/product/akbun-gitdesktop/src-tauri/src/commands.rs
+++ b/product/akbun-gitdesktop/src-tauri/src/commands.rs
@@ -341,7 +341,10 @@ pub fn create_branch(repo_path: String, name: String, start_point: String) -> Re
 pub fn delete_branches(repo_path: String, names: Vec<String>) -> BranchDeletionResult {
     let mut result = BranchDeletionResult::default();
     for name in names {
-        let deletion = run_git(&repo_path, &["branch".into(), "-D".into(), name.clone()]);
+        let deletion = run_git(
+            &repo_path,
+            &["branch".into(), "-D".into(), "--".into(), name.clone()],
+        );
         match deletion {
             Ok(_) => result.deleted.push(name),
             Err(error) => result.failed.push(BranchDeletionFailure { name, error }),

--- a/product/akbun-gitdesktop/src/renderer/src/api.ts
+++ b/product/akbun-gitdesktop/src/renderer/src/api.ts
@@ -105,8 +105,8 @@ const api = {
   getDefaultBranch: (repoPath: string) => call<string>('get_default_branch', { repoPath }),
   createBranch: (repoPath: string, name: string, startPoint: string) =>
     call<void>('create_branch', { repoPath, name, startPoint }),
-  deleteBranches: (repoPath: string, names: string[], force: boolean) =>
-    call<BranchDeletionResult>('delete_branches', { repoPath, names, force }),
+  deleteBranches: (repoPath: string, names: string[]) =>
+    call<BranchDeletionResult>('delete_branches', { repoPath, names }),
   createWorktree: (repoPath: string, worktreePath: string, branch: string, createNewBranch: boolean) =>
     call<void>('create_worktree', { repoPath, worktreePath, branch, createNewBranch }),
   removeWorktree,

--- a/product/akbun-gitdesktop/src/renderer/src/components/BranchPanel.tsx
+++ b/product/akbun-gitdesktop/src/renderer/src/components/BranchPanel.tsx
@@ -169,29 +169,19 @@ export default function BranchPanel({
       ? `\n\nExcluded from deletion:\n${excluded.map((branch) => branch.name).join('\n')}`
       : ''
     const names = deletableBranches.map((branch) => branch.name)
-    if (!window.confirm(`Delete ${branchLabel(names.length)}?\n\n${names.join('\n')}${excludedDetail}`)) return
+    if (!window.confirm(
+      `Force delete ${branchLabel(names.length)}?\n\n${names.join('\n')}` +
+      `\n\nCommits not merged into another branch may be lost.${excludedDetail}`
+    )) return
 
-    const safelyDeleted = await window.gitdesktop.deleteBranches(repoPath, names, false)
-    if (!safelyDeleted.ok) {
-      onError(safelyDeleted.error)
+    const deletion = await window.gitdesktop.deleteBranches(repoPath, names)
+    if (!deletion.ok) {
+      onError(deletion.error)
       return
     }
 
-    const deleted = [...safelyDeleted.data.deleted]
-    const failures = [...safelyDeleted.data.failed]
-    const unmerged = safelyDeleted.data.unmerged
-    if (
-      unmerged.length > 0 &&
-      window.confirm(`Force delete ${branchLabel(unmerged.length)} not fully merged?\n\n${unmerged.join('\n')}`)
-    ) {
-      const forciblyDeleted = await window.gitdesktop.deleteBranches(repoPath, unmerged, true)
-      if (forciblyDeleted.ok) {
-        deleted.push(...forciblyDeleted.data.deleted)
-        failures.push(...forciblyDeleted.data.failed)
-      } else {
-        failures.push(...unmerged.map((name) => ({ name, error: forciblyDeleted.error })))
-      }
-    }
+    const deleted = deletion.data.deleted
+    const failures = deletion.data.failed
 
     const deletedSet = new Set(deleted)
     const remaining = selectedNames.filter((name) => !deletedSet.has(name))

--- a/product/akbun-gitdesktop/src/shared/types.ts
+++ b/product/akbun-gitdesktop/src/shared/types.ts
@@ -32,7 +32,6 @@ export interface BranchDeletionFailure {
 
 export interface BranchDeletionResult {
   deleted: string[]
-  unmerged: string[]
   failed: BranchDeletionFailure[]
 }
 


### PR DESCRIPTION
# 구현

로컬 브랜치 삭제 경로를 단일 강제 삭제 명령으로 단순화하고 손실 경고 추가
- JavaScript 테스트 6개, Rust 테스트 3개, 타입 검사, 웹 빌드, Tauri 컴파일 통과

# 어려웠던 점

squash merge된 브랜치와 Git 안전 삭제의 커밋 조상 판정 불일치
- 코드가 반영됐어도 브랜치 끝 커밋이 master의 조상이 아니므로 미병합으로 판정

# 리스크

강제 삭제 시 다른 브랜치에 없는 커밋 접근 경로 손실 가능
- 현재 브랜치와 원격 브랜치 제외, 삭제 전 손실 경고와 명시적 확인 적용

Issue #1119