### PR TITLE
fix: akbun-makevideo 재생 연속성과 seek 응답성 개선

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-live-playback-reconfiguration.md
+++ b/product/akbun-makevideo/adr/2026-08-live-playback-reconfiguration.md
@@ -1,0 +1,30 @@
+# Playback settings switch after the replacement picture is ready
+
+## Decision
+
+- Preview quality, proxy use, guides, compositor backend and graphics device changes take effect while playback continues
+- Audio clock, transport and the current picture stay active while the replacement video path prepares
+- A setting that only changes drawing is read on the next frame
+- A setting that needs a new video path switches only after that path has produced its first frame
+- Results from an older setting generation are discarded after the switch
+- A failed explicit choice keeps the previous path, restores the previous setting and reports the failure
+- Automatic selection may try another graphics device or the CPU before restoring the previous setting
+- Keep one native surface and presenter for the session; replacement paths never attach another window layer
+- Reuse the compositor when the selected physical adapter is unchanged
+- Merge an automatic proxy refresh into the latest confirmed settings instead of restoring an older settings snapshot
+- Treat every settings entry point as one latest-wins sequence; a failed newest request restores the backend-confirmed snapshot
+
+## Why
+
+- Editing settings need immediate visual feedback during playback
+- Releasing the current session before attaching its replacement can leave audio running over a frozen or missing picture
+- Keeping the current path alive during preparation trades a short period of duplicate resource use for continuous picture and sound
+- A fixed native surface prevents abandoned replacement layers from covering the committed picture
+
+## Consequence
+
+- The stopped-only reconfiguration rule in [2026-08-persistent-playback-pipeline.md](./2026-08-persistent-playback-pipeline.md) is superseded
+- Immediate means that the old picture keeps moving until the first replacement frame is ready, not that device initialization must finish inside one frame
+- The same adapter keeps the GPU texture path; a different adapter temporarily requires readback and upload through the fixed presenter
+- Explicit setting generations take priority over automatic proxy refreshes, and only the newest generation may commit
+- Playback quality checks must fail on a frozen picture, an audio gap, an old-generation frame after the switch or a setting that claims a failed explicit choice

--- a/product/akbun-makevideo/adr/2026-08-persistent-playback-pipeline.md
+++ b/product/akbun-makevideo/adr/2026-08-persistent-playback-pipeline.md
@@ -1,5 +1,7 @@
 # Keep the playback pipeline through pause
 
+> Runtime setting reconfiguration is superseded by [2026-08-live-playback-reconfiguration.md](./2026-08-live-playback-reconfiguration.md). Play and pause still follow this record.
+
 ## Decision
 
 - Native monitor는 session 하나당 decoder, audio mixer, output device를 한 번만 생성

--- a/product/akbun-makevideo/adr/2026-08-prefetch-frame-source.md
+++ b/product/akbun-makevideo/adr/2026-08-prefetch-frame-source.md
@@ -6,7 +6,7 @@ Decode each clip on its own thread into a bounded queue of finished frames, and 
 
 Keep ffmpeg as a separate process per clip. Revisit linking it as a library only if a measurement says the process route cannot reach the target rate.
 
-Define seek as one operation: throw every queue away and refill from the target. Playing and paused take that same path.
+The rule that every seek throws every queue away is superseded by [2026-08-reusable-seek-decoder.md](./2026-08-reusable-seek-decoder.md). Short forward seeks now keep a live decoder, while backward and large seeks still restart it.
 
 Leave the behaviour of a broken source as it is — the clip stops drawing and the rest of the timeline runs on.
 

--- a/product/akbun-makevideo/adr/2026-08-reusable-seek-decoder.md
+++ b/product/akbun-makevideo/adr/2026-08-reusable-seek-decoder.md
@@ -1,0 +1,34 @@
+# Short forward seeks reuse a decoder and may show two earlier frames
+
+## Decision
+
+- Keep the isolated ffmpeg subprocess architecture
+- Reuse a live decoder for a forward seek of at most 24 project frames
+- Restart the decoder for a backward or larger seek
+- During playing seek, temporarily show only a current-generation frame at `T-1` or `T-2`
+- Clear an unrelated pre-seek picture before settling; blank is allowed until `T-2`, `T-1` or `T` is available
+- Never show a future frame early
+- Replace the temporary frame with exact `T` as soon as it is ready, even when the audio clock has advanced
+- While paused, including mouse release after scrubbing, wait for exact `T`
+- Play or pause while a seek is still settling does not cancel exact `T`
+- Close the audio output gate as soon as seek is requested; reopen it only after the old ring is flushed and the new position is buffered
+- Rapid seeks may share one audio-ring flush, but completion belongs to the newest target
+- Keep paused decoders idle for two seconds, then release them without clearing the last picture
+- Count decoded queues, retained neighbor and pending-presentation frames, including text and shape raster bytes, in the reported memory ceiling
+
+Do not add a separate application keyframe index while decoding remains an ffmpeg subprocess. The decoder command uses input-side `-ss` before `-i`; [ffmpeg already seeks through the container index to a nearby seek point and, with accurate seek enabled, decodes and discards up to the requested timestamp](https://ffmpeg.org/ffmpeg.html#Main-options).
+
+## Why
+
+- Reusing a process avoids repeated startup cost during nearby forward scrubbing
+- Restarting backward and distant seeks keeps the subprocess protocol simple and deterministic
+- A picture at most two frames behind gives immediate feedback without pretending that a distant or future frame is exact
+- Exact-only paused frames keep edit decisions trustworthy
+- A second keyframe cache would duplicate ffmpeg's container index and would need another discard/mapping layer to preserve exact project-frame timing
+- Running, idle and released states keep quick resume cheap without retaining decoder memory indefinitely
+
+## Consequence
+
+- The all-seeks-restart rule in [2026-08-prefetch-frame-source.md](./2026-08-prefetch-frame-source.md) is superseded
+- `supply-soak` measures repeated short-forward and backward seeks separately
+- `present-soak` fails when audio advances by more than two project frames while the accepted visible frame does not advance

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -26,3 +26,5 @@
 | [2026-08-program-monitor-transform.md](./2026-08-program-monitor-transform.md) | Transform Visual Items in project space through an editor-only monitor pass |
 | [2026-08-edit-point-navigation.md](./2026-08-edit-point-navigation.md) | Visible clip boundaries drive previous and next edit navigation |
 | [2026-08-persistent-playback-pipeline.md](./2026-08-persistent-playback-pipeline.md) | Play and pause keep one decoder and audio pipeline alive |
+| [2026-08-live-playback-reconfiguration.md](./2026-08-live-playback-reconfiguration.md) | Playback settings switch after the replacement picture is ready |
+| [2026-08-reusable-seek-decoder.md](./2026-08-reusable-seek-decoder.md) | Short forward seeks reuse a decoder and may show two earlier frames |

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/engine.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/engine.rs
@@ -198,9 +198,11 @@ impl Engine {
         let thread_feed = Arc::clone(&feed);
         let feeder = std::thread::spawn(move || {
             let mut block = vec![0.0f32; BLOCK_FRAMES * CHANNELS];
+            let mut seeks_received = 0u64;
             // A flush that has been asked for and not yet answered, with where
-            // the source landed. While this is set, nothing may be pushed.
-            let mut awaiting: Option<(u64, i64)> = None;
+            // the source landed and how many seeks it represents. While this
+            // is set, nothing may be pushed.
+            let mut awaiting: Option<(u64, i64, u64)> = None;
             thread_clock.restart(0);
             loop {
                 match commands.try_recv() {
@@ -211,7 +213,8 @@ impl Engine {
                         // while the callback catches up.
                         let request = producer.request_flush();
                         source.seek(sample);
-                        awaiting = Some((request, source.position()));
+                        seeks_received += 1;
+                        awaiting = Some((request, source.position(), seeks_received));
                         thread_feed.ended.store(false, Ordering::Relaxed);
                         // The ring is about to be empty, so what it held before
                         // the seek is not a low water mark for what comes after.
@@ -221,7 +224,7 @@ impl Engine {
                     Err(TryRecvError::Empty) => {}
                 }
 
-                if let Some((request, position)) = awaiting {
+                if let Some((request, position, completed_seeks)) = awaiting {
                     if producer.flushed() < request {
                         std::thread::sleep(POLL);
                         continue;
@@ -231,7 +234,12 @@ impl Engine {
                     // these are last, so anyone who sees `seeks_done` move can
                     // trust everything above it.
                     thread_clock.restart(position.max(0) as u64);
-                    thread_feed.seeks_done.fetch_add(1, Ordering::SeqCst);
+                    // Several seeks can be coalesced into one callback flush.
+                    // Publish the number represented by the newest target,
+                    // rather than counting that one flush as one seek.
+                    thread_feed
+                        .seeks_done
+                        .store(completed_seeks, Ordering::SeqCst);
                     awaiting = None;
                 }
 
@@ -486,6 +494,34 @@ mod tests {
         }
         assert_eq!(clock.position_samples(), 48_000);
         assert_eq!(rest.len() / CHANNELS, 24_000, "exactly what was left");
+    }
+
+    #[test]
+    fn rapid_seeks_coalesced_by_one_flush_all_settle_on_the_latest_target() {
+        let project = one_clip_project();
+        let (engine, consumer, clock) = Engine::start(
+            &project,
+            Buffering::default(),
+            level_readers(1.0),
+            options(),
+        );
+        assert!(engine.wait_until_ready(2_048, Instant::now() + Duration::from_secs(10)));
+
+        engine.seek_sample(12_000);
+        engine.seek_sample(24_000);
+        // Let the feeder receive both commands before the consumer answers.
+        // One callback then acknowledges both flush requests at once.
+        std::thread::sleep(Duration::from_millis(50));
+        consumer.take_flush();
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !engine.settled() && Instant::now() < deadline {
+            consumer.take_flush();
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(engine.settled(), "coalesced seeks never settled");
+        assert_eq!(clock.position_samples(), 24_000);
+        assert_eq!(engine.feed().seeks_done(), 2);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/bin/supply_soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/bin/supply_soak.rs
@@ -10,7 +10,7 @@
 //! supply layer has a pass mark now, and it is checked by running it rather
 //! than by watching it.
 
-use makevideo_compositor::source::{Buffering, FfmpegReaders, FrameSource};
+use makevideo_compositor::source::{Buffering, FfmpegReaders, FrameSource, MAX_FORWARD_SEEK};
 use makevideo_compositor::supply::{measure, ProjectInfo, Run, Scenario, ScenarioReport};
 use makevideo_render::{ffmpeg, layout, Project, TrackKind};
 use std::collections::BTreeMap;
@@ -149,17 +149,31 @@ fn run() -> Result<Run, String> {
     ));
     drop(source);
 
-    // Seeks, which is where a refill that is too slow shows. Both are the same
-    // operation inside the source: empty the queues, fill them from the target.
+    // A backward seek takes the refill path: the old forward reader cannot
+    // produce an earlier frame, so queues are rebuilt from zero.
     let mut source = build(&with_video_tracks(&project, 1), &options);
     let every = (options.seek_every_seconds * rate.as_f64())
         .round()
         .max(1.0) as u64;
     scenarios.push(measure(
         &mut source,
-        &Scenario::new("repeated-seek", frames)
+        &Scenario::new("repeated-backward-seek", frames)
             .seeking(every, 0)
             .noting("videoTracks", "1".into()),
+    ));
+    drop(source);
+
+    // A nearby forward target stays inside the live-reader reuse window. Its
+    // report is separate from the backward refill so a regression cannot hide
+    // in their combined percentile.
+    let short_forward = 12.min(MAX_FORWARD_SEEK);
+    let mut source = build(&with_video_tracks(&project, 1), &options);
+    scenarios.push(measure(
+        &mut source,
+        &Scenario::new("repeated-short-forward-seek", frames)
+            .seeking_forward(every, short_forward)
+            .noting("videoTracks", "1".into())
+            .noting("seekFrames", short_forward.to_string()),
     ));
     drop(source);
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/cpu.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/cpu.rs
@@ -129,6 +129,14 @@ fn draw(frame: &mut [u8], width: u32, height: u32, source: &Source<'_>, placemen
 /// the render pipeline.
 #[inline]
 fn blend_pixel(destination: &mut [u8], texel: [u8; 4], opacity: f32) {
+    // Decoded video is normally opaque. Avoid four floating-point blend
+    // operations per pixel for the overwhelmingly common full-opacity path;
+    // four FHD tracks otherwise spend most of their frame budget multiplying
+    // values whose result is simply the source byte.
+    if texel[3] == 255 && opacity >= 1.0 {
+        destination.copy_from_slice(&texel);
+        return;
+    }
     let source_alpha = (texel[3] as f32 / 255.0) * opacity;
     if source_alpha <= 0.0 {
         return;

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -22,10 +22,11 @@
 use crate::{lut::Lut, Placement as Draw, Source};
 use makevideo_render::layout::{self, Placement, Rect};
 use makevideo_render::{ffmpeg, AssetKind, Project, Rate, RationalTime};
+use std::collections::VecDeque;
 use std::io::Read;
 use std::process::{Child, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::mpsc::{sync_channel, Receiver, TryRecvError};
+use std::sync::mpsc::{sync_channel, Receiver, TryRecvError, TrySendError};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -45,8 +46,44 @@ pub const DEFAULT_DEPTH: usize = 6;
 /// frame is late by all of it, so it is done half a second early instead.
 pub const DEFAULT_LEAD: i64 = 15;
 
+/// A decoder already moving forward is cheaper to keep than an ffmpeg process
+/// is to restart. Beyond this distance the queued work is no longer a useful
+/// head start, so the old seek path remains the safer bound.
+pub const MAX_FORWARD_SEEK: i64 = 24;
+
+/// While a seek is still decoding its exact target, playback may use only a
+/// project frame immediately behind it. Paused stills never use this path.
+pub const SEEK_NEIGHBOR_FRAMES: i64 = 2;
+
+/// How long a paused decoder keeps its process and bounded queue warm.
+/// Resuming inside this window avoids another process spawn; after it, the
+/// isolated child is released instead of occupying memory indefinitely.
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// How long `take_by` sleeps between attempts while it waits.
 const POLL: Duration = Duration::from_micros(500);
+
+trait LifecycleClock: Send + Sync {
+    fn now(&self) -> Duration;
+}
+
+struct SystemClock {
+    started: Instant,
+}
+
+impl SystemClock {
+    fn new() -> SystemClock {
+        SystemClock {
+            started: Instant::now(),
+        }
+    }
+}
+
+impl LifecycleClock for SystemClock {
+    fn now(&self) -> Duration {
+        self.started.elapsed()
+    }
+}
 
 /// Raw frames for one clip, in order, already scaled to the size they will be
 /// drawn at.
@@ -147,6 +184,7 @@ impl Readers for FfmpegReaders {
 
 struct FfmpegReader {
     child: Arc<Mutex<Child>>,
+    cancelled: Arc<AtomicBool>,
     stdout: ChildStdout,
     fallback: Option<(String, Vec<String>)>,
     began: bool,
@@ -160,14 +198,15 @@ impl FfmpegReader {
     ) -> Option<FfmpegReader> {
         let (child, stdout) = Self::spawn(ffmpeg, args)?;
         Some(FfmpegReader {
-            child,
+            child: Arc::new(Mutex::new(child)),
+            cancelled: Arc::new(AtomicBool::new(false)),
             stdout,
             fallback,
             began: false,
         })
     }
 
-    fn spawn(ffmpeg: &str, args: &[String]) -> Option<(Arc<Mutex<Child>>, ChildStdout)> {
+    fn spawn(ffmpeg: &str, args: &[String]) -> Option<(Child, ChildStdout)> {
         let mut child = Command::new(ffmpeg)
             .args(args)
             .stdin(Stdio::null())
@@ -178,22 +217,26 @@ impl FfmpegReader {
             .spawn()
             .ok()?;
         let stdout = child.stdout.take()?;
-        Some((Arc::new(Mutex::new(child)), stdout))
+        Some((child, stdout))
     }
 
     fn retry_with_software(&mut self) -> bool {
         let Some((ffmpeg, args)) = self.fallback.take() else {
             return false;
         };
-        {
-            let mut child = self.child.lock().unwrap();
-            let _ = child.kill();
-            let _ = child.wait();
+        // Keep the stable slot locked through replacement. A cancellation
+        // racing the fallback then waits and kills the new child, rather than
+        // returning after killing only the child that just failed.
+        let mut current = self.child.lock().unwrap();
+        let _ = current.kill();
+        let _ = current.wait();
+        if self.cancelled.load(Ordering::SeqCst) {
+            return false;
         }
         let Some((child, stdout)) = Self::spawn(&ffmpeg, &args) else {
             return false;
         };
-        self.child = child;
+        *current = child;
         self.stdout = stdout;
         true
     }
@@ -201,10 +244,12 @@ impl FfmpegReader {
 
 struct FfmpegCancel {
     child: Arc<Mutex<Child>>,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl CancelRead for FfmpegCancel {
     fn cancel(&self) {
+        self.cancelled.store(true, Ordering::SeqCst);
         let _ = self.child.lock().unwrap().kill();
     }
 }
@@ -225,6 +270,7 @@ impl FrameReader for FfmpegReader {
     fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {
         Some(Arc::new(FfmpegCancel {
             child: Arc::clone(&self.child),
+            cancelled: Arc::clone(&self.cancelled),
         }))
     }
 }
@@ -343,6 +389,57 @@ pub enum Supply {
     End,
 }
 
+/// Resource state of this source's decoder processes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecoderLifecycle {
+    Running,
+    Idle,
+    Released,
+}
+
+struct DecodedFrame {
+    generation: u64,
+    frame: i64,
+    pixels: Vec<u8>,
+}
+
+#[derive(Clone, Copy)]
+struct DecoderDemand {
+    generation: u64,
+    first_frame: i64,
+}
+
+struct DecoderControl {
+    demand: Mutex<DecoderDemand>,
+    wake: std::sync::Condvar,
+}
+
+impl DecoderControl {
+    fn new(generation: u64, first_frame: i64) -> DecoderControl {
+        DecoderControl {
+            demand: Mutex::new(DecoderDemand {
+                generation,
+                first_frame,
+            }),
+            wake: std::sync::Condvar::new(),
+        }
+    }
+
+    fn retarget(&self, generation: u64, first_frame: i64) {
+        let mut demand = self.demand.lock().unwrap();
+        *demand = DecoderDemand {
+            generation,
+            first_frame,
+        };
+        self.wake.notify_all();
+    }
+
+    fn notify(&self) {
+        let _demand = self.demand.lock().unwrap();
+        self.wake.notify_all();
+    }
+}
+
 impl Supply {
     pub fn frame(self) -> Option<Frame> {
         match self {
@@ -357,16 +454,22 @@ struct Stream {
     placement: Placement,
     lut: Option<Arc<Lut>>,
     frame_bytes: usize,
-    receiver: Option<Receiver<Vec<u8>>>,
+    receiver: Option<Receiver<DecodedFrame>>,
+    /// Frames retained from an existing queue across a short forward seek.
+    /// Their generation is promoted only after their absolute project frame
+    /// proves they are still valid for the new target.
+    ready: VecDeque<DecodedFrame>,
     /// The frame taken out of the queue but not yet handed over, because some
     /// other clip was not ready. This is what makes a starved poll consume
     /// nothing.
-    pending: Option<Vec<u8>>,
-    /// What is sitting in the queue, so the memory can be reported without
-    /// draining it.
-    queued: Arc<AtomicUsize>,
+    pending: Option<DecodedFrame>,
+    /// Every decoded frame not yet consumed, whether it is in the channel, in
+    /// `ready`, or in `pending`. Sharing the count with the producer keeps a
+    /// retargeted queue within the same memory bound while it is being drained.
+    buffered: Arc<AtomicUsize>,
     decoder: Option<JoinHandle<()>>,
     cancellation: Arc<DecoderCancellation>,
+    control: Arc<DecoderControl>,
     /// The source could not be opened or has run out. Its clip stops drawing.
     dead: bool,
 }
@@ -393,6 +496,10 @@ impl DecoderCancellation {
             reader.cancel();
         }
     }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
 }
 
 impl Stream {
@@ -414,12 +521,23 @@ pub struct FrameSource {
     rate: Rate,
     frames: i64,
     position: i64,
+    generation: u64,
+    /// A tolerant seek consumes at most two earlier project frames while it
+    /// waits for the exact target. The latest complete one is offered to the
+    /// playback scheduler, but never returned by `take` itself.
+    seek_probe: Option<i64>,
+    seek_neighbor: Option<Frame>,
+    lifecycle_clock: Arc<dyn LifecycleClock>,
+    idle_timeout: Duration,
+    idle_since: Option<Duration>,
     /// The edit this source was built from, kept for the text and shape items.
     /// They are rasterized per frame (and cached by content) rather than
     /// decoded, so they have no stream of their own.
     project: Project,
     width: u32,
     height: u32,
+    video_frame_ceiling: usize,
+    visual_frame_ceiling: usize,
 }
 
 impl FrameSource {
@@ -433,24 +551,47 @@ impl FrameSource {
         buffering: Buffering,
         readers: Arc<dyn Readers>,
     ) -> FrameSource {
+        Self::new_with_clock(
+            project,
+            width,
+            height,
+            buffering,
+            readers,
+            Arc::new(SystemClock::new()),
+            DEFAULT_IDLE_TIMEOUT,
+        )
+    }
+
+    fn new_with_clock(
+        project: &Project,
+        width: u32,
+        height: u32,
+        buffering: Buffering,
+        readers: Arc<dyn Readers>,
+        lifecycle_clock: Arc<dyn LifecycleClock>,
+        idle_timeout: Duration,
+    ) -> FrameSource {
         let streams = layout::placements(project, width, height)
             .into_iter()
             .map(|placement| Stream {
                 frame_bytes: (placement.dst.w as usize) * (placement.dst.h as usize) * 4,
-                lut: project.clip(&placement.clip_id)
+                lut: project
+                    .clip(&placement.clip_id)
                     .and_then(|clip| clip.lut_path.as_deref())
                     .and_then(|path| Lut::from_cube_file(path).ok())
                     .map(Arc::new),
                 placement,
                 receiver: None,
+                ready: VecDeque::new(),
                 pending: None,
-                queued: Arc::new(AtomicUsize::new(0)),
+                buffered: Arc::new(AtomicUsize::new(0)),
                 decoder: None,
                 cancellation: Arc::new(DecoderCancellation::default()),
+                control: Arc::new(DecoderControl::new(0, 0)),
                 dead: false,
             })
             .collect();
-        FrameSource {
+        let mut source = FrameSource {
             readers,
             streams,
             retiring: Vec::new(),
@@ -458,10 +599,24 @@ impl FrameSource {
             rate: project.rate(),
             frames: layout::frame_count(project),
             position: 0,
+            generation: 0,
+            seek_probe: None,
+            seek_neighbor: None,
+            lifecycle_clock,
+            idle_timeout,
+            idle_since: None,
             project: project.clone(),
             width,
             height,
-        }
+            video_frame_ceiling: 0,
+            visual_frame_ceiling: 0,
+        };
+        // Immutable project/layout bounds are sampled every playback tick.
+        // Calculate them once instead of allocating and sweeping events at
+        // frame rate, which matters on the already-busy multi-track CPU path.
+        source.video_frame_ceiling = source.calculate_video_frame_ceiling();
+        source.visual_frame_ceiling = source.calculate_visual_frame_ceiling();
+        source
     }
 
     pub fn rate(&self) -> Rate {
@@ -480,30 +635,51 @@ impl FrameSource {
 
     /// Frames sitting decoded, over every clip.
     pub fn buffered_frames(&self) -> usize {
-        self.streams
+        let decoded = self
+            .streams
             .iter()
-            .map(|stream| {
-                stream.queued.load(Ordering::SeqCst) + usize::from(stream.pending.is_some())
-            })
-            .sum()
+            .map(|stream| stream.buffered.load(Ordering::SeqCst))
+            .sum::<usize>();
+        decoded
+            + self
+                .seek_neighbor
+                .as_ref()
+                .map(|frame| frame.layers.len())
+                .unwrap_or(0)
     }
 
     /// What those frames cost, which is the number the buffering settings are
     /// really trading against.
     pub fn buffered_bytes(&self) -> usize {
-        self.streams
+        let decoded = self
+            .streams
             .iter()
-            .map(|stream| {
-                (stream.queued.load(Ordering::SeqCst) + usize::from(stream.pending.is_some()))
-                    * stream.frame_bytes
-            })
-            .sum()
+            .map(|stream| stream.buffered.load(Ordering::SeqCst) * stream.frame_bytes)
+            .sum::<usize>();
+        decoded
+            + self
+                .seek_neighbor
+                .as_ref()
+                .map(|frame| {
+                    frame
+                        .layers
+                        .iter()
+                        .map(|layer| layer.pixels.len())
+                        .sum::<usize>()
+                        + frame
+                            .visuals
+                            .iter()
+                            .map(|layer| layer.pixels.len())
+                            .sum::<usize>()
+                })
+                .unwrap_or(0)
     }
 
     /// The most the queues can hold at one instant: every clip that can be
-    /// buffering at the same time, full, plus the one frame each can be holding
-    /// in its pending slot. The supply meter holds the source to this, which is
-    /// what turns "bounded memory" from a claim into a check.
+    /// buffering at the same time, full, plus one pending frame per stream and
+    /// one complete project-frame neighbor retained during a seek. The supply
+    /// meter holds the source to this, which is what turns "bounded memory"
+    /// from a claim into a check.
     ///
     /// Summing every clip in the project instead would be a bound nothing could
     /// ever reach — a hundred clips one after another are never buffering
@@ -511,6 +687,17 @@ impl FrameSource {
     /// exists from `lead` frames before it appears until the playhead leaves
     /// it, so what is wanted is the heaviest overlap of those spans.
     pub fn buffer_ceiling(&self) -> usize {
+        (self.buffering.depth + 2) * self.video_frame_ceiling + self.visual_frame_ceiling
+    }
+
+    /// Largest simultaneous decoded video payload for one project frame.
+    /// Schedulers that retain a frame after decode use one extra copy of this
+    /// bound beyond the source's own queues.
+    pub fn frame_ceiling(&self) -> usize {
+        self.video_frame_ceiling + self.visual_frame_ceiling
+    }
+
+    fn calculate_video_frame_ceiling(&self) -> usize {
         // (position, starting, bytes). An end is applied before a start at the
         // same position, because that is the order `tend` does it in.
         let mut events: Vec<(i64, u8, usize)> = Vec::new();
@@ -534,7 +721,27 @@ impl FrameSource {
                 live -= bytes;
             }
         }
-        (self.buffering.depth + 1) * worst
+        worst
+    }
+
+    fn calculate_visual_frame_ceiling(&self) -> usize {
+        let mut events: Vec<(i64, u8, usize)> =
+            crate::text::byte_spans(&self.project, self.width, self.height)
+                .into_iter()
+                .flat_map(|(from, until, bytes)| [(from, 1, bytes), (until, 0, bytes)])
+                .collect();
+        events.sort_by_key(|(position, starting, _)| (*position, *starting));
+
+        let (mut live, mut worst) = (0usize, 0usize);
+        for (_, starting, bytes) in events {
+            if starting == 1 {
+                live += bytes;
+                worst = worst.max(live);
+            } else {
+                live -= bytes;
+            }
+        }
+        worst
     }
 
     /// The clips with a decoder running, in paint order.
@@ -546,59 +753,202 @@ impl FrameSource {
             .collect()
     }
 
-    /// Move the playhead. Every queue is thrown away and refilled from the
-    /// target, which is the whole of seeking: playing and paused take the same
-    /// path, so there is one behaviour to get right and one to test.
-    ///
-    /// Returns without waiting for anything. The decoders start immediately and
-    /// the first frame arrives when it arrives; `take` says `Starved` until
-    /// then.
-    pub fn seek(&mut self, frame: i64) {
-        for index in 0..self.streams.len() {
-            self.retire(index);
-            // A fresh decoder is a fresh attempt: a clip whose source ran out
-            // before the old position may well have frames at the new one.
-            self.streams[index].dead = false;
+    /// Whether decoder processes are being used, retained briefly while
+    /// paused, or fully released.
+    pub fn decoder_lifecycle(&self) -> DecoderLifecycle {
+        if !self.has_decoder_pipeline() {
+            DecoderLifecycle::Released
+        } else if self.idle_since.is_some() {
+            DecoderLifecycle::Idle
+        } else {
+            DecoderLifecycle::Running
         }
-        self.position = frame.clamp(0, self.frames);
-        self.tend();
+    }
+
+    /// Keep live decoders warm while no frame is being requested.
+    pub fn idle_decoders(&mut self) {
+        if self.has_decoder_pipeline() && self.idle_since.is_none() {
+            self.idle_since = Some(self.lifecycle_clock.now());
+        }
+    }
+
+    /// A new frame request makes retained decoders active again.
+    pub fn resume_decoders(&mut self) {
+        self.idle_since = None;
+    }
+
+    /// Release decoders whose idle window has elapsed. This does not redraw or
+    /// clear a sink, so the last exact paused frame remains visible.
+    pub fn maintain_decoders(&mut self) {
+        let Some(since) = self.idle_since else {
+            return;
+        };
+        if self.lifecycle_clock.now().saturating_sub(since) < self.idle_timeout {
+            return;
+        }
+        for index in 0..self.streams.len() {
+            if self.stream_has_pipeline(index) {
+                self.retire(index);
+            }
+        }
         self.reap();
+    }
+
+    /// Move the playhead. A short forward move keeps a live decoder and advances
+    /// it to the target; a backward or large move keeps the isolated-process
+    /// restart path.
+    ///
+    /// While the exact frame is on its way, up to two complete project frames
+    /// immediately before it are made available through [`Self::take_neighbor_before`].
+    /// They never come back from [`Self::take`], so callers that require an exact
+    /// frame do not have to defend against an approximation.
+    pub fn seek(&mut self, frame: i64) {
+        self.seek_with_tolerance(frame, SEEK_NEIGHBOR_FRAMES);
+    }
+
+    /// Seek without exposing an approximate frame. Paused stills use this path,
+    /// while retaining the cheap forward-decoder reuse.
+    pub fn seek_exact(&mut self, frame: i64) {
+        self.seek_with_tolerance(frame, 0);
+    }
+
+    fn seek_with_tolerance(&mut self, frame: i64, tolerance: i64) {
+        self.resume_decoders();
+        let target = frame.clamp(0, self.frames);
+        let old_position = self.position;
+        let reuse = target >= old_position && target - old_position <= MAX_FORWARD_SEEK;
+        self.generation = self.generation.wrapping_add(1);
+        self.release_seek_neighbor();
+
+        let mut first = (target - tolerance.max(0)).max(0);
+        if reuse {
+            // Frames before the consumer's current position are already gone.
+            first = first.max(old_position);
+        }
+        if target >= self.frames || first >= target {
+            self.seek_probe = None;
+        } else {
+            self.seek_probe = Some(first);
+        }
+
+        if reuse {
+            for index in 0..self.streams.len() {
+                if self.stream_has_pipeline(index) {
+                    let wanted = first.max(self.streams[index].placement.start_frame);
+                    self.retarget(index, wanted);
+                }
+            }
+        } else {
+            for index in 0..self.streams.len() {
+                self.retire(index);
+                // A fresh decoder is a fresh attempt: a clip whose source ran
+                // out before the old position may have frames at the new one.
+                self.streams[index].dead = false;
+            }
+        }
+
+        self.position = target;
+        self.tend_at(self.seek_probe.unwrap_or(target));
+        self.reap();
+    }
+
+    /// Take the newest complete frame behind an in-progress seek target.
+    /// Exact and future frames are never returned here.
+    pub fn take_neighbor_before(&mut self, target: i64, tolerance: i64) -> Option<Frame> {
+        if self.position != target {
+            return None;
+        }
+        let neighbor = self.seek_neighbor.take()?;
+        let distance = target - neighbor.frame;
+        if distance > 0 && distance <= tolerance.max(0) {
+            Some(neighbor)
+        } else {
+            None
+        }
     }
 
     /// One poll. Never blocks and never decodes.
     pub fn take(&mut self) -> Supply {
+        self.resume_decoders();
         self.reap();
-        // Before the end check, so the last clip's decoder is retired by
-        // reaching the end of the timeline rather than by dropping the source.
-        self.tend();
         if self.position >= self.frames {
+            // Before returning, retire the last clip by reaching the timeline
+            // end rather than waiting for the whole source to drop.
+            self.tend_at(self.position);
             return Supply::End;
         }
 
-        let frame = self.position;
+        loop {
+            let frame = self.seek_probe.unwrap_or(self.position);
+            self.tend_at(frame);
+            match self.take_frame(frame) {
+                Supply::Ready(ready) if frame < self.position => {
+                    self.release_seek_neighbor();
+                    self.seek_neighbor = Some(ready);
+                    let next = frame + 1;
+                    self.seek_probe = (next < self.position).then_some(next);
+                }
+                Supply::Ready(ready) => {
+                    self.seek_probe = None;
+                    self.release_seek_neighbor();
+                    self.position += 1;
+                    return Supply::Ready(ready);
+                }
+                supply => return supply,
+            }
+        }
+    }
+
+    fn take_frame(&mut self, frame: i64) -> Supply {
         let mut starved = false;
         let mut finished = Vec::new();
         for stream in self.streams.iter_mut() {
             if !stream.wants(frame) || stream.dead || stream.pending.is_some() {
                 continue;
             }
-            match stream.receiver.as_ref().map(|queue| queue.try_recv()) {
-                Some(Ok(pixels)) => {
-                    stream.queued.fetch_sub(1, Ordering::SeqCst);
-                    stream.pending = Some(pixels);
+            loop {
+                let received = stream
+                    .ready
+                    .pop_front()
+                    .map(Ok)
+                    .or_else(|| stream.receiver.as_ref().map(|queue| queue.try_recv()));
+                if matches!(&received, Some(Ok(_))) {
+                    stream.control.notify();
                 }
-                Some(Err(TryRecvError::Disconnected)) => {
-                    // Empty and closed. The source is over, so the clip stops
-                    // drawing rather than holding the playhead.
-                    stream.dead = true;
-                    stream.receiver = None;
-                    // Its thread has already ended, so the handle is retired
-                    // here rather than at the end of the clip. Otherwise a
-                    // source that died on frame 10 of a ten minute clip is
-                    // reported as decoding for the other ten minutes.
-                    finished.extend(stream.decoder.take());
+                match received {
+                    Some(Ok(decoded))
+                        if decoded.generation != self.generation || decoded.frame < frame =>
+                    {
+                        stream.buffered.fetch_sub(1, Ordering::SeqCst);
+                        stream.control.notify();
+                    }
+                    Some(Ok(decoded)) if decoded.frame == frame => {
+                        stream.pending = Some(decoded);
+                        break;
+                    }
+                    Some(Ok(decoded)) => {
+                        // It is newer than the requested project frame. Keep it
+                        // for its own turn and never draw it early.
+                        stream.ready.push_front(decoded);
+                        starved = true;
+                        break;
+                    }
+                    Some(Err(TryRecvError::Disconnected)) => {
+                        // Empty and closed. The source is over, so the clip
+                        // stops drawing rather than holding the playhead.
+                        stream.dead = true;
+                        stream.receiver = None;
+                        // Its thread already ended, so retire the handle where
+                        // it died rather than reporting it for the rest of the
+                        // clip.
+                        finished.extend(stream.decoder.take());
+                        break;
+                    }
+                    Some(Err(TryRecvError::Empty)) | None => {
+                        starved = true;
+                        break;
+                    }
                 }
-                Some(Err(TryRecvError::Empty)) | None => starved = true,
             }
         }
         self.retiring.append(&mut finished);
@@ -611,18 +961,42 @@ impl FrameSource {
             .iter_mut()
             .filter(|stream| stream.wants(frame))
             .filter_map(|stream| {
-                stream.pending.take().map(|pixels| Layer {
-                    clip_id: stream.placement.clip_id.clone(),
-                    pixels,
-                    dst: stream.placement.dst,
-                    opacity: stream.placement.opacity,
-                    lut: stream.lut.clone(),
+                stream.pending.take().map(|decoded| {
+                    stream.buffered.fetch_sub(1, Ordering::SeqCst);
+                    stream.control.notify();
+                    Layer {
+                        clip_id: stream.placement.clip_id.clone(),
+                        pixels: decoded.pixels,
+                        dst: stream.placement.dst,
+                        opacity: stream.placement.opacity,
+                        lut: stream.lut.clone(),
+                    }
                 })
             })
             .collect();
-        self.position += 1;
         let visuals = crate::text::layers_at(&self.project, frame, self.width, self.height);
-        Supply::Ready(Frame { frame, layers, visuals })
+        Supply::Ready(Frame {
+            frame,
+            layers,
+            visuals,
+        })
+    }
+
+    fn has_decoder_pipeline(&self) -> bool {
+        (0..self.streams.len()).any(|index| self.stream_has_pipeline(index))
+            || self.retiring.iter().any(|decoder| !decoder.is_finished())
+    }
+
+    fn stream_has_pipeline(&self, index: usize) -> bool {
+        let stream = &self.streams[index];
+        stream.decoder.is_some()
+            || stream.receiver.is_some()
+            || !stream.ready.is_empty()
+            || stream.pending.is_some()
+    }
+
+    fn release_seek_neighbor(&mut self) {
+        self.seek_neighbor = None;
     }
 
     /// Poll until the frame is there or `deadline` passes. `Starved` coming
@@ -644,14 +1018,17 @@ impl FrameSource {
 
     /// Start the decoders that are about to be needed and stop the ones that
     /// are done.
-    fn tend(&mut self) {
-        let position = self.position;
+    fn tend_at(&mut self, position: i64) {
         let lead = self.buffering.lead;
         for index in 0..self.streams.len() {
             let stream = &self.streams[index];
             let over = position >= stream.placement.end_frame();
             if over {
-                if stream.decoder.is_some() || stream.pending.is_some() {
+                if stream.decoder.is_some()
+                    || stream.receiver.is_some()
+                    || !stream.ready.is_empty()
+                    || stream.pending.is_some()
+                {
                     self.retire(index);
                 }
                 continue;
@@ -660,13 +1037,13 @@ impl FrameSource {
                 && !stream.dead
                 && position + lead >= stream.placement.start_frame
             {
-                self.start(index);
+                self.start(index, position);
             }
         }
     }
 
-    fn start(&mut self, index: usize) {
-        let (rate, frames, position) = (self.rate, self.frames, self.position);
+    fn start(&mut self, index: usize, position: i64) {
+        let (rate, frames, generation) = (self.rate, self.frames, self.generation);
         let readers = Arc::clone(&self.readers);
         let depth = self.buffering.depth;
         let stream = &mut self.streams[index];
@@ -690,11 +1067,14 @@ impl FrameSource {
         };
 
         let frame_bytes = stream.frame_bytes;
-        let (sender, receiver) = sync_channel::<Vec<u8>>(depth);
-        let queued = Arc::new(AtomicUsize::new(0));
-        let counter = Arc::clone(&queued);
+        let (sender, receiver) = sync_channel::<DecodedFrame>(depth);
+        let buffer_limit = depth + 1;
+        let buffered = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&buffered);
         let cancellation = Arc::new(DecoderCancellation::default());
         let decoder_cancellation = Arc::clone(&cancellation);
+        let control = Arc::new(DecoderControl::new(generation, first));
+        let decoder_control = Arc::clone(&control);
         let decoder = std::thread::spawn(move || {
             let Some(mut reader) = readers.open(&request) else {
                 // Dropping the sender closes the queue, which is how the
@@ -704,24 +1084,94 @@ impl FrameSource {
             if decoder_cancellation.attach(reader.cancellation()) {
                 return;
             }
+            let mut frame = first;
             loop {
                 let mut buffer = vec![0u8; frame_bytes];
                 if !reader.read(&mut buffer) {
                     break;
                 }
-                counter.fetch_add(1, Ordering::SeqCst);
-                // Blocks once the queue is full, which is what bounds the
-                // memory: a decoder that gets ahead simply waits.
-                if sender.send(buffer).is_err() {
-                    counter.fetch_sub(1, Ordering::SeqCst);
-                    break;
+                let mut pixels = Some(buffer);
+                loop {
+                    if decoder_cancellation.is_cancelled() {
+                        return;
+                    }
+                    let demand = decoder_control.demand.lock().unwrap();
+                    if frame < demand.first_frame {
+                        break;
+                    }
+                    if counter.load(Ordering::SeqCst) >= buffer_limit {
+                        drop(decoder_control.wake.wait(demand).unwrap());
+                        continue;
+                    }
+                    let decoded = DecodedFrame {
+                        generation: demand.generation,
+                        frame,
+                        pixels: pixels.take().unwrap(),
+                    };
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    match sender.try_send(decoded) {
+                        Ok(()) => break,
+                        Err(TrySendError::Full(decoded)) => {
+                            counter.fetch_sub(1, Ordering::SeqCst);
+                            pixels = Some(decoded.pixels);
+                            drop(decoder_control.wake.wait(demand).unwrap());
+                        }
+                        Err(TrySendError::Disconnected(_)) => {
+                            counter.fetch_sub(1, Ordering::SeqCst);
+                            return;
+                        }
+                    }
                 }
+                frame += 1;
             }
         });
         stream.receiver = Some(receiver);
-        stream.queued = queued;
+        stream.ready.clear();
+        stream.pending = None;
+        stream.buffered = buffered;
         stream.decoder = Some(decoder);
         stream.cancellation = cancellation;
+        stream.control = control;
+    }
+
+    fn retarget(&mut self, index: usize, first_frame: i64) {
+        let generation = self.generation;
+        let stream = &mut self.streams[index];
+        stream.control.retarget(generation, first_frame);
+
+        let mut decoded = Vec::new();
+        decoded.extend(stream.pending.take());
+        decoded.extend(stream.ready.drain(..));
+        let mut disconnected = false;
+        if let Some(receiver) = stream.receiver.as_ref() {
+            loop {
+                match receiver.try_recv() {
+                    Ok(frame) => decoded.push(frame),
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
+            }
+        }
+        stream.control.notify();
+
+        decoded.sort_by_key(|frame| frame.frame);
+        for mut frame in decoded {
+            if frame.frame < first_frame {
+                stream.buffered.fetch_sub(1, Ordering::SeqCst);
+                stream.control.notify();
+                continue;
+            }
+            frame.generation = generation;
+            stream.ready.push_back(frame);
+        }
+        if disconnected {
+            if let Some(handle) = stream.decoder.take() {
+                self.retiring.push(handle);
+            }
+        }
     }
 
     /// Drop a clip's queue and interrupt a decoder blocked in a read. Nothing is
@@ -729,9 +1179,12 @@ impl FrameSource {
     fn retire(&mut self, index: usize) {
         let stream = &mut self.streams[index];
         stream.cancellation.cancel();
+        stream.control.notify();
         stream.receiver = None;
+        stream.ready.clear();
         stream.pending = None;
-        stream.queued = Arc::new(AtomicUsize::new(0));
+        stream.buffered = Arc::new(AtomicUsize::new(0));
+        stream.control = Arc::new(DecoderControl::new(self.generation, self.position));
         let decoder = stream.decoder.take();
         if let Some(handle) = decoder {
             self.retiring.push(handle);
@@ -770,6 +1223,7 @@ impl Drop for FrameSource {
 mod tests {
     use super::*;
     use makevideo_render::{Asset, Clip, ProjectSettings, Track, TrackKind, FORMAT_VERSION};
+    use std::sync::atomic::AtomicU64;
     use std::sync::Condvar;
 
     /// A source that hands back frames tagged with the clip and the frame
@@ -879,6 +1333,23 @@ mod tests {
     struct BlockingReaders {
         stopped: Arc<(Mutex<bool>, Condvar)>,
         reading: Arc<AtomicBool>,
+    }
+
+    #[derive(Default)]
+    struct FakeLifecycleClock {
+        millis: AtomicU64,
+    }
+
+    impl FakeLifecycleClock {
+        fn advance(&self, millis: u64) {
+            self.millis.fetch_add(millis, Ordering::SeqCst);
+        }
+    }
+
+    impl LifecycleClock for FakeLifecycleClock {
+        fn now(&self) -> Duration {
+            Duration::from_millis(self.millis.load(Ordering::SeqCst))
+        }
     }
 
     impl Readers for BlockingReaders {
@@ -1016,9 +1487,29 @@ mod tests {
                 end_arrow: false,
             },
         });
-        let mut source = source(&with_shape, Buffering::default(), Arc::new(Fakes::default()));
+        let mut source = source(
+            &with_shape,
+            Buffering::default(),
+            Arc::new(Fakes::default()),
+        );
         let covered = next(&mut source);
         assert_eq!(covered.sources().len(), 2, "the clip and the shape");
+        let video_bytes = 16 * 16 * 4;
+        let visual_bytes = 8 * 8 * 4;
+        assert_eq!(covered.visuals[0].pixels.len(), visual_bytes);
+        assert_eq!(source.frame_ceiling(), video_bytes + visual_bytes);
+        assert_eq!(
+            source.buffer_ceiling(),
+            (source.buffering.depth + 2) * video_bytes + visual_bytes
+        );
+        let decoded_bytes = source.buffered_bytes();
+        source.seek_neighbor = Some(covered);
+        assert_eq!(
+            source.buffered_bytes(),
+            decoded_bytes + video_bytes + visual_bytes,
+            "a retained seek frame counts both clip and visual pixels"
+        );
+        source.seek_neighbor = None;
         let after = next(&mut source);
         assert_eq!(after.sources().len(), 1, "the shape has ended");
     }
@@ -1202,7 +1693,11 @@ mod tests {
         );
         let one_frame = 16 * 16 * 4;
         let sequential = source(&sequence, Buffering::new(3, 0), Arc::new(Fakes::default()));
-        assert_eq!(sequential.buffer_ceiling(), 4 * one_frame);
+        assert_eq!(
+            sequential.buffer_ceiling(),
+            5 * one_frame,
+            "depth, pending, and one retained seek neighbor"
+        );
 
         // Two tracks that overlap are two queues at once, and a lead makes the
         // next clip's queue overlap the one before it.
@@ -1214,9 +1709,9 @@ mod tests {
             vec![asset("a1"), asset("a2")],
         );
         let overlapping = source(&stacked, Buffering::new(3, 0), Arc::new(Fakes::default()));
-        assert_eq!(overlapping.buffer_ceiling(), 8 * one_frame);
+        assert_eq!(overlapping.buffer_ceiling(), 10 * one_frame);
         let led = source(&sequence, Buffering::new(3, 5), Arc::new(Fakes::default()));
-        assert_eq!(led.buffer_ceiling(), 8 * one_frame, "the lead overlaps");
+        assert_eq!(led.buffer_ceiling(), 10 * one_frame, "the lead overlaps");
     }
 
     #[test]
@@ -1265,7 +1760,7 @@ mod tests {
     }
 
     #[test]
-    fn seeking_throws_the_queues_away_and_refills_from_the_target() {
+    fn a_short_forward_seek_reuses_the_live_decoder() {
         let project = one_clip();
         let readers = Arc::new(Fakes::default());
         let mut source = source(&project, Buffering::new(6, 0), Arc::clone(&readers));
@@ -1279,12 +1774,185 @@ mod tests {
         assert_eq!(
             source_frame(&frame, "c1"),
             20,
-            "the frames buffered before the seek must not be shown"
+            "queued frames before the target must not be shown"
         );
         let opened = readers.opens();
-        assert_eq!(opened.len(), 2, "a seek is a new decoder");
-        assert_eq!(opened[1].in_frame, 20);
-        assert_eq!(opened[1].frames, 10, "what is left of the clip");
+        assert_eq!(opened.len(), 1, "the live decoder advances in place");
+    }
+
+    #[test]
+    fn a_large_forward_seek_reopens_the_decoder() {
+        let project = one_clip();
+        let readers = Arc::new(Fakes::default());
+        let mut source = source(&project, Buffering::new(2, 0), Arc::clone(&readers));
+        next(&mut source);
+
+        source.seek_exact(MAX_FORWARD_SEEK + 2);
+        assert_eq!(next(&mut source).frame, MAX_FORWARD_SEEK + 2);
+        let opened = readers.opens();
+        assert_eq!(opened.len(), 2);
+        assert_eq!(opened[1].in_frame, MAX_FORWARD_SEEK + 2);
+    }
+
+    #[test]
+    fn a_seek_offers_only_real_frames_one_or_two_behind_the_target() {
+        let project = one_clip();
+        let mut source = source(&project, Buffering::new(3, 0), Arc::new(Fakes::default()));
+        source.position = 20;
+        source.generation = 7;
+        source.seek_probe = Some(18);
+        let (_sender, receiver) = sync_channel(3);
+        source.streams[0].receiver = Some(receiver);
+
+        for expected in [18, 19] {
+            source.streams[0].ready.push_back(DecodedFrame {
+                generation: 7,
+                frame: expected,
+                pixels: vec![expected as u8; 16 * 16 * 4],
+            });
+            source.streams[0].buffered.fetch_add(1, Ordering::SeqCst);
+            assert!(matches!(source.take(), Supply::Starved));
+            assert_eq!(
+                source.buffered_frames(),
+                1,
+                "the retained neighbor is included in source accounting"
+            );
+            let neighbor = source
+                .take_neighbor_before(20, SEEK_NEIGHBOR_FRAMES)
+                .expect("current-generation neighbor");
+            assert_eq!(source.buffered_frames(), 0);
+            assert_eq!(neighbor.frame, expected);
+            assert_eq!(source_frame(&neighbor, "c1"), expected as u8);
+            assert_eq!(source.position(), 20, "the logical target stays exact");
+        }
+
+        source.streams[0].ready.push_back(DecodedFrame {
+            generation: 7,
+            frame: 20,
+            pixels: vec![20; 16 * 16 * 4],
+        });
+        source.streams[0].buffered.fetch_add(1, Ordering::SeqCst);
+        let Supply::Ready(exact) = source.take() else {
+            panic!("exact frame did not replace the neighbor");
+        };
+        assert_eq!(exact.frame, 20);
+        assert_eq!(source_frame(&exact, "c1"), 20);
+        assert_eq!(source.buffered_frames(), 0);
+    }
+
+    #[test]
+    fn neighbor_boundary_rejects_three_behind_and_future_frames() {
+        let project = one_clip();
+        let mut source = source(&project, Buffering::default(), Arc::new(Fakes::default()));
+        source.position = 20;
+        for allowed in [19, 18] {
+            source.seek_neighbor = Some(Frame {
+                frame: allowed,
+                layers: Vec::new(),
+                visuals: Vec::new(),
+            });
+            assert_eq!(
+                source
+                    .take_neighbor_before(20, SEEK_NEIGHBOR_FRAMES)
+                    .map(|frame| frame.frame),
+                Some(allowed)
+            );
+        }
+        for forbidden in [17, 20, 21] {
+            source.seek_neighbor = Some(Frame {
+                frame: forbidden,
+                layers: Vec::new(),
+                visuals: Vec::new(),
+            });
+            assert!(source
+                .take_neighbor_before(20, SEEK_NEIGHBOR_FRAMES)
+                .is_none());
+        }
+    }
+
+    #[test]
+    fn a_stale_generation_cannot_become_an_exact_or_neighbor_frame() {
+        let project = one_clip();
+        let mut source = source(&project, Buffering::default(), Arc::new(Fakes::default()));
+        source.generation = 2;
+        source.position = 10;
+        source.streams[0].ready.push_back(DecodedFrame {
+            generation: 1,
+            frame: 10,
+            pixels: vec![10; 16 * 16 * 4],
+        });
+        source.streams[0].buffered.store(1, Ordering::SeqCst);
+
+        assert!(matches!(source.take_frame(10), Supply::Starved));
+        assert_eq!(source.streams[0].buffered.load(Ordering::SeqCst), 0);
+        assert!(source
+            .take_neighbor_before(10, SEEK_NEIGHBOR_FRAMES)
+            .is_none());
+    }
+
+    #[test]
+    fn an_idle_decoder_is_released_after_the_timeout_and_can_reopen() {
+        let project = one_clip();
+        let readers = Arc::new(Fakes::default());
+        let clock = Arc::new(FakeLifecycleClock::default());
+        let lifecycle_clock: Arc<dyn LifecycleClock> = clock.clone();
+        let mut source = FrameSource::new_with_clock(
+            &project,
+            16,
+            16,
+            Buffering::new(2, 0),
+            Arc::clone(&readers) as Arc<dyn Readers>,
+            lifecycle_clock,
+            Duration::from_millis(100),
+        );
+        assert_eq!(source.decoder_lifecycle(), DecoderLifecycle::Released);
+        next(&mut source);
+        assert_eq!(source.decoder_lifecycle(), DecoderLifecycle::Running);
+
+        source.seek_neighbor = Some(Frame {
+            frame: 0,
+            layers: vec![Layer {
+                clip_id: "c1".into(),
+                pixels: vec![0; 16 * 16 * 4],
+                dst: source.streams[0].placement.dst,
+                opacity: 1.0,
+                lut: None,
+            }],
+            visuals: Vec::new(),
+        });
+        source.idle_decoders();
+        assert_eq!(source.decoder_lifecycle(), DecoderLifecycle::Idle);
+        clock.advance(99);
+        source.maintain_decoders();
+        assert_eq!(source.decoder_lifecycle(), DecoderLifecycle::Idle);
+        clock.advance(1);
+        source.maintain_decoders();
+        let release_deadline = Instant::now() + Duration::from_secs(1);
+        while source.decoder_lifecycle() != DecoderLifecycle::Released {
+            assert!(
+                Instant::now() < release_deadline,
+                "the cancelled decoder thread did not release"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+            source.maintain_decoders();
+        }
+        assert!(source.decoding().is_empty());
+        assert_eq!(
+            source.buffered_frames(),
+            1,
+            "the neighbor is a separate slot"
+        );
+        assert_eq!(
+            source
+                .take_neighbor_before(1, SEEK_NEIGHBOR_FRAMES)
+                .map(|frame| frame.frame),
+            Some(0)
+        );
+        assert_eq!(source.buffered_frames(), 0);
+
+        source.seek_exact(5);
+        assert_eq!(source.decoder_lifecycle(), DecoderLifecycle::Running);
+        assert!(wait_for(|| readers.opens().len() == 2));
     }
 
     #[test]
@@ -1323,6 +1991,7 @@ mod tests {
         }
         source.seek(0);
         assert_eq!(next(&mut source).layers.len(), 1, "it draws again");
+        assert_eq!(readers.opens().len(), 2, "backward seek reopens");
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
@@ -16,7 +16,7 @@
 //! the queues have to survive being read at exactly one frame per frame period,
 //! which is the only rate at which a buffer can run dry.
 
-use crate::source::{FrameSource, Supply};
+use crate::source::{FrameSource, Supply, MAX_FORWARD_SEEK};
 use makevideo_render::Rate;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -65,9 +65,15 @@ pub struct Scenario {
     /// How many frames to pull. Reaching the end of the timeline wraps back to
     /// the start, which is counted as a seek.
     pub frames: u64,
-    /// Seek back to `seek_to` every this many frames.
+    /// Seek every this many delivered frames.
     pub seek_every: Option<u64>,
+    /// Absolute target used by [`Scenario::seeking`]. Kept for report
+    /// compatibility with existing backward-seek runs.
     pub seek_to: i64,
+    /// Positive offset from the source's current position. Absent from old
+    /// scenario JSON, so existing report consumers still see the same fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seek_by: Option<i64>,
     /// How long past its due time a frame may still arrive before the run is
     /// called stalled and abandoned.
     pub stall_grace_ms: u64,
@@ -81,6 +87,7 @@ impl Scenario {
             frames,
             seek_every: None,
             seek_to: 0,
+            seek_by: None,
             stall_grace_ms: 2_000,
             metadata: BTreeMap::new(),
         }
@@ -89,12 +96,25 @@ impl Scenario {
     pub fn seeking(mut self, every: u64, to: i64) -> Scenario {
         self.seek_every = Some(every);
         self.seek_to = to;
+        self.seek_by = None;
+        self
+    }
+
+    pub fn seeking_forward(mut self, every: u64, by: i64) -> Scenario {
+        self.seek_every = Some(every);
+        self.seek_by = Some(by.clamp(1, MAX_FORWARD_SEEK));
         self
     }
 
     pub fn noting(mut self, key: &str, value: String) -> Scenario {
         self.metadata.insert(key.to_string(), value);
         self
+    }
+
+    fn seek_target(&self, current: i64) -> i64 {
+        self.seek_by
+            .map(|by| current.saturating_add(by))
+            .unwrap_or(self.seek_to)
     }
 }
 
@@ -252,7 +272,7 @@ pub fn measure(source: &mut FrameSource, scenario: &Scenario) -> ScenarioReport 
                 }
                 if let Some(every) = scenario.seek_every {
                     if delivered % every == 0 {
-                        source.seek(scenario.seek_to);
+                        source.seek(scenario.seek_target(source.position()));
                         seeks += 1;
                         due = Instant::now();
                         shown_at = None;
@@ -500,12 +520,26 @@ mod tests {
     }
 
     #[test]
-    fn a_seek_is_counted_and_its_first_frame_is_a_startup_delay() {
+    fn a_backward_seek_is_counted_and_its_first_frame_is_a_startup_delay() {
         let mut source = source(Duration::from_millis(1));
         let report = measure(
             &mut source,
-            &Scenario::new("repeated-seek", 20).seeking(5, 0),
+            &Scenario::new("repeated-backward-seek", 20).seeking(5, 0),
         );
+        assert_eq!(report.metrics.seeks, 4);
+        assert_eq!(report.metrics.total_frames, 20);
+        assert!(report.metrics.startup_delay_p99_ms.is_some());
+        assert!(!report.metrics.stalled, "{report:?}");
+    }
+
+    #[test]
+    fn a_short_forward_seek_uses_each_current_position_as_its_origin() {
+        let scenario = Scenario::new("repeated-short-forward-seek", 20).seeking_forward(5, 12);
+        assert_eq!(scenario.seek_target(5), 17);
+        assert_eq!(scenario.seek_target(22), 34);
+
+        let mut source = source(Duration::from_millis(1));
+        let report = measure(&mut source, &scenario);
         assert_eq!(report.metrics.seeks, 4);
         assert_eq!(report.metrics.total_frames, 20);
         assert!(report.metrics.startup_delay_p99_ms.is_some());

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -69,6 +69,45 @@ pub fn item_rasters(project: &Project, width: u32, height: u32) -> Vec<ItemRaste
     each_visual_item(project, width, height, None)
 }
 
+/// Timeline spans and logical RGBA bytes for text and shape layers.
+///
+/// The source memory meter needs the same dimensions as rasterization without
+/// eagerly rasterizing every visual in a project just to calculate a bound.
+pub(crate) fn byte_spans(project: &Project, width: u32, height: u32) -> Vec<(i64, i64, usize)> {
+    let scale_x = width as f32 / project.settings.width.max(1) as f32;
+    let scale_y = height as f32 / project.settings.height.max(1) as f32;
+    let mut spans = Vec::new();
+    for track in project.tracks.iter().filter(|track| track.contributes()) {
+        if !matches!(
+            track.kind,
+            makevideo_render::TrackKind::Video | makevideo_render::TrackKind::Subtitle
+        ) {
+            continue;
+        }
+        for item in &track.visual_items {
+            if !matches!(
+                &item.content,
+                VisualContent::Text { .. } | VisualContent::Shape { .. }
+            ) {
+                continue;
+            }
+            let transform = visual_transform(project, track, item);
+            let (item_width, item_height) = visual_dimensions(transform, scale_x, scale_y);
+            let end = item.end_frame();
+            if end > item.start {
+                spans.push((
+                    item.start,
+                    end,
+                    (item_width as usize)
+                        .saturating_mul(item_height as usize)
+                        .saturating_mul(4),
+                ));
+            }
+        }
+    }
+    spans
+}
+
 /// The one walk both entry points share: tracks in project order, items in
 /// z order within a track, which is also the paint order. `at` narrows it to
 /// the items covering one frame.
@@ -94,20 +133,8 @@ fn each_visual_item(
             .collect();
         items.sort_by_key(|item| item.z_index);
         for item in items {
-            let transform = if track.kind == makevideo_render::TrackKind::Subtitle {
-                makevideo_render::VisualTransform {
-                    x: 96.0,
-                    y: project.settings.height as f32 * 0.78,
-                    width: project.settings.width as f32 - 192.0,
-                    height: project.settings.height as f32 * 0.16,
-                    rotation: 0.0,
-                    opacity: 1.0,
-                }
-            } else {
-                item.transform
-            };
-            let item_width = (transform.width * scale_x).round().max(1.0) as u32;
-            let item_height = (transform.height * scale_y).round().max(1.0) as u32;
+            let transform = visual_transform(project, track, item);
+            let (item_width, item_height) = visual_dimensions(transform, scale_x, scale_y);
             let pixels = match &item.content {
                 VisualContent::Text { text, style } => {
                     let style = track.subtitle_style.as_ref().unwrap_or(style);
@@ -155,6 +182,36 @@ fn each_visual_item(
         }
     }
     layers
+}
+
+fn visual_transform(
+    project: &Project,
+    track: &makevideo_render::Track,
+    item: &makevideo_render::VisualItem,
+) -> makevideo_render::VisualTransform {
+    if track.kind == makevideo_render::TrackKind::Subtitle {
+        makevideo_render::VisualTransform {
+            x: 96.0,
+            y: project.settings.height as f32 * 0.78,
+            width: project.settings.width as f32 - 192.0,
+            height: project.settings.height as f32 * 0.16,
+            rotation: 0.0,
+            opacity: 1.0,
+        }
+    } else {
+        item.transform
+    }
+}
+
+fn visual_dimensions(
+    transform: makevideo_render::VisualTransform,
+    scale_x: f32,
+    scale_y: f32,
+) -> (u32, u32) {
+    (
+        (transform.width * scale_x).round().max(1.0) as u32,
+        (transform.height * scale_y).round().max(1.0) as u32,
+    )
 }
 
 /// Write an RGBA raster as a PAM still, for handing to ffmpeg as an overlay

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/bin/present_soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/bin/present_soak.rs
@@ -29,8 +29,10 @@ use makevideo_compositor::source::{
 use makevideo_compositor::{Backend, Compositor};
 use makevideo_present::schedule::DEFAULT_RESYNC;
 use makevideo_present::sink::OffscreenSink;
-use makevideo_present::soak::{measure, ProjectInfo, Run, Scenario, ScenarioReport};
-use makevideo_present::transport::{Setup, Transport};
+use makevideo_present::soak::{
+    measure, measure_video_replacement, ProjectInfo, Run, Scenario, ScenarioReport,
+};
+use makevideo_present::transport::{Setup, Transport, VideoSetup};
 use makevideo_render::{ffmpeg, Project, TrackKind};
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -169,6 +171,7 @@ fn run_scenario(
     settings: &Settings,
     compositor: &Arc<Compositor>,
     scenario: &Scenario,
+    replace_after: Option<u64>,
 ) -> ScenarioReport {
     let (width, height) = ffmpeg::output_size(&project.settings, settings.preset);
     let (mut transport, consumer) = Transport::start(Setup {
@@ -184,7 +187,25 @@ fn run_scenario(
     });
     let clock = Arc::clone(transport.audio().clock());
     let mut sink = OffscreenSink::new(Arc::clone(compositor), width, height);
-    measure(&mut transport, consumer, clock, &mut sink, scenario)
+    match replace_after {
+        Some(after) => measure_video_replacement(
+            &mut transport,
+            consumer,
+            clock,
+            &mut sink,
+            scenario,
+            VideoSetup {
+                project,
+                width,
+                height,
+                frame_buffering: FrameBuffering::new(settings.frame_depth, settings.frame_lead),
+                frame_readers: Arc::new(FrameReaders::new(&ffmpeg_path(), None)),
+                resync_after: settings.resync,
+            },
+            after,
+        ),
+        None => measure(&mut transport, consumer, clock, &mut sink, scenario),
+    }
 }
 
 fn run() -> Result<Run, String> {
@@ -215,10 +236,28 @@ fn run() -> Result<Run, String> {
         &settings,
         &compositor,
         &Scenario::new("continuous-playback", frames).noting("videoTracks", "1".into()),
+        None,
+    ));
+
+    // Rebuild only the video half while the old one keeps following the audio
+    // clock. The candidate is cold on purpose; its first accepted frame is the
+    // generation handoff, and every visible frame before that must still come
+    // from the advancing old path.
+    let replace_after = (frames / 3).min(frames.saturating_sub(1));
+    scenarios.push(run_scenario(
+        &one,
+        &settings,
+        &compositor,
+        &Scenario::new("live-reconfiguration", frames)
+            .noting("videoTracks", "1".into())
+            .noting("replacementAfterFrames", replace_after.to_string()),
+        Some(replace_after),
     ));
 
     // Seeks, which is where the two halves landing in different places shows.
-    let every = (settings.seek_every_seconds * rate.as_f64()).round().max(1.0) as u64;
+    let every = (settings.seek_every_seconds * rate.as_f64())
+        .round()
+        .max(1.0) as u64;
     scenarios.push(run_scenario(
         &one,
         &settings,
@@ -226,6 +265,7 @@ fn run() -> Result<Run, String> {
         &Scenario::new("repeated-seek", frames)
             .seeking(every, 0)
             .noting("videoTracks", "1".into()),
+        None,
     ));
 
     // And once per track count: a layer is a decoder and a draw call, so this
@@ -238,6 +278,7 @@ fn run() -> Result<Run, String> {
             &compositor,
             &Scenario::new("increasing-track-count", frames)
                 .noting("videoTracks", visible.to_string()),
+            None,
         ));
     }
 
@@ -256,11 +297,7 @@ fn run() -> Result<Run, String> {
     config.insert("compositor".into(), compositor.adapter().to_string());
     config.insert("gpu".into(), compositor.is_gpu().to_string());
 
-    let report = Run::new(
-        ProjectInfo::new(width, height, rate),
-        config,
-        scenarios,
-    );
+    let report = Run::new(ProjectInfo::new(width, height, rate), config, scenarios);
     if let Some(path) = &settings.report {
         let json = serde_json::to_string_pretty(&report)
             .map_err(|error| format!("cannot write the report: {error}"))?;

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -120,6 +120,12 @@ enum Mode {
     Paused,
 }
 
+enum PendingDisplay {
+    PausedFrame(Frame),
+    ExactFrame { frame: Frame, due: i128 },
+    Clear,
+}
+
 /// Where the audio clock is, as a frame index on the project rate.
 ///
 /// **Floor, not nearest.** Frame *n* is the current frame from the instant it
@@ -180,11 +186,29 @@ pub struct Scheduler {
     mode: Mode,
     /// A frame that should be on screen while paused and is not there yet.
     still: Option<i64>,
+    /// The exact frame requested or last shown while paused. `FrameSource`
+    /// points at the next frame after a successful take, so it cannot be used
+    /// as the visible paused position or as the target of a same-frame redraw.
+    paused_at: i64,
+    /// The pixels last shown while paused. Guide-only redraws reuse them, so
+    /// changing an editor overlay never seeks or reopens a decoder.
+    paused_frame: Option<Frame>,
     /// Set while a seek has been asked of the audio engine and not yet
     /// answered. Nothing is judged late during it: the clock is standing still
     /// at the old position and would make every frame look impossibly early,
     /// then impossibly late the moment it moves.
     settling: bool,
+    /// The logical seek target remains exact while an earlier neighbor may be
+    /// shown temporarily. Cleared only when that exact frame is consumed.
+    seeking_exact: Option<i64>,
+    /// A playing seek cannot leave an unrelated old frame on screen while
+    /// audio and decoding settle. Cleared before any retained or new frame is
+    /// allowed to reach the sink.
+    clear_before_seek: bool,
+    /// A fully decoded frame whose sink had no drawable. Keeping its pixels
+    /// avoids reopening ffmpeg on every timeout and lets an occluded candidate
+    /// commit internally, then present this same frame when the view returns.
+    pending_display: Option<PendingDisplay>,
     /// The sound has run out, so the clock will never advance again.
     ///
     /// Without this the last frames of a timeline can never be shown. The clock
@@ -212,7 +236,12 @@ impl Scheduler {
             // played still shows the top of the timeline.
             mode: Mode::Paused,
             still: Some(0),
+            paused_at: 0,
+            paused_frame: None,
             settling: false,
+            seeking_exact: None,
+            clear_before_seek: false,
+            pending_display: None,
             sound_over: false,
         }
     }
@@ -233,28 +262,63 @@ impl Scheduler {
         self.mode == Mode::Playing
     }
 
+    pub fn required_exact(&self) -> Option<i64> {
+        self.seeking_exact
+    }
+
     /// Where the picture is. Playing, that is the clock; paused, it is the
     /// frame that was asked for, because the clock is not moving.
     pub fn position(&self) -> i64 {
         match self.mode {
             Mode::Playing => clock_frame(&self.clock, self.rate).clamp(0, self.source.frames()),
-            Mode::Paused => self.source.position().clamp(0, self.source.frames()),
+            Mode::Paused => self.paused_at,
         }
     }
 
     pub fn buffered_bytes(&self) -> usize {
         self.source.buffered_bytes()
+            + self
+                .paused_frame
+                .as_ref()
+                .map(frame_bytes)
+                .unwrap_or_default()
+            + self
+                .pending_display
+                .as_ref()
+                .map(pending_display_bytes)
+                .unwrap_or_default()
     }
 
     pub fn buffer_ceiling(&self) -> usize {
-        self.source.buffer_ceiling()
+        self.source.buffer_ceiling() + self.source.frame_ceiling()
     }
 
     /// Start following the clock. The caller starts the sound; this only stops
     /// holding the still.
     pub fn play(&mut self) {
+        self.source.resume_decoders();
         self.mode = Mode::Playing;
-        self.still = None;
+        // A paused seek may still be decoding its exact frame. Playing does
+        // not cancel that user request: keep T exact once, then catch up to
+        // the audio clock. A frame already waiting on the sink is promoted by
+        // the branch below; `still` is the not-yet-decoded half of the same
+        // promise.
+        let waiting_still = self.still.take();
+        self.paused_frame = None;
+        match self.pending_display.take() {
+            Some(PendingDisplay::PausedFrame(frame)) => {
+                let due = frame_due_samples(frame.frame, self.rate);
+                self.seeking_exact = Some(frame.frame);
+                self.pending_display = Some(PendingDisplay::ExactFrame { frame, due });
+            }
+            pending => self.pending_display = pending,
+        }
+        if self.seeking_exact.is_none() {
+            self.seeking_exact = waiting_still;
+        }
+        if self.seeking_exact.is_some() {
+            self.clear_before_seek = true;
+        }
     }
 
     /// Stop following the clock and leave the frame under the playhead on
@@ -266,6 +330,9 @@ impl Scheduler {
     pub fn pause(&mut self, frame: i64) {
         self.mode = Mode::Paused;
         self.settling = false;
+        self.seeking_exact = None;
+        self.clear_before_seek = false;
+        self.pending_display = None;
         self.sound_over = false;
         self.show_still(frame);
     }
@@ -280,10 +347,16 @@ impl Scheduler {
     pub fn seek(&mut self, frame: i64) {
         let target = frame.clamp(0, self.source.frames());
         self.sound_over = false;
+        self.pending_display = None;
         match self.mode {
             Mode::Playing => {
                 self.source.seek(target);
+                self.seeking_exact = Some(target);
                 self.settling = true;
+                // The old visible frame may be anywhere on the timeline. It
+                // is not a valid seek neighbor, so remove it before waiting
+                // for current-generation T-2, T-1 or exact T.
+                self.clear_before_seek = true;
             }
             Mode::Paused => self.show_still(target),
         }
@@ -292,6 +365,37 @@ impl Scheduler {
     /// The audio engine has finished its half of a seek.
     pub fn settled(&mut self) {
         self.settling = false;
+    }
+
+    /// Keep a playing scheduler from judging frames against a clock whose
+    /// asynchronous seek has not landed yet.
+    pub fn wait_for_settle(&mut self) {
+        self.settling = true;
+    }
+
+    /// Align a replacement path to the current audio clock without promising
+    /// to display the now-stale starting frame. User seeks use [`Self::seek`]
+    /// and retain their exact-frame guarantee.
+    pub fn align_playback(&mut self, frame: i64) {
+        let target = frame.clamp(0, self.source.frames());
+        self.sound_over = false;
+        self.pending_display = None;
+        self.seeking_exact = None;
+        self.clear_before_seek = false;
+        self.settling = false;
+        self.source.seek(target);
+    }
+
+    pub fn redraw(&mut self) {
+        if self.mode != Mode::Paused || self.pending_display.is_some() {
+            return;
+        }
+        if let Some(frame) = self.paused_frame.take() {
+            self.pending_display = Some(PendingDisplay::PausedFrame(frame));
+            self.still = None;
+        } else {
+            self.show_still(self.paused_at);
+        }
     }
 
     /// Tell the scheduler whether the sound is over.
@@ -305,12 +409,21 @@ impl Scheduler {
 
     fn show_still(&mut self, frame: i64) {
         let target = frame.clamp(0, self.source.frames());
-        self.source.seek(target);
+        self.paused_at = target;
+        self.paused_frame = None;
+        self.source.seek_exact(target);
         self.still = Some(target);
     }
 
     /// One step.
     pub fn tick(&mut self, sink: &mut dyn Sink) -> Tick {
+        self.source.maintain_decoders();
+        if self.clear_before_seek {
+            return self.clear_seek_surface(sink);
+        }
+        if self.pending_display.is_some() {
+            return self.retry_pending_display(sink);
+        }
         match self.mode {
             Mode::Paused => self.tick_paused(sink),
             Mode::Playing => self.tick_playing(sink),
@@ -323,8 +436,20 @@ impl Scheduler {
         };
         match self.source.take() {
             Supply::Ready(frame) => {
-                self.still = None;
-                self.draw(sink, &frame, None)
+                let tick = self.draw(sink, &frame, None);
+                if present_waiting(&tick) {
+                    self.pending_display = Some(PendingDisplay::PausedFrame(frame));
+                    self.still = None;
+                    // The decoded pixels are retained for the surface retry,
+                    // so no decoder needs to stay hot while the window is
+                    // hidden or temporarily unable to present.
+                    self.source.idle_decoders();
+                } else {
+                    self.paused_frame = Some(frame);
+                    self.still = None;
+                    self.source.idle_decoders();
+                }
+                tick
             }
             Supply::Starved => {
                 self.counters.starved.fetch_add(1, Ordering::Relaxed);
@@ -332,14 +457,23 @@ impl Scheduler {
             }
             // Past the end: there is no frame to hold, so the monitor goes
             // black rather than keeping whatever was last drawn.
-            Supply::End => {
-                self.still = None;
-                let _ = target;
-                match sink.clear() {
-                    Ok(()) => Tick::Ended,
-                    Err(reason) => self.fail(reason),
+            Supply::End => match sink.clear() {
+                Ok(()) => {
+                    self.still = None;
+                    Tick::Ended
                 }
-            }
+                Err(reason) => {
+                    let tick = self.sink_failure(reason);
+                    if present_waiting(&tick) {
+                        self.pending_display = Some(PendingDisplay::Clear);
+                        self.still = None;
+                    } else {
+                        self.still = None;
+                    }
+                    let _ = target;
+                    tick
+                }
+            },
         }
     }
 
@@ -349,7 +483,14 @@ impl Scheduler {
         }
         let clock = clock_frame(&self.clock, self.rate);
         let next = self.source.position();
-        let decision = step(next, clock, self.resync_after);
+        // A seek neighbor is only a temporary picture. The requested exact
+        // frame must reach the sink once even if decode time lets the audio
+        // clock move past the ordinary resync threshold in the meantime.
+        let decision = if self.seeking_exact.is_some() {
+            Step::Present
+        } else {
+            step(next, clock, self.resync_after)
+        };
         // Holding for a clock that has stopped is waiting for ever. When the
         // sound is over what is left of the picture is due now, so the timeline
         // ends on its last frame rather than one before it.
@@ -368,26 +509,110 @@ impl Scheduler {
             }
             Step::Skip => match self.source.take() {
                 Supply::Ready(frame) => {
+                    if self.seeking_exact == Some(frame.frame) {
+                        let due = frame_due_samples(frame.frame, self.rate);
+                        let tick = self.draw(sink, &frame, Some(due));
+                        if present_waiting(&tick) {
+                            self.pending_display = Some(PendingDisplay::ExactFrame { frame, due });
+                        } else {
+                            self.seeking_exact = None;
+                        }
+                        return tick;
+                    }
                     self.counters.skipped.fetch_add(1, Ordering::Relaxed);
                     Tick::Skipped { frame: frame.frame }
                 }
-                Supply::Starved => {
-                    self.counters.starved.fetch_add(1, Ordering::Relaxed);
-                    Tick::Starved
-                }
+                Supply::Starved => self.starved_or_neighbor(sink),
                 Supply::End => Tick::Ended,
             },
             Step::Present => match self.source.take() {
                 Supply::Ready(frame) => {
+                    if self.seeking_exact == Some(frame.frame) {
+                        let due = frame_due_samples(frame.frame, self.rate);
+                        let tick = self.draw(sink, &frame, Some(due));
+                        if present_waiting(&tick) {
+                            self.pending_display = Some(PendingDisplay::ExactFrame { frame, due });
+                        } else {
+                            self.seeking_exact = None;
+                        }
+                        return tick;
+                    }
                     let due = frame_due_samples(frame.frame, self.rate);
                     self.draw(sink, &frame, Some(due))
                 }
-                Supply::Starved => {
-                    self.counters.starved.fetch_add(1, Ordering::Relaxed);
-                    Tick::Starved
-                }
+                Supply::Starved => self.starved_or_neighbor(sink),
                 Supply::End => Tick::Ended,
             },
+        }
+    }
+
+    fn starved_or_neighbor(&mut self, sink: &mut dyn Sink) -> Tick {
+        self.counters.starved.fetch_add(1, Ordering::Relaxed);
+        let Some(target) = self.seeking_exact else {
+            return Tick::Starved;
+        };
+        let Some(frame) = self
+            .source
+            .take_neighbor_before(target, makevideo_compositor::source::SEEK_NEIGHBOR_FRAMES)
+        else {
+            return Tick::Starved;
+        };
+        let due = frame_due_samples(frame.frame, self.rate);
+        self.draw(sink, &frame, Some(due))
+    }
+
+    fn retry_pending_display(&mut self, sink: &mut dyn Sink) -> Tick {
+        let pending = self
+            .pending_display
+            .take()
+            .expect("pending display was checked before retry");
+        match pending {
+            PendingDisplay::PausedFrame(frame) => {
+                let tick = self.draw(sink, &frame, None);
+                if present_waiting(&tick) {
+                    self.pending_display = Some(PendingDisplay::PausedFrame(frame));
+                } else {
+                    self.paused_frame = Some(frame);
+                    self.still = None;
+                    self.source.idle_decoders();
+                }
+                tick
+            }
+            PendingDisplay::ExactFrame { frame, due } => {
+                let tick = self.draw(sink, &frame, Some(due));
+                if present_waiting(&tick) {
+                    self.pending_display = Some(PendingDisplay::ExactFrame { frame, due });
+                } else {
+                    self.seeking_exact = None;
+                }
+                tick
+            }
+            PendingDisplay::Clear => match sink.clear() {
+                Ok(()) => Tick::Ended,
+                Err(reason) => {
+                    let tick = self.sink_failure(reason);
+                    if present_waiting(&tick) {
+                        self.pending_display = Some(PendingDisplay::Clear);
+                    }
+                    tick
+                }
+            },
+        }
+    }
+
+    fn clear_seek_surface(&mut self, sink: &mut dyn Sink) -> Tick {
+        match sink.clear() {
+            Ok(()) => {
+                self.clear_before_seek = false;
+                Tick::Idle
+            }
+            Err(reason) => {
+                let tick = self.sink_failure(reason);
+                if !present_waiting(&tick) {
+                    self.clear_before_seek = false;
+                }
+                tick
+            }
         }
     }
 
@@ -397,7 +622,7 @@ impl Scheduler {
     fn draw(&mut self, sink: &mut dyn Sink, frame: &Frame, due: Option<i128>) -> Tick {
         let started = std::time::Instant::now();
         if let Err(reason) = sink.show(frame) {
-            return self.fail(reason);
+            return self.sink_failure(reason);
         }
         self.counters.presented.fetch_add(1, Ordering::Relaxed);
         let present_ms = started.elapsed().as_secs_f64() * 1000.0;
@@ -416,6 +641,16 @@ impl Scheduler {
         Tick::Failed { reason }
     }
 
+    fn sink_failure(&self, reason: String) -> Tick {
+        if reason == crate::transport::PRESENT_DEFERRED
+            || reason == crate::transport::PRESENT_HIDDEN
+        {
+            Tick::Failed { reason }
+        } else {
+            self.fail(reason)
+        }
+    }
+
     /// How long until `next` is due, capped so a command is never waited out.
     fn until_due(&self, next: i64, clock: i64) -> Duration {
         if next <= clock {
@@ -429,14 +664,46 @@ impl Scheduler {
     }
 }
 
+fn present_waiting(tick: &Tick) -> bool {
+    matches!(
+        tick,
+        Tick::Failed { reason }
+            if reason == crate::transport::PRESENT_DEFERRED
+                || reason == crate::transport::PRESENT_HIDDEN
+    )
+}
+
+fn pending_display_bytes(pending: &PendingDisplay) -> usize {
+    let frame = match pending {
+        PendingDisplay::PausedFrame(frame) | PendingDisplay::ExactFrame { frame, .. } => frame,
+        PendingDisplay::Clear => return 0,
+    };
+    frame_bytes(frame)
+}
+
+fn frame_bytes(frame: &Frame) -> usize {
+    frame
+        .layers
+        .iter()
+        .map(|layer| layer.pixels.len())
+        .sum::<usize>()
+        + frame
+            .visuals
+            .iter()
+            .map(|layer| layer.pixels.len())
+            .sum::<usize>()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::schedule::DEFAULT_RESYNC;
-    use makevideo_compositor::source::{Buffering, FrameReader, Open, Readers};
+    use makevideo_compositor::source::{Buffering, CancelRead, FrameReader, Open, Readers};
     use makevideo_render::{
         Asset, AssetKind, Clip, Project, ProjectSettings, Track, TrackKind, FORMAT_VERSION,
     };
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::{Condvar, Mutex};
 
     /// Hands back frames instantly, so what a test measures is the scheduler
     /// and never a decoder.
@@ -454,6 +721,90 @@ mod tests {
     impl Readers for Always {
         fn open(&self, _request: &Open) -> Option<Box<dyn FrameReader>> {
             Some(Box::new(Instant0))
+        }
+    }
+
+    struct CountingReaders(Arc<AtomicUsize>);
+
+    impl Readers for CountingReaders {
+        fn open(&self, _request: &Open) -> Option<Box<dyn FrameReader>> {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Some(Box::new(Instant0))
+        }
+    }
+
+    #[derive(Default)]
+    struct GateState {
+        through: i64,
+        cancelled: bool,
+    }
+
+    #[derive(Default)]
+    struct Gate {
+        state: Mutex<GateState>,
+        wake: Condvar,
+    }
+
+    impl Gate {
+        fn allow(&self, through: i64) {
+            let mut state = self.state.lock().unwrap();
+            state.through = state.through.max(through);
+            self.wake.notify_all();
+        }
+
+        fn cancel(&self) {
+            self.state.lock().unwrap().cancelled = true;
+            self.wake.notify_all();
+        }
+    }
+
+    struct GatedReader {
+        next: i64,
+        remaining: i64,
+        gate: Arc<Gate>,
+    }
+
+    impl FrameReader for GatedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> bool {
+            if self.remaining <= 0 {
+                return false;
+            }
+            let mut state = self.gate.state.lock().unwrap();
+            while self.next > state.through && !state.cancelled {
+                state = self.gate.wake.wait(state).unwrap();
+            }
+            if state.cancelled {
+                return false;
+            }
+            drop(state);
+            buffer.fill(self.next as u8);
+            self.next += 1;
+            self.remaining -= 1;
+            true
+        }
+
+        fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {
+            Some(Arc::new(GateCancel(Arc::clone(&self.gate))))
+        }
+    }
+
+    struct GateCancel(Arc<Gate>);
+
+    impl CancelRead for GateCancel {
+        fn cancel(&self) {
+            self.0.cancel();
+        }
+    }
+
+    struct GatedReaders(Arc<Gate>);
+
+    impl Readers for GatedReaders {
+        fn open(&self, request: &Open) -> Option<Box<dyn FrameReader>> {
+            Some(Box::new(GatedReader {
+                next: request.in_frame,
+                remaining: request.frames,
+                gate: Arc::clone(&self.0),
+            }))
         }
     }
 
@@ -493,6 +844,27 @@ mod tests {
 
         fn clear(&mut self) -> Result<(), String> {
             Err("the surface is gone".into())
+        }
+    }
+
+    struct DeferExactOnce {
+        exact: i64,
+        deferred: bool,
+        shown: Vec<i64>,
+    }
+
+    impl Sink for DeferExactOnce {
+        fn show(&mut self, frame: &Frame) -> Result<(), String> {
+            if frame.frame == self.exact && !self.deferred {
+                self.deferred = true;
+                return Err(crate::transport::PRESENT_DEFERRED.into());
+            }
+            self.shown.push(frame.frame);
+            Ok(())
+        }
+
+        fn clear(&mut self) -> Result<(), String> {
+            Ok(())
         }
     }
 
@@ -592,7 +964,267 @@ mod tests {
         ));
         assert_eq!(scheduler.tick(&mut sink), Tick::Idle);
         assert_eq!(sink.shown, vec![0, 120]);
-        assert_eq!(scheduler.position(), 121);
+        assert_eq!(scheduler.position(), 120);
+
+        scheduler.seek(scheduler.position());
+        assert!(matches!(
+            settle(&mut scheduler, &mut sink),
+            Tick::Presented { frame: 120, .. }
+        ));
+        assert_eq!(sink.shown, vec![0, 120, 120]);
+        assert_eq!(scheduler.position(), 120);
+    }
+
+    #[test]
+    fn a_playing_seek_clears_the_unrelated_old_picture_before_waiting() {
+        let gate = Arc::new(Gate::default());
+        let (mut scheduler, _clock) = scheduler(Arc::new(GatedReaders(Arc::clone(&gate))));
+        let mut sink = Recorder::default();
+        settle(&mut scheduler, &mut sink);
+        assert_eq!(sink.shown, vec![0]);
+
+        scheduler.play();
+        scheduler.seek(20);
+        assert_eq!(scheduler.tick(&mut sink), Tick::Idle);
+        assert_eq!(sink.cleared, 1);
+        assert_eq!(sink.shown, vec![0]);
+        assert_eq!(scheduler.tick(&mut sink), Tick::Idle);
+        assert_eq!(sink.cleared, 1, "the seek clear happens exactly once");
+    }
+
+    #[test]
+    fn paused_redraw_reuses_the_visible_pixels_without_reopening_a_decoder() {
+        let opens = Arc::new(AtomicUsize::new(0));
+        let (mut scheduler, _clock) = scheduler(Arc::new(CountingReaders(Arc::clone(&opens))));
+        let mut sink = Recorder::default();
+        settle(&mut scheduler, &mut sink);
+        let opened = opens.load(Ordering::Relaxed);
+
+        scheduler.redraw();
+        assert!(matches!(
+            scheduler.tick(&mut sink),
+            Tick::Presented { frame: 0, .. }
+        ));
+        assert_eq!(opens.load(Ordering::Relaxed), opened);
+        assert_eq!(sink.shown, vec![0, 0]);
+    }
+
+    #[test]
+    fn a_paused_seek_waits_for_the_exact_frame_without_showing_a_neighbor() {
+        let gate = Arc::new(Gate::default());
+        let (mut scheduler, _clock) = scheduler(Arc::new(GatedReaders(Arc::clone(&gate))));
+        let mut sink = Recorder::default();
+        settle(&mut scheduler, &mut sink);
+        sink.shown.clear();
+
+        scheduler.seek(20);
+        gate.allow(19);
+        for _ in 0..50 {
+            scheduler.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(
+            sink.shown.is_empty(),
+            "no earlier frame may be shown paused"
+        );
+        gate.allow(20);
+        assert!(matches!(
+            settle(&mut scheduler, &mut sink),
+            Tick::Presented { frame: 20, .. }
+        ));
+        assert_eq!(sink.shown, vec![20]);
+    }
+
+    #[test]
+    fn play_keeps_a_paused_exact_frame_that_waited_for_a_drawable() {
+        let (mut scheduler, clock) = scheduler(Arc::new(Always));
+        let mut initial = Recorder::default();
+        settle(&mut scheduler, &mut initial);
+        scheduler.seek(20);
+
+        let mut sink = DeferExactOnce {
+            exact: 20,
+            deferred: false,
+            shown: Vec::new(),
+        };
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let tick = scheduler.tick(&mut sink);
+            if matches!(
+                tick,
+                Tick::Failed { ref reason }
+                    if reason == crate::transport::PRESENT_DEFERRED
+            ) {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(
+            scheduler.source.decoder_lifecycle(),
+            makevideo_compositor::source::DecoderLifecycle::Idle,
+            "retained pixels let a hidden paused surface idle its decoder"
+        );
+        assert_eq!(
+            scheduler.buffer_ceiling(),
+            scheduler.source.buffer_ceiling() + scheduler.source.frame_ceiling()
+        );
+        assert!(scheduler.buffered_bytes() <= scheduler.buffer_ceiling());
+
+        scheduler.play();
+        park(&clock, 20);
+        assert_eq!(scheduler.tick(&mut sink), Tick::Idle);
+        assert!(matches!(
+            scheduler.tick(&mut sink),
+            Tick::Presented { frame: 20, .. }
+        ));
+        assert_eq!(sink.shown, vec![20]);
+        assert_eq!(scheduler.counters.failures.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn play_keeps_a_paused_exact_frame_that_is_still_decoding() {
+        let gate = Arc::new(Gate::default());
+        let (mut scheduler, clock) = scheduler(Arc::new(GatedReaders(Arc::clone(&gate))));
+        let mut initial = Recorder::default();
+        settle(&mut scheduler, &mut initial);
+        let mut sink = Recorder::default();
+
+        scheduler.seek(20);
+        scheduler.play();
+        park(&clock, 35);
+        scheduler.settled();
+        assert_eq!(scheduler.required_exact(), Some(20));
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        for _ in 0..50 {
+            scheduler.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(sink.shown.is_empty(), "paused exact seek has no neighbor");
+
+        gate.allow(20);
+        while !sink.shown.contains(&20) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "exact frame was cancelled by play"
+            );
+            scheduler.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(sink.shown, vec![20]);
+    }
+
+    #[test]
+    fn a_seek_neighbor_is_replaced_by_exact_even_after_the_clock_advances() {
+        let gate = Arc::new(Gate::default());
+        let (mut scheduler, clock) = scheduler(Arc::new(GatedReaders(Arc::clone(&gate))));
+        let mut sink = Recorder::default();
+        settle(&mut scheduler, &mut sink);
+        sink.shown.clear();
+
+        scheduler.play();
+        scheduler.seek(20);
+        park(&clock, 20);
+        scheduler.settled();
+        gate.allow(18);
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while sink.shown.is_empty() {
+            assert!(std::time::Instant::now() < deadline, "no neighbor arrived");
+            scheduler.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(sink.shown, vec![18]);
+
+        // The target is now late. It must still replace the temporary
+        // neighbor once, before ordinary skip-late catch-up resumes.
+        park(&clock, 36);
+        gate.allow(20);
+        while !sink.shown.contains(&20) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "exact frame was skipped"
+            );
+            scheduler.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(sink.shown, vec![18, 20]);
+
+        gate.allow(36);
+        while !sink.shown.contains(&36) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "clock frame did not arrive"
+            );
+            scheduler.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(sink.shown.last(), Some(&36));
+        assert!(
+            !(21..36).any(|frame| sink.shown.contains(&frame)),
+            "frames between exact 20 and clock 36 are skipped"
+        );
+    }
+
+    #[test]
+    fn a_transient_timeout_retries_exact_before_resyncing_to_a_far_clock() {
+        let (mut scheduler, clock) = scheduler(Arc::new(Always));
+        let mut initial = Recorder::default();
+        settle(&mut scheduler, &mut initial);
+        scheduler.play();
+        scheduler.seek(20);
+        park(&clock, 35);
+        scheduler.settled();
+
+        let mut sink = DeferExactOnce {
+            exact: 20,
+            deferred: false,
+            shown: Vec::new(),
+        };
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let tick = scheduler.tick(&mut sink);
+            if matches!(
+                tick,
+                Tick::Failed { ref reason }
+                    if reason == crate::transport::PRESENT_DEFERRED
+            ) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "exact frame was never tried"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(scheduler.seeking_exact, Some(20));
+        assert!(!sink.shown.contains(&20));
+
+        while !sink.shown.contains(&20) {
+            scheduler.tick(&mut sink);
+            assert!(
+                std::time::Instant::now() < deadline,
+                "exact frame was not retried after timeout"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(scheduler.seeking_exact, None);
+        assert_eq!(scheduler.counters.failures.load(Ordering::Relaxed), 0);
+
+        let clock_frame = clock_frame(&clock, Rate::fps(30));
+        while !sink.shown.contains(&clock_frame) {
+            scheduler.tick(&mut sink);
+            assert!(
+                std::time::Instant::now() < deadline,
+                "playback did not catch up after the exact frame"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(
+            !(21..clock_frame).any(|frame| sink.shown.contains(&frame)),
+            "catch-up frames must be skipped, not presented"
+        );
     }
 
     /// The rule the issue is about. The clock is ten frames on, the source is

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
@@ -19,11 +19,12 @@
 //!
 //! [`OffscreenSink`]: crate::sink::OffscreenSink
 
-use crate::player::Tick;
-use crate::transport::Transport;
+use crate::player::{clock_frame, Sink, Tick, IDLE};
+use crate::transport::{Transport, VideoReplacement, VideoSetup};
 use makevideo_audio::engine::Feed;
 use makevideo_audio::realtime::{Clock, Consumer, CHANNELS, ENGINE_HZ};
 use makevideo_audio::soak::BUFFER_FRAMES;
+use makevideo_compositor::source::Frame;
 use makevideo_render::Rate;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -238,6 +239,183 @@ fn within(value: Option<f64>, limit: f64) -> bool {
     value.map(|value| value <= limit).unwrap_or(true)
 }
 
+fn startup_caught_up(late_ms: f64, rate: Rate) -> bool {
+    late_ms < 1_000.0 / rate.as_f64()
+}
+
+fn pace_driver(tick: &Tick) {
+    match tick {
+        Tick::Held { wait } if !wait.is_zero() => std::thread::sleep(*wait),
+        Tick::Starved => std::thread::sleep(Duration::from_millis(1)),
+        Tick::Idle | Tick::Failed { .. } => std::thread::sleep(IDLE),
+        _ => {}
+    }
+}
+
+/// One successful change to what the viewer can actually see.
+///
+/// A frame number alone is ambiguous during a live replacement: old and new
+/// video paths can both draw frame 120. The generation makes the handoff itself
+/// visible to the meter without changing the scheduler's public tick format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VisibleIdentity {
+    generation: u64,
+    frame: Option<i64>,
+}
+
+fn visible_within_seek_window(visible: Option<VisibleIdentity>, target: i64) -> bool {
+    let Some(frame) = visible.and_then(|identity| identity.frame) else {
+        return true;
+    };
+    frame >= target.saturating_sub(2) && frame <= target
+}
+
+/// Fails when time moves but the visible identity does not.
+///
+/// A picture normally remains visible throughout its own frame period, so two
+/// project frames of slack are allowed. The third frame with the same identity
+/// is a frozen picture, even if transport ticks or audio callbacks continue.
+struct VisibleContinuity {
+    current: Option<(VisibleIdentity, i64)>,
+    failed: bool,
+}
+
+impl VisibleContinuity {
+    const MAX_STATIC_FRAMES: i64 = 2;
+
+    fn new() -> VisibleContinuity {
+        VisibleContinuity {
+            current: None,
+            failed: false,
+        }
+    }
+
+    fn observe(&mut self, clock: i64, visible: Option<VisibleIdentity>) -> bool {
+        if self.failed {
+            return false;
+        }
+        let Some(visible) = visible else {
+            return true;
+        };
+        match self.current {
+            Some((identity, began)) if identity.frame == visible.frame && clock >= began => {
+                // Keep the generation for handoff diagnostics, but not as a
+                // new picture. Re-presenting frame 120 through generation 1
+                // after generation 0 showed frame 120 does not buy another
+                // two frames of freeze time.
+                self.current = Some((visible, began));
+                if clock - began > Self::MAX_STATIC_FRAMES {
+                    self.failed = true;
+                }
+            }
+            _ => self.current = Some((visible, clock)),
+        }
+        !self.failed
+    }
+
+    fn reset(&mut self, clock: i64, visible: Option<VisibleIdentity>) {
+        self.current = visible.map(|identity| (identity, clock));
+    }
+}
+
+/// Records identity only after the wrapped sink accepted a draw. That is the
+/// point at which a scheduler frame became a visible frame rather than merely
+/// decoded work.
+struct IdentifiedSink<'a> {
+    sink: &'a mut dyn Sink,
+    generation: u64,
+    visible: Option<VisibleIdentity>,
+}
+
+impl<'a> IdentifiedSink<'a> {
+    fn new(sink: &'a mut dyn Sink) -> IdentifiedSink<'a> {
+        IdentifiedSink {
+            sink,
+            generation: 0,
+            visible: None,
+        }
+    }
+
+    fn generation(&mut self, generation: u64) {
+        self.generation = generation;
+    }
+
+    fn visible(&self) -> Option<VisibleIdentity> {
+        self.visible
+    }
+}
+
+impl Sink for IdentifiedSink<'_> {
+    fn show(&mut self, frame: &Frame) -> Result<(), String> {
+        self.sink.show(frame)?;
+        self.visible = Some(VisibleIdentity {
+            generation: self.generation,
+            frame: Some(frame.frame),
+        });
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<(), String> {
+        self.sink.clear()?;
+        self.visible = Some(VisibleIdentity {
+            generation: self.generation,
+            frame: None,
+        });
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CounterTotals {
+    resyncs: u64,
+    starved: u64,
+    failures: u64,
+}
+
+impl CounterTotals {
+    fn active(transport: &Transport) -> CounterTotals {
+        let counters = transport.scheduler().counters();
+        CounterTotals {
+            resyncs: counters.resyncs(),
+            starved: counters.starved(),
+            failures: counters.failures(),
+        }
+    }
+
+    fn add(&mut self, other: CounterTotals) {
+        self.resyncs += other.resyncs;
+        self.starved += other.starved;
+        self.failures += other.failures;
+    }
+}
+
+struct ReplacementPlan<'a> {
+    setup: Option<VideoSetup<'a>>,
+    after_presented: u64,
+    started: bool,
+    committed: bool,
+    failed: bool,
+}
+
+impl<'a> ReplacementPlan<'a> {
+    fn new(setup: VideoSetup<'a>, after_presented: u64) -> ReplacementPlan<'a> {
+        ReplacementPlan {
+            setup: Some(setup),
+            after_presented,
+            started: false,
+            committed: false,
+            failed: false,
+        }
+    }
+
+    fn start(&mut self, transport: &mut Transport) {
+        if let Some(setup) = self.setup.take() {
+            transport.prepare_video(setup);
+            self.started = true;
+        }
+    }
+}
+
 /// The device, with the driver replaced by a stopwatch.
 ///
 /// Popping one buffer per buffer period is what a real callback does, and it is
@@ -247,6 +425,7 @@ fn within(value: Option<f64>, limit: f64) -> bool {
 /// one thing only it can cause.
 struct Speaker {
     stop: Arc<AtomicBool>,
+    active: Arc<AtomicBool>,
     /// Set by the measuring loop around a seek. While it is on the ring is
     /// being refilled on purpose and a short pop is not the engine failing.
     /// `audio-soak` draws the same line with its own `refill_since`.
@@ -259,6 +438,7 @@ struct Speaker {
 impl Speaker {
     fn start(consumer: Consumer, clock: Arc<Clock>, feed: Arc<Feed>) -> Speaker {
         let stop = Arc::new(AtomicBool::new(false));
+        let active = Arc::new(AtomicBool::new(false));
         let refilling = Arc::new(AtomicBool::new(true));
         let underruns = Arc::new(AtomicU64::new(0));
         let buffers = Arc::new(AtomicU64::new(0));
@@ -269,8 +449,9 @@ impl Speaker {
         clock.set_latency(BUFFER_FRAMES as u64);
 
         let thread = {
-            let (stop, refilling, underruns, buffers) = (
+            let (stop, active, refilling, underruns, buffers) = (
                 Arc::clone(&stop),
+                Arc::clone(&active),
                 Arc::clone(&refilling),
                 Arc::clone(&underruns),
                 Arc::clone(&buffers),
@@ -288,6 +469,13 @@ impl Speaker {
                         // trying to make the time up in a burst of pops, which
                         // would move the clock faster than the world.
                         due = now;
+                    }
+                    // Match the real output callback: a paused or refilling
+                    // device still acknowledges a requested seek flush, but
+                    // does not expose samples or advance the playback clock.
+                    consumer.take_flush();
+                    if !active.load(Ordering::SeqCst) {
+                        continue;
                     }
                     let taken = consumer.pop(&mut buffer);
                     clock.advance(taken as u64);
@@ -312,11 +500,31 @@ impl Speaker {
         };
         Speaker {
             stop,
+            active,
             refilling,
             underruns,
             buffers,
             thread: Some(thread),
         }
+    }
+
+    fn sync(&self, transport: &Transport) {
+        self.active.store(
+            transport.is_playing() && transport.audio_ready(),
+            Ordering::SeqCst,
+        );
+    }
+
+    fn sync_after_tick(&self, transport: &Transport, tick: &Tick) {
+        if matches!(tick, Tick::Ended) {
+            self.mute();
+        } else {
+            self.sync(transport);
+        }
+    }
+
+    fn mute(&self) {
+        self.active.store(false, Ordering::SeqCst);
     }
 }
 
@@ -339,11 +547,47 @@ pub fn measure(
     transport: &mut Transport,
     consumer: Consumer,
     clock: Arc<Clock>,
-    sink: &mut dyn crate::player::Sink,
+    sink: &mut dyn Sink,
     scenario: &Scenario,
 ) -> ScenarioReport {
+    measure_inner(transport, consumer, clock, sink, scenario, None)
+}
+
+/// Measure a video-only live replacement after the old path has already drawn
+/// `after_presented` frames.
+///
+/// The candidate and active scheduler share the audio clock. Until the
+/// candidate presents its first frame, the old scheduler is still ticked into
+/// generation 0; the accepted candidate frame starts generation 1.
+pub fn measure_video_replacement(
+    transport: &mut Transport,
+    consumer: Consumer,
+    clock: Arc<Clock>,
+    sink: &mut dyn Sink,
+    scenario: &Scenario,
+    setup: VideoSetup<'_>,
+    after_presented: u64,
+) -> ScenarioReport {
+    measure_inner(
+        transport,
+        consumer,
+        clock,
+        sink,
+        scenario,
+        Some(ReplacementPlan::new(setup, after_presented)),
+    )
+}
+
+fn measure_inner(
+    transport: &mut Transport,
+    consumer: Consumer,
+    clock: Arc<Clock>,
+    sink: &mut dyn Sink,
+    scenario: &Scenario,
+    mut replacement: Option<ReplacementPlan<'_>>,
+) -> ScenarioReport {
     let rate = transport.scheduler().rate();
-    let limits = Limits::new(rate, transport.scheduler().buffer_ceiling() as u64);
+    let mut limits = Limits::new(rate, transport.video_buffer_ceiling() as u64);
     let grace = Duration::from_millis(scenario.stall_grace_ms);
     // What the timeline being played is worth in wall clock, times the
     // allowance, plus one grace period so a short scenario is not judged by
@@ -351,7 +595,11 @@ pub fn measure(
     let budget = Duration::from_secs_f64(
         scenario.frames as f64 / rate.as_f64() * scenario.budget_multiple.max(1.0),
     ) + grace;
-    let speaker = Speaker::start(consumer, clock, Arc::clone(transport.audio().feed()));
+    let speaker = Speaker::start(
+        consumer,
+        Arc::clone(&clock),
+        Arc::clone(transport.audio().feed()),
+    );
     let started = Instant::now();
 
     let mut intervals: Vec<f64> = Vec::new();
@@ -365,6 +613,11 @@ pub fn measure(
     let mut overran = false;
     let mut last_present: Option<Instant> = None;
     let mut since_seek = 0u64;
+    let mut visible_sink = IdentifiedSink::new(sink);
+    let mut continuity = VisibleContinuity::new();
+    let mut retired_counters = CounterTotals::default();
+    let mut reset_continuity = false;
+    let mut visible_seek_target = None;
 
     // Set while waiting for the first frame of a start or a seek. What it
     // measures is a startup delay, and nothing inside it counts as an interval:
@@ -375,76 +628,175 @@ pub fn measure(
     let mut progress = Instant::now();
 
     transport.play();
+    speaker.sync(transport);
+    if let Some(plan) = replacement.as_mut() {
+        if plan.after_presented == 0 {
+            plan.start(transport);
+        }
+    }
 
     while presented < scenario.frames && !stalled && !overran {
-        let tick = transport.tick(sink);
-        match tick {
-            Tick::Presented { late_ms, .. } => {
-                let at = Instant::now();
-                speaker.refilling.store(false, Ordering::Relaxed);
-                if let Some(began) = waiting_since.take() {
-                    // The first frame of a start or a seek. It is a refill, and
-                    // a refill is reported once — as a startup delay. Charging
-                    // it again as drift and as an interval would make every
-                    // seek look like the scheduler losing the sound, when what
-                    // it did was empty the queues on purpose and fill them from
-                    // the target. The frame supply and audio meters draw the
-                    // same line, and it is the same line the knowledge note
-                    // about a harness not counting its own delay draws.
-                    startups.push(millis(began.elapsed()));
-                } else {
-                    if let Some(previous) = last_present {
-                        intervals.push(millis(at - previous));
+        peak = peak.max(transport.video_buffered_bytes());
+        limits.peak_buffered_bytes = limits
+            .peak_buffered_bytes
+            .max(transport.video_buffer_ceiling() as u64);
+        // A seek requested while processing this batch takes effect on the
+        // next driver turn. Starting there, blank or T-2/T-1/T are the only
+        // legal visible states until exact T has appeared.
+        let enforce_seek_window = visible_seek_target.is_some();
+        let ticks = match replacement.as_mut() {
+            Some(plan) if plan.started && !plan.committed && !plan.failed => {
+                // Match the app loop: the committed path presents first, then
+                // the candidate tries the same FIFO surface. Measuring the
+                // candidate first hides the extra present cost on its commit
+                // turn and can miss a real handoff hitch.
+                visible_sink.generation(0);
+                let active_tick = transport.tick(&mut visible_sink);
+                speaker.sync_after_tick(transport, &active_tick);
+                let active_visible = visible_sink.visible();
+                let active_before = CounterTotals::active(transport);
+                pace_driver(&active_tick);
+                visible_sink.generation(1);
+                match transport.tick_video_replacement(&mut visible_sink) {
+                    VideoReplacement::Committed(tick) => {
+                        retired_counters.add(active_before);
+                        plan.committed = true;
+                        vec![
+                            (active_tick, active_visible, true),
+                            (tick, visible_sink.visible(), false),
+                        ]
                     }
-                    drift.push(late_ms.abs());
-                    lateness.push(late_ms);
+                    VideoReplacement::Failed(reason) => {
+                        plan.failed = true;
+                        vec![
+                            (active_tick, active_visible, true),
+                            (Tick::Failed { reason }, visible_sink.visible(), false),
+                        ]
+                    }
+                    VideoReplacement::Pending => {
+                        visible_sink.generation(0);
+                        vec![(active_tick, active_visible, true)]
+                    }
                 }
-                last_present = Some(at);
-                presented += 1;
-                since_seek += 1;
-                progress = at;
-                peak = peak.max(transport.scheduler().buffered_bytes());
-
-                if let Some(every) = scenario.seek_every {
-                    if since_seek >= every {
+            }
+            Some(plan) => {
+                visible_sink.generation(u64::from(plan.committed));
+                let tick = transport.tick(&mut visible_sink);
+                speaker.sync_after_tick(transport, &tick);
+                vec![(tick, visible_sink.visible(), false)]
+            }
+            None => {
+                let tick = transport.tick(&mut visible_sink);
+                speaker.sync_after_tick(transport, &tick);
+                vec![(tick, visible_sink.visible(), false)]
+            }
+        };
+        for (tick, visible, already_paced) in ticks {
+            if !already_paced {
+                pace_driver(&tick);
+            }
+            match tick {
+                Tick::Presented { late_ms, .. } => {
+                    let at = Instant::now();
+                    // The exact first frame is deliberately presented even when a
+                    // cold multi-track decoder lets the audio clock move past it.
+                    // Keep that catch-up inside startup until the visible frame is
+                    // within one frame of the clock; otherwise frame 1 is counted
+                    // as a steady-state drop immediately after frame 0.
+                    let caught_up = startup_caught_up(late_ms, rate);
+                    if waiting_since.is_some() && !caught_up {
                         speaker.refilling.store(true, Ordering::Relaxed);
-                        transport.seek(scenario.seek_to);
-                        seeks += 1;
-                        since_seek = 0;
-                        last_present = None;
-                        waiting_since = Some(Instant::now());
+                    } else if let Some(began) = waiting_since.take() {
+                        speaker.refilling.store(false, Ordering::Relaxed);
+                        // The first frame of a start or a seek. It is a refill, and
+                        // a refill is reported once — as a startup delay. Charging
+                        // it again as drift and as an interval would make every
+                        // seek look like the scheduler losing the sound, when what
+                        // it did was empty the queues on purpose and fill them from
+                        // the target. The frame supply and audio meters draw the
+                        // same line, and it is the same line the knowledge note
+                        // about a harness not counting its own delay draws.
+                        startups.push(millis(began.elapsed()));
+                    } else {
+                        speaker.refilling.store(false, Ordering::Relaxed);
+                        if let Some(previous) = last_present {
+                            intervals.push(millis(at - previous));
+                        }
+                        drift.push(late_ms.abs());
+                        lateness.push(late_ms);
+                    }
+                    last_present = Some(at);
+                    presented += 1;
+                    since_seek += 1;
+                    progress = at;
+                    peak = peak.max(transport.video_buffered_bytes());
+
+                    if let Some(every) = scenario.seek_every {
+                        if since_seek >= every {
+                            speaker.refilling.store(true, Ordering::Relaxed);
+                            speaker.mute();
+                            transport.seek(scenario.seek_to);
+                            visible_seek_target = Some(
+                                scenario.seek_to.clamp(0, transport.frames()),
+                            );
+                            seeks += 1;
+                            since_seek = 0;
+                            last_present = None;
+                            waiting_since = Some(Instant::now());
+                            reset_continuity = true;
+                        }
+                    }
+                }
+                Tick::Skipped { .. } => {
+                    if waiting_since.is_some() {
+                        skipped_refilling += 1;
+                    } else {
+                        skipped += 1;
+                    }
+                    progress = Instant::now();
+                }
+                Tick::Resynced { .. } | Tick::Failed { .. } => {
+                    progress = Instant::now();
+                }
+                Tick::Held { .. } | Tick::Starved | Tick::Idle => {}
+                // A soak longer than the timeline wraps rather than stopping, and a
+                // wrap is a seek: both halves are thrown away and refilled.
+                Tick::Ended => {
+                    speaker.refilling.store(true, Ordering::Relaxed);
+                    speaker.mute();
+                    transport.seek(0);
+                    visible_seek_target = Some(0);
+                    seeks += 1;
+                    since_seek = 0;
+                    last_present = None;
+                    waiting_since = Some(Instant::now());
+                    progress = Instant::now();
+                    reset_continuity = true;
+                }
+            }
+            let clock_now = clock_frame(&clock, rate);
+            if reset_continuity {
+                continuity.reset(clock_now, visible);
+                reset_continuity = false;
+            } else if !continuity.observe(clock_now, visible) {
+                stalled = true;
+            }
+            if enforce_seek_window {
+                if let Some(target) = visible_seek_target {
+                    if !visible_within_seek_window(visible, target) {
+                        stalled = true;
+                    } else if visible.and_then(|identity| identity.frame) == Some(target) {
+                        visible_seek_target = None;
                     }
                 }
             }
-            Tick::Skipped { .. } => {
-                if waiting_since.is_some() {
-                    skipped_refilling += 1;
-                } else {
-                    skipped += 1;
-                }
-                progress = Instant::now();
+        }
+        if let Some(plan) = replacement.as_mut() {
+            if !plan.started && presented >= plan.after_presented {
+                plan.start(transport);
             }
-            Tick::Resynced { .. } | Tick::Failed { .. } => {
-                progress = Instant::now();
-            }
-            Tick::Held { wait } => {
-                if !wait.is_zero() {
-                    std::thread::sleep(wait);
-                }
-            }
-            Tick::Starved | Tick::Idle => {
-                std::thread::sleep(Duration::from_millis(1));
-            }
-            // A soak longer than the timeline wraps rather than stopping, and a
-            // wrap is a seek: both halves are thrown away and refilled.
-            Tick::Ended => {
-                speaker.refilling.store(true, Ordering::Relaxed);
-                transport.seek(0);
-                seeks += 1;
-                since_seek = 0;
-                last_present = None;
-                waiting_since = Some(Instant::now());
-                progress = Instant::now();
+            if plan.failed {
+                stalled = true;
             }
         }
         if progress.elapsed() >= grace {
@@ -455,14 +807,28 @@ pub fn measure(
         }
     }
 
+    let replacement_failed = replacement
+        .as_ref()
+        .map(|plan| plan.failed)
+        .unwrap_or(false);
+    if replacement
+        .as_ref()
+        .map(|plan| !plan.committed)
+        .unwrap_or(false)
+    {
+        stalled = true;
+    }
+
     let counters = transport.scheduler().counters();
     let metrics = Metrics {
         presented_frames: presented,
         skipped_frames: skipped,
         skipped_while_refilling: skipped_refilling,
-        resyncs: counters.resyncs(),
-        starved_polls: counters.starved(),
-        draw_failures: counters.failures(),
+        resyncs: retired_counters.resyncs + counters.resyncs(),
+        starved_polls: retired_counters.starved + counters.starved(),
+        draw_failures: retired_counters.failures
+            + counters.failures()
+            + u64::from(replacement_failed),
         present_interval_p50_ms: percentile(&intervals, 0.5),
         present_interval_p99_ms: percentile(&intervals, 0.99),
         av_drift_p50_ms: percentile(&drift, 0.5),
@@ -501,8 +867,7 @@ pub fn measure(
             && (metrics.underruns as f64) / (metrics.audio_buffers as f64) <= limits.underrun_rate,
         // A run that drew nothing has no percentiles, and every `within` above
         // would wave it through on `None`. This is the check that refuses it.
-        drew_every_frame: metrics.presented_frames >= scenario.frames
-            && metrics.draw_failures == 0,
+        drew_every_frame: metrics.presented_frames >= scenario.frames && metrics.draw_failures == 0,
         not_stalled: !metrics.stalled,
         finished_in_time: !metrics.overran,
     };
@@ -591,6 +956,7 @@ mod tests {
     use crate::sink::CountingSink;
     use crate::transport::Setup;
     use makevideo_audio::engine::Options as AudioOptions;
+    use makevideo_audio::realtime::Ring;
     use makevideo_audio::source::{
         Buffering as AudioBuffering, Open as AudioOpen, PcmReader, Readers as AudioReaders,
     };
@@ -602,6 +968,28 @@ mod tests {
     };
 
     struct Paced(Duration);
+
+    #[test]
+    fn an_inactive_speaker_flushes_without_advancing_the_clock() {
+        let (producer, consumer) = Ring::new(BUFFER_FRAMES * 2);
+        let samples = vec![0.0; BUFFER_FRAMES * CHANNELS];
+        assert_eq!(producer.push(&samples), BUFFER_FRAMES);
+        let clock = Arc::new(Clock::new());
+        let speaker = Speaker::start(
+            consumer,
+            Arc::clone(&clock),
+            Arc::new(Feed::default()),
+        );
+        let flush = producer.request_flush();
+        let deadline = Instant::now() + Duration::from_millis(100);
+        while producer.flushed() < flush && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        assert_eq!(producer.flushed(), flush);
+        assert_eq!(clock.played_frames(), 0);
+        drop(speaker);
+    }
 
     impl FrameReader for Paced {
         fn read(&mut self, buffer: &mut [u8]) -> bool {
@@ -618,6 +1006,30 @@ mod tests {
     impl FrameReaders for Pace {
         fn open(&self, _request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
             Some(Box::new(Paced(self.0)))
+        }
+    }
+
+    struct FirstDelayed {
+        delay: Option<Duration>,
+    }
+
+    impl FrameReader for FirstDelayed {
+        fn read(&mut self, buffer: &mut [u8]) -> bool {
+            if let Some(delay) = self.delay.take() {
+                std::thread::sleep(delay);
+            }
+            buffer.fill(7);
+            true
+        }
+    }
+
+    struct DelayFirst(Duration);
+
+    impl FrameReaders for DelayFirst {
+        fn open(&self, _request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
+            Some(Box::new(FirstDelayed {
+                delay: Some(self.0),
+            }))
         }
     }
 
@@ -699,6 +1111,39 @@ mod tests {
         measure(&mut transport, consumer, clock, &mut sink, scenario)
     }
 
+    fn run_replacement(first_frame_delay: Duration, scenario: &Scenario) -> ScenarioReport {
+        let project = project();
+        let (mut transport, consumer) = Transport::start(Setup {
+            project: &project,
+            width: 16,
+            height: 16,
+            frame_buffering: FrameBuffering::new(6, 15),
+            frame_readers: Arc::new(Pace(Duration::from_millis(1))),
+            audio_buffering: AudioBuffering::default(),
+            audio_readers: Arc::new(Quiet),
+            audio: AudioOptions::default(),
+            resync_after: DEFAULT_RESYNC,
+        });
+        let clock = Arc::clone(transport.audio().clock());
+        let mut sink = CountingSink::default();
+        measure_video_replacement(
+            &mut transport,
+            consumer,
+            clock,
+            &mut sink,
+            scenario,
+            VideoSetup {
+                project: &project,
+                width: 16,
+                height: 16,
+                frame_buffering: FrameBuffering::new(6, 15),
+                frame_readers: Arc::new(DelayFirst(first_frame_delay)),
+                resync_after: DEFAULT_RESYNC,
+            },
+            10,
+        )
+    }
+
     #[test]
     fn a_source_that_keeps_up_presents_every_frame_in_time() {
         let report = run(
@@ -762,6 +1207,82 @@ mod tests {
         assert!(report.metrics.startup_delay_p99_ms.is_some());
     }
 
+    fn visible(generation: u64, frame: i64) -> Option<VisibleIdentity> {
+        Some(VisibleIdentity {
+            generation,
+            frame: Some(frame),
+        })
+    }
+
+    #[test]
+    fn an_advancing_clock_with_one_fixed_visible_frame_fails() {
+        let mut continuity = VisibleContinuity::new();
+        assert!(continuity.observe(100, visible(0, 100)));
+        assert!(continuity.observe(102, visible(0, 100)));
+        assert!(
+            !continuity.observe(103, visible(0, 100)),
+            "the audio clock crossed three frames while the screen stayed fixed"
+        );
+    }
+
+    #[test]
+    fn a_generation_handoff_on_the_same_frame_does_not_restart_the_freeze_window() {
+        let mut continuity = VisibleContinuity::new();
+        assert!(continuity.observe(100, visible(0, 100)));
+        assert!(continuity.observe(101, visible(0, 100)));
+        assert!(continuity.observe(102, visible(1, 100)));
+        assert!(
+            !continuity.observe(103, visible(1, 100)),
+            "a new generation showing the same frame is still one frozen picture"
+        );
+    }
+
+    #[test]
+    fn old_video_may_keep_advancing_until_the_candidate_commits() {
+        let mut continuity = VisibleContinuity::new();
+        let observations = [
+            (40, visible(0, 40)),
+            (41, visible(0, 41)),
+            (42, visible(0, 42)),
+            (43, visible(0, 43)),
+            // The same project frame in a new generation is the first-frame
+            // commit, not a frozen copy of the old one.
+            (43, visible(1, 43)),
+            (44, visible(1, 44)),
+        ];
+        assert!(observations
+            .into_iter()
+            .all(|(clock, identity)| continuity.observe(clock, identity)));
+    }
+
+    #[test]
+    fn a_playing_seek_accepts_only_blank_or_two_frames_before_exact() {
+        assert!(visible_within_seek_window(None, 20));
+        assert!(visible_within_seek_window(
+            Some(VisibleIdentity {
+                generation: 0,
+                frame: None,
+            }),
+            20,
+        ));
+        for frame in [18, 19, 20] {
+            assert!(visible_within_seek_window(visible(0, frame), 20));
+        }
+        assert!(!visible_within_seek_window(visible(0, 17), 20));
+        assert!(!visible_within_seek_window(visible(0, 21), 20));
+    }
+
+    #[test]
+    fn a_delayed_replacement_passes_while_the_old_video_keeps_moving() {
+        let report = run_replacement(
+            Duration::from_millis(20),
+            &Scenario::new("live-reconfiguration", 60),
+        );
+        assert_eq!(report.metrics.presented_frames, 60, "{report:?}");
+        assert!(!report.metrics.stalled, "{report:?}");
+        assert!(report.evaluation.pass, "{report:?}");
+    }
+
     #[test]
     fn the_percentiles_pick_the_same_element_the_other_meters_do() {
         let values: Vec<f64> = (1..=100).map(|value| value as f64).collect();
@@ -769,6 +1290,13 @@ mod tests {
         assert_eq!(percentile(&values, 0.99), Some(99.0));
         assert_eq!(percentile(&values, 1.0), Some(100.0));
         assert_eq!(percentile(&[], 0.5), None);
+    }
+
+    #[test]
+    fn startup_ends_only_when_the_picture_is_less_than_one_frame_late() {
+        let rate = Rate::fps(30);
+        assert!(startup_caught_up(33.0, rate));
+        assert!(!startup_caught_up(34.0, rate));
     }
 
     /// Every `within` says yes to `None`, so a run that drew nothing at all

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/surface.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/surface.rs
@@ -16,7 +16,43 @@ use crate::player::Sink;
 use makevideo_compositor::gpu::GpuCompositor;
 use makevideo_compositor::source::Frame;
 use makevideo_compositor::{Compositor, Placement, Source};
+use makevideo_render::layout::Rect;
 use std::sync::Arc;
+
+/// Editor-only marks drawn by the monitor surface after the project frame.
+/// They live here, rather than in `Frame`, so render and export can never
+/// accidentally include them.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Guides {
+    pub action_safe_area: bool,
+    pub title_safe_area: bool,
+    pub rule_of_thirds: bool,
+    pub center_lines: bool,
+}
+
+struct GuideLayer {
+    pixels: Vec<u8>,
+    width: u32,
+    height: u32,
+    dst: Rect,
+}
+
+struct GuideOverlay {
+    layers: Vec<GuideLayer>,
+}
+
+impl GuideOverlay {
+    #[cfg(test)]
+    fn bytes(&self) -> usize {
+        self.layers.iter().map(|layer| layer.pixels.len()).sum()
+    }
+}
+
+impl Guides {
+    pub fn visible(self) -> bool {
+        self.action_safe_area || self.title_safe_area || self.rule_of_thirds || self.center_lines
+    }
+}
 
 /// What the surface is asked for, in order of preference.
 ///
@@ -40,6 +76,16 @@ pub struct SurfaceSink {
     /// the same number and mixing them up puts the picture in a corner.
     width: u32,
     height: u32,
+    guides: Guides,
+    guide_overlay: Option<Arc<GuideOverlay>>,
+    outcome: PresentOutcome,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PresentOutcome {
+    Presented,
+    Deferred,
+    Hidden,
 }
 
 impl SurfaceSink {
@@ -96,7 +142,39 @@ impl SurfaceSink {
             config,
             width,
             height,
+            guides: Guides::default(),
+            guide_overlay: None,
+            outcome: PresentOutcome::Deferred,
         })
+    }
+
+    pub fn with_guides(mut self, guides: Guides) -> SurfaceSink {
+        self.set_guides(guides);
+        self
+    }
+
+    /// Replace only the editor overlay. The surface, compositor and decoded
+    /// frame path stay intact; the next `show` uses the new marks.
+    pub fn set_guides(&mut self, guides: Guides) {
+        if self.guides == guides {
+            return;
+        }
+        self.guides = guides;
+        self.guide_overlay = guide_overlay(self.width, self.height, guides).map(Arc::new);
+    }
+
+    /// Change the coordinate space of the project frame without replacing the
+    /// window surface. Preview-quality switches use the same swapchain with a
+    /// differently sized decoded/composited frame.
+    pub fn set_frame_size(&mut self, width: u32, height: u32) {
+        let width = width.max(1);
+        let height = height.max(1);
+        if self.width == width && self.height == height {
+            return;
+        }
+        self.width = width;
+        self.height = height;
+        self.guide_overlay = guide_overlay(width, height, self.guides).map(Arc::new);
     }
 
     /// The view changed size. Cheap, and safe to call with the same size.
@@ -116,6 +194,13 @@ impl SurfaceSink {
         self.config.format
     }
 
+    /// Whether the most recent draw acquired and presented a swapchain image.
+    /// Occlusion and timeout keep playback healthy but are not a candidate
+    /// commit point.
+    pub fn present_outcome(&self) -> PresentOutcome {
+        self.outcome
+    }
+
     fn gpu(&self) -> Result<&GpuCompositor, String> {
         self.compositor
             .gpu()
@@ -123,6 +208,7 @@ impl SurfaceSink {
     }
 
     fn draw(&mut self, layers: &[(Source<'_>, Placement)]) -> Result<(), String> {
+        self.outcome = PresentOutcome::Deferred;
         let gpu = self.gpu()?;
         let texture = match self.surface.get_current_texture() {
             wgpu::CurrentSurfaceTexture::Success(texture)
@@ -135,6 +221,11 @@ impl SurfaceSink {
                 match self.surface.get_current_texture() {
                     wgpu::CurrentSurfaceTexture::Success(texture)
                     | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                    wgpu::CurrentSurfaceTexture::Occluded => {
+                        self.outcome = PresentOutcome::Hidden;
+                        return Ok(());
+                    }
+                    wgpu::CurrentSurfaceTexture::Timeout => return Ok(()),
                     other => return Err(format!("the monitor surface is gone: {other:?}")),
                 }
             }
@@ -142,9 +233,11 @@ impl SurfaceSink {
             // There is nowhere to draw and nothing is wrong: the frame is over
             // and playback goes on. Reporting a failure here would fill the
             // error log every time somebody minimised the app.
-            wgpu::CurrentSurfaceTexture::Occluded | wgpu::CurrentSurfaceTexture::Timeout => {
-                return Ok(())
+            wgpu::CurrentSurfaceTexture::Occluded => {
+                self.outcome = PresentOutcome::Hidden;
+                return Ok(());
             }
+            wgpu::CurrentSurfaceTexture::Timeout => return Ok(()),
             other => return Err(format!("cannot draw the monitor: {other:?}")),
         };
         let view = texture
@@ -152,19 +245,276 @@ impl SurfaceSink {
             .create_view(&wgpu::TextureViewDescriptor::default());
         gpu.draw_onto(&view, &self.pipeline, self.width, self.height, layers)?;
         gpu.queue().present(texture);
+        self.outcome = PresentOutcome::Presented;
         Ok(())
     }
 }
 
 impl Sink for SurfaceSink {
     fn show(&mut self, frame: &Frame) -> Result<(), String> {
-        let layers = frame.sources();
+        let overlay = self.guide_overlay.as_ref().map(Arc::clone);
+        let mut layers = frame.sources();
+        if let Some(overlay) = overlay.as_deref() {
+            layers.extend(overlay.layers.iter().map(|guide| {
+                (
+                    Source {
+                        rgba: &guide.pixels,
+                        width: guide.width,
+                        height: guide.height,
+                        lut: None,
+                    },
+                    Placement {
+                        dst: guide.dst,
+                        opacity: 1.0,
+                    },
+                )
+            }));
+        }
         self.draw(&layers)
     }
 
     fn clear(&mut self) -> Result<(), String> {
-        self.draw(&[])
+        let overlay = self.guide_overlay.as_ref().map(Arc::clone);
+        let layers = overlay
+            .as_deref()
+            .map(|overlay| {
+                overlay
+                    .layers
+                    .iter()
+                    .map(|guide| {
+                        (
+                            Source {
+                                rgba: &guide.pixels,
+                                width: guide.width,
+                                height: guide.height,
+                                lut: None,
+                            },
+                            Placement {
+                                dst: guide.dst,
+                                opacity: 1.0,
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        self.draw(&layers)
     }
+}
+
+fn guide_overlay(width: u32, height: u32, guides: Guides) -> Option<GuideOverlay> {
+    if width == 0 || height == 0 || !guides.visible() {
+        return None;
+    }
+    let mut layers = Vec::new();
+    let scale = (width.max(height) / 960).max(1);
+    let pale = [0xe8, 0xee, 0xf7, 0xff];
+    let gold = [0xf7, 0xd1, 0x54, 0xff];
+    if guides.action_safe_area {
+        dashed_rect(
+            &mut layers,
+            width,
+            height,
+            inset_rect(width, height, 35, 1_000),
+            pale,
+            scale,
+            6 * scale,
+            4 * scale,
+        );
+    }
+    if guides.title_safe_area {
+        dashed_rect(
+            &mut layers,
+            width,
+            height,
+            inset_rect(width, height, 50, 1_000),
+            gold,
+            scale,
+            6 * scale,
+            4 * scale,
+        );
+    }
+    if guides.rule_of_thirds {
+        for x in [width / 3, width.saturating_mul(2) / 3] {
+            layers.push(dashed_vertical(
+                width,
+                height,
+                0,
+                height.saturating_sub(1),
+                x,
+                pale,
+                scale,
+                3 * scale,
+                3 * scale,
+            ));
+        }
+        for y in [height / 3, height.saturating_mul(2) / 3] {
+            layers.push(dashed_horizontal(
+                width,
+                height,
+                0,
+                width.saturating_sub(1),
+                y,
+                pale,
+                scale,
+                3 * scale,
+                3 * scale,
+            ));
+        }
+    }
+    if guides.center_lines {
+        let line = scale.saturating_mul(2);
+        layers.push(dashed_vertical(
+            width,
+            height,
+            0,
+            height.saturating_sub(1),
+            width / 2,
+            pale,
+            line,
+            3 * scale,
+            3 * scale,
+        ));
+        layers.push(dashed_horizontal(
+            width,
+            height,
+            0,
+            width.saturating_sub(1),
+            height / 2,
+            pale,
+            line,
+            3 * scale,
+            3 * scale,
+        ));
+    }
+    Some(GuideOverlay { layers })
+}
+
+#[derive(Clone, Copy)]
+struct GuideRect {
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+}
+
+fn inset_rect(width: u32, height: u32, numerator: u32, denominator: u32) -> GuideRect {
+    let x = width.saturating_mul(numerator) / denominator;
+    let y = height.saturating_mul(numerator) / denominator;
+    GuideRect {
+        x,
+        y,
+        w: width.saturating_sub(2 * x).max(1),
+        h: height.saturating_sub(2 * y).max(1),
+    }
+}
+
+fn dashed_rect(
+    layers: &mut Vec<GuideLayer>,
+    width: u32,
+    height: u32,
+    rect: GuideRect,
+    colour: [u8; 4],
+    line: u32,
+    dash: u32,
+    gap: u32,
+) {
+    let right = rect
+        .x
+        .saturating_add(rect.w)
+        .saturating_sub(1)
+        .min(width - 1);
+    let bottom = rect
+        .y
+        .saturating_add(rect.h)
+        .saturating_sub(1)
+        .min(height - 1);
+    layers.push(dashed_horizontal(
+        width, height, rect.x, right, rect.y, colour, line, dash, gap,
+    ));
+    layers.push(dashed_horizontal(
+        width, height, rect.x, right, bottom, colour, line, dash, gap,
+    ));
+    layers.push(dashed_vertical(
+        width, height, rect.y, bottom, rect.x, colour, line, dash, gap,
+    ));
+    layers.push(dashed_vertical(
+        width, height, rect.y, bottom, right, colour, line, dash, gap,
+    ));
+}
+
+fn dashed_horizontal(
+    _width: u32,
+    height: u32,
+    start: u32,
+    end: u32,
+    y: u32,
+    colour: [u8; 4],
+    line: u32,
+    dash: u32,
+    gap: u32,
+) -> GuideLayer {
+    let length = end.saturating_sub(start).saturating_add(1).max(1);
+    let thickness = line.min(height.saturating_sub(y)).max(1);
+    let mut pixels = vec![0; length as usize * thickness as usize * 4];
+    for x in 0..length {
+        if x % (dash + gap).max(1) < dash {
+            for row in 0..thickness {
+                let at = ((row * length + x) * 4) as usize;
+                pixels[at..at + 4].copy_from_slice(&colour);
+            }
+        }
+    }
+    GuideLayer {
+        pixels,
+        width: length,
+        height: thickness,
+        dst: Rect {
+            x: coordinate(start),
+            y: coordinate(y),
+            w: length,
+            h: thickness,
+        },
+    }
+}
+
+fn dashed_vertical(
+    width: u32,
+    _height: u32,
+    start: u32,
+    end: u32,
+    x: u32,
+    colour: [u8; 4],
+    line: u32,
+    dash: u32,
+    gap: u32,
+) -> GuideLayer {
+    let length = end.saturating_sub(start).saturating_add(1).max(1);
+    let thickness = line.min(width.saturating_sub(x)).max(1);
+    let mut pixels = vec![0; thickness as usize * length as usize * 4];
+    for y in 0..length {
+        if y % (dash + gap).max(1) < dash {
+            for column in 0..thickness {
+                let at = ((y * thickness + column) * 4) as usize;
+                pixels[at..at + 4].copy_from_slice(&colour);
+            }
+        }
+    }
+    GuideLayer {
+        pixels,
+        width: thickness,
+        height: length,
+        dst: Rect {
+            x: coordinate(x),
+            y: coordinate(start),
+            w: thickness,
+            h: length,
+        },
+    }
+}
+
+fn coordinate(value: u32) -> i32 {
+    i32::try_from(value).unwrap_or(i32::MAX)
 }
 
 /// The first of [`WANTED`] the window offers, then any other non-sRGB one,
@@ -186,6 +536,83 @@ fn pick_format(offered: &[wgpu::TextureFormat]) -> Option<wgpu::TextureFormat> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn overlay_pixel(overlay: &GuideOverlay, x: u32, y: u32) -> [u8; 4] {
+        let mut found = [0, 0, 0, 0];
+        for layer in &overlay.layers {
+            let left = layer.dst.x.max(0) as u32;
+            let top = layer.dst.y.max(0) as u32;
+            if x < left || y < top || x >= left + layer.width || y >= top + layer.height {
+                continue;
+            }
+            let local_x = x - left;
+            let local_y = y - top;
+            let at = ((local_y * layer.width + local_x) * 4) as usize;
+            let pixel = [
+                layer.pixels[at],
+                layer.pixels[at + 1],
+                layer.pixels[at + 2],
+                layer.pixels[at + 3],
+            ];
+            if pixel[3] != 0 {
+                found = pixel;
+            }
+        }
+        found
+    }
+
+    #[test]
+    fn disabled_guides_allocate_no_overlay() {
+        assert!(guide_overlay(1920, 1080, Guides::default()).is_none());
+    }
+
+    #[test]
+    fn title_safe_uses_the_same_inset_and_colour_as_the_page_guide() {
+        let overlay = guide_overlay(
+            100,
+            100,
+            Guides {
+                title_safe_area: true,
+                ..Guides::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(overlay_pixel(&overlay, 5, 5), [0xf7, 0xd1, 0x54, 0xff]);
+        assert_eq!(overlay_pixel(&overlay, 1, 1), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn thirds_and_centres_are_monitor_overlay_pixels() {
+        let overlay = guide_overlay(
+            90,
+            60,
+            Guides {
+                rule_of_thirds: true,
+                center_lines: true,
+                ..Guides::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(overlay_pixel(&overlay, 30, 0), [0xe8, 0xee, 0xf7, 0xff]);
+        assert_eq!(overlay_pixel(&overlay, 45, 0), [0xe8, 0xee, 0xf7, 0xff]);
+        assert_eq!(overlay_pixel(&overlay, 1, 1), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn four_k_guides_use_strips_smaller_than_one_megabyte() {
+        let overlay = guide_overlay(
+            3840,
+            2160,
+            Guides {
+                action_safe_area: true,
+                title_safe_area: true,
+                rule_of_thirds: true,
+                center_lines: true,
+            },
+        )
+        .unwrap();
+        assert!(overlay.bytes() < 1_000_000, "{} bytes", overlay.bytes());
+    }
 
     #[test]
     fn bgra_is_taken_first_because_that_is_what_a_mac_offers() {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
@@ -21,6 +21,12 @@ use makevideo_compositor::source::{
 use makevideo_render::{Project, RationalTime};
 use std::sync::Arc;
 
+/// A sink call completed without a swapchain image actually reaching the
+/// display (for example while the window is occluded). Candidate replacement
+/// treats this as retryable readiness, not a commit or an explicit failure.
+pub const PRESENT_DEFERRED: &str = "the monitor did not present a drawable yet";
+pub const PRESENT_HIDDEN: &str = "the monitor is hidden until its view becomes visible";
+
 /// Everything needed to start playing a timeline.
 pub struct Setup<'a> {
     pub project: &'a Project,
@@ -38,10 +44,40 @@ pub struct Setup<'a> {
     pub resync_after: i64,
 }
 
+/// The video-only half of a replacement playback path.
+///
+/// Audio deliberately is not here. A replacement follows the clock already
+/// owned by [`Transport`], so changing preview quality, proxies or the
+/// compositor cannot reopen the output device or move the audible playhead.
+pub struct VideoSetup<'a> {
+    pub project: &'a Project,
+    pub width: u32,
+    pub height: u32,
+    pub frame_buffering: FrameBuffering,
+    pub frame_readers: Arc<dyn FrameReaders>,
+    pub resync_after: i64,
+}
+
+/// What trying the video-only replacement did on this tick.
+#[derive(Debug, Clone, PartialEq)]
+pub enum VideoReplacement {
+    /// It has not presented a frame yet, so the old scheduler remains active.
+    Pending,
+    /// Its first frame reached the candidate sink and it is now the active
+    /// scheduler. The tick is returned so the driver can account for it.
+    Committed(Tick),
+    /// The candidate sink refused the frame. It has been discarded and the
+    /// old scheduler is still active.
+    Failed(String),
+}
+
 /// The two halves of playback, moved together.
 pub struct Transport {
     audio: AudioEngine,
     scheduler: Scheduler,
+    /// A video path warming against the same audio clock. It cannot replace
+    /// `scheduler` until one of its frames has actually reached its sink.
+    candidate: Option<Scheduler>,
     /// Seeks asked of the audio engine since it started. **Never reset**, because
     /// `Feed::seeks_done` is not reset either and the two are only comparable
     /// as running totals.
@@ -57,6 +93,13 @@ pub struct Transport {
     asked: u64,
     /// A seek has been asked for and not yet answered.
     waiting: bool,
+    /// The frame the audio engine is moving to while `waiting` is true.
+    /// `Scheduler::position()` still reads the old audio clock during that
+    /// window, so a replacement must align to this value instead.
+    waiting_target: Option<i64>,
+    /// The scheduler has exhausted the timeline. The audio clock can still
+    /// floor to the last frame, so position alone cannot identify replay.
+    ended: bool,
 }
 
 impl Transport {
@@ -84,8 +127,11 @@ impl Transport {
             Transport {
                 audio,
                 scheduler,
+                candidate: None,
                 asked: 0,
                 waiting: false,
+                waiting_target: None,
+                ended: false,
             },
             consumer,
         )
@@ -93,6 +139,24 @@ impl Transport {
 
     pub fn scheduler(&self) -> &Scheduler {
         &self.scheduler
+    }
+
+    pub fn video_buffered_bytes(&self) -> usize {
+        self.scheduler.buffered_bytes().saturating_add(
+            self.candidate
+                .as_ref()
+                .map(Scheduler::buffered_bytes)
+                .unwrap_or_default(),
+        )
+    }
+
+    pub fn video_buffer_ceiling(&self) -> usize {
+        self.scheduler.buffer_ceiling().saturating_add(
+            self.candidate
+                .as_ref()
+                .map(Scheduler::buffer_ceiling)
+                .unwrap_or_default(),
+        )
     }
 
     pub fn audio(&self) -> &AudioEngine {
@@ -103,9 +167,22 @@ impl Transport {
         self.scheduler.is_playing()
     }
 
+    /// Whether the device may expose the ring without playing samples from the
+    /// position a seek just left. A completed flush alone is not enough: wait
+    /// until the new position has a normal buffer (or genuinely reached end).
+    pub fn audio_ready(&self) -> bool {
+        !self.waiting
+            && (self.audio.buffered_frames() >= self.audio.target_fill()
+                || self.audio.feed().ended())
+    }
+
     /// Where the playhead is, in frames of the project rate.
     pub fn position(&self) -> i64 {
-        self.scheduler.position()
+        // The audio clock still reports the old frame until its asynchronous
+        // seek flush completes. During that window the user-visible playhead
+        // is the requested target, not the clock being left behind.
+        self.waiting_target
+            .unwrap_or_else(|| self.scheduler.position())
     }
 
     pub fn frames(&self) -> i64 {
@@ -120,13 +197,44 @@ impl Transport {
     /// ring to fill would be the transport waiting for the consumer, and the
     /// consumer is somebody else's thread.
     pub fn play(&mut self) {
+        // Play after the timeline ended means replay, not another immediate
+        // Ended tick. Use the ordinary seek handshake so sound, clock and the
+        // exact first picture all restart together.
+        if self.ended || self.scheduler.position() >= self.scheduler.frames() {
+            self.seek(0);
+        }
         self.scheduler.play();
+        if self.waiting {
+            self.scheduler.wait_for_settle();
+        }
+        if let Some(candidate) = self.candidate.as_mut() {
+            candidate.play();
+            if self.waiting {
+                candidate.wait_for_settle();
+            }
+        }
     }
 
     /// Stop, and leave the frame the playhead landed on drawn.
     pub fn pause(&mut self) {
-        let at = self.scheduler.position();
+        // The audio seek completes asynchronously, so its clock may still be
+        // at the old frame. Pausing does not cancel the user's target: keep T
+        // as the exact paused still until the audio half settles.
+        let waiting_audio = self.waiting_target;
+        let pending_exact = self.scheduler.required_exact();
+        let at = waiting_audio
+            .or(pending_exact)
+            .unwrap_or_else(|| self.scheduler.position());
         self.scheduler.pause(at);
+        if let Some(candidate) = self.candidate.as_mut() {
+            candidate.pause(at);
+        }
+        // Audio may already have settled and advanced while exact T is still
+        // decoding. If T is what pause preserves, move the sound back to the
+        // same point instead of resuming later from T+n.
+        if waiting_audio.is_none() && pending_exact.is_some() {
+            self.seek_audio(at);
+        }
     }
 
     /// Move both halves to `frame`.
@@ -137,13 +245,14 @@ impl Transport {
     /// frame — 16.7 ms at 30 fps — against a mixer that keeps the exact sample.
     pub fn seek(&mut self, frame: i64) {
         let target = frame.clamp(0, self.scheduler.frames());
+        self.ended = false;
         // The scheduler first: it stops judging the clock the moment it is
         // told, and the engine's answer can arrive at any point after this.
         self.scheduler.seek(target);
-        let sample = RationalTime::new(target, self.scheduler.rate()).to_samples(ENGINE_HZ);
-        self.audio.seek_sample(sample);
-        self.asked += 1;
-        self.waiting = true;
+        if let Some(candidate) = self.candidate.as_mut() {
+            candidate.seek(target);
+        }
+        self.seek_audio(target);
     }
 
     /// One step of the picture. Call it in a loop, sleeping for what a
@@ -153,22 +262,181 @@ impl Transport {
     /// the *engine's* answer being waited for, and the scheduler is the half
     /// that does not know there is an engine.
     pub fn tick(&mut self, sink: &mut dyn Sink) -> Tick {
-        if self.waiting && self.audio.feed().seeks_done() >= self.asked {
-            self.scheduler.settled();
-            self.waiting = false;
-        }
+        self.settle_video();
         // Whether the clock has stopped for good is a question about the feeder
         // and the ring together, and the transport is the only thing holding
         // both. The scheduler sees a clock, and a clock that has stopped looks
         // exactly like one that has not been popped for a moment.
         self.scheduler.set_sound_over(self.sound_over());
-        self.scheduler.tick(sink)
+        let tick = match self.scheduler.tick(sink) {
+            Tick::Failed { reason } if reason == PRESENT_DEFERRED || reason == PRESENT_HIDDEN => {
+                Tick::Idle
+            }
+            tick => tick,
+        };
+        if tick == Tick::Ended {
+            self.ended = true;
+        }
+        tick
+    }
+
+    /// Start decoding a replacement video path without changing the current
+    /// one. A newer call supersedes an older candidate, but neither affects
+    /// the audio engine or the scheduler currently visible.
+    pub fn prepare_video(&mut self, setup: VideoSetup<'_>) {
+        let source = FrameSource::new(
+            setup.project,
+            setup.width,
+            setup.height,
+            setup.frame_buffering,
+            setup.frame_readers,
+        );
+        let mut candidate =
+            Scheduler::new(source, Arc::clone(self.audio.clock()), setup.resync_after);
+        let at = self.replacement_target();
+        if self.scheduler.is_playing() {
+            candidate.play();
+            if let Some(exact) = self
+                .waiting_target
+                .or_else(|| self.scheduler.required_exact())
+            {
+                candidate.seek(exact);
+                if !self.waiting {
+                    candidate.settled();
+                }
+            } else {
+                candidate.align_playback(at);
+            }
+        } else {
+            candidate.seek(at);
+        }
+        self.candidate = Some(candidate);
+    }
+
+    /// Try the candidate once. The old path is untouched until this returns
+    /// [`VideoReplacement::Committed`]. The sink call happens before the swap,
+    /// which makes "ready" mean visible rather than merely decoded.
+    pub fn tick_video_replacement(&mut self, sink: &mut dyn Sink) -> VideoReplacement {
+        self.settle_video();
+        let sound_over = self.sound_over();
+        let active_exact = self.scheduler.required_exact();
+        let active_position = self.scheduler.position();
+        let Some(candidate) = self.candidate.as_mut() else {
+            return VideoReplacement::Pending;
+        };
+        if candidate.is_playing()
+            && !self.waiting
+            && active_exact.is_none()
+            && candidate.required_exact().is_some()
+        {
+            candidate.align_playback(active_position);
+        }
+        candidate.set_sound_over(sound_over);
+        let mut observed = PresentedSink::new(sink);
+        let tick = candidate.tick(&mut observed);
+        let reached_sink = observed.reached_sink;
+        match tick {
+            Tick::Presented { .. } | Tick::Ended if reached_sink => {
+                self.scheduler = self.candidate.take().expect("candidate was just borrowed");
+                // A video-only replacement does not change transport intent.
+                // At the natural end its paused candidate may present the
+                // last indexed frame rather than return Ended, but Play must
+                // still mean replay from zero.
+                self.ended |= tick == Tick::Ended;
+                VideoReplacement::Committed(tick)
+            }
+            Tick::Failed { reason } if reason == PRESENT_DEFERRED => VideoReplacement::Pending,
+            Tick::Failed { reason } if reason == PRESENT_HIDDEN => {
+                self.scheduler = self.candidate.take().expect("candidate was just borrowed");
+                VideoReplacement::Committed(Tick::Idle)
+            }
+            Tick::Failed { reason } => {
+                self.candidate = None;
+                VideoReplacement::Failed(reason)
+            }
+            _ => VideoReplacement::Pending,
+        }
+    }
+
+    /// Throw away a candidate that timed out or was superseded. The current
+    /// video path and the audio engine are unchanged.
+    pub fn cancel_video_replacement(&mut self) {
+        self.candidate = None;
+    }
+
+    /// Ask the current video source for the frame under a paused playhead
+    /// again without seeking or reopening audio. While playing, the next
+    /// ordinary frame is already the redraw.
+    pub fn redraw_video(&mut self) {
+        if self.scheduler.is_playing() {
+            return;
+        }
+        self.scheduler.redraw();
+        if let Some(candidate) = self.candidate.as_mut() {
+            candidate.redraw();
+        }
+    }
+
+    pub fn has_video_replacement(&self) -> bool {
+        self.candidate.is_some()
+    }
+
+    fn settle_video(&mut self) {
+        if self.waiting && self.audio.feed().seeks_done() >= self.asked {
+            self.scheduler.settled();
+            if let Some(candidate) = self.candidate.as_mut() {
+                candidate.settled();
+            }
+            self.waiting = false;
+            self.waiting_target = None;
+        }
+    }
+
+    fn replacement_target(&self) -> i64 {
+        self.waiting_target
+            .unwrap_or_else(|| self.scheduler.position())
+    }
+
+    fn seek_audio(&mut self, target: i64) {
+        let sample = RationalTime::new(target, self.scheduler.rate()).to_samples(ENGINE_HZ);
+        self.audio.seek_sample(sample);
+        self.asked += 1;
+        self.waiting = true;
+        self.waiting_target = Some(target);
     }
 
     /// The mix has reached the end of the timeline and everything mixed has
     /// been played. Nothing will move the clock after this.
     pub fn sound_over(&self) -> bool {
         !self.waiting && self.audio.feed().ended() && self.audio.buffered_frames() == 0
+    }
+}
+
+struct PresentedSink<'a> {
+    sink: &'a mut dyn Sink,
+    reached_sink: bool,
+}
+
+impl<'a> PresentedSink<'a> {
+    fn new(sink: &'a mut dyn Sink) -> PresentedSink<'a> {
+        PresentedSink {
+            sink,
+            reached_sink: false,
+        }
+    }
+}
+
+impl Sink for PresentedSink<'_> {
+    fn show(&mut self, frame: &makevideo_compositor::source::Frame) -> Result<(), String> {
+        self.sink.show(frame)?;
+        self.reached_sink = true;
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<(), String> {
+        self.sink.clear()?;
+        self.reached_sink = true;
+        Ok(())
     }
 }
 
@@ -179,10 +447,14 @@ mod tests {
     use crate::sink::CountingSink;
     use makevideo_audio::realtime::{Clock, CHANNELS};
     use makevideo_audio::source::{Open as AudioOpen, PcmReader};
-    use makevideo_compositor::source::{FrameReader, Open as FrameOpen, Readers as Frames};
+    use makevideo_compositor::source::{
+        CancelRead, FrameReader, Open as FrameOpen, Readers as Frames,
+    };
     use makevideo_render::{
         Asset, AssetKind, Clip, Project, ProjectSettings, Rate, Track, TrackKind, FORMAT_VERSION,
     };
+    use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+    use std::sync::Mutex;
     use std::time::{Duration, Instant};
 
     struct Blank;
@@ -199,6 +471,279 @@ mod tests {
     impl Frames for BlankFrames {
         fn open(&self, _request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
             Some(Box::new(Blank))
+        }
+    }
+
+    struct NumberGate {
+        through: AtomicI64,
+        cancelled: AtomicBool,
+    }
+
+    impl NumberGate {
+        fn new(through: i64) -> NumberGate {
+            NumberGate {
+                through: AtomicI64::new(through),
+                cancelled: AtomicBool::new(false),
+            }
+        }
+
+        fn allow(&self, through: i64) {
+            self.through.fetch_max(through, Ordering::Relaxed);
+        }
+    }
+
+    struct NumberedGateReader {
+        next: i64,
+        remaining: i64,
+        gate: Arc<NumberGate>,
+    }
+
+    impl FrameReader for NumberedGateReader {
+        fn read(&mut self, buffer: &mut [u8]) -> bool {
+            if self.remaining <= 0 {
+                return false;
+            }
+            while self.next > self.gate.through.load(Ordering::Relaxed)
+                && !self.gate.cancelled.load(Ordering::Relaxed)
+            {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            if self.gate.cancelled.load(Ordering::Relaxed) {
+                return false;
+            }
+            buffer.fill(self.next as u8);
+            self.next += 1;
+            self.remaining -= 1;
+            true
+        }
+
+        fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {
+            Some(Arc::new(NumberGateCancel(Arc::clone(&self.gate))))
+        }
+    }
+
+    struct NumberGateCancel(Arc<NumberGate>);
+
+    impl CancelRead for NumberGateCancel {
+        fn cancel(&self) {
+            self.0.cancelled.store(true, Ordering::Relaxed);
+        }
+    }
+
+    struct NumberedGateFrames(Arc<NumberGate>);
+
+    impl Frames for NumberedGateFrames {
+        fn open(&self, request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
+            Some(Box::new(NumberedGateReader {
+                next: request.in_frame,
+                remaining: request.frames,
+                gate: Arc::clone(&self.0),
+            }))
+        }
+    }
+
+    struct Solid {
+        value: u8,
+    }
+
+    impl FrameReader for Solid {
+        fn read(&mut self, buffer: &mut [u8]) -> bool {
+            buffer.fill(self.value);
+            true
+        }
+    }
+
+    struct SolidFrames(u8);
+
+    impl Frames for SolidFrames {
+        fn open(&self, _request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
+            Some(Box::new(Solid { value: self.0 }))
+        }
+    }
+
+    struct RecordingFrames(Arc<Mutex<Vec<i64>>>);
+
+    impl Frames for RecordingFrames {
+        fn open(&self, request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
+            self.0.lock().unwrap().push(request.in_frame);
+            Some(Box::new(Blank))
+        }
+    }
+
+    struct Gated {
+        value: u8,
+        ready: Arc<AtomicBool>,
+    }
+
+    impl FrameReader for Gated {
+        fn read(&mut self, buffer: &mut [u8]) -> bool {
+            while !self.ready.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            buffer.fill(self.value);
+            true
+        }
+
+        fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {
+            Some(Arc::new(OpenGate(Arc::clone(&self.ready))))
+        }
+    }
+
+    struct OpenGate(Arc<AtomicBool>);
+
+    impl CancelRead for OpenGate {
+        fn cancel(&self) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    struct GatedFrames {
+        value: u8,
+        ready: Arc<AtomicBool>,
+    }
+
+    struct Blocked {
+        value: u8,
+        ready: Arc<AtomicBool>,
+        cancelled: Arc<AtomicBool>,
+    }
+
+    impl FrameReader for Blocked {
+        fn read(&mut self, buffer: &mut [u8]) -> bool {
+            while !self.ready.load(Ordering::Relaxed) && !self.cancelled.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            if self.cancelled.load(Ordering::Relaxed) {
+                return false;
+            }
+            buffer.fill(self.value);
+            true
+        }
+
+        fn cancellation(&self) -> Option<Arc<dyn CancelRead>> {
+            Some(Arc::new(CancelFlag(Arc::clone(&self.cancelled))))
+        }
+    }
+
+    struct CancelFlag(Arc<AtomicBool>);
+
+    impl CancelRead for CancelFlag {
+        fn cancel(&self) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
+
+    struct BlockingFrames {
+        value: u8,
+        ready: Arc<AtomicBool>,
+    }
+
+    impl Frames for BlockingFrames {
+        fn open(&self, _request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
+            Some(Box::new(Blocked {
+                value: self.value,
+                ready: Arc::clone(&self.ready),
+                cancelled: Arc::new(AtomicBool::new(false)),
+            }))
+        }
+    }
+
+    impl Frames for GatedFrames {
+        fn open(&self, _request: &FrameOpen) -> Option<Box<dyn FrameReader>> {
+            Some(Box::new(Gated {
+                value: self.value,
+                ready: Arc::clone(&self.ready),
+            }))
+        }
+    }
+
+    #[derive(Clone)]
+    struct Values {
+        generation: u8,
+        shown: Arc<Mutex<Vec<(u8, u8)>>>,
+        fail: bool,
+    }
+
+    impl Sink for Values {
+        fn show(&mut self, frame: &makevideo_compositor::source::Frame) -> Result<(), String> {
+            if self.fail {
+                return Err("candidate surface refused".into());
+            }
+            let value = frame
+                .layers
+                .first()
+                .and_then(|layer| layer.pixels.first())
+                .copied()
+                .unwrap_or_default();
+            self.shown.lock().unwrap().push((self.generation, value));
+            Ok(())
+        }
+
+        fn clear(&mut self) -> Result<(), String> {
+            if self.fail {
+                Err("candidate surface refused".into())
+            } else {
+                self.shown.lock().unwrap().push((self.generation, 0));
+                Ok(())
+            }
+        }
+    }
+
+    struct FrameNumbers(Arc<Mutex<Vec<i64>>>);
+
+    impl Sink for FrameNumbers {
+        fn show(&mut self, frame: &makevideo_compositor::source::Frame) -> Result<(), String> {
+            self.0.lock().unwrap().push(frame.frame);
+            Ok(())
+        }
+
+        fn clear(&mut self) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    struct DeferredSink {
+        deferred: usize,
+        attempts: usize,
+        shown: Vec<i64>,
+    }
+
+    #[derive(Default)]
+    struct HiddenSink {
+        attempts: usize,
+    }
+
+    impl Sink for HiddenSink {
+        fn show(&mut self, _frame: &makevideo_compositor::source::Frame) -> Result<(), String> {
+            self.attempts += 1;
+            Err(PRESENT_HIDDEN.into())
+        }
+
+        fn clear(&mut self) -> Result<(), String> {
+            self.attempts += 1;
+            Err(PRESENT_HIDDEN.into())
+        }
+    }
+
+    impl Sink for DeferredSink {
+        fn show(&mut self, frame: &makevideo_compositor::source::Frame) -> Result<(), String> {
+            self.attempts += 1;
+            if self.deferred != 0 {
+                self.deferred -= 1;
+                return Err(PRESENT_DEFERRED.into());
+            }
+            self.shown.push(frame.frame);
+            Ok(())
+        }
+
+        fn clear(&mut self) -> Result<(), String> {
+            self.attempts += 1;
+            if self.deferred != 0 {
+                self.deferred -= 1;
+                Err(PRESENT_DEFERRED.into())
+            } else {
+                Ok(())
+            }
         }
     }
 
@@ -262,17 +807,35 @@ mod tests {
     }
 
     fn transport(project: &Project) -> (Transport, Consumer) {
+        transport_with_frames(project, Arc::new(BlankFrames))
+    }
+
+    fn transport_with_frames(
+        project: &Project,
+        frame_readers: Arc<dyn Frames>,
+    ) -> (Transport, Consumer) {
         Transport::start(Setup {
             project,
             width: 16,
             height: 16,
             frame_buffering: FrameBuffering::new(6, 15),
-            frame_readers: Arc::new(BlankFrames),
+            frame_readers,
             audio_buffering: AudioBuffering::default(),
             audio_readers: Arc::new(SilentSources),
             audio: AudioOptions::default(),
             resync_after: DEFAULT_RESYNC,
         })
+    }
+
+    fn replacement<'a>(project: &'a Project, readers: Arc<dyn Frames>) -> VideoSetup<'a> {
+        VideoSetup {
+            project,
+            width: 16,
+            height: 16,
+            frame_buffering: FrameBuffering::new(6, 15),
+            frame_readers: readers,
+            resync_after: DEFAULT_RESYNC,
+        }
     }
 
     /// Drain the ring the way a device does.
@@ -367,6 +930,219 @@ mod tests {
         );
     }
 
+    #[test]
+    fn seek_audio_is_not_exposed_until_the_new_position_is_buffered() {
+        let project = project();
+        let (mut transport, consumer) = transport(&project);
+        let mut sink = CountingSink::default();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !transport.audio_ready() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(transport.audio_ready(), "initial audio never filled");
+
+        transport.play();
+        transport.seek(150);
+        assert!(
+            !transport.audio_ready(),
+            "the old ring must not be heard after seek"
+        );
+
+        while !transport.audio_ready() && Instant::now() < deadline {
+            consumer.take_flush();
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(
+            transport.audio_ready(),
+            "new-position audio never became ready"
+        );
+        assert_eq!(transport.position(), 150);
+    }
+
+    #[test]
+    fn replacement_during_seek_opens_at_the_pending_audio_target() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        let opened = Arc::new(Mutex::new(Vec::new()));
+        transport.play();
+        transport.seek(150);
+        assert_eq!(transport.position(), 150);
+        assert_eq!(transport.replacement_target(), 150);
+
+        transport.prepare_video(replacement(
+            &project,
+            Arc::new(RecordingFrames(Arc::clone(&opened))),
+        ));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while opened.lock().unwrap().is_empty() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let first = opened.lock().unwrap().first().copied();
+        assert!(
+            first.is_some_and(|frame| frame >= 148),
+            "replacement opened at the old clock instead of seek 150: {first:?}"
+        );
+    }
+
+    #[test]
+    fn pause_before_audio_seek_settles_keeps_the_requested_frame() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        transport.play();
+        transport.seek(150);
+        transport.pause();
+
+        assert_eq!(transport.position(), 150);
+        assert_eq!(transport.scheduler().required_exact(), None);
+        assert_eq!(transport.replacement_target(), 150);
+    }
+
+    #[test]
+    fn play_after_a_paused_backward_seek_never_reads_the_old_audio_clock() {
+        let project = project();
+        let (mut transport, consumer) = transport(&project);
+        let clock = Arc::clone(transport.audio().clock());
+        let mut sink = CountingSink::default();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while sink.shown == 0 && Instant::now() < deadline {
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+
+        transport.play();
+        let old = RationalTime::new(150, transport.scheduler.rate()).to_samples(ENGINE_HZ);
+        clock.restart(old as u64);
+        transport.pause();
+        transport.seek(20);
+        transport.play();
+
+        assert_eq!(transport.position(), 20);
+        assert_eq!(transport.tick(&mut sink), Tick::Idle);
+        assert_eq!(transport.scheduler().counters().resyncs(), 0);
+
+        while transport.waiting && Instant::now() < deadline {
+            consumer.take_flush();
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!transport.waiting, "backward seek did not settle");
+        assert_eq!(transport.scheduler().counters().resyncs(), 0);
+    }
+
+    #[test]
+    fn pause_after_audio_settles_still_keeps_exact_video_and_audio_at_the_target() {
+        let project = project();
+        let gate = Arc::new(NumberGate::new(18));
+        let (mut transport, consumer) = transport_with_frames(
+            &project,
+            Arc::new(NumberedGateFrames(Arc::clone(&gate))),
+        );
+        let clock = Arc::clone(transport.audio().clock());
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = FrameNumbers(Arc::clone(&shown));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while shown.lock().unwrap().is_empty() && Instant::now() < deadline {
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        transport.play();
+        transport.seek(20);
+        while transport.waiting && Instant::now() < deadline {
+            drain(&consumer, &clock, 512);
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!transport.waiting, "audio seek did not settle");
+        assert_eq!(transport.scheduler.required_exact(), Some(20));
+
+        transport.pause();
+        assert_eq!(transport.position(), 20);
+        assert!(transport.waiting, "audio must return from T+n to exact T");
+        gate.allow(20);
+        while (transport.waiting || !shown.lock().unwrap().contains(&20))
+            && Instant::now() < deadline
+        {
+            consumer.take_flush();
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!transport.waiting);
+        assert_eq!(clock.position(transport.scheduler.rate()).value(), 20);
+        assert!(shown.lock().unwrap().contains(&20));
+    }
+
+    #[test]
+    fn play_at_the_end_restarts_from_the_first_frame() {
+        let project = project();
+        let (mut transport, consumer) = transport(&project);
+        let clock = Arc::clone(transport.audio().clock());
+        let mut sink = CountingSink::default();
+
+        transport.seek(transport.frames());
+        transport.play();
+        assert_eq!(transport.replacement_target(), 0);
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let first = loop {
+            drain(&consumer, &clock, 512);
+            if let Tick::Presented { frame, .. } = transport.tick(&mut sink) {
+                break frame;
+            }
+            assert!(Instant::now() < deadline, "replay never produced a frame");
+            std::thread::sleep(Duration::from_millis(1));
+        };
+        assert_eq!(first, 0);
+        assert!(transport.is_playing());
+    }
+
+    #[test]
+    fn play_after_a_natural_end_restarts_even_if_the_clock_floors_to_the_last_frame() {
+        let project = project();
+        let (mut transport, consumer) = transport(&project);
+        let clock = Arc::clone(transport.audio().clock());
+        let mut sink = CountingSink::default();
+        transport.play();
+        transport.seek(transport.frames() - 1);
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            drain(&consumer, &clock, 512);
+            if transport.tick(&mut sink) == Tick::Ended {
+                break;
+            }
+            assert!(Instant::now() < deadline, "timeline never ended");
+        }
+        assert!(transport.ended);
+
+        let last = transport.frames() - 1;
+        let sample = RationalTime::new(last, transport.scheduler.rate()).to_samples(ENGINE_HZ);
+        clock.restart(sample as u64);
+        transport.pause();
+        assert_eq!(transport.position(), last);
+
+        transport.prepare_video(replacement(&project, Arc::new(SolidFrames(9))));
+        loop {
+            if matches!(
+                transport.tick_video_replacement(&mut sink),
+                VideoReplacement::Committed(_)
+            ) {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "ended replacement never committed"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(transport.ended, "video replacement cleared natural end");
+
+        transport.play();
+        assert_eq!(transport.replacement_target(), 0);
+        assert!(!transport.ended);
+    }
+
     /// The second seek is the one that used to break. `Feed::seeks_done` is a
     /// running total, so a transport that reset its own count found the
     /// engine's already past it and called the seek settled before it was.
@@ -457,5 +1233,308 @@ mod tests {
             let back = RationalTime::new(samples, Rate::new(ENGINE_HZ, 1)).rescaled(rate);
             assert_eq!(back.value(), frame, "frame {frame}");
         }
+    }
+
+    #[test]
+    fn old_video_advances_until_the_candidate_is_presented_then_never_returns() {
+        let project = project();
+        let (mut transport, consumer) = transport(&project);
+        let clock = Arc::clone(transport.audio().clock());
+        let same_clock = Arc::clone(transport.audio().clock());
+        let ready = Arc::new(AtomicBool::new(false));
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let mut old = Values {
+            generation: 0,
+            shown: Arc::clone(&shown),
+            fail: false,
+        };
+        let mut candidate = Values {
+            generation: 1,
+            shown: Arc::clone(&shown),
+            fail: false,
+        };
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while shown.lock().unwrap().is_empty() && Instant::now() < deadline {
+            transport.tick(&mut old);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        transport.play();
+        let one_path_ceiling = transport.video_buffer_ceiling();
+        transport.prepare_video(replacement(
+            &project,
+            Arc::new(GatedFrames {
+                value: 9,
+                ready: Arc::clone(&ready),
+            }),
+        ));
+        assert_eq!(transport.video_buffer_ceiling(), one_path_ceiling * 2);
+        assert!(transport.video_buffered_bytes() <= transport.video_buffer_ceiling());
+        assert!(Arc::ptr_eq(&same_clock, transport.audio().clock()));
+
+        let before = shown.lock().unwrap().len();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while shown.lock().unwrap().len() < before + 3 && Instant::now() < deadline {
+            drain(&consumer, &clock, 512);
+            transport.tick(&mut old);
+            assert_eq!(
+                transport.tick_video_replacement(&mut candidate),
+                VideoReplacement::Pending
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(shown.lock().unwrap().len() >= before + 3);
+        assert!(shown.lock().unwrap().iter().all(|entry| *entry == (0, 3)));
+
+        ready.store(true, Ordering::Relaxed);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            drain(&consumer, &clock, 512);
+            transport.tick(&mut old);
+            if matches!(
+                transport.tick_video_replacement(&mut candidate),
+                VideoReplacement::Committed(_)
+            ) {
+                break;
+            }
+            assert!(Instant::now() < deadline, "candidate never presented");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(transport.video_buffer_ceiling(), one_path_ceiling);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let first_new = shown
+            .lock()
+            .unwrap()
+            .iter()
+            .position(|entry| entry.0 == 1)
+            .expect("candidate presentation is the commit point");
+        while shown.lock().unwrap().len() < first_new + 3 && Instant::now() < deadline {
+            drain(&consumer, &clock, 512);
+            transport.tick(&mut candidate);
+        }
+        let log = shown.lock().unwrap();
+        assert!(log[..first_new].iter().all(|entry| *entry == (0, 3)));
+        assert!(log[first_new..].iter().all(|entry| *entry == (1, 9)));
+    }
+
+    #[test]
+    fn a_slow_playing_candidate_catches_up_before_its_first_present() {
+        let project = project();
+        let (mut transport, consumer) = transport(&project);
+        let clock = Arc::clone(transport.audio().clock());
+        let ready = Arc::new(AtomicBool::new(false));
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let mut active = CountingSink::default();
+        let mut candidate = FrameNumbers(Arc::clone(&shown));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while active.shown == 0 && Instant::now() < deadline {
+            transport.tick(&mut active);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        transport.play();
+        transport.prepare_video(replacement(
+            &project,
+            Arc::new(BlockingFrames {
+                value: 9,
+                ready: Arc::clone(&ready),
+            }),
+        ));
+
+        while transport.position() < 40 && Instant::now() < deadline {
+            drain(&consumer, &clock, 512);
+            transport.tick(&mut active);
+            assert_eq!(
+                transport.tick_video_replacement(&mut candidate),
+                VideoReplacement::Pending
+            );
+        }
+        let current = transport.position();
+        assert!(current >= 40, "audio clock did not advance: {current}");
+        ready.store(true, Ordering::Relaxed);
+
+        while !matches!(
+            transport.tick_video_replacement(&mut candidate),
+            VideoReplacement::Committed(_)
+        ) {
+            assert!(Instant::now() < deadline, "candidate never caught up");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(
+            shown
+                .lock()
+                .unwrap()
+                .first()
+                .copied()
+                .is_some_and(|frame| frame >= current),
+            "candidate jumped backward from clock {current}: {:?}",
+            shown.lock().unwrap().as_slice()
+        );
+    }
+
+    #[test]
+    fn a_candidate_surface_failure_keeps_the_old_video_and_audio_clock() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        let clock = Arc::clone(transport.audio().clock());
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let mut old = Values {
+            generation: 0,
+            shown: Arc::clone(&shown),
+            fail: false,
+        };
+        let mut failing = Values {
+            generation: 1,
+            shown: Arc::clone(&shown),
+            fail: true,
+        };
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while shown.lock().unwrap().is_empty() && Instant::now() < deadline {
+            transport.tick(&mut old);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        transport.prepare_video(replacement(&project, Arc::new(SolidFrames(9))));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match transport.tick_video_replacement(&mut failing) {
+                VideoReplacement::Failed(reason) => {
+                    assert_eq!(reason, "candidate surface refused");
+                    break;
+                }
+                _ => assert!(
+                    Instant::now() < deadline,
+                    "candidate never reached its sink"
+                ),
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(!transport.has_video_replacement());
+        assert!(Arc::ptr_eq(&clock, transport.audio().clock()));
+
+        let before = shown.lock().unwrap().len();
+        transport.redraw_video();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while shown.lock().unwrap().len() == before && Instant::now() < deadline {
+            transport.tick(&mut old);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(shown.lock().unwrap().last().copied(), Some((0, 3)));
+    }
+
+    #[test]
+    fn a_candidate_waits_for_an_actual_present_after_occlusion() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        let mut sink = DeferredSink {
+            deferred: 1,
+            attempts: 0,
+            shown: Vec::new(),
+        };
+        transport.prepare_video(replacement(&project, Arc::new(SolidFrames(9))));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while sink.attempts == 0 && Instant::now() < deadline {
+            assert_eq!(
+                transport.tick_video_replacement(&mut sink),
+                VideoReplacement::Pending
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(sink.attempts, 1);
+        assert!(sink.shown.is_empty());
+        assert!(transport.has_video_replacement());
+
+        while !matches!(
+            transport.tick_video_replacement(&mut sink),
+            VideoReplacement::Committed(_)
+        ) {
+            assert!(Instant::now() < deadline, "candidate never retried present");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(sink.shown, vec![0]);
+    }
+
+    #[test]
+    fn a_hidden_candidate_commits_without_waiting_and_presents_exact_when_shown() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        let mut hidden = HiddenSink::default();
+        transport.prepare_video(replacement(&project, Arc::new(SolidFrames(9))));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match transport.tick_video_replacement(&mut hidden) {
+                VideoReplacement::Committed(Tick::Idle) => break,
+                VideoReplacement::Pending => {
+                    assert!(Instant::now() < deadline, "hidden candidate never decoded");
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                other => panic!("unexpected hidden replacement result: {other:?}"),
+            }
+        }
+        assert_eq!(hidden.attempts, 1);
+        assert!(!transport.has_video_replacement());
+
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let mut visible = FrameNumbers(Arc::clone(&shown));
+        assert!(matches!(
+            transport.tick(&mut visible),
+            Tick::Presented { frame: 0, .. }
+        ));
+        assert_eq!(shown.lock().unwrap().as_slice(), &[0]);
+    }
+
+    #[test]
+    fn a_new_candidate_supersedes_the_old_candidate_without_mixing_frames() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        let shown = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = Values {
+            generation: 2,
+            shown: Arc::clone(&shown),
+            fail: false,
+        };
+        transport.prepare_video(replacement(&project, Arc::new(SolidFrames(7))));
+        transport.prepare_video(replacement(&project, Arc::new(SolidFrames(9))));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !matches!(
+            transport.tick_video_replacement(&mut sink),
+            VideoReplacement::Committed(_)
+        ) {
+            assert!(Instant::now() < deadline, "new candidate never presented");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(shown.lock().unwrap().as_slice(), &[(2, 9)]);
+    }
+
+    #[test]
+    fn guide_redraw_keeps_the_exact_paused_picture_without_a_replacement() {
+        let project = project();
+        let (mut transport, _consumer) = transport(&project);
+        let frames = Arc::new(Mutex::new(Vec::new()));
+        let mut sink = FrameNumbers(Arc::clone(&frames));
+        transport.seek(120);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while frames.lock().unwrap().last().copied() != Some(120) && Instant::now() < deadline {
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert_eq!(frames.lock().unwrap().last().copied(), Some(120));
+        assert!(!transport.has_video_replacement());
+
+        transport.redraw_video();
+        let before = frames.lock().unwrap().len();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while frames.lock().unwrap().len() == before && Instant::now() < deadline {
+            transport.tick(&mut sink);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let shown = frames.lock().unwrap();
+        assert_eq!(shown[shown.len() - 2..], [120, 120]);
+        assert!(!transport.has_video_replacement());
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -10,7 +10,9 @@
 //! preview and the render read the same document rather than being handed a
 //! copy of the timeline along with the request.
 
-use crate::playback::{Config as PlaybackConfig, Session, Status as PlaybackStatus};
+use crate::playback::{
+    Config as PlaybackConfig, Session, Status as PlaybackStatus, EXPLICIT_RECONFIGURE_PENDING,
+};
 use crate::viewport::MonitorPlace;
 use makevideo_compositor::{Backend, Compositor};
 // Aliased because this file also spawns processes, and two things called
@@ -20,6 +22,7 @@ use makevideo_edit::{
     VisualTransform,
 };
 use makevideo_present::fallback::{choose, Choice};
+use makevideo_present::surface::Guides;
 use makevideo_render::accel::{self, Acceleration};
 use makevideo_render::{ffmpeg, probe, tools, workspace, Asset, AssetKind, Project, Rate};
 use serde::{Deserialize, Serialize};
@@ -28,7 +31,7 @@ use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
@@ -70,14 +73,14 @@ pub struct Settings {
     /// to always use libx264. There is no "force GPU": if the hardware path
     /// fails there is nothing to do but use the CPU, so auto already covers it.
     pub render_acceleration: String,
-    /// Whether the graphics device is used at all: "gpu" or "cpu". This is the
-    /// only axis, and it decides three things at once — what draws the exact
-    /// frame, which engine plays, and what draws the render.
+    /// Whether the graphics device or CPU composites: "gpu" or "cpu". Both
+    /// play through the persistent native monitor; CPU frames use a small GPU
+    /// presenter only for the final upload.
     ///
     /// | | exact frame | playback | render |
     /// | --- | --- | --- | --- |
     /// | gpu | the compositor | native monitor | the compositor, filter graph if it fails |
-    /// | cpu | not asked for | media elements | the filter graph |
+    /// | cpu | software compositor | native monitor | the filter graph |
     ///
     /// ffmpeg is needed either way: it decodes for both and encodes for both.
     /// What changes is who puts the layers on top of each other.
@@ -87,10 +90,8 @@ pub struct Settings {
     /// device quietly draws with the software compositor rather than refusing.
     pub compositor: String,
     /// Which graphics adapter to draw on, by the name `graphics_devices`
-    /// reports. Empty is whatever wgpu picks, which is the right answer on a
-    /// machine with one GPU. A name this machine does not have is also the
-    /// automatic pick, so a settings file survives being carried to another
-    /// machine or unplugging an eGPU.
+    /// reports. Empty is whatever wgpu picks. A live change to a missing named
+    /// adapter is rejected and the active path and saved setting are kept.
     pub gpu_device: String,
     /// Use ready proxy files for preview and playback. Proxy creation remains
     /// automatic so disabling this changes only which media is read.
@@ -145,6 +146,12 @@ pub struct AppState {
     /// whether the timeline moved while it was working.
     pub document: Arc<Mutex<Document>>,
     pub settings: Mutex<Settings>,
+    /// Serialises only generation allocation and the final disk/state commit.
+    /// Candidate preparation stays outside it so a later request can supersede
+    /// one still waiting for its first frame.
+    pub settings_transaction: Mutex<()>,
+    pub settings_generation: AtomicU64,
+    pub playback_settings: PlaybackSettingsGate,
     /// The running ffmpeg, so Cancel has something to kill. Shared with the
     /// thread that reads its progress.
     pub render: Arc<Mutex<Option<Child>>>,
@@ -160,11 +167,82 @@ pub struct AppState {
     pub compositor: Mutex<Vec<((Backend, String), Arc<Compositor>)>>,
     /// The native monitor, when one is running. `None` is either the media
     /// element preview or nothing open yet, and the page is told which.
-    pub playback: Mutex<Option<Session>>,
+    pub playback: Mutex<Option<Arc<Session>>>,
+    /// Invalidates a session that was being built when release/delete ran.
+    /// The registry lock cannot cover `Session::start`, because surface and
+    /// decoder startup must not block transport/status commands.
+    pub playback_epoch: AtomicU64,
     pub proxies: Arc<Mutex<ProxyState>>,
     pub proxy_workers: Mutex<Vec<JoinHandle<()>>>,
     pub waveforms: Arc<Mutex<WaveformState>>,
     pub waveform_workers: Mutex<Vec<JoinHandle<()>>>,
+}
+
+#[derive(Default)]
+pub struct PlaybackSettingsGate {
+    state: Mutex<PlaybackGateState>,
+    idle: Condvar,
+}
+
+#[derive(Default)]
+struct PlaybackGateState {
+    settings: usize,
+    attaching: bool,
+}
+
+#[derive(Clone, Copy)]
+enum PlaybackLease {
+    Settings,
+    Attach,
+}
+
+impl PlaybackSettingsGate {
+    fn enter(&self) -> PlaybackSettingsGuard<'_> {
+        let mut state = self.state.lock().unwrap();
+        while state.attaching {
+            state = self.idle.wait(state).unwrap();
+        }
+        state.settings += 1;
+        PlaybackSettingsGuard {
+            gate: self,
+            lease: PlaybackLease::Settings,
+        }
+    }
+
+    fn enter_attach(&self) -> PlaybackSettingsGuard<'_> {
+        let mut state = self.state.lock().unwrap();
+        while state.settings != 0 || state.attaching {
+            state = self.idle.wait(state).unwrap();
+        }
+        state.attaching = true;
+        PlaybackSettingsGuard {
+            gate: self,
+            lease: PlaybackLease::Attach,
+        }
+    }
+
+    fn wait(&self) {
+        let mut state = self.state.lock().unwrap();
+        while state.settings != 0 || state.attaching {
+            state = self.idle.wait(state).unwrap();
+        }
+    }
+}
+
+struct PlaybackSettingsGuard<'a> {
+    gate: &'a PlaybackSettingsGate,
+    lease: PlaybackLease,
+}
+
+impl Drop for PlaybackSettingsGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.gate.state.lock().unwrap();
+        match self.lease {
+            PlaybackLease::Settings => state.settings -= 1,
+            PlaybackLease::Attach => state.attaching = false,
+        }
+        self.gate.idle.notify_all();
+    }
 }
 
 #[derive(Debug, Default)]
@@ -407,18 +485,11 @@ pub struct CompositorInfo {
     pub fell_back: bool,
 }
 
-/// Which playback engine the compositor setting implies.
-///
-/// Not a setting of its own any more. The native monitor draws on a graphics
-/// surface, so "stay off the graphics device" and "play on one" was a pair a
-/// user could ask for and never get — `Session::start` refused it and the app
-/// fell back, which is a choice that reads as broken rather than as declined.
-fn wanted_engine(settings: &Settings) -> &'static str {
-    if stays_on_cpu(settings) {
-        "media-element"
-    } else {
-        "native"
-    }
+/// CPU and GPU composition both use the persistent native monitor. The CPU
+/// path uploads one finished RGBA layer through a presentation-only GPU; media
+/// elements are only the startup fallback when no native presenter exists.
+fn wanted_engine(_settings: &Settings) -> &'static str {
+    "native"
 }
 
 /// Whether the setting asks to stay off the graphics device.
@@ -441,6 +512,18 @@ fn wanted_backend(setting: &str) -> Backend {
     }
 }
 
+fn explicit_playback_backend(settings: &Settings) -> Backend {
+    if stays_on_cpu(settings) {
+        Backend::Cpu
+    } else {
+        Backend::Gpu
+    }
+}
+
+fn automatic_playback_backend(settings: &Settings) -> Backend {
+    wanted_backend(&settings.compositor)
+}
+
 /// The adapter name a setting asks for, or `None` for whatever wgpu picks.
 fn wanted_device(setting: &str) -> Option<&str> {
     let name = setting.trim();
@@ -460,10 +543,119 @@ fn compositor(state: &State<AppState>, backend: Backend, device: Option<&str>) -
     if let Some((_, existing)) = made.iter().find(|(kind, _)| *kind == key) {
         return Arc::clone(existing);
     }
+    if let Some(existing) = made
+        .iter()
+        .find(|(cached, existing)| {
+            lenient_cache_matches(
+                backend,
+                device,
+                cached,
+                existing.is_gpu(),
+                existing.adapter(),
+            )
+        })
+        .map(|(_, existing)| Arc::clone(existing))
+    {
+        made.push((key, Arc::clone(&existing)));
+        return existing;
+    }
     let built =
         Arc::new(Compositor::with_device(backend, device).unwrap_or_else(|_| Compositor::new()));
     made.push((key, Arc::clone(&built)));
     built
+}
+
+/// A playback compositor that honours an explicit choice. Unlike the general
+/// preview/render helper above, a named GPU that is absent is an error: a live
+/// reconfiguration must roll back instead of silently moving to another card.
+fn strict_compositor(
+    state: &State<AppState>,
+    backend: Backend,
+    device: Option<&str>,
+) -> Result<Arc<Compositor>, String> {
+    let mut made = state.compositor.lock().unwrap();
+    // Cache keys describe what originally requested a compositor, not what
+    // adapter it actually opened. Reuse an Auto compositor that already owns
+    // the requested GPU so a no-op explicit choice stays the same Arc and the
+    // native surface keeps its zero-copy path.
+    if let Some(existing) = made
+        .iter()
+        .find(|(cached, existing)| {
+            strict_cache_matches(
+                backend,
+                device,
+                cached,
+                existing.is_gpu(),
+                existing.adapter(),
+            )
+        })
+        .map(|(_, existing)| Arc::clone(existing))
+    {
+        validate_strict_compositor(backend, device, &existing)?;
+        let key = (backend, device.unwrap_or_default().to_string());
+        if !made.iter().any(|(cached, _)| *cached == key) {
+            made.push((key, Arc::clone(&existing)));
+        }
+        return Ok(existing);
+    }
+    let built = Arc::new(Compositor::with_device(backend, device)?);
+    validate_strict_compositor(backend, device, &built)?;
+    let key = (backend, device.unwrap_or_default().to_string());
+    made.push((key, Arc::clone(&built)));
+    Ok(built)
+}
+
+fn lenient_cache_matches(
+    backend: Backend,
+    device: Option<&str>,
+    cached: &(Backend, String),
+    is_gpu: bool,
+    adapter: &str,
+) -> bool {
+    match (backend, device) {
+        (Backend::Auto, Some(name)) => is_gpu && adapter == name,
+        (Backend::Auto, None) => is_gpu && cached.1.is_empty() && cached.0 == Backend::Gpu,
+        (Backend::Gpu, Some(name)) => is_gpu && adapter == name,
+        (Backend::Gpu, None) => is_gpu && cached.1.is_empty(),
+        (Backend::Cpu, None) => !is_gpu,
+        (Backend::Cpu, Some(_)) => false,
+    }
+}
+
+fn strict_cache_matches(
+    backend: Backend,
+    device: Option<&str>,
+    cached: &(Backend, String),
+    is_gpu: bool,
+    adapter: &str,
+) -> bool {
+    match (backend, device) {
+        (Backend::Gpu, Some(name)) => is_gpu && adapter == name,
+        (Backend::Gpu, None) => is_gpu && cached.1.is_empty(),
+        (Backend::Cpu, None) => !is_gpu,
+        _ => false,
+    }
+}
+
+fn validate_strict_compositor(
+    backend: Backend,
+    device: Option<&str>,
+    compositor: &Compositor,
+) -> Result<(), String> {
+    if backend == Backend::Gpu && !compositor.is_gpu() {
+        return Err("the requested graphics compositor is not available".into());
+    }
+    if backend == Backend::Cpu && compositor.is_gpu() {
+        return Err("the requested CPU compositor is not available".into());
+    }
+    if let Some(name) = device {
+        if name != compositor.adapter() {
+            return Err(format!(
+                "graphics device `{name}` is not available; the current setting was kept"
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// The compositor the settings ask for.
@@ -649,7 +841,11 @@ pub fn delete_project(
         dir.join(workspace::PROJECT_FILE)
     };
 
+    state.playback_epoch.fetch_add(1, Ordering::SeqCst);
     let session = state.playback.lock().unwrap().take();
+    if let Some(session) = session.as_ref() {
+        session.stop();
+    }
     drop(session);
     stop_proxy_workers(&app, &state);
     stop_waveform_workers(&app, &state);
@@ -760,15 +956,180 @@ pub async fn preview_frame(
     Ok(tauri::ipc::Response::new(payload))
 }
 
+enum PlaybackRollback {
+    None,
+    Video,
+    Guides(Guides),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlaybackChange {
+    None,
+    Video,
+    Guides,
+}
+
+fn playback_change(
+    before: &Settings,
+    after: &Settings,
+    has_unconfirmed_settings: bool,
+) -> PlaybackChange {
+    if has_unconfirmed_settings || playback_video_settings_changed(before, after) {
+        PlaybackChange::Video
+    } else if playback_guides_changed(before, after) {
+        PlaybackChange::Guides
+    } else {
+        PlaybackChange::None
+    }
+}
+
+fn restore_confirmed_playback(
+    latest: &AtomicU64,
+    generation: u64,
+    session: Option<&Arc<Session>>,
+    rollback: &PlaybackRollback,
+) -> Option<String> {
+    match (session, rollback) {
+        (Some(session), PlaybackRollback::Video) => {
+            restore_if_current(latest, generation, || {
+                // Read at rollback time. An automatic proxy refresh may have
+                // updated the confirmed paths while this settings candidate
+                // was building, and the unpersisted candidate never changes
+                // the confirmed snapshot.
+                session.reconfigure(generation, session.confirmed_config())?;
+                session.confirm_settings_generation(generation);
+                Ok(())
+            })
+        }
+        (Some(session), PlaybackRollback::Guides(guides)) => {
+            restore_if_current(latest, generation, || {
+                session.set_guides(generation, *guides)?;
+                session.confirm_settings_generation(generation);
+                Ok(())
+            })
+        }
+        _ => None,
+    }
+}
+
+fn restore_if_current(
+    latest: &AtomicU64,
+    generation: u64,
+    restore: impl FnOnce() -> Result<(), String>,
+) -> Option<String> {
+    if latest.load(Ordering::Relaxed) != generation {
+        return None;
+    }
+    match restore() {
+        Ok(()) => None,
+        Err(_) if latest.load(Ordering::Relaxed) != generation => None,
+        Err(reason) => Some(reason),
+    }
+}
+
+fn playback_settings_error(error: String, rollback_error: Option<String>) -> String {
+    match rollback_error {
+        Some(reason) => format!(
+            "{error}; the saved setting was kept, but restoring playback also failed: {reason}"
+        ),
+        None => error,
+    }
+}
+
 #[tauri::command]
 pub fn save_settings(
     app: AppHandle,
     state: State<AppState>,
     settings: Settings,
 ) -> Result<Bootstrap, String> {
-    crate::store::prepare_log_dir(&app, &settings)?;
+    let _playback_settings = state.playback_settings.enter();
+    let session = playback_session(&state);
+    let generation = {
+        let _commit = state.settings_transaction.lock().unwrap();
+        let generation = state.settings_generation.fetch_add(1, Ordering::Relaxed) + 1;
+        if let Some(session) = session.as_ref() {
+            session.reserve_settings_generation(generation);
+        }
+        generation
+    };
+    let before = state.settings.lock().unwrap().clone();
+    let change = if let Some(session) = session.as_ref() {
+        playback_change(&before, &settings, session.has_unconfirmed_settings())
+    } else {
+        PlaybackChange::None
+    };
+    let rollback = match (session.as_ref(), change) {
+        (Some(_), PlaybackChange::Video) => PlaybackRollback::Video,
+        (Some(session), PlaybackChange::Guides) => {
+            PlaybackRollback::Guides(session.confirmed_config().guides)
+        }
+        _ => PlaybackRollback::None,
+    };
+
+    if let Err(error) = crate::store::prepare_log_dir(&app, &settings) {
+        let rollback_error = restore_confirmed_playback(
+            &state.settings_generation,
+            generation,
+            session.as_ref(),
+            &rollback,
+        );
+        return Err(playback_settings_error(error, rollback_error));
+    }
+
+    let apply = if let Some(session) = session.as_ref() {
+        if change == PlaybackChange::Video {
+            let graphics_changed = before.compositor != settings.compositor
+                || before.gpu_device != settings.gpu_device;
+            let new_config = if graphics_changed {
+                explicit_playback_config(&app, &state, &settings)
+            } else {
+                automatic_playback_config(&app, &state, &settings)
+            };
+            new_config.and_then(|config| session.reconfigure(generation, config).map(|_| ()))
+        } else if change == PlaybackChange::Guides {
+            session
+                .set_guides(generation, playback_guides(&settings))
+                .map(|_| ())
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    };
+    if let Err(error) = apply {
+        let rollback_error = restore_confirmed_playback(
+            &state.settings_generation,
+            generation,
+            session.as_ref(),
+            &rollback,
+        );
+        return Err(playback_settings_error(error, rollback_error));
+    }
+
+    if state.settings_generation.load(Ordering::Relaxed) != generation {
+        return Err("a newer settings change superseded this one".into());
+    }
+    let transaction = state.settings_transaction.lock().unwrap();
+    if state.settings_generation.load(Ordering::Relaxed) != generation {
+        return Err("a newer settings change superseded this one".into());
+    }
+    if let Err(error) = crate::store::save_settings(&app, &settings) {
+        let rollback_error = restore_confirmed_playback(
+            &state.settings_generation,
+            generation,
+            session.as_ref(),
+            &rollback,
+        );
+        return Err(playback_settings_error(error, rollback_error));
+    }
+    if change != PlaybackChange::None {
+        let session = session
+            .as_ref()
+            .expect("a playback change only exists with an active session");
+        session.confirm_settings_generation(generation);
+    }
+
     apply_theme(&app, &settings.theme);
-    crate::store::save_settings(&app, &settings)?;
     {
         let mut current = state.settings.lock().unwrap();
         // Pointing at a different ffmpeg means a different set of encoders, so
@@ -778,7 +1139,9 @@ pub fn save_settings(
         }
         *current = settings;
     }
-    Ok(bootstrap(app, state))
+    let response = bootstrap(app, state.clone());
+    drop(transaction);
+    Ok(response)
 }
 
 #[tauri::command]
@@ -2246,11 +2609,13 @@ pub fn playback_attach(
     place: MonitorPlace,
     frame: i64,
 ) -> PlaybackChoice {
+    let _attach = state.playback_settings.enter_attach();
+    let attach_epoch = state.playback_epoch.load(Ordering::SeqCst);
     let settings = state.settings.lock().unwrap().clone();
     // Already running: place it and hand back what it is doing. The page asks
     // again on every layout change, and tearing the session down to build the
     // same one would restart the decoders every time somebody dragged a panel.
-    if let Some(session) = state.playback.lock().unwrap().as_ref() {
+    if let Some(session) = playback_session(&state) {
         session.place(place);
         return PlaybackChoice::from(Choice::native(), Some(session.status()));
     }
@@ -2264,15 +2629,35 @@ pub fn playback_attach(
         return PlaybackChoice::from(choose(wanted, Ok(())), None);
     }
 
-    let started = start_session(&window, &state, &settings, place, frame);
-    let (session, outcome) = match started {
-        Ok(session) => (Some(session), Ok(())),
-        Err(reason) => (None, Err(reason)),
+    let session = match start_session(&window, &state, &settings, place, frame) {
+        Ok(session) => Arc::new(session),
+        Err(reason) => {
+            if let Some(existing) = playback_session(&state) {
+                return PlaybackChoice::from(Choice::native(), Some(existing.status()));
+            }
+            return PlaybackChoice::from(choose(wanted, Err(reason)), None);
+        }
     };
-    let choice = choose(wanted, outcome);
-    let status = session.as_ref().map(|session| session.status());
-    *state.playback.lock().unwrap() = session;
-    PlaybackChoice::from(choice, status)
+    match store_if_current(
+        &state.playback,
+        &state.playback_epoch,
+        attach_epoch,
+        Arc::clone(&session),
+    ) {
+        Ok(()) => PlaybackChoice::from(Choice::native(), Some(session.status())),
+        Err(rejected) => {
+            rejected.stop();
+            if state.playback_epoch.load(Ordering::SeqCst) == attach_epoch {
+                if let Some(existing) = playback_session(&state) {
+                    return PlaybackChoice::from(Choice::native(), Some(existing.status()));
+                }
+            }
+            PlaybackChoice::from(
+                Choice::fallback("playback attach was cancelled before it became active"),
+                None,
+            )
+        }
+    }
 }
 
 fn start_session(
@@ -2285,29 +2670,7 @@ fn start_session(
     if !place.is_visible() {
         return Err("the monitor has no room on screen yet".into());
     }
-    let project = state.document.lock().unwrap().project().clone();
-    let ffmpeg = find_tool(&window.app_handle().clone(), "ffmpeg", &settings.ffmpeg_dir)
-        .ok_or("ffmpeg was not found, so nothing can be decoded")?;
-    // The monitor draws the project's own frame, the same one the render
-    // writes. What differs is only how big the view showing it is, which the
-    // surface handles by scaling on presentation.
-    let compositor = settings_compositor(state, settings);
-    let proxy_paths = if settings.proxy_enabled {
-        ready_proxy_paths(&state.proxies.lock().unwrap())
-    } else {
-        HashMap::new()
-    };
-    let hwaccel = acceleration(state, Some(&ffmpeg))
-        .available
-        .and_then(|candidate| candidate.hwaccel);
-    let (preview_width, preview_height) = native_preview_dimensions(
-        project.settings.width,
-        project.settings.height,
-        &settings.preview_quality,
-    );
-    let config = PlaybackConfig::new(compositor, ffmpeg, preview_width, preview_height)
-        .with_proxies(proxy_paths)
-        .with_hwaccel(hwaccel);
+    let config = automatic_playback_config(&window.app_handle(), state, settings)?;
     Session::start(
         window,
         Arc::clone(&state.document),
@@ -2315,6 +2678,106 @@ fn start_session(
         place,
         frame.max(0),
     )
+}
+
+fn explicit_playback_config(
+    app: &AppHandle,
+    state: &State<AppState>,
+    settings: &Settings,
+) -> Result<PlaybackConfig, String> {
+    let backend = explicit_playback_backend(settings);
+    let device = if backend == Backend::Gpu {
+        wanted_device(&settings.gpu_device)
+    } else {
+        None
+    };
+    let compositor = strict_compositor(state, backend, device)?;
+    let presenter = if compositor.is_gpu() {
+        Arc::clone(&compositor)
+    } else {
+        strict_compositor(state, Backend::Gpu, None)?
+    };
+    build_playback_config(app, state, settings, compositor, presenter)
+}
+
+fn automatic_playback_config(
+    app: &AppHandle,
+    state: &State<AppState>,
+    settings: &Settings,
+) -> Result<PlaybackConfig, String> {
+    let compositor = compositor(
+        state,
+        automatic_playback_backend(settings),
+        wanted_device(&settings.gpu_device),
+    );
+    let presenter = if compositor.is_gpu() {
+        Arc::clone(&compositor)
+    } else {
+        strict_compositor(state, Backend::Gpu, None)?
+    };
+    build_playback_config(app, state, settings, compositor, presenter)
+}
+
+fn build_playback_config(
+    app: &AppHandle,
+    state: &State<AppState>,
+    settings: &Settings,
+    compositor: Arc<Compositor>,
+    presenter: Arc<Compositor>,
+) -> Result<PlaybackConfig, String> {
+    let project = state.document.lock().unwrap().project().clone();
+    let ffmpeg = find_tool(app, "ffmpeg", &settings.ffmpeg_dir)
+        .ok_or("ffmpeg was not found, so nothing can be decoded")?;
+    let proxy_paths = if settings.proxy_enabled {
+        ready_proxy_paths(&state.proxies.lock().unwrap())
+    } else {
+        HashMap::new()
+    };
+    let current_ffmpeg_dir = state.settings.lock().unwrap().ffmpeg_dir.clone();
+    let probe = if current_ffmpeg_dir == settings.ffmpeg_dir {
+        acceleration(state, Some(&ffmpeg))
+    } else {
+        detect_acceleration(&ffmpeg)
+    };
+    let hwaccel = probe.available.and_then(|candidate| candidate.hwaccel);
+    let (preview_width, preview_height) = native_preview_dimensions(
+        project.settings.width,
+        project.settings.height,
+        &settings.preview_quality,
+    );
+    let config = PlaybackConfig::new(compositor, ffmpeg, preview_width, preview_height)
+        .with_presenter(presenter)
+        .with_hwaccel(hwaccel)
+        .with_guides(playback_guides(settings));
+    Ok(if settings.proxy_enabled {
+        config.with_proxies(proxy_paths)
+    } else {
+        config
+    })
+}
+
+fn playback_video_settings_changed(before: &Settings, after: &Settings) -> bool {
+    before.preview_quality != after.preview_quality
+        || before.compositor != after.compositor
+        || before.gpu_device != after.gpu_device
+        || before.proxy_enabled != after.proxy_enabled
+        || before.ffmpeg_dir != after.ffmpeg_dir
+}
+
+fn playback_guides_changed(before: &Settings, after: &Settings) -> bool {
+    before.show_action_safe_area != after.show_action_safe_area
+        || before.show_title_safe_area != after.show_title_safe_area
+        || before.show_rule_of_thirds != after.show_rule_of_thirds
+        || before.show_center_lines != after.show_center_lines
+}
+
+fn playback_guides(settings: &Settings) -> Guides {
+    Guides {
+        action_safe_area: settings.show_action_safe_area,
+        title_safe_area: settings.show_title_safe_area,
+        rule_of_thirds: settings.show_rule_of_thirds,
+        center_lines: settings.show_center_lines,
+    }
 }
 
 fn native_preview_dimensions(width: u32, height: u32, quality: &str) -> (u32, u32) {
@@ -2336,23 +2799,53 @@ fn native_preview_dimensions(width: u32, height: u32, quality: &str) -> (u32, u3
 pub fn playback_release(state: State<AppState>) {
     // Dropped outside the lock: taking the session down joins its thread, and
     // holding the lock through that would block every other command.
+    state.playback_epoch.fetch_add(1, Ordering::SeqCst);
     let session = state.playback.lock().unwrap().take();
+    if let Some(session) = session.as_ref() {
+        session.stop();
+    }
     drop(session);
 }
 
+/// Refresh ready proxy paths without releasing the native session. The same
+/// first-present transaction used by settings changes keeps audio and the old
+/// video path live until the refreshed path is visible.
 #[tauri::command]
-pub fn playback_play(state: State<AppState>) -> Option<PlaybackStatus> {
-    with_session(&state, |session| session.play())
+pub fn playback_refresh(state: State<AppState>) -> Result<Option<PlaybackStatus>, String> {
+    loop {
+        state.playback_settings.wait();
+        let Some(session) = playback_session(&state) else {
+            return Ok(None);
+        };
+        let proxy_paths = ready_proxy_paths(&state.proxies.lock().unwrap());
+        match session.refresh_proxies(proxy_paths) {
+            Ok(status) => return Ok(Some(status)),
+            Err(reason) if proxy_refresh_should_retry(&reason) => continue,
+            Err(reason) => return Err(reason),
+        }
+    }
+}
+
+fn proxy_refresh_should_retry(reason: &str) -> bool {
+    reason == EXPLICIT_RECONFIGURE_PENDING
 }
 
 #[tauri::command]
-pub fn playback_pause(state: State<AppState>) -> Option<PlaybackStatus> {
-    with_session(&state, |session| session.pause())
+pub fn playback_play(state: State<AppState>) -> Result<Option<PlaybackStatus>, String> {
+    with_session_result(&state, |session| session.play())
 }
 
 #[tauri::command]
-pub fn playback_seek(state: State<AppState>, frame: i64) -> Option<PlaybackStatus> {
-    with_session(&state, |session| session.seek(frame.max(0)))
+pub fn playback_pause(state: State<AppState>) -> Result<Option<PlaybackStatus>, String> {
+    with_session_result(&state, |session| session.pause())
+}
+
+#[tauri::command]
+pub fn playback_seek(
+    state: State<AppState>,
+    frame: i64,
+) -> Result<Option<PlaybackStatus>, String> {
+    with_session_result(&state, |session| session.seek(frame.max(0)))
 }
 
 /// The timeline changed. A stopped playhead redraws its frame; a playing one
@@ -2387,37 +2880,295 @@ pub fn playback_visible(state: State<AppState>, visible: bool) -> Option<Playbac
 /// draw it, which is its own animation frame.
 #[tauri::command]
 pub fn playback_status(state: State<AppState>) -> Option<PlaybackStatus> {
-    state
-        .playback
-        .lock()
-        .unwrap()
-        .as_ref()
-        .map(|session| session.status())
+    playback_session(&state).map(|session| session.status())
 }
 
 fn with_session<F>(state: &State<AppState>, act: F) -> Option<PlaybackStatus>
 where
     F: FnOnce(&Session),
 {
-    let running = state.playback.lock().unwrap();
-    let session = running.as_ref()?;
-    act(session);
+    let session = playback_session(state)?;
+    act(&session);
     Some(session.status())
+}
+
+fn with_session_result<F>(
+    state: &State<AppState>,
+    act: F,
+) -> Result<Option<PlaybackStatus>, String>
+where
+    F: FnOnce(&Session) -> Result<(), String>,
+{
+    let Some(session) = playback_session(state) else {
+        return Ok(None);
+    };
+    act(&session)?;
+    Ok(Some(session.status()))
+}
+
+fn playback_session(state: &State<AppState>) -> Option<Arc<Session>> {
+    clone_arc(&state.playback)
+}
+
+fn clone_arc<T>(slot: &Mutex<Option<Arc<T>>>) -> Option<Arc<T>> {
+    slot.lock().unwrap().as_ref().map(Arc::clone)
+}
+
+fn store_if_current<T>(
+    slot: &Mutex<Option<Arc<T>>>,
+    epoch: &AtomicU64,
+    started_at: u64,
+    value: Arc<T>,
+) -> Result<(), Arc<T>> {
+    let mut slot = slot.lock().unwrap();
+    if epoch.load(Ordering::SeqCst) != started_at || slot.is_some() {
+        return Err(value);
+    }
+    *slot = Some(value);
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        native_preview_dimensions, process_metrics_rows, process_tree_rss_bytes, srt_contents,
-        srt_cues, srt_frame, srt_timestamp, wanted_device, Settings,
+        automatic_playback_backend, clone_arc, explicit_playback_backend, lenient_cache_matches,
+        native_preview_dimensions, playback_change, playback_guides_changed,
+        playback_video_settings_changed, process_metrics_rows, process_tree_rss_bytes,
+        proxy_refresh_should_retry, restore_if_current, srt_contents, srt_cues, srt_frame,
+        srt_timestamp, store_if_current, strict_cache_matches, validate_strict_compositor,
+        wanted_device, PlaybackChange, PlaybackSettingsGate, Settings,
     };
+    use makevideo_compositor::{Backend, Compositor};
     use makevideo_render::Rate;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::mpsc::channel;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
     #[test]
     fn an_unset_graphics_device_is_the_automatic_pick() {
         assert_eq!(wanted_device(""), None);
         assert_eq!(wanted_device("   "), None);
         assert_eq!(wanted_device("Apple M3 Pro"), Some("Apple M3 Pro"));
+    }
+
+    #[test]
+    fn startup_is_lenient_but_an_explicit_live_gpu_choice_is_strict() {
+        let settings = Settings::default();
+        assert_eq!(automatic_playback_backend(&settings), Backend::Auto);
+        assert_eq!(explicit_playback_backend(&settings), Backend::Gpu);
+
+        let mut cpu = settings;
+        cpu.compositor = "cpu".into();
+        assert_eq!(automatic_playback_backend(&cpu), Backend::Cpu);
+        assert_eq!(explicit_playback_backend(&cpu), Backend::Cpu);
+    }
+
+    #[test]
+    fn strict_validation_rechecks_a_cached_compositor() {
+        let cpu = Compositor::with_backend(Backend::Cpu).unwrap();
+        assert!(validate_strict_compositor(Backend::Gpu, None, &cpu).is_err());
+        assert!(validate_strict_compositor(Backend::Cpu, Some("missing adapter"), &cpu).is_err());
+        assert!(validate_strict_compositor(Backend::Cpu, None, &cpu).is_ok());
+    }
+
+    #[test]
+    fn named_gpu_reuses_the_actual_default_adapter_and_creates_an_alias() {
+        let default_key = (Backend::Auto, String::new());
+        assert!(strict_cache_matches(
+            Backend::Gpu,
+            Some("Apple M3"),
+            &default_key,
+            true,
+            "Apple M3",
+        ));
+        assert!(lenient_cache_matches(
+            Backend::Auto,
+            Some("Apple M3"),
+            &default_key,
+            true,
+            "Apple M3",
+        ));
+    }
+
+    #[test]
+    fn clearing_a_named_gpu_uses_only_the_default_cache_identity() {
+        let named_key = (Backend::Gpu, "Discrete GPU".into());
+        let default_key = (Backend::Auto, String::new());
+        assert!(!strict_cache_matches(
+            Backend::Gpu,
+            None,
+            &named_key,
+            true,
+            "Discrete GPU",
+        ));
+        assert!(strict_cache_matches(
+            Backend::Gpu,
+            None,
+            &default_key,
+            true,
+            "Default GPU",
+        ));
+        assert!(!lenient_cache_matches(
+            Backend::Auto,
+            None,
+            &named_key,
+            true,
+            "Discrete GPU",
+        ));
+    }
+
+    #[test]
+    fn automatic_refresh_waits_for_every_explicit_settings_transaction() {
+        let gate = Arc::new(PlaybackSettingsGate::default());
+        let first = gate.enter();
+        let second = gate.enter();
+        let (sent, received) = channel();
+        let waiting = Arc::clone(&gate);
+        let thread = std::thread::spawn(move || {
+            waiting.wait();
+            let _ = sent.send(());
+        });
+
+        assert!(received.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(first);
+        assert!(received.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(second);
+        assert_eq!(received.recv_timeout(Duration::from_secs(1)), Ok(()));
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn explicit_settings_wait_until_an_attach_snapshot_is_stored() {
+        let gate = Arc::new(PlaybackSettingsGate::default());
+        let attach = gate.enter_attach();
+        let (sent, received) = channel();
+        let waiting = Arc::clone(&gate);
+        let thread = std::thread::spawn(move || {
+            let _settings = waiting.enter();
+            let _ = sent.send(());
+        });
+
+        assert!(received.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(attach);
+        assert_eq!(received.recv_timeout(Duration::from_secs(1)), Ok(()));
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn attach_waits_until_the_latest_settings_transaction_finishes() {
+        let gate = Arc::new(PlaybackSettingsGate::default());
+        let settings = gate.enter();
+        let (sent, received) = channel();
+        let waiting = Arc::clone(&gate);
+        let thread = std::thread::spawn(move || {
+            let _attach = waiting.enter_attach();
+            let _ = sent.send(());
+        });
+
+        assert!(received.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(settings);
+        assert_eq!(received.recv_timeout(Duration::from_secs(1)), Ok(()));
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn proxy_refresh_waits_for_an_attaching_session_before_lookup() {
+        let gate = Arc::new(PlaybackSettingsGate::default());
+        let attach = gate.enter_attach();
+        let (sent, received) = channel();
+        let waiting = Arc::clone(&gate);
+        let thread = std::thread::spawn(move || {
+            waiting.wait();
+            let _ = sent.send(());
+        });
+
+        assert!(received.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(attach);
+        assert_eq!(received.recv_timeout(Duration::from_secs(1)), Ok(()));
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn an_auto_refresh_retries_the_explicit_priority_race() {
+        assert!(proxy_refresh_should_retry(
+            crate::playback::EXPLICIT_RECONFIGURE_PENDING
+        ));
+        assert!(!proxy_refresh_should_retry("candidate surface refused"));
+    }
+
+    #[test]
+    fn guide_only_changes_do_not_choose_the_video_replacement_path() {
+        let before = Settings::default();
+        let mut after = before.clone();
+        after.show_rule_of_thirds = true;
+        assert!(playback_guides_changed(&before, &after));
+        assert!(!playback_video_settings_changed(&before, &after));
+
+        after.preview_quality = "full".into();
+        assert!(playback_video_settings_changed(&before, &after));
+    }
+
+    #[test]
+    fn reverting_to_confirmed_settings_replaces_an_unconfirmed_live_candidate() {
+        let mut confirmed = Settings::default();
+        confirmed.preview_quality = "full".into();
+        let mut first = confirmed.clone();
+        first.preview_quality = "half".into();
+
+        assert_eq!(
+            playback_change(&confirmed, &first, false),
+            PlaybackChange::Video
+        );
+        assert_eq!(
+            playback_change(&confirmed, &confirmed, false),
+            PlaybackChange::None
+        );
+        assert_eq!(
+            playback_change(&confirmed, &confirmed, true),
+            PlaybackChange::Video
+        );
+    }
+
+    #[test]
+    fn cloning_a_playback_handle_releases_the_registry_lock_before_waiting() {
+        let slot = Mutex::new(Some(Arc::new(7)));
+        let handle = clone_arc(&slot).unwrap();
+        assert!(slot.try_lock().is_ok());
+        assert_eq!(*handle, 7);
+    }
+
+    #[test]
+    fn release_epoch_prevents_a_late_attach_from_repopulating_the_registry() {
+        let slot = Mutex::new(None);
+        let epoch = AtomicU64::new(4);
+        let started_at = epoch.load(std::sync::atomic::Ordering::SeqCst);
+        epoch.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        let rejected = store_if_current(&slot, &epoch, started_at, Arc::new(7));
+        assert!(rejected.is_err());
+        assert!(slot.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn newest_failed_setting_restores_confirmed_playback_after_older_commit() {
+        let latest = AtomicU64::new(2);
+        let live = AtomicU64::new(1);
+        assert_eq!(
+            restore_if_current(&latest, 2, || {
+                live.store(0, std::sync::atomic::Ordering::Relaxed);
+                Ok(())
+            }),
+            None
+        );
+        assert_eq!(live.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+        latest.store(3, std::sync::atomic::Ordering::Relaxed);
+        let _ = restore_if_current(&latest, 2, || {
+            live.store(9, std::sync::atomic::Ordering::Relaxed);
+            Ok(())
+        });
+        assert_eq!(live.load(std::sync::atomic::Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ mod store;
 mod viewport;
 
 use commands::AppState;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex};
 use tauri::Manager;
 
@@ -36,11 +36,15 @@ pub fn run() {
             app.manage(AppState {
                 document: Arc::new(Mutex::new(document)),
                 settings: Mutex::new(settings),
+                settings_transaction: Mutex::new(()),
+                settings_generation: AtomicU64::new(0),
+                playback_settings: commands::PlaybackSettingsGate::default(),
                 render: Arc::new(Mutex::new(None)),
                 cancelled: Arc::new(AtomicBool::new(false)),
                 accel: Mutex::new(None),
                 compositor: Mutex::new(Vec::new()),
                 playback: Mutex::new(None),
+                playback_epoch: AtomicU64::new(0),
                 proxies: Arc::new(Mutex::new(commands::ProxyState::default())),
                 proxy_workers: Mutex::new(Vec::new()),
                 waveforms: Arc::new(Mutex::new(commands::WaveformState::default())),
@@ -78,6 +82,7 @@ pub fn run() {
             commands::cancel_render,
             commands::preview_frame,
             commands::playback_attach,
+            commands::playback_refresh,
             commands::playback_release,
             commands::playback_play,
             commands::playback_pause,

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -27,29 +27,38 @@ use makevideo_audio::source::{
     Buffering as AudioBuffering, FfmpegReaders as AudioReaders, DEFAULT_DEPTH as AUDIO_DEPTH,
     DEFAULT_LEAD as AUDIO_LEAD,
 };
-use makevideo_compositor::source::{Buffering as FrameBuffering, FfmpegReaders as FrameReaders};
+use makevideo_compositor::source::{
+    Buffering as FrameBuffering, FfmpegReaders as FrameReaders, Frame, Layer,
+};
 use makevideo_compositor::Compositor;
-use makevideo_present::player::{Tick, IDLE};
+use makevideo_present::player::{Sink, Tick, IDLE};
 use makevideo_present::schedule::DEFAULT_RESYNC;
-use makevideo_present::surface::SurfaceSink;
-use makevideo_present::transport::{Setup, Transport};
+use makevideo_present::surface::{Guides, PresentOutcome, SurfaceSink};
+use makevideo_present::transport::{
+    Setup, Transport, VideoReplacement, VideoSetup, PRESENT_DEFERRED, PRESENT_HIDDEN,
+};
+use makevideo_render::layout::Rect;
 use makevideo_render::Project;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender, TryRecvError};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// How long the loop sleeps with nothing to do. Long enough that a paused
 /// editor is an idle thread, short enough that play is answered inside a frame.
 const REST: Duration = IDLE;
+const RECONFIGURE_TIMEOUT: Duration = Duration::from_secs(5);
+pub const EXPLICIT_RECONFIGURE_PENDING: &str =
+    "an explicit playback setting is still being applied";
+const SETTINGS_SUPERSEDED: &str = "a newer playback configuration superseded this one";
 
 enum Command {
-    Play,
-    Pause,
-    Seek(i64),
+    Play(Sender<()>),
+    Pause(Sender<()>),
+    Seek(i64, Sender<()>),
     /// The panel moved or the window resized, and the surface is now this many
     /// physical pixels. Carried to the loop rather than done where it was
     /// noticed, because only the thread drawing on a surface may reconfigure
@@ -57,21 +66,80 @@ enum Command {
     /// is what the view answered *after* it was moved, which is the only
     /// reading that accounts for the display it ended up on.
     Resize(u32, u32),
+    Show,
+    Hide,
     /// The timeline changed under a paused playhead: redraw the still.
     Redraw,
+    Reconfigure {
+        generation: u64,
+        settings_generation: u64,
+        config: Config,
+        reply: Sender<Result<(), String>>,
+    },
+    RefreshProxies {
+        generation: u64,
+        proxy_paths: HashMap<String, String>,
+        reply: Sender<Result<(), String>>,
+    },
+    CancelReconfigure(u64),
+    SetGuides {
+        generation: u64,
+        settings_generation: u64,
+        guides: Guides,
+        reply: Sender<Result<(), String>>,
+    },
     Stop,
 }
 
 /// What the page reads back. Atomics because the page asks on its own schedule
 /// and the loop must never wait for it.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct Shared {
     position: AtomicI64,
     playing: AtomicBool,
+    generation: AtomicU64,
+    requested_generation: AtomicU64,
+    reconfiguring: AtomicBool,
+    settings_order: SettingsOrder,
+    live_config: Mutex<Option<Config>>,
+    confirmed_config: Mutex<Option<Config>>,
     /// Set once when the surface refuses. The page shows it and offers the
     /// media element preview; it is not cleared, because a monitor that has
     /// failed once is not something to keep quiet about.
     failed: Mutex<Option<String>>,
+}
+
+#[derive(Debug, Default)]
+struct SettingsOrder {
+    state: Mutex<SettingsOrderState>,
+}
+
+#[derive(Debug, Default)]
+struct SettingsOrderState {
+    latest: u64,
+    committed: u64,
+    confirmed: u64,
+}
+
+impl SettingsOrder {
+    fn reserve(&self, generation: u64) {
+        let mut state = self.state.lock().unwrap();
+        state.latest = state.latest.max(generation);
+    }
+
+    fn lock_if_current(&self, generation: u64) -> Option<MutexGuard<'_, SettingsOrderState>> {
+        let state = self.state.lock().unwrap();
+        if state.latest == generation {
+            Some(state)
+        } else {
+            None
+        }
+    }
+
+    fn has_unconfirmed(&self) -> bool {
+        let state = self.state.lock().unwrap();
+        state.committed > state.confirmed
+    }
 }
 
 impl Shared {
@@ -86,6 +154,34 @@ impl Shared {
     pub fn failure(&self) -> Option<String> {
         self.failed.lock().unwrap().clone()
     }
+
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
+    }
+
+    pub fn reconfiguring(&self) -> bool {
+        self.reconfiguring.load(Ordering::Relaxed)
+    }
+
+    fn initialize_config(&self, config: &Config) {
+        *self.live_config.lock().unwrap() = Some(config.clone());
+        *self.confirmed_config.lock().unwrap() = Some(config.clone());
+    }
+
+    fn set_live_config(&self, config: &Config) {
+        *self.live_config.lock().unwrap() = Some(config.clone());
+    }
+
+    fn set_confirmed_proxy_paths(&self, config: &Config) {
+        let mut confirmed = self.confirmed_config.lock().unwrap();
+        if let Some(confirmed) = confirmed.as_mut() {
+            confirmed.proxy_paths = if confirmed.proxy_enabled {
+                config.proxy_paths.clone()
+            } else {
+                HashMap::new()
+            };
+        }
+    }
 }
 
 /// What the page is told about the monitor.
@@ -95,6 +191,8 @@ pub struct Status {
     pub engine: &'static str,
     pub position: i64,
     pub playing: bool,
+    pub generation: u64,
+    pub reconfiguring: bool,
     /// Frames drawn and frames dropped since this session started.
     pub presented: u64,
     pub skipped: u64,
@@ -114,11 +212,18 @@ pub struct Session {
     control: Sender<Command>,
     shared: Arc<Shared>,
     counters: Arc<Counters>,
+    /// Shared with the realtime callback so seek, pause and stop can close the
+    /// sound gate before the frame loop finishes its current composition.
+    active: Arc<AtomicBool>,
+    /// Seek/pause requests sent but not yet applied. A frame finishing after
+    /// the caller closed `active` must not reopen it while this is non-zero.
+    audio_blockers: Arc<AtomicU64>,
     /// Placement is a main thread call and the loop is not on it, so the
     /// viewport is moved and messaged from whichever thread asks. See
     /// `viewport::macos`.
     viewport: Arc<Mutex<Viewport>>,
-    thread: Option<JoinHandle<()>>,
+    thread: Mutex<Option<JoinHandle<()>>>,
+    stopped: AtomicBool,
 }
 
 /// Totals that outlive a play, so pausing does not reset what the page shows.
@@ -165,8 +270,14 @@ fn signed_milliseconds(micros: i64) -> f64 {
 }
 
 /// Everything the loop needs that does not change while it runs.
+#[derive(Clone)]
 pub struct Config {
     pub compositor: Arc<Compositor>,
+    /// The GPU used only to put a finished frame on the native surface. For a
+    /// GPU compositor this is the same object. For CPU composition it uploads
+    /// one full-frame RGBA layer, keeping CPU/GPU switches inside one native
+    /// playback session.
+    pub presenter: Arc<Compositor>,
     pub ffmpeg: String,
     pub width: u32,
     pub height: u32,
@@ -174,12 +285,15 @@ pub struct Config {
     pub audio_buffering: AudioBuffering,
     pub resync_after: i64,
     pub proxy_paths: HashMap<String, String>,
+    pub proxy_enabled: bool,
     pub hwaccel: Option<String>,
+    pub guides: Guides,
 }
 
 impl Config {
     pub fn new(compositor: Arc<Compositor>, ffmpeg: String, width: u32, height: u32) -> Config {
         Config {
+            presenter: Arc::clone(&compositor),
             compositor,
             ffmpeg,
             width,
@@ -188,17 +302,30 @@ impl Config {
             audio_buffering: AudioBuffering::new(AUDIO_DEPTH, AUDIO_LEAD),
             resync_after: DEFAULT_RESYNC,
             proxy_paths: HashMap::new(),
+            proxy_enabled: false,
             hwaccel: None,
+            guides: Guides::default(),
         }
     }
 
     pub fn with_proxies(mut self, proxy_paths: HashMap<String, String>) -> Config {
         self.proxy_paths = proxy_paths;
+        self.proxy_enabled = true;
         self
     }
 
     pub fn with_hwaccel(mut self, hwaccel: Option<String>) -> Config {
         self.hwaccel = hwaccel;
+        self
+    }
+
+    pub fn with_presenter(mut self, presenter: Arc<Compositor>) -> Config {
+        self.presenter = presenter;
+        self
+    }
+
+    pub fn with_guides(mut self, guides: Guides) -> Config {
+        self.guides = guides;
         self
     }
 }
@@ -217,40 +344,56 @@ impl Session {
         place: MonitorPlace,
         frame: i64,
     ) -> Result<Session, String> {
-        if config.compositor.gpu().is_none() {
+        if config.presenter.gpu().is_none() {
             return Err("this machine has no graphics device, so the monitor cannot draw".into());
         }
         let viewport = Viewport::attach(window, place)?;
         let (surface_width, surface_height) = viewport.surface_size();
+        let presenter = Arc::clone(&config.presenter);
         let sink = SurfaceSink::new(
-            Arc::clone(&config.compositor),
+            Arc::clone(&presenter),
             viewport.target()?,
             surface_width,
             surface_height,
             config.width,
             config.height,
-        )?;
+        )?
+        .with_guides(config.guides);
 
         let shared = Arc::new(Shared::default());
+        shared.initialize_config(&config);
         let counters = Arc::new(Counters::default());
+        let active = Arc::new(AtomicBool::new(false));
+        let audio_blockers = Arc::new(AtomicU64::new(0));
         let (control, commands) = channel();
         let project = makevideo_proxy::playback_project(
             document.lock().unwrap().project(),
             &config.proxy_paths,
         );
+        let frame = frame.clamp(0, project.duration_frames());
+        shared.position.store(frame, Ordering::Relaxed);
 
         let thread = {
-            let (shared, counters) = (Arc::clone(&shared), Arc::clone(&counters));
+            let (shared, counters, active, audio_blockers) = (
+                Arc::clone(&shared),
+                Arc::clone(&counters),
+                Arc::clone(&active),
+                Arc::clone(&audio_blockers),
+            );
             std::thread::spawn(move || {
                 run(Loop {
                     document,
                     config,
+                    presenter,
                     sink,
                     commands,
                     shared,
                     counters,
+                    active,
+                    audio_blockers,
                     project,
                     frame,
+                    visibility: MonitorVisibility::Visible,
                 })
             })
         };
@@ -259,25 +402,188 @@ impl Session {
             control,
             shared,
             counters,
+            active,
+            audio_blockers,
             viewport: Arc::new(Mutex::new(viewport)),
-            thread: Some(thread),
+            thread: Mutex::new(Some(thread)),
+            stopped: AtomicBool::new(false),
         })
     }
 
-    pub fn play(&self) {
-        let _ = self.control.send(Command::Play);
+    pub fn play(&self) -> Result<(), String> {
+        self.acknowledged_command(Command::Play)
     }
 
-    pub fn pause(&self) {
-        let _ = self.control.send(Command::Pause);
+    pub fn pause(&self) -> Result<(), String> {
+        self.acknowledged_muting_command(Command::Pause)
     }
 
-    pub fn seek(&self, frame: i64) {
-        let _ = self.control.send(Command::Seek(frame));
+    pub fn seek(&self, frame: i64) -> Result<(), String> {
+        self.acknowledged_muting_command(|reply| Command::Seek(frame, reply))
+    }
+
+    fn acknowledged_muting_command(
+        &self,
+        command: impl FnOnce(Sender<()>) -> Command,
+    ) -> Result<(), String> {
+        self.audio_blockers.fetch_add(1, Ordering::SeqCst);
+        self.active.store(false, Ordering::SeqCst);
+        let result = self.acknowledged_command(command);
+        if result.is_err() {
+            self.audio_blockers.fetch_sub(1, Ordering::SeqCst);
+        }
+        result
+    }
+
+    fn acknowledged_command(
+        &self,
+        command: impl FnOnce(Sender<()>) -> Command,
+    ) -> Result<(), String> {
+        let (reply, answer) = channel();
+        self.control
+            .send(command(reply))
+            .map_err(|_| "the playback session is no longer running".to_string())?;
+        answer
+            .recv()
+            .map_err(|_| "the playback command stopped before it was applied".to_string())
     }
 
     pub fn redraw(&self) {
         let _ = self.control.send(Command::Redraw);
+    }
+
+    /// Announce a settings request before its potentially slow config build.
+    /// The loop holds the same short lock across candidate commit, so an older
+    /// build that arrives later cannot become the active picture.
+    pub fn reserve_settings_generation(&self, generation: u64) {
+        self.shared.settings_order.reserve(generation);
+    }
+
+    pub fn has_unconfirmed_settings(&self) -> bool {
+        self.shared.settings_order.has_unconfirmed()
+    }
+
+    pub fn confirm_settings_generation(&self, generation: u64) {
+        let Some(mut order) = self.shared.settings_order.lock_if_current(generation) else {
+            return;
+        };
+        // Keep the live snapshot locked until confirmed is replaced. An
+        // automatic proxy commit updates live and then confirmed; letting it
+        // cross between clone and overwrite could lose the newly ready path.
+        let live = self.shared.live_config.lock().unwrap();
+        *self.shared.confirmed_config.lock().unwrap() = live.clone();
+        order.confirmed = generation;
+    }
+
+    pub fn confirmed_config(&self) -> Config {
+        self.shared
+            .confirmed_config
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("a session starts with a confirmed playback config")
+    }
+
+    pub fn set_guides(&self, settings_generation: u64, guides: Guides) -> Result<Status, String> {
+        if self.stopped.load(Ordering::Relaxed) {
+            return Err("the playback session has stopped".into());
+        }
+        let generation = self
+            .shared
+            .requested_generation
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        let (reply, answer) = channel();
+        self.control
+            .send(Command::SetGuides {
+                generation,
+                settings_generation,
+                guides,
+                reply,
+            })
+            .map_err(|_| {
+                "the playback session stopped before guides could be updated".to_string()
+            })?;
+        answer
+            .recv_timeout(Duration::from_secs(1))
+            .map_err(|_| "the playback session did not update guides in time".to_string())??;
+        Ok(self.status())
+    }
+
+    /// Warm a new video path against the existing audio clock and switch only
+    /// after its first frame has reached the candidate surface.
+    pub fn reconfigure(&self, settings_generation: u64, config: Config) -> Result<Status, String> {
+        if self.stopped.load(Ordering::Relaxed) {
+            return Err("the playback session has stopped".into());
+        }
+        let generation = self
+            .shared
+            .requested_generation
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        let (reply, answer) = channel();
+        self.shared.reconfiguring.store(true, Ordering::Relaxed);
+        if self
+            .control
+            .send(Command::Reconfigure {
+                generation,
+                settings_generation,
+                config,
+                reply,
+            })
+            .is_err()
+        {
+            self.shared.reconfiguring.store(false, Ordering::Relaxed);
+            return Err("the playback session stopped before it could be reconfigured".into());
+        }
+        self.wait_for_reconfigure(generation, answer)
+    }
+
+    /// Ask the loop to merge newly ready proxy files into whichever explicit
+    /// config is current when it handles the command. No stale quality, GPU or
+    /// compositor snapshot crosses this boundary.
+    pub fn refresh_proxies(&self, proxy_paths: HashMap<String, String>) -> Result<Status, String> {
+        if self.stopped.load(Ordering::Relaxed) {
+            return Err("the playback session has stopped".into());
+        }
+        let generation = self
+            .shared
+            .requested_generation
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        let (reply, answer) = channel();
+        self.shared.reconfiguring.store(true, Ordering::Relaxed);
+        if self
+            .control
+            .send(Command::RefreshProxies {
+                generation,
+                proxy_paths,
+                reply,
+            })
+            .is_err()
+        {
+            self.shared.reconfiguring.store(false, Ordering::Relaxed);
+            return Err("the playback session stopped before proxies could be refreshed".into());
+        }
+        self.wait_for_reconfigure(generation, answer)
+    }
+
+    fn wait_for_reconfigure(
+        &self,
+        generation: u64,
+        answer: Receiver<Result<(), String>>,
+    ) -> Result<Status, String> {
+        match answer.recv_timeout(RECONFIGURE_TIMEOUT + Duration::from_secs(1)) {
+            Ok(Ok(())) => Ok(self.status()),
+            Ok(Err(reason)) => Err(reason),
+            Err(_) => {
+                let _ = self.control.send(Command::CancelReconfigure(generation));
+                if self.shared.requested_generation.load(Ordering::Relaxed) == generation {
+                    self.shared.reconfiguring.store(false, Ordering::Relaxed);
+                }
+                Err("the replacement playback path did not answer in time".into())
+            }
+        }
     }
 
     /// The panel moved or the window resized.
@@ -299,7 +605,39 @@ impl Session {
     /// Only the view moves. The loop keeps drawing, so what is behind a sheet
     /// stays live and the picture does not have to be rebuilt when it closes.
     pub fn set_visible(&self, visible: bool) {
-        self.viewport.lock().unwrap().set_visible(visible);
+        let visible = apply_session_visibility(
+            &self.stopped,
+            &self.viewport,
+            visible,
+            |viewport, visible| viewport.set_visible(visible),
+        );
+        if !self.stopped.load(Ordering::Relaxed) {
+            let command = if visible {
+                Command::Show
+            } else {
+                Command::Hide
+            };
+            let _ = self.control.send(command);
+        }
+    }
+
+    /// Stop the loop even when another command still holds an `Arc<Session>`.
+    /// Release uses this before dropping the registry handle, so an in-flight
+    /// reconfigure cannot keep audio or the native view visibly alive.
+    pub fn stop(&self) {
+        if self.stopped.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        self.audio_blockers.fetch_add(1, Ordering::SeqCst);
+        self.active.store(false, Ordering::SeqCst);
+        if let Ok(mut viewport) = self.viewport.try_lock() {
+            viewport.set_visible(false);
+        }
+        let _ = self.control.send(Command::Stop);
+        if let Some(thread) = self.thread.lock().unwrap().take() {
+            let _ = thread.join();
+        }
+        self.viewport.lock().unwrap().set_visible(false);
     }
 
     pub fn status(&self) -> Status {
@@ -307,6 +645,8 @@ impl Session {
             engine: "native",
             position: self.shared.position(),
             playing: self.shared.playing(),
+            generation: self.shared.generation(),
+            reconfiguring: self.shared.reconfiguring(),
             presented: self.counters.presented.load(Ordering::Relaxed),
             skipped: self.counters.skipped.load(Ordering::Relaxed),
             resynced: self.counters.resynced.load(Ordering::Relaxed),
@@ -322,12 +662,21 @@ impl Session {
     }
 }
 
+fn apply_session_visibility<T>(
+    stopped: &AtomicBool,
+    viewport: &Mutex<T>,
+    visible: bool,
+    apply: impl FnOnce(&mut T, bool),
+) -> bool {
+    let mut viewport = viewport.lock().unwrap();
+    let visible = visible && !stopped.load(Ordering::Relaxed);
+    apply(&mut viewport, visible);
+    visible
+}
+
 impl Drop for Session {
     fn drop(&mut self) {
-        let _ = self.control.send(Command::Stop);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
+        self.stop();
         // The view goes last. The surface lives on the loop's thread and the
         // join above is what proves it is gone, so this cannot pull a window
         // out from under a swapchain.
@@ -337,12 +686,164 @@ impl Drop for Session {
 struct Loop {
     document: Arc<Mutex<makevideo_edit::Document>>,
     config: Config,
+    presenter: Arc<Compositor>,
     sink: SurfaceSink,
     commands: Receiver<Command>,
     shared: Arc<Shared>,
     counters: Arc<Counters>,
+    active: Arc<AtomicBool>,
+    audio_blockers: Arc<AtomicU64>,
     project: Project,
     frame: i64,
+    visibility: MonitorVisibility,
+}
+
+/// Presentation remains native for both compositor choices. The GPU path
+/// draws the frame's layers directly. The CPU path composes RGBA first, then
+/// uploads that one finished layer through a small GPU presenter.
+struct MonitorSink<'a> {
+    compositor: &'a Compositor,
+    surface: &'a mut SurfaceSink,
+    width: u32,
+    height: u32,
+    direct: bool,
+    guides: Guides,
+    visibility: MonitorVisibility,
+}
+
+#[derive(Clone, Copy)]
+enum MonitorVisibility {
+    Visible,
+    Hidden,
+}
+
+impl<'a> MonitorSink<'a> {
+    fn visible(
+        config: &'a Config,
+        presenter: &Arc<Compositor>,
+        surface: &'a mut SurfaceSink,
+    ) -> MonitorSink<'a> {
+        Self::with_visibility(config, presenter, surface, MonitorVisibility::Visible)
+    }
+
+    fn hidden(
+        config: &'a Config,
+        presenter: &Arc<Compositor>,
+        surface: &'a mut SurfaceSink,
+    ) -> MonitorSink<'a> {
+        Self::with_visibility(config, presenter, surface, MonitorVisibility::Hidden)
+    }
+
+    fn with_visibility(
+        config: &'a Config,
+        presenter: &Arc<Compositor>,
+        surface: &'a mut SurfaceSink,
+        visibility: MonitorVisibility,
+    ) -> MonitorSink<'a> {
+        MonitorSink {
+            direct: config.compositor.is_gpu() && Arc::ptr_eq(&config.compositor, presenter),
+            compositor: &config.compositor,
+            surface,
+            width: config.width,
+            height: config.height,
+            guides: config.guides,
+            visibility,
+        }
+    }
+
+    fn finish_present(&self) -> Result<(), String> {
+        match self.surface.present_outcome() {
+            PresentOutcome::Presented => Ok(()),
+            PresentOutcome::Deferred => Err(PRESENT_DEFERRED.into()),
+            PresentOutcome::Hidden => Err(PRESENT_HIDDEN.into()),
+        }
+    }
+
+    fn ensure_visible(&self) -> Result<(), String> {
+        match self.visibility {
+            MonitorVisibility::Visible => Ok(()),
+            MonitorVisibility::Hidden => Err(PRESENT_HIDDEN.into()),
+        }
+    }
+}
+
+impl Sink for MonitorSink<'_> {
+    fn show(&mut self, frame: &Frame) -> Result<(), String> {
+        self.ensure_visible()?;
+        if self.direct {
+            self.surface.set_frame_size(self.width, self.height);
+            self.surface.set_guides(self.guides);
+            self.surface.show(frame)?;
+            return self.finish_present();
+        }
+        let pixels = self
+            .compositor
+            .compose(self.width, self.height, &frame.sources())?;
+        let uploaded = Frame {
+            frame: frame.frame,
+            layers: vec![Layer {
+                clip_id: "monitor-cpu-composite".into(),
+                pixels,
+                dst: Rect {
+                    x: 0,
+                    y: 0,
+                    w: self.width,
+                    h: self.height,
+                },
+                opacity: 1.0,
+                lut: None,
+            }],
+            visuals: Vec::new(),
+        };
+        self.surface.set_frame_size(self.width, self.height);
+        self.surface.set_guides(self.guides);
+        self.surface.show(&uploaded)?;
+        self.finish_present()
+    }
+
+    fn clear(&mut self) -> Result<(), String> {
+        self.ensure_visible()?;
+        self.surface.set_frame_size(self.width, self.height);
+        self.surface.set_guides(self.guides);
+        self.surface.clear()?;
+        self.finish_present()
+    }
+}
+
+fn monitor_sink<'a>(
+    config: &'a Config,
+    presenter: &Arc<Compositor>,
+    surface: &'a mut SurfaceSink,
+    visibility: MonitorVisibility,
+) -> MonitorSink<'a> {
+    match visibility {
+        MonitorVisibility::Visible => MonitorSink::visible(config, presenter, surface),
+        MonitorVisibility::Hidden => MonitorSink::hidden(config, presenter, surface),
+    }
+}
+
+struct PendingReconfigure {
+    generation: u64,
+    owner: ReplacementOwner,
+    config: Config,
+    project: Project,
+    reply: Sender<Result<(), String>>,
+    deadline: Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReplacementOwner {
+    Settings(u64),
+    ProxyRefresh,
+}
+
+impl ReplacementOwner {
+    fn settings_generation(self) -> Option<u64> {
+        match self {
+            ReplacementOwner::Settings(generation) => Some(generation),
+            ReplacementOwner::ProxyRefresh => None,
+        }
+    }
 }
 
 /// Decoder, audio mixer and output device that survive play/pause toggles.
@@ -354,37 +855,96 @@ struct Pipeline {
     active: Arc<AtomicBool>,
 }
 
+fn sync_audio_active(pipeline: &Pipeline, audio_blockers: &AtomicU64) {
+    let ready = pipeline.transport.is_playing() && pipeline.transport.audio_ready();
+    if !ready || audio_blockers.load(Ordering::SeqCst) != 0 {
+        pipeline.active.store(false, Ordering::SeqCst);
+        return;
+    }
+    pipeline.active.store(true, Ordering::SeqCst);
+    // A caller can close the gate between the check and the store above.
+    // Recheck after opening so every interleaving ends closed when a command
+    // is pending.
+    if audio_blockers.load(Ordering::SeqCst) != 0 {
+        pipeline.active.store(false, Ordering::SeqCst);
+    }
+}
+
 fn run(mut state: Loop) {
     let frame = state.frame;
     let mut current = pipeline(&mut state, frame);
+    let mut pending: Option<PendingReconfigure> = None;
+    let mut latest_generation = 0;
     loop {
         match state.commands.try_recv() {
-            Ok(Command::Stop) | Err(TryRecvError::Disconnected) => break,
-            Ok(Command::Play) => {
-                current.active.store(true, Ordering::Relaxed);
+            Ok(Command::Stop) | Err(TryRecvError::Disconnected) => {
+                if let Some(candidate) = pending.take() {
+                    let _ = candidate.reply.send(Err(
+                        "the playback session stopped during reconfiguration".into(),
+                    ));
+                }
+                break;
+            }
+            Ok(Command::Play(reply)) => {
                 current.transport.play();
                 state.shared.playing.store(true, Ordering::Relaxed);
+                state
+                    .shared
+                    .position
+                    .store(current.transport.position(), Ordering::Relaxed);
+                sync_audio_active(&current, &state.audio_blockers);
+                let _ = reply.send(());
                 continue;
             }
-            Ok(Command::Pause) => {
-                current.active.store(false, Ordering::Relaxed);
+            Ok(Command::Pause(reply)) => {
+                current.active.store(false, Ordering::SeqCst);
                 current.transport.pause();
                 state.shared.playing.store(false, Ordering::Relaxed);
+                state
+                    .shared
+                    .position
+                    .store(current.transport.position(), Ordering::Relaxed);
+                state.audio_blockers.fetch_sub(1, Ordering::SeqCst);
+                let _ = reply.send(());
                 continue;
             }
-            Ok(Command::Seek(frame)) => {
+            Ok(Command::Seek(frame, reply)) => {
+                // Close the callback gate before the asynchronous decoder sees
+                // the seek. Until its flush arrives the ring still contains
+                // samples from the position being left.
+                current.active.store(false, Ordering::SeqCst);
                 current.transport.seek(frame);
-                state.shared.position.store(frame, Ordering::Relaxed);
+                state
+                    .shared
+                    .position
+                    .store(current.transport.position(), Ordering::Relaxed);
+                state.audio_blockers.fetch_sub(1, Ordering::SeqCst);
+                let _ = reply.send(());
                 continue;
             }
             Ok(Command::Resize(width, height)) => {
                 state.sink.resize(width, height);
                 continue;
             }
+            Ok(Command::Show) => {
+                state.visibility = MonitorVisibility::Visible;
+                current.transport.redraw_video();
+                continue;
+            }
+            Ok(Command::Hide) => {
+                state.visibility = MonitorVisibility::Hidden;
+                continue;
+            }
             Ok(Command::Redraw) => {
                 if !current.transport.is_playing() {
+                    cancel_pending(
+                        &mut current.transport,
+                        &mut pending,
+                        &state.shared,
+                        "the timeline changed while the replacement was preparing",
+                    );
                     let at = current.transport.position();
-                    current.active.store(false, Ordering::Relaxed);
+                    current.active.store(false, Ordering::SeqCst);
                     state.project = makevideo_proxy::playback_project(
                         state.document.lock().unwrap().project(),
                         &state.config.proxy_paths,
@@ -393,14 +953,186 @@ fn run(mut state: Loop) {
                 }
                 continue;
             }
+            Ok(Command::Reconfigure {
+                generation,
+                settings_generation,
+                mut config,
+                reply,
+            }) => {
+                if state
+                    .shared
+                    .settings_order
+                    .lock_if_current(settings_generation)
+                    .is_none()
+                {
+                    let _ = reply.send(Err(SETTINGS_SUPERSEDED.into()));
+                    state
+                        .shared
+                        .reconfiguring
+                        .store(pending.is_some(), Ordering::Relaxed);
+                    continue;
+                }
+                if !accept_generation(&mut latest_generation, generation) {
+                    let _ = reply.send(Err(SETTINGS_SUPERSEDED.into()));
+                    state
+                        .shared
+                        .reconfiguring
+                        .store(pending.is_some(), Ordering::Relaxed);
+                    continue;
+                }
+                let reason = if pending
+                    .as_ref()
+                    .is_some_and(|candidate| candidate.owner == ReplacementOwner::ProxyRefresh)
+                {
+                    EXPLICIT_RECONFIGURE_PENDING
+                } else {
+                    SETTINGS_SUPERSEDED
+                };
+                cancel_pending(&mut current.transport, &mut pending, &state.shared, reason);
+                merge_active_proxy_paths(&mut config, &state.config);
+                let project = prepare_candidate(&mut current.transport, &state.document, &config);
+                pending = Some(PendingReconfigure {
+                    generation,
+                    owner: ReplacementOwner::Settings(settings_generation),
+                    config,
+                    project,
+                    reply,
+                    deadline: Instant::now() + RECONFIGURE_TIMEOUT,
+                });
+                state.shared.reconfiguring.store(true, Ordering::Relaxed);
+                continue;
+            }
+            Ok(Command::RefreshProxies {
+                generation,
+                proxy_paths,
+                reply,
+            }) => {
+                if !proxy_refresh_allowed(pending.as_ref().map(|candidate| candidate.owner)) {
+                    let _ = reply.send(Err(EXPLICIT_RECONFIGURE_PENDING.into()));
+                    continue;
+                }
+                if !accept_generation(&mut latest_generation, generation) {
+                    let _ = reply.send(Err(EXPLICIT_RECONFIGURE_PENDING.into()));
+                    continue;
+                }
+                cancel_pending_with_result(
+                    &mut current.transport,
+                    &mut pending,
+                    &state.shared,
+                    Ok(()),
+                );
+                let config = refreshed_proxy_config(&state.config, proxy_paths);
+                if config.proxy_paths == state.config.proxy_paths {
+                    state.shared.reconfiguring.store(false, Ordering::Relaxed);
+                    let _ = reply.send(Ok(()));
+                    continue;
+                }
+                let project = prepare_candidate(&mut current.transport, &state.document, &config);
+                pending = Some(PendingReconfigure {
+                    generation,
+                    owner: ReplacementOwner::ProxyRefresh,
+                    config,
+                    project,
+                    reply,
+                    deadline: Instant::now() + RECONFIGURE_TIMEOUT,
+                });
+                state.shared.reconfiguring.store(true, Ordering::Relaxed);
+                continue;
+            }
+            Ok(Command::CancelReconfigure(generation)) => {
+                if pending
+                    .as_ref()
+                    .is_some_and(|candidate| candidate.generation == generation)
+                {
+                    cancel_pending(
+                        &mut current.transport,
+                        &mut pending,
+                        &state.shared,
+                        "the replacement playback request timed out",
+                    );
+                }
+                continue;
+            }
+            Ok(Command::SetGuides {
+                generation,
+                settings_generation,
+                guides,
+                reply,
+            }) => {
+                let Some(mut settings_guard) = state
+                    .shared
+                    .settings_order
+                    .lock_if_current(settings_generation)
+                else {
+                    let _ = reply.send(Err(SETTINGS_SUPERSEDED.into()));
+                    state
+                        .shared
+                        .reconfiguring
+                        .store(pending.is_some(), Ordering::Relaxed);
+                    continue;
+                };
+                if !accept_generation(&mut latest_generation, generation) {
+                    let _ = reply.send(Err(SETTINGS_SUPERSEDED.into()));
+                    continue;
+                }
+                let reason = if pending
+                    .as_ref()
+                    .is_some_and(|candidate| candidate.owner == ReplacementOwner::ProxyRefresh)
+                {
+                    EXPLICIT_RECONFIGURE_PENDING
+                } else {
+                    SETTINGS_SUPERSEDED
+                };
+                cancel_pending(&mut current.transport, &mut pending, &state.shared, reason);
+                state.config.guides = guides;
+                state.sink.set_guides(guides);
+                current.transport.redraw_video();
+                state.shared.set_live_config(&state.config);
+                settings_guard.committed = settings_generation;
+                let _ = reply.send(Ok(()));
+                continue;
+            }
             Err(TryRecvError::Empty) => {}
         }
 
-        let tick = current.transport.tick(&mut state.sink);
+        if pending.as_ref().is_some_and(|candidate| {
+            candidate
+                .owner
+                .settings_generation()
+                .is_some_and(|generation| {
+                    state
+                        .shared
+                        .settings_order
+                        .lock_if_current(generation)
+                        .is_none()
+                })
+        }) {
+            cancel_pending(
+                &mut current.transport,
+                &mut pending,
+                &state.shared,
+                SETTINGS_SUPERSEDED,
+            );
+            continue;
+        }
+
+        let tick = {
+            let mut sink = monitor_sink(
+                &state.config,
+                &state.presenter,
+                &mut state.sink,
+                state.visibility,
+            );
+            current.transport.tick(&mut sink)
+        };
         state
             .shared
             .position
             .store(current.transport.position(), Ordering::Relaxed);
+
+        if tick != Tick::Ended {
+            sync_audio_active(&current, &state.audio_blockers);
+        }
 
         match tick {
             Tick::Presented {
@@ -429,7 +1161,7 @@ fn run(mut state: Loop) {
                 // frame up, which is what the transport does anyway; going back
                 // to the top would lose the place somebody was working at.
                 if current.transport.is_playing() {
-                    current.active.store(false, Ordering::Relaxed);
+                    current.active.store(false, Ordering::SeqCst);
                     current.transport.pause();
                     state.shared.playing.store(false, Ordering::Relaxed);
                 }
@@ -449,7 +1181,166 @@ fn run(mut state: Loop) {
                 state.counters.resynced.fetch_add(1, Ordering::Relaxed);
             }
         }
+
+        if pending
+            .as_ref()
+            .is_some_and(|candidate| Instant::now() >= candidate.deadline)
+        {
+            cancel_pending(
+                &mut current.transport,
+                &mut pending,
+                &state.shared,
+                "the replacement playback path did not present a frame in time",
+            );
+            continue;
+        }
+
+        let settings_generation = pending
+            .as_ref()
+            .and_then(|candidate| candidate.owner.settings_generation());
+        let mut settings_guard = match settings_generation {
+            Some(generation) => match state.shared.settings_order.lock_if_current(generation) {
+                Some(guard) => Some(guard),
+                None => {
+                    cancel_pending(
+                        &mut current.transport,
+                        &mut pending,
+                        &state.shared,
+                        SETTINGS_SUPERSEDED,
+                    );
+                    continue;
+                }
+            },
+            None => None,
+        };
+        let replacement = pending.as_ref().map(|candidate| {
+            let mut sink = monitor_sink(
+                &candidate.config,
+                &state.presenter,
+                &mut state.sink,
+                state.visibility,
+            );
+            current.transport.tick_video_replacement(&mut sink)
+        });
+        match replacement {
+            Some(VideoReplacement::Committed(tick)) => {
+                let candidate = pending.take().expect("a replacement just committed");
+                state.config = candidate.config;
+                state.project = candidate.project;
+                state.shared.set_live_config(&state.config);
+                if candidate.owner == ReplacementOwner::ProxyRefresh {
+                    state.shared.set_confirmed_proxy_paths(&state.config);
+                }
+                state
+                    .shared
+                    .generation
+                    .store(candidate.generation, Ordering::Relaxed);
+                if let (Some(generation), Some(guard)) = (
+                    candidate.owner.settings_generation(),
+                    settings_guard.as_mut(),
+                ) {
+                    guard.committed = generation;
+                }
+                state.shared.reconfiguring.store(false, Ordering::Relaxed);
+                if let Tick::Presented {
+                    present_ms,
+                    late_ms,
+                    ..
+                } = tick
+                {
+                    state.counters.presented.fetch_add(1, Ordering::Relaxed);
+                    state.counters.record_present(present_ms, late_ms);
+                } else if tick == Tick::Ended && current.transport.is_playing() {
+                    current.active.store(false, Ordering::SeqCst);
+                    current.transport.pause();
+                    state.shared.playing.store(false, Ordering::Relaxed);
+                }
+                let _ = candidate.reply.send(Ok(()));
+            }
+            Some(VideoReplacement::Failed(reason)) => {
+                let candidate = pending.take().expect("a replacement just failed");
+                state
+                    .sink
+                    .set_frame_size(state.config.width, state.config.height);
+                state.sink.set_guides(state.config.guides);
+                state.shared.reconfiguring.store(false, Ordering::Relaxed);
+                let _ = candidate.reply.send(Err(reason));
+            }
+            Some(VideoReplacement::Pending) | None => {}
+        }
+        drop(settings_guard);
     }
+    state.shared.reconfiguring.store(false, Ordering::Relaxed);
+}
+
+fn cancel_pending(
+    transport: &mut Transport,
+    pending: &mut Option<PendingReconfigure>,
+    shared: &Shared,
+    reason: &str,
+) {
+    cancel_pending_with_result(transport, pending, shared, Err(reason.to_string()));
+}
+
+fn cancel_pending_with_result(
+    transport: &mut Transport,
+    pending: &mut Option<PendingReconfigure>,
+    shared: &Shared,
+    result: Result<(), String>,
+) {
+    transport.cancel_video_replacement();
+    if let Some(candidate) = pending.take() {
+        let _ = candidate.reply.send(result);
+    }
+    shared.reconfiguring.store(false, Ordering::Relaxed);
+}
+
+fn prepare_candidate(
+    transport: &mut Transport,
+    document: &Arc<Mutex<makevideo_edit::Document>>,
+    config: &Config,
+) -> Project {
+    let project =
+        makevideo_proxy::playback_project(document.lock().unwrap().project(), &config.proxy_paths);
+    transport.prepare_video(VideoSetup {
+        project: &project,
+        width: config.width,
+        height: config.height,
+        frame_buffering: config.frame_buffering,
+        frame_readers: Arc::new(FrameReaders::new(&config.ffmpeg, config.hwaccel.as_deref())),
+        resync_after: config.resync_after,
+    });
+    project
+}
+
+fn accept_generation(latest: &mut u64, generation: u64) -> bool {
+    if generation <= *latest {
+        return false;
+    }
+    *latest = generation;
+    true
+}
+
+fn proxy_refresh_allowed(pending: Option<ReplacementOwner>) -> bool {
+    !matches!(pending, Some(ReplacementOwner::Settings(_)))
+}
+
+fn refreshed_proxy_config(active: &Config, proxy_paths: HashMap<String, String>) -> Config {
+    let mut config = active.clone();
+    config.proxy_paths = if config.proxy_enabled {
+        proxy_paths
+    } else {
+        HashMap::new()
+    };
+    config
+}
+
+fn merge_active_proxy_paths(candidate: &mut Config, active: &Config) {
+    if !candidate.proxy_enabled {
+        candidate.proxy_paths.clear();
+        return;
+    }
+    candidate.proxy_paths.extend(active.proxy_paths.clone());
 }
 
 fn pipeline(state: &mut Loop, frame: i64) -> Pipeline {
@@ -473,7 +1364,7 @@ fn pipeline(state: &mut Loop, frame: i64) -> Pipeline {
     if frame > 0 {
         transport.seek(frame);
     }
-    let active = Arc::new(AtomicBool::new(false));
+    let active = Arc::clone(&state.active);
     let device = DeviceSink::open(consumer, clock, Arc::clone(&active));
     Pipeline {
         transport,
@@ -517,5 +1408,190 @@ mod tests {
         assert_eq!(counters.peak_present_us.load(Ordering::Relaxed), 4_250);
         assert_eq!(counters.last_late_us.load(Ordering::Relaxed), 8_750);
         assert_eq!(counters.peak_late_us.load(Ordering::Relaxed), 8_750);
+    }
+
+    #[test]
+    fn a_later_generation_supersedes_pending_and_stale_work_cannot_return() {
+        let mut latest = 0;
+        assert!(accept_generation(&mut latest, 1));
+        assert!(accept_generation(&mut latest, 3));
+        assert!(!accept_generation(&mut latest, 2));
+        assert!(!accept_generation(&mut latest, 3));
+        assert_eq!(latest, 3);
+    }
+
+    #[test]
+    fn a_slow_older_settings_build_cannot_commit_after_a_newer_generation() {
+        let order = Arc::new(SettingsOrder::default());
+        order.reserve(1);
+        let (release, delayed) = std::sync::mpsc::channel();
+        let (sent, answer) = std::sync::mpsc::channel();
+        let worker_order = Arc::clone(&order);
+        let worker = std::thread::spawn(move || {
+            delayed.recv().unwrap();
+            sent.send(worker_order.lock_if_current(1).is_some())
+                .unwrap();
+        });
+
+        order.reserve(2);
+        release.send(()).unwrap();
+        assert_eq!(answer.recv().unwrap(), false);
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn settings_reservation_cannot_cross_a_candidate_commit_lock() {
+        let order = Arc::new(SettingsOrder::default());
+        order.reserve(1);
+        let commit = order.lock_if_current(1).unwrap();
+        let (sent, answer) = std::sync::mpsc::channel();
+        let worker_order = Arc::clone(&order);
+        let worker = std::thread::spawn(move || {
+            worker_order.reserve(2);
+            sent.send(()).unwrap();
+        });
+
+        assert!(answer.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(commit);
+        assert_eq!(answer.recv_timeout(Duration::from_secs(1)), Ok(()));
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn committed_settings_remain_unconfirmed_until_persistence_succeeds() {
+        let order = SettingsOrder::default();
+        order.reserve(1);
+        {
+            let mut commit = order.lock_if_current(1).unwrap();
+            commit.committed = 1;
+        }
+        assert!(order.has_unconfirmed());
+
+        order.reserve(2);
+        {
+            let mut restore = order.lock_if_current(2).unwrap();
+            restore.committed = 2;
+        }
+        order.lock_if_current(2).unwrap().confirmed = 2;
+        assert!(!order.has_unconfirmed());
+    }
+
+    #[test]
+    fn confirmed_config_survives_an_unpersisted_live_commit() {
+        let compositor =
+            Arc::new(Compositor::with_backend(makevideo_compositor::Backend::Cpu).unwrap());
+        let confirmed = Config::new(Arc::clone(&compositor), "ffmpeg".into(), 1920, 1080);
+        let live = Config::new(compositor, "ffmpeg".into(), 960, 540);
+        let shared = Shared::default();
+        shared.initialize_config(&confirmed);
+        shared.settings_order.reserve(1);
+        {
+            let mut commit = shared.settings_order.lock_if_current(1).unwrap();
+            shared.set_live_config(&live);
+            commit.committed = 1;
+        }
+
+        shared.settings_order.reserve(2);
+        assert!(shared.settings_order.has_unconfirmed());
+        let rollback = shared.confirmed_config.lock().unwrap().clone().unwrap();
+        assert_eq!((rollback.width, rollback.height), (1920, 1080));
+        assert_eq!(
+            shared
+                .live_config
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|config| (config.width, config.height)),
+            Some((960, 540))
+        );
+    }
+
+    #[test]
+    fn confirmed_rollback_keeps_a_proxy_that_became_ready_during_live_settings() {
+        let compositor =
+            Arc::new(Compositor::with_backend(makevideo_compositor::Backend::Cpu).unwrap());
+        let mut old_paths = HashMap::new();
+        old_paths.insert("asset".into(), "/proxy/r0.mov".into());
+        let confirmed = Config::new(Arc::clone(&compositor), "ffmpeg".into(), 1920, 1080)
+            .with_proxies(old_paths);
+        let live = Config::new(Arc::clone(&compositor), "ffmpeg".into(), 960, 540)
+            .with_proxies(confirmed.proxy_paths.clone());
+        let shared = Shared::default();
+        shared.initialize_config(&confirmed);
+        shared.set_live_config(&live);
+
+        let mut ready_paths = HashMap::new();
+        ready_paths.insert("asset".into(), "/proxy/r1.mov".into());
+        let refreshed = Config::new(compositor, "ffmpeg".into(), 960, 540)
+            .with_proxies(ready_paths);
+        shared.set_confirmed_proxy_paths(&refreshed);
+
+        let rollback = shared.confirmed_config.lock().unwrap().clone().unwrap();
+        assert_eq!((rollback.width, rollback.height), (1920, 1080));
+        assert_eq!(rollback.proxy_paths["asset"], "/proxy/r1.mov");
+    }
+
+    #[test]
+    fn a_late_visible_command_cannot_undo_release_final_hide() {
+        let stopped = AtomicBool::new(true);
+        let visible = Mutex::new(false);
+        apply_session_visibility(&stopped, &visible, true, |slot, wanted| *slot = wanted);
+        assert!(!*visible.lock().unwrap());
+    }
+
+    #[test]
+    fn automatic_refresh_cannot_supersede_an_explicit_candidate() {
+        assert!(!proxy_refresh_allowed(Some(ReplacementOwner::Settings(7))));
+        assert!(proxy_refresh_allowed(Some(ReplacementOwner::ProxyRefresh)));
+        assert!(proxy_refresh_allowed(None));
+    }
+
+    #[test]
+    fn proxy_refresh_merges_only_paths_into_the_active_explicit_config() {
+        let compositor =
+            Arc::new(Compositor::with_backend(makevideo_compositor::Backend::Cpu).unwrap());
+        let mut old = HashMap::new();
+        old.insert("asset".into(), "/proxy/old.mov".into());
+        let active = Config::new(compositor, "ffmpeg-new".into(), 960, 540)
+            .with_proxies(old)
+            .with_guides(Guides {
+                center_lines: true,
+                ..Guides::default()
+            });
+        let mut ready = HashMap::new();
+        ready.insert("asset".into(), "/proxy/new.mov".into());
+
+        let refreshed = refreshed_proxy_config(&active, ready.clone());
+        assert_eq!(refreshed.proxy_paths, ready);
+        assert_eq!(refreshed.ffmpeg, "ffmpeg-new");
+        assert_eq!((refreshed.width, refreshed.height), (960, 540));
+        assert!(refreshed.guides.center_lines);
+
+        let disabled = Config::new(active.compositor, "ffmpeg-new".into(), 960, 540);
+        assert!(refreshed_proxy_config(&disabled, ready)
+            .proxy_paths
+            .is_empty());
+    }
+
+    #[test]
+    fn explicit_candidate_keeps_proxy_paths_an_auto_refresh_already_committed() {
+        let compositor =
+            Arc::new(Compositor::with_backend(makevideo_compositor::Backend::Cpu).unwrap());
+        let mut active_paths = HashMap::new();
+        active_paths.insert("asset".into(), "/proxy/r1.mov".into());
+        let active = Config::new(Arc::clone(&compositor), "ffmpeg".into(), 480, 270)
+            .with_proxies(active_paths);
+        let mut candidate_paths = HashMap::new();
+        candidate_paths.insert("asset".into(), "/proxy/r0.mov".into());
+        let mut candidate =
+            Config::new(compositor, "ffmpeg".into(), 1920, 1080).with_proxies(candidate_paths);
+
+        merge_active_proxy_paths(&mut candidate, &active);
+        assert_eq!(candidate.proxy_paths.len(), 1);
+        assert_eq!(candidate.proxy_paths["asset"], "/proxy/r1.mov");
+
+        candidate.proxy_enabled = false;
+        merge_active_proxy_paths(&mut candidate, &active);
+        assert!(candidate.proxy_paths.is_empty());
     }
 }

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -122,6 +122,7 @@ if (!window.__TAURI__) {
     // browser there was never a graphics surface to lose.
     playbackAttach: async () => ({ engine: 'media-element', fellBack: null, status: null }),
     playbackRelease: async () => {},
+    playbackRefresh: async () => null,
     playbackPlay: async () => null,
     playbackPause: async () => null,
     playbackSeek: async () => null,
@@ -288,6 +289,7 @@ window.api = {
   // frames never do. See wiki/architecture/viewport.md.
   playbackAttach: (place, frame) => invoke('playback_attach', { place, frame }),
   playbackRelease: () => invoke('playback_release'),
+  playbackRefresh: () => invoke('playback_refresh'),
   playbackPlay: () => invoke('playback_play'),
   playbackPause: () => invoke('playback_pause'),
   playbackSeek: (frame) => invoke('playback_seek', { frame }),

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -590,6 +590,7 @@
   <script src="transform.js"></script>
   <script src="guides.js"></script>
   <script src="monitor.js"></script>
+  <script src="latest.js"></script>
   <script src="renderer.js"></script>
 </body>
 </html>

--- a/product/akbun-makevideo/workspace/src/latest.js
+++ b/product/akbun-makevideo/workspace/src/latest.js
@@ -1,0 +1,63 @@
+'use strict';
+
+(function () {
+
+/** Run requests concurrently, but let only the newest one change page state. */
+function createLatestRequest() {
+  let generation = 0;
+
+  return async function latest(start, onSuccess, onFailure) {
+    const token = (generation += 1);
+    let value;
+    try {
+      value = await start();
+    } catch (error) {
+      if (token !== generation) return false;
+      await onFailure(error, () => token === generation);
+      return token === generation;
+    }
+    if (token !== generation) return false;
+    await onSuccess(value, () => token === generation);
+    return token === generation;
+  };
+}
+
+/** Persist optimistic values, restoring the last confirmed value on failure. */
+function createLatestPersistence(options) {
+  const latest = createLatestRequest();
+
+  return function persist(requested, callbacks = {}) {
+    if (options.optimistic) options.optimistic(requested);
+    return latest(
+      () => options.save(requested),
+      async (value, isCurrent) => {
+        await options.confirm(value);
+        if (!isCurrent()) return;
+        if (callbacks.confirm) await callbacks.confirm(value);
+      },
+      async (error, isCurrent) => {
+        let confirmed = options.confirmed();
+        if (options.recover) {
+          try {
+            confirmed = await options.recover();
+          } catch (_recoveryError) {
+            // Keep the last local checkpoint when the confirmation read also
+            // fails; the original save error remains the useful one to show.
+          }
+        }
+        if (!isCurrent()) return;
+        await options.restore(confirmed);
+        if (!isCurrent()) return;
+        if (callbacks.fail) await callbacks.fail(error);
+        else if (options.fail) await options.fail(error);
+      },
+    );
+  };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createLatestRequest, createLatestPersistence };
+} else {
+  globalThis.latestLib = { createLatestRequest, createLatestPersistence };
+}
+})();

--- a/product/akbun-makevideo/workspace/src/monitor.js
+++ b/product/akbun-makevideo/workspace/src/monitor.js
@@ -89,17 +89,91 @@ function createMonitor(options) {
   let covered = false;
   let editing = false;
   let lastVisible = null;
+  let sendingVisibility = null;
+  let pendingVisibility = null;
   let lastPlace = null;
   let polling = false;
   let position = 0;
   let playing = false;
   let attaching = null;
+  let releasing = null;
+  let attachmentEpoch = 0;
   let attachWanted = false;
   let placing = null;
   let pendingPlace = null;
   let mediaRefreshPending = false;
   let refreshingMedia = null;
+  let transportIntent = 0;
+  let transportAcknowledged = 0;
+  let transportVersion = 0;
+  let transportQueue = Promise.resolve();
+  let transportCommand = null;
+  let transportPending = 0;
+  let transportNeedsSnapshot = false;
+  let previewOwnsTimeline = true;
   let viewport = GEO.fittedViewport();
+
+  function acknowledgeTransport(intent) {
+    transportAcknowledged = Math.max(transportAcknowledged, intent);
+  }
+
+  function scheduleTransport(command, completesIntent = true) {
+    transportCommand = command;
+    const intent = transportIntent;
+    const version = transportVersion;
+    transportPending += 1;
+    const run = transportQueue.catch(() => {}).then(async () => {
+      while (version === transportVersion) {
+        if (!native) return;
+        const epoch = attachmentEpoch;
+        try {
+          const status = await command();
+          if (version !== transportVersion) return;
+          if (epoch !== attachmentEpoch) continue;
+          if (completesIntent) {
+            acknowledgeTransport(intent);
+            if (intent === transportIntent) takeForEpoch(status, epoch);
+          }
+          return;
+        } catch (_error) {
+          if (version !== transportVersion) return;
+          // A command rejected by a session being replaced still belongs on
+          // the replacement. A same-session rejection cannot apply later:
+          // Rust answers only after apply or after the command channel closes.
+          if (epoch !== attachmentEpoch) continue;
+          if (completesIntent) acknowledgeTransport(intent);
+          return;
+        }
+      }
+    });
+    const request = run.finally(() => {
+      transportPending -= 1;
+    });
+    transportQueue = request;
+    return request;
+  }
+
+  function settleLocalTransport() {
+    transportVersion += 1;
+    transportCommand = null;
+    transportNeedsSnapshot = false;
+    acknowledgeTransport(transportIntent);
+  }
+
+  function queueTransportSnapshot(target, shouldPlay) {
+    transportNeedsSnapshot = false;
+    void scheduleTransport(() => api.playbackSeek(target), false);
+    void scheduleTransport(() =>
+      shouldPlay ? api.playbackPlay() : api.playbackPause()
+    );
+  }
+
+  function scheduleTransportSnapshot(target, shouldPlay) {
+    transportVersion += 1;
+    transportQueue = Promise.resolve();
+    transportCommand = null;
+    queueTransportSnapshot(target, shouldPlay);
+  }
 
   function timelineMode() {
     return preview.mode() === 'timeline';
@@ -124,6 +198,80 @@ function createMonitor(options) {
     return preview.total();
   }
 
+  function boundedPosition(value, fallback = position) {
+    const numeric = Number(value);
+    const candidate = Number.isFinite(numeric) ? numeric : fallback;
+    const duration = Number(total());
+    const end = Number.isFinite(duration) ? Math.max(duration, 0) : Math.max(candidate, 0);
+    return Math.max(0, Math.min(Math.round(candidate), end));
+  }
+
+  function previewPosition(fallback = position) {
+    const value = typeof preview.position === 'function' ? preview.position() : fallback;
+    return boundedPosition(value, fallback);
+  }
+
+  function previewPlaying(fallback = playing) {
+    const value = typeof preview.isPlaying === 'function' ? preview.isPlaying() : fallback;
+    return typeof value === 'boolean' ? value : fallback;
+  }
+
+  function rememberPreviewIntent(target, active) {
+    if (!timelineMode()) return;
+    transportIntent += 1;
+    position = boundedPosition(target);
+    playing = Boolean(active);
+    transportNeedsSnapshot = true;
+  }
+
+  function capturePreviewTransport() {
+    if (!timelineMode() || !previewOwnsTimeline) return;
+    const nextPosition = previewPosition();
+    const nextPlaying = previewPlaying();
+    if (nextPosition !== position || nextPlaying !== playing) {
+      transportIntent += 1;
+      position = nextPosition;
+      playing = nextPlaying;
+      transportNeedsSnapshot = true;
+    }
+  }
+
+  function handTimelineToPreview() {
+    if (!timelineMode() || previewOwnsTimeline) return;
+    previewOwnsTimeline = true;
+    preview.seek(position);
+    if (playing) preview.play();
+    else preview.pause();
+  }
+
+  async function flushVisibility(epoch) {
+    while (epoch === attachmentEpoch && pendingVisibility) {
+      const next = pendingVisibility.value;
+      pendingVisibility = null;
+      try {
+        await api.playbackVisible(next);
+        if (epoch !== attachmentEpoch) {
+          lastVisible = null;
+          return;
+        }
+      } catch (_error) {
+        if (epoch === attachmentEpoch && lastVisible === next) lastVisible = null;
+      }
+    }
+  }
+
+  function queueVisibility(wanted) {
+    pendingVisibility = { value: wanted };
+    if (sendingVisibility) return;
+    const epoch = attachmentEpoch;
+    const request = flushVisibility(epoch).finally(() => {
+      if (sendingVisibility !== request) return;
+      sendingVisibility = null;
+      if (pendingVisibility) queueVisibility(pendingVisibility.value);
+    });
+    sendingVisibility = request;
+  }
+
   /** Send the view's visibility only when it actually changes. The renderer
    *  asks on every timeline redraw, and one command per redraw would be a
    *  round trip for every keystroke that moves a clip.
@@ -142,7 +290,7 @@ function createMonitor(options) {
     });
     if (wanted === lastVisible) return;
     lastVisible = wanted;
-    api.playbackVisible(wanted).catch(() => {});
+    queueVisibility(wanted);
   }
 
   /** The stage box as it is right now, from the panel and the project.
@@ -181,15 +329,25 @@ function createMonitor(options) {
    *  reason, which is the whole point of keeping that preview. */
   async function attach() {
     if (!api || !api.available) return false;
+    const requestedAt = attachmentEpoch;
+    if (releasing) {
+      await releasing;
+      if (requestedAt !== attachmentEpoch) return false;
+    }
     attachWanted = true;
     if (options.pageOverlayActive && options.pageOverlayActive()) {
       attachWanted = false;
-      native = false;
-      lastPlace = null;
-      lastVisible = null;
-      preview.seek(position);
+      if (native || attaching) {
+        await release();
+      } else {
+        native = false;
+        lastPlace = null;
+        lastVisible = null;
+      }
+      handTimelineToPreview();
       return false;
     }
+    if (!native) capturePreviewTransport();
     const place = currentPlace();
     // No room yet. The window is still being laid out, or the panel is dragged
     // shut. Giving up here permanently was a silent fallback to the media
@@ -201,36 +359,79 @@ function createMonitor(options) {
     // opens, and a second attach mid-flight would start a session the first one
     // is about to replace.
     if (attaching) return attaching;
+    const startedNonnative = !native;
+    const attachIntent = transportIntent;
+    const epoch = (attachmentEpoch += 1);
     attaching = (async () => {
       try {
         const answer = await api.playbackAttach(place, Math.round(position));
+        if (epoch !== attachmentEpoch) return false;
         const choice = readChoice(answer);
+        if (choice.native && startedNonnative) capturePreviewTransport();
         native = choice.native;
         lastPlace = native ? place : null;
         if (native) {
-          // The stacked elements are not what is on screen any more, and every
-          // one of them holds a decoder.
-          preview.pause();
-          preview.clear();
-          preview.clearExact();
+          const snapshotPosition = position;
+          const snapshotPlaying = playing;
+          const intentChanged = attachIntent !== transportIntent;
+          const replacementHasUnacknowledgedTransport =
+            startedNonnative &&
+            !previewOwnsTimeline &&
+            transportAcknowledged < transportIntent;
+          const needsSnapshot =
+            transportNeedsSnapshot ||
+            (startedNonnative && snapshotPlaying) ||
+            replacementHasUnacknowledgedTransport;
+          if (!needsSnapshot && !intentChanged && answer.status) {
+            takeForEpoch(answer.status, epoch);
+          }
+          if (timelineMode()) {
+            // The stacked timeline elements are not what is on screen any
+            // more, and every one of them holds a decoder. An asset preview is
+            // still a media element on both engines and must keep playing.
+            preview.pause();
+            preview.clear();
+            preview.clearExact();
+          } else if (typeof preview.clearTimeline === 'function') {
+            preview.clearTimeline();
+          }
+          previewOwnsTimeline = false;
+          if (needsSnapshot) {
+            scheduleTransportSnapshot(snapshotPosition, snapshotPlaying);
+          } else if (
+            transportPending === 0 &&
+            transportAcknowledged < transportIntent &&
+            transportCommand
+          ) {
+            void scheduleTransport(transportCommand);
+          }
+        } else {
+          handTimelineToPreview();
         }
         lastVisible = null;
         syncVisibility();
         if (onNotice) onNotice(choice.notice);
         return native;
       } catch (error) {
-        native = false;
+        if (epoch !== attachmentEpoch) return false;
+        if (startedNonnative) {
+          native = false;
+          handTimelineToPreview();
+        }
         if (onNotice) onNotice(String(error));
-        return false;
+        return native;
       } finally {
-        attaching = null;
+        if (epoch === attachmentEpoch) attaching = null;
       }
     })();
     return attaching;
   }
 
   async function release() {
-    if (!api || !api.available) return;
+    // Forget an attach immediately. Its native answer can arrive after the
+    // release command, but it belongs to the session the page just discarded.
+    attachmentEpoch += 1;
+    attaching = null;
     native = false;
     // Including a want that was still waiting for room. Releasing is the page
     // saying it does not have a monitor any more, and the retry would hand it
@@ -238,22 +439,45 @@ function createMonitor(options) {
     attachWanted = false;
     lastPlace = null;
     lastVisible = null;
+    pendingVisibility = null;
     covered = false;
+    polling = 0;
+    pendingPlace = null;
+    // An already sent placement still belongs to the old backend session.
+    // Forget its queue owner so the replacement session can place itself now;
+    // the old completion checks both this promise identity and the epoch.
+    placing = null;
+    if (!api || !api.available) return;
+    if (releasing) return releasing;
+    const request = (async () => {
+      try {
+        await api.playbackRelease();
+      } catch (error) {
+        // Nothing to do about it and nothing depends on it: the session is
+        // already forgotten here, and dropping it is what its own thread does.
+      }
+    })();
+    releasing = request;
     try {
-      await api.playbackRelease();
-    } catch (error) {
-      // Nothing to do about it and nothing depends on it: the session is
-      // already forgotten here, and dropping it is what its own thread does.
+      await request;
+    } finally {
+      if (releasing === request) releasing = null;
     }
   }
 
   async function applyMediaRefresh() {
-    if (!mediaRefreshPending || refreshingMedia || currentlyPlaying()) return refreshingMedia;
+    if (!mediaRefreshPending || refreshingMedia) return refreshingMedia;
     mediaRefreshPending = false;
+    const epoch = attachmentEpoch;
+    const intent = transportIntent;
+    const acknowledged = transportAcknowledged;
     refreshingMedia = (async () => {
-      if (drivingNatively()) {
-        await release();
-        await attach();
+      // The backend waits for an in-flight attach before looking up the
+      // session. Calling while attach is pending matters: otherwise a proxy
+      // that becomes ready between the attach snapshot and its answer is lost.
+      if (api && api.available) {
+        const status = await api.playbackRefresh();
+        if (intent === transportIntent && intent <= acknowledged) takeForEpoch(status, epoch);
       }
       // Nothing for the media elements. Their pool is keyed by the path
       // `playbackPath` hands back, and the animation frame compares it on every
@@ -265,14 +489,10 @@ function createMonitor(options) {
       await refreshingMedia;
     } finally {
       refreshingMedia = null;
-      if (mediaRefreshPending && !currentlyPlaying()) {
+      if (mediaRefreshPending) {
         void applyMediaRefresh().catch(() => {});
       }
     }
-  }
-
-  function currentlyPlaying() {
-    return drivingNatively() ? playing : preview.isPlaying();
   }
 
   /** Tell Rust where the box is now, and whether there is still room for it.
@@ -281,13 +501,18 @@ function createMonitor(options) {
    *  one command per pixel the box actually moved rather than one per frame.
    *  Returns the box it measured, so the frame loop can use it again without a
    *  second layout read. */
-  async function flushPlace() {
-    while (pendingPlace) {
+  async function flushPlace(epoch) {
+    while (epoch === attachmentEpoch && pendingPlace) {
       const next = pendingPlace;
       pendingPlace = null;
       try {
         await api.playbackPlace(next);
+        if (epoch !== attachmentEpoch) {
+          lastPlace = null;
+          return;
+        }
       } catch (_error) {
+        if (epoch === attachmentEpoch && samePlace(lastPlace, next)) lastPlace = null;
         // A later frame will measure again. Placement failure must not stop
         // playback or leave an unhandled rejection in the page.
       }
@@ -297,10 +522,13 @@ function createMonitor(options) {
   function queuePlace(next) {
     pendingPlace = next;
     if (placing) return;
-    placing = flushPlace().finally(() => {
+    const epoch = attachmentEpoch;
+    const request = flushPlace(epoch).finally(() => {
+      if (placing !== request) return;
       placing = null;
       if (pendingPlace) queuePlace(pendingPlace);
     });
+    placing = request;
   }
 
   function place() {
@@ -328,16 +556,23 @@ function createMonitor(options) {
    *  answer cannot queue up behind itself. */
   function poll() {
     if (!drivingNatively() || polling) return;
-    polling = true;
+    const epoch = attachmentEpoch;
+    const intent = transportIntent;
+    const acknowledged = transportAcknowledged;
+    polling = epoch;
     api
       .playbackStatus()
       .then((status) => {
-        polling = false;
+        if (polling === epoch) polling = 0;
         if (!status) return;
-        take(status);
+        if (intent !== transportIntent) return;
+        // A poll started after a click can still outrun the native command.
+        // Ignore it until a later poll starts after that command answers.
+        if (intent > acknowledged) return;
+        takeForEpoch(status, epoch);
       })
       .catch(() => {
-        polling = false;
+        if (polling === epoch) polling = 0;
       });
   }
 
@@ -351,6 +586,11 @@ function createMonitor(options) {
     // Reaching the end stops the monitor on its own, and the page's play button
     // has to notice.
     if (wasPlaying && !playing && onTick) onTick(position, false);
+  }
+
+  function takeForEpoch(status, epoch) {
+    if (epoch !== attachmentEpoch) return;
+    take(status);
   }
 
   /** The box is re-measured on every animation frame, and `place()` compares
@@ -383,12 +623,12 @@ function createMonitor(options) {
     place,
     usesNativeMonitor: drivingNatively,
 
-    /** Use newly generated proxy paths without replacing a live decoder.
+    /** Use newly generated proxy paths without replacing the native session.
      *
      *  A native session captures its proxy map when it starts, while media
-     *  elements capture their paths when they are drawn. Replacing either
-     *  during playback stops the current stream, so defer the refresh until
-     *  playback is stopped. */
+     *  elements capture their paths when they are drawn. Rust prepares the new
+     *  native source while the old one keeps playing; media elements notice a
+     *  changed path in their animation pass without an explicit refresh. */
     refreshMedia() {
       mediaRefreshPending = true;
       return applyMediaRefresh();
@@ -421,31 +661,35 @@ function createMonitor(options) {
     },
 
     play() {
-      const start = () => {
-        if (!drivingNatively()) return preview.play();
-        if (total() <= 0) return;
-        if (position >= total()) position = 0;
-        playing = true;
-        if (onTick) onTick(position, true);
-        return api.playbackPlay().then(take).catch(() => {});
-      };
-      return mediaRefreshPending ? Promise.resolve(applyMediaRefresh()).then(start) : start();
+      if (!drivingNatively()) {
+        handTimelineToPreview();
+        const result = preview.play();
+        if (timelineMode()) {
+          const active = Math.max(Number(total()) || 0, 0) > 0;
+          rememberPreviewIntent(previewPosition(position), active);
+        }
+        return result;
+      }
+      if (total() <= 0) return;
+      if (position >= total()) position = 0;
+      transportIntent += 1;
+      playing = true;
+      if (onTick) onTick(position, true);
+      return scheduleTransport(() => api.playbackPlay());
     },
 
     async pause() {
       if (!drivingNatively()) {
-        await Promise.resolve(preview.pause());
-        await applyMediaRefresh();
+        handTimelineToPreview();
+        const result = preview.pause();
+        if (timelineMode()) rememberPreviewIntent(previewPosition(position), false);
+        await Promise.resolve(result);
         return;
       }
+      transportIntent += 1;
       playing = false;
       if (onTick) onTick(position, false);
-      try {
-        take(await api.playbackPause());
-      } catch (_error) {
-        return;
-      }
-      await applyMediaRefresh();
+      await scheduleTransport(() => api.playbackPause());
     },
 
     toggle() {
@@ -453,15 +697,25 @@ function createMonitor(options) {
     },
 
     isPlaying() {
-      return currentlyPlaying();
+      return drivingNatively() || (timelineMode() && !previewOwnsTimeline)
+        ? playing
+        : preview.isPlaying();
     },
 
     seek(frames) {
-      if (!drivingNatively()) return preview.seek(frames);
+      if (!drivingNatively()) {
+        handTimelineToPreview();
+        const result = preview.seek(frames);
+        if (timelineMode()) {
+          rememberPreviewIntent(boundedPosition(frames), previewPlaying(playing));
+        }
+        return result;
+      }
       const target = Math.max(0, Math.min(Math.round(frames), Math.max(total(), 0)));
+      transportIntent += 1;
       position = target;
       if (onTick) onTick(position, playing);
-      return api.playbackSeek(target).catch(() => {});
+      return scheduleTransport(() => api.playbackSeek(target));
     },
 
     /** The timeline changed under a stopped playhead. A playing one is left
@@ -477,7 +731,9 @@ function createMonitor(options) {
     },
 
     position() {
-      return drivingNatively() ? position : preview.position();
+      return drivingNatively() || (timelineMode() && !previewOwnsTimeline)
+        ? position
+        : preview.position();
     },
 
     total,
@@ -485,25 +741,45 @@ function createMonitor(options) {
     prune: preview.prune,
 
     clear() {
+      transportIntent += 1;
+      settleLocalTransport();
       position = 0;
       playing = false;
       preview.clear();
+      if (!native) previewOwnsTimeline = true;
     },
 
     showAsset(asset) {
+      const leavingTimeline = timelineMode();
+      if (leavingTimeline && !native) capturePreviewTransport();
+      if (leavingTimeline) {
+        transportIntent += 1;
+        playing = false;
+        if (native) {
+          void scheduleTransport(() => api.playbackPause());
+        } else {
+          transportNeedsSnapshot = true;
+        }
+      }
       // An asset preview is a media element in the page on both engines, so
       // the monitor stops playing *and* gets out of the way. Without the
       // second half the asset plays behind a native view still showing the
       // last timeline frame, because that view is over the webview.
-      if (native) api.playbackPause().catch(() => {});
       preview.showAsset(asset);
       syncVisibility();
     },
 
     showTimeline() {
+      transportIntent += 1;
       preview.showTimeline();
       position = 0;
       playing = false;
+      previewOwnsTimeline = !native;
+      if (native) {
+        queueTransportSnapshot(position, playing);
+      } else {
+        settleLocalTransport();
+      }
       place();
       syncVisibility();
     },

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -440,7 +440,7 @@ function createPreview(options) {
     }
   }
 
-  function clear() {
+  function clearTimeline() {
     for (const entry of pool.values()) {
       entry.element.pause && entry.element.pause();
       if (entry.kind === 'video' && qualityMonitor) qualityMonitor.unwatchVideo(entry.element);
@@ -448,6 +448,10 @@ function createPreview(options) {
       entry.element.remove();
     }
     pool.clear();
+  }
+
+  function clear() {
+    clearTimeline();
     positionFrames = 0;
     starting = false;
     playing = false;
@@ -556,6 +560,7 @@ function createPreview(options) {
     total: totalFrames,
     mode: () => mode,
     prune,
+    clearTimeline,
     clear,
     showAsset,
     showTimeline,

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -2046,10 +2046,16 @@ function persistSettings(settings = state.settings, callbacks) {
   return persistLatestSettings({ ...settings }, callbacks);
 }
 
+function persistSettingsInBackground() {
+  void persistSettings().catch((error) => {
+    reportError(error, 'settings:persist:callback');
+  });
+}
+
 function toggleSnap() {
   state.settings.snap = !state.settings.snap;
   dom.btnMagnet.classList.toggle('on', state.settings.snap);
-  void persistSettings();
+  persistSettingsInBackground();
 }
 
 // --- dragging clips --------------------------------------------------------
@@ -3425,7 +3431,7 @@ function wireTransport() {
   dom.previewQuality.addEventListener('change', () => {
     state.settings.previewQuality = dom.previewQuality.value;
     preview.setQuality(state.settings.previewQuality);
-    void persistSettings();
+    persistSettingsInBackground();
   });
   dom.stage.addEventListener('wheel', (event) => {
     if (!event.metaKey) return;

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -245,6 +245,34 @@ let visualDrag = null;
 let editorOverlayActive = false;
 let stageResizeObserver = null;
 
+const persistLatestSettings = globalThis.latestLib.createLatestPersistence({
+  save: (settings) => window.api.saveSettings(settings),
+  optimistic: (settings) => {
+    // Every settings entry point contributes to the next full snapshot. A
+    // toolbar click during a slow sheet save must not silently drop the sheet
+    // fields simply because its backend answer is still pending.
+    state.settings = { ...settings };
+  },
+  confirmed: () => state.boot,
+  recover: () => window.api.bootstrap(),
+  confirm: async (boot) => {
+    state.boot = boot;
+    await applySettings(boot.settings);
+    updateToolWarning();
+  },
+  restore: (boot) => {
+    state.boot = boot;
+    return applySettings(boot.settings);
+  },
+  fail: async (error) => {
+    reportError(error, 'settings:persist');
+    await window.api.message(`That setting could not be saved.\n\n${error}`, {
+      title: 'Settings',
+      kind: 'error',
+    });
+  },
+});
+
 // --- helpers ---------------------------------------------------------------
 
 function errorText(error) {
@@ -1220,7 +1248,8 @@ function editorOverlayWanted() {
   return Boolean(
     preview &&
     preview.mode() === 'timeline' &&
-    (G.visible(state.settings) || (state.selectedVisualItemId && !preview.isPlaying()))
+    ((G.visible(state.settings) && !preview.usesNativeMonitor()) ||
+      (state.selectedVisualItemId && !preview.isPlaying()))
   );
 }
 
@@ -1240,7 +1269,8 @@ function syncEditorOverlay() {
 function renderStageOverlay() {
   const canvas = dom.stageOverlay;
   const item = selectedVisualItem();
-  const showGuides = G.visible(state.settings);
+  const showGuides = G.visible(state.settings) &&
+    (!preview || !preview.usesNativeMonitor());
   if (!canvas || (!item && !showGuides)) {
     if (canvas) canvas.width = 0;
     return;
@@ -2007,32 +2037,19 @@ async function setClipLut(clipId) {
  *
  *  These are one-click toggles, so blocking on the write would make the button
  *  feel slow for something that has already visibly happened. What must not
- *  happen is an unhandled rejection: the toggle is put back and the reason is
- *  shown, so a setting that did not persist does not silently look as though it
- *  did. `bootstrap` is the source of truth on the next launch either way.
+ *  happen is an unhandled rejection: the whole toolbar is put back to the last
+ *  backend-confirmed boot settings and the reason is shown. An earlier
+ *  optimistic value may itself have been superseded, so it is not a rollback
+ *  point. `bootstrap` is the source of truth on the next launch either way.
  */
-async function persistSettings(revert) {
-  try {
-    state.boot = await window.api.saveSettings(state.settings);
-    state.settings = state.boot.settings;
-  } catch (error) {
-    reportError(error, 'settings:persist');
-    if (revert) revert();
-    await window.api.message(`That setting could not be saved.\n\n${error}`, {
-      title: 'Settings',
-      kind: 'error',
-    });
-  }
+function persistSettings(settings = state.settings, callbacks) {
+  return persistLatestSettings({ ...settings }, callbacks);
 }
 
 function toggleSnap() {
-  const previous = state.settings.snap;
-  state.settings.snap = !previous;
+  state.settings.snap = !state.settings.snap;
   dom.btnMagnet.classList.toggle('on', state.settings.snap);
-  persistSettings(() => {
-    state.settings.snap = previous;
-    dom.btnMagnet.classList.toggle('on', previous);
-  });
+  void persistSettings();
 }
 
 // --- dragging clips --------------------------------------------------------
@@ -2821,13 +2838,13 @@ function accelerationNote() {
   return `No usable hardware encoder. ${reasons}`;
 }
 
-/** Whether the setting says to stay off the graphics device.
+/** Whether the setting says to composite the project frame on the CPU.
  *
  *  Mirrors `stays_on_cpu` in Rust, and for the same reason: this one answer
- *  decides the exact frame, the playback engine and the render, and asking the
- *  question three different ways is how those three drift apart. Only "cpu" is
- *  cpu — a settings file written before this was two choices can still hold
- *  "auto" or "ffmpeg", and both of those meant the graphics device. */
+ *  decides the exact frame and the render, and asking the question in several
+ *  places is how those answers drift apart. The native monitor stays attached
+ *  for both choices; CPU composition still uploads its finished picture to the
+ *  display. Only "cpu" is cpu — older "auto" and "ffmpeg" values mean GPU. */
 function staysOnCpu() {
   return state.settings.compositor === 'cpu';
 }
@@ -2839,7 +2856,10 @@ function staysOnCpu() {
 function compositorNote(setting) {
   const found = (state.boot && state.boot.compositor) || {};
   if (setting === 'cpu') {
-    return 'Nothing opens the graphics device. Playback is stacked <video> elements, the exact frame is not asked for, and the render is drawn by the ffmpeg filter graph. ffmpeg is still what decodes and encodes either way.';
+    if (state.playbackNotice) {
+      return `The CPU combines the layers, but the native monitor could not start: ${state.playbackNotice}. The older preview is playing instead.`;
+    }
+    return 'The CPU combines the layers while the native monitor keeps playing. A graphics device only displays the finished picture; ffmpeg still decodes, renders and encodes.';
   }
   const both =
     'The stage and the render come out of the same shader, so what is on screen is what lands in the file. Playback draws straight onto a surface in the window with the audio clock deciding when.';
@@ -2882,8 +2902,8 @@ async function fillGraphicsDevices() {
     select.appendChild(new Option(`${chosen} — not on this machine`, chosen));
   }
   select.value = chosen;
-  // The sheet's own pending choice, not the saved one. Picking CPU should grey
-  // this out at once rather than after Apply.
+  // The sheet's own pending choice, not the saved one. CPU composition uses an
+  // automatic presentation device, so there is no compositor device to pick.
   const onCpu = el('as-compositor').value === 'cpu';
   select.disabled = onCpu;
   const drawing = (state.boot && state.boot.compositor && state.boot.compositor.device) || 'nothing yet';
@@ -2892,8 +2912,8 @@ async function fillGraphicsDevices() {
     return;
   }
   note.textContent = onCpu
-    ? 'The CPU setting never opens a graphics device, so this is not used.'
-    : `Drawing on ${drawing}. Changing this restarts the monitor.`;
+    ? 'The CPU combines the frame; an automatic graphics device only displays the result.'
+    : `Drawing on ${drawing}. A change switches after the replacement picture is ready.`;
 }
 
 function fillAppSheet() {
@@ -2982,12 +3002,9 @@ function collectShortcutOverrides() {
 }
 
 function applySettings(next) {
-  const wasCompositor = state.settings.compositor;
-  const wasDevice = state.settings.gpuDevice;
-  const wasPreviewQuality = state.settings.previewQuality;
-  const usedProxies = state.settings.proxyEnabled;
-  const usedGuides = G.visible(state.settings);
-  state.settings = next;
+  // Never alias state.boot.settings: toolbar changes are optimistic, while the
+  // boot copy is the last backend-confirmed rollback point.
+  state.settings = { ...next };
   renderShortcutLabels();
   preview.setQuality(next.previewQuality);
   preview.setMuteWhileScrubbing(next.previewMuteWhileScrubbing);
@@ -2995,34 +3012,19 @@ function applySettings(next) {
   dom.btnMagnet.classList.toggle('on', next.snap);
   syncEditorOverlay();
   renderStageOverlay();
-  // A session captures its compositor and its engine when it starts, so both of
-  // the things this setting decides need the running one taken down and asked
-  // for again rather than hoping the next command notices.
-  //
-  // This is also what attaches the first time. The page's own compositor value
-  // is not one the setting can hold, so bootstrap landing *is* a change and
-  // lands here — which is why there is no separate attach after it.
-  let monitorUpdate = null;
-  if (
-    wasCompositor !== next.compositor ||
-    wasDevice !== next.gpuDevice ||
-    wasPreviewQuality !== next.previewQuality
-  ) {
-    monitorUpdate = attachMonitor(true);
-  } else if (usedGuides !== G.visible(next)) {
-    monitorUpdate = attachMonitor(true);
-  } else if (usedProxies !== next.proxyEnabled) {
-    if (preview.usesNativeMonitor()) monitorUpdate = attachMonitor(true);
-    else preview.redraw();
-  }
-  return monitorUpdate || Promise.resolve();
+  drawStageVisuals();
+  // Rust applies settings to an active session before saveSettings returns.
+  // The idempotent attach is only needed when there is no native monitor yet,
+  // including the first bootstrap and a change away from media elements.
+  if (!preview.usesNativeMonitor()) return attachMonitor(false);
+  return Promise.resolve();
 }
 
 /** Ask Rust for a monitor, or give the one that is running a new box.
  *
  *  Called when a project opens, when the playback setting changes and when the
- *  window settles after a layout. `restart` takes down whatever is there first,
- *  which is what a settings change needs and a resize must not do. */
+ *  window settles after a layout. `restart` is reserved for a different
+ *  project; settings are reconfigured inside the running Rust session. */
 async function attachMonitor(restart) {
   if (!preview) return;
   if (restart) {
@@ -3030,6 +3032,11 @@ async function attachMonitor(restart) {
     await preview.release();
   }
   await preview.attach();
+  // Attaching decides whether guides belong to Rust or the page. Re-evaluate
+  // after the answer so native guides never leave the surface hidden behind an
+  // exact DOM frame, while a media-element fallback still draws them here.
+  syncEditorOverlay();
+  renderStageOverlay();
   updateToolWarning();
   updateMonitorZoomUi();
   // Which engine is running decides who draws the text and shape layers, and
@@ -3416,16 +3423,9 @@ function wireTransport() {
   let monitorPan = null;
   dom.btnPlay.addEventListener('click', () => preview.toggle());
   dom.previewQuality.addEventListener('change', () => {
-    const previous = state.settings.previewQuality;
     state.settings.previewQuality = dom.previewQuality.value;
     preview.setQuality(state.settings.previewQuality);
-    void persistSettings(() => {
-      state.settings.previewQuality = previous;
-      dom.previewQuality.value = previous;
-      preview.setQuality(previous);
-    }).then(() => {
-      if (preview.usesNativeMonitor()) return attachMonitor(true);
-    });
+    void persistSettings();
   });
   dom.stage.addEventListener('wheel', (event) => {
     if (!event.metaKey) return;
@@ -3529,18 +3529,15 @@ function wireSheets() {
       logRotationUnit: el('as-log-unit').value,
     });
     closeSheet('app-settings');
-    try {
-      state.boot = await window.api.saveSettings(next);
-    } catch (error) {
-      reportError(error, 'settings:save');
-      await window.api.message(`Those settings could not be saved.\n\n${error}`, {
-        title: 'Settings',
-        kind: 'error',
-      });
-      return;
-    }
-    applySettings(state.boot.settings);
-    updateToolWarning();
+    await persistSettings(next, {
+      fail: async (error) => {
+        reportError(error, 'settings:save');
+        await window.api.message(`Those settings could not be saved.\n\n${error}`, {
+          title: 'Settings',
+          kind: 'error',
+        });
+      },
+    });
   });
   el('shortcut-save').addEventListener('click', async () => {
     const error = el('shortcut-error');
@@ -3552,16 +3549,14 @@ function wireSheets() {
       error.hidden = false;
       return;
     }
-    try {
-      state.boot = await window.api.saveSettings(Object.assign({}, state.settings, { shortcutOverrides }));
-    } catch (cause) {
-      reportError(cause, 'settings:shortcuts');
-      error.textContent = `Those shortcuts could not be saved. ${cause}`;
-      error.hidden = false;
-      return;
-    }
-    closeSheet('shortcut-settings');
-    applySettings(state.boot.settings);
+    await persistSettings(Object.assign({}, state.settings, { shortcutOverrides }), {
+      confirm: () => closeSheet('shortcut-settings'),
+      fail: (cause) => {
+        reportError(cause, 'settings:shortcuts');
+        error.textContent = `Those shortcuts could not be saved. ${cause}`;
+        error.hidden = false;
+      },
+    });
   });
   el('proxy-generate').addEventListener('click', async () => {
     if (!state.path) return;
@@ -3580,17 +3575,15 @@ function wireSheets() {
       proxyEnabled: el('proxy-enabled').checked,
     });
     closeSheet('proxy-settings');
-    try {
-      state.boot = await window.api.saveSettings(next);
-    } catch (error) {
-      reportError(error, 'settings:proxy');
-      await window.api.message(`The proxy setting could not be saved.\n\n${error}`, {
-        title: 'Proxy Media',
-        kind: 'error',
-      });
-      return;
-    }
-    applySettings(state.boot.settings);
+    await persistSettings(next, {
+      fail: async (error) => {
+        reportError(error, 'settings:proxy');
+        await window.api.message(`The proxy setting could not be saved.\n\n${error}`, {
+          title: 'Proxy Media',
+          kind: 'error',
+        });
+      },
+    });
   });
   el('as-workspace-pick').addEventListener('click', async () => {
     const folder = await window.api.pickFolder('Workspace folder');
@@ -3716,7 +3709,6 @@ async function boot() {
     wrap: dom.stageWrap,
     api: window.api,
     getProject: () => state.project,
-    pageOverlayActive: () => G.visible(state.settings),
     onNotice: (reason) => {
       state.playbackNotice = reason;
       updateToolWarning();

--- a/product/akbun-makevideo/workspace/test/latest.test.js
+++ b/product/akbun-makevideo/workspace/test/latest.test.js
@@ -1,0 +1,272 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { createLatestRequest, createLatestPersistence } = require('../src/latest.js');
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+test('an older superseded failure cannot revert or notify', async () => {
+  const latest = createLatestRequest();
+  const old = deferred();
+  const current = deferred();
+  const applied = [];
+  const failures = [];
+
+  const oldRun = latest(
+    () => old.promise,
+    (value) => applied.push(value),
+    (error) => failures.push(error.message),
+  );
+  const currentRun = latest(
+    () => current.promise,
+    (value) => applied.push(value),
+    (error) => failures.push(error.message),
+  );
+
+  old.reject(new Error('superseded'));
+  assert.strictEqual(await oldRun, false);
+  assert.deepStrictEqual(applied, []);
+  assert.deepStrictEqual(failures, []);
+
+  current.resolve('latest settings');
+  assert.strictEqual(await currentRun, true);
+  assert.deepStrictEqual(applied, ['latest settings']);
+  assert.deepStrictEqual(failures, []);
+});
+
+test('an older success cannot replace the latest settings state', async () => {
+  const latest = createLatestRequest();
+  const old = deferred();
+  const current = deferred();
+  const applied = [];
+
+  const oldRun = latest(
+    () => old.promise,
+    (value) => applied.push(value),
+    () => assert.fail('the old request succeeded'),
+  );
+  const currentRun = latest(
+    () => current.promise,
+    (value) => applied.push(value),
+    () => assert.fail('the latest request succeeded'),
+  );
+
+  old.resolve('old settings');
+  assert.strictEqual(await oldRun, false);
+  assert.deepStrictEqual(applied, []);
+
+  current.resolve('latest settings');
+  assert.strictEqual(await currentRun, true);
+  assert.deepStrictEqual(applied, ['latest settings']);
+});
+
+test('only the latest failure runs its revert and notice path', async () => {
+  const latest = createLatestRequest();
+  const failures = [];
+
+  const applied = await latest(
+    async () => {
+      throw new Error('cannot save');
+    },
+    () => assert.fail('a failed save cannot succeed'),
+    (error) => failures.push(error.message),
+  );
+
+  assert.strictEqual(applied, true);
+  assert.deepStrictEqual(failures, ['cannot save']);
+});
+
+function settingsHarness(initial) {
+  let confirmed = { ...initial };
+  let ui = { ...initial };
+  const requests = [];
+  const failures = [];
+  const persist = createLatestPersistence({
+    save: (settings) => {
+      const waiting = deferred();
+      requests.push({ settings, waiting });
+      return waiting.promise;
+    },
+    confirmed: () => confirmed,
+    optimistic: (settings) => {
+      ui = { ...settings };
+    },
+    confirm: (settings) => {
+      confirmed = { ...settings };
+      ui = { ...settings };
+    },
+    restore: (settings) => {
+      ui = { ...settings };
+    },
+    fail: (error) => failures.push(error.message),
+  });
+  return {
+    change(patch) {
+      ui = { ...ui, ...patch };
+      return persist({ ...ui });
+    },
+    confirmed: () => confirmed,
+    ui: () => ui,
+    requests,
+    failures,
+  };
+}
+
+test('quality then snap rollback together to the last confirmed settings', async () => {
+  const initial = { previewQuality: 'full', snap: false };
+  const settings = settingsHarness(initial);
+
+  const quality = settings.change({ previewQuality: 'half' });
+  const snap = settings.change({ snap: true });
+  assert.deepStrictEqual(settings.requests.map((request) => request.settings), [
+    { previewQuality: 'half', snap: false },
+    { previewQuality: 'half', snap: true },
+  ]);
+
+  settings.requests[0].waiting.reject(new Error('superseded'));
+  assert.strictEqual(await quality, false);
+  settings.requests[1].waiting.reject(new Error('latest failed'));
+  assert.strictEqual(await snap, true);
+
+  assert.deepStrictEqual(settings.confirmed(), initial);
+  assert.deepStrictEqual(settings.ui(), initial);
+  assert.deepStrictEqual(settings.failures, ['latest failed']);
+});
+
+test('a late quality success does not move the confirmed rollback point', async () => {
+  const initial = { previewQuality: 'full', snap: false };
+  const settings = settingsHarness(initial);
+
+  const half = settings.change({ previewQuality: 'half' });
+  const quarter = settings.change({ previewQuality: 'quarter' });
+  settings.requests[0].waiting.resolve({ previewQuality: 'half', snap: false });
+  assert.strictEqual(await half, false);
+  assert.deepStrictEqual(settings.confirmed(), initial);
+  assert.deepStrictEqual(settings.ui(), { previewQuality: 'quarter', snap: false });
+
+  settings.requests[1].waiting.reject(new Error('quarter failed'));
+  assert.strictEqual(await quarter, true);
+  assert.deepStrictEqual(settings.confirmed(), initial);
+  assert.deepStrictEqual(settings.ui(), initial);
+});
+
+test('all settings callers share latest-wins while keeping their own failure UI', async () => {
+  const requests = [];
+  const failures = [];
+  let confirmed = { previewQuality: 'full', proxyEnabled: false };
+  let ui = { ...confirmed };
+  const persist = createLatestPersistence({
+    save: (settings) => {
+      const waiting = deferred();
+      requests.push({ settings, waiting });
+      return waiting.promise;
+    },
+    confirmed: () => confirmed,
+    optimistic: (settings) => {
+      ui = { ...settings };
+    },
+    confirm: (settings) => {
+      confirmed = { ...settings };
+      ui = { ...settings };
+    },
+    restore: (settings) => {
+      ui = { ...settings };
+    },
+  });
+
+  const toolbar = persist({ ...ui, previewQuality: 'half' }, {
+    fail: () => failures.push('toolbar'),
+  });
+  const sheet = persist({ ...ui, proxyEnabled: true }, {
+    fail: () => failures.push('sheet'),
+  });
+
+  requests[0].waiting.reject(new Error('superseded'));
+  assert.strictEqual(await toolbar, false);
+  requests[1].waiting.resolve({ previewQuality: 'half', proxyEnabled: true });
+  assert.strictEqual(await sheet, true);
+  assert.deepStrictEqual(confirmed, { previewQuality: 'half', proxyEnabled: true });
+  assert.deepStrictEqual(ui, confirmed);
+  assert.deepStrictEqual(failures, []);
+});
+
+test('a request superseded during confirm cannot run its caller callback', async () => {
+  const oldSave = deferred();
+  const currentSave = deferred();
+  const oldConfirm = deferred();
+  const callbacks = [];
+  let saves = 0;
+  let confirmed = 'initial';
+  const persist = createLatestPersistence({
+    save: () => {
+      saves += 1;
+      return saves === 1 ? oldSave.promise : currentSave.promise;
+    },
+    confirmed: () => confirmed,
+    confirm: async (value) => {
+      confirmed = value;
+      if (value === 'old') await oldConfirm.promise;
+    },
+    restore: () => {},
+  });
+
+  const old = persist('old', { confirm: () => callbacks.push('old') });
+  oldSave.resolve('old');
+  await Promise.resolve();
+  const current = persist('current', { confirm: () => callbacks.push('current') });
+  currentSave.resolve('current');
+  assert.strictEqual(await current, true);
+  oldConfirm.resolve();
+  assert.strictEqual(await old, false);
+
+  assert.deepStrictEqual(callbacks, ['current']);
+});
+
+test('latest failure restores the backend checkpoint an older success committed', async () => {
+  const oldSave = deferred();
+  const currentSave = deferred();
+  let saves = 0;
+  let localConfirmed = 'initial';
+  let backendConfirmed = 'initial';
+  let ui = 'initial';
+  const persist = createLatestPersistence({
+    save: () => {
+      saves += 1;
+      return saves === 1 ? oldSave.promise : currentSave.promise;
+    },
+    optimistic: (value) => {
+      ui = value;
+    },
+    confirmed: () => localConfirmed,
+    recover: async () => backendConfirmed,
+    confirm: (value) => {
+      localConfirmed = value;
+      ui = value;
+    },
+    restore: (value) => {
+      localConfirmed = value;
+      ui = value;
+    },
+  });
+
+  const old = persist('A');
+  const current = persist('B');
+  backendConfirmed = 'A';
+  oldSave.resolve('A');
+  assert.strictEqual(await old, false);
+  currentSave.reject(new Error('B failed'));
+  assert.strictEqual(await current, true);
+
+  assert.strictEqual(localConfirmed, 'A');
+  assert.strictEqual(ui, 'A');
+});

--- a/product/akbun-makevideo/workspace/test/monitor.test.js
+++ b/product/akbun-makevideo/workspace/test/monitor.test.js
@@ -70,8 +70,68 @@ test('the native monitor yields to the editor-only selection pass', async () => 
   assert.deepStrictEqual(visibility, [true, false, true]);
 });
 
+test('a rejected visibility change is retried while the same cover remains', async () => {
+  const visibility = [];
+  let rejectedHide = false;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({ mode: () => 'timeline', total: () => 1 }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async (visible) => {
+        visibility.push(visible);
+        if (!visible && !rejectedHide) {
+          rejectedHide = true;
+          throw new Error('view was being replaced');
+        }
+      },
+    },
+  });
+
+  await monitor.attach();
+  monitor.setVisible(false);
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.place();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(visibility, [true, false, false]);
+});
+
+test('visibility changes reach the backend in the order the page chose them', async () => {
+  const visibility = [];
+  let finishHide;
+  const hideAnswer = new Promise((resolve) => {
+    finishHide = resolve;
+  });
+  const monitor = createMonitor({
+    preview: strictPreviewStub({ mode: () => 'timeline', total: () => 1 }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: (visible) => {
+        visibility.push(visible);
+        return visible || visibility.length === 1 ? Promise.resolve() : hideAnswer;
+      },
+    },
+  });
+
+  await monitor.attach();
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.setVisible(false);
+  monitor.setVisible(true);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepStrictEqual(visibility, [true, false]);
+
+  finishHide();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepStrictEqual(visibility, [true, false, true]);
+});
+
 test('a page overlay keeps the preview in the webview', async () => {
   let attached = 0;
+  let released = 0;
   const seeks = [];
   let overlayActive = false;
   const monitor = createMonitor({
@@ -90,6 +150,9 @@ test('a page overlay keeps the preview in the webview', async () => {
         attached += 1;
         return { engine: 'native' };
       },
+      playbackRelease: async () => {
+        released += 1;
+      },
       playbackSeek: async () => {},
       playbackVisible: async () => {},
     },
@@ -97,10 +160,12 @@ test('a page overlay keeps the preview in the webview', async () => {
   });
 
   await monitor.attach();
-  monitor.seek(1);
+  await monitor.seek(1);
   overlayActive = true;
   assert.strictEqual(await monitor.attach(), false);
   assert.strictEqual(attached, 1);
+  assert.strictEqual(released, 1);
+  assert.strictEqual(monitor.usesNativeMonitor(), false);
   assert.deepStrictEqual(seeks, [1]);
 });
 
@@ -209,6 +274,33 @@ test('the same box twice is one command, so a drag is not a command per frame', 
   assert.strictEqual(places.length, 1);
 });
 
+test('a rejected placement is retried for the unchanged box', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  let attempts = 0;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({ mode: () => 'timeline', total: () => 1 }),
+    wrap: panel.element,
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async () => {},
+      playbackPlace: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('surface was busy');
+      },
+    },
+  });
+
+  await monitor.attach();
+  panel.moveTo(100, 0);
+  monitor.place();
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.place();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(attempts, 2);
+});
+
 test('a backing scale change places the unchanged viewport again', async () => {
   const previousWindow = global.window;
   global.window = { devicePixelRatio: 1 };
@@ -268,6 +360,46 @@ test('slow native placement keeps only the newest measured box', async () => {
   await new Promise((resolve) => setImmediate(resolve));
   assert.strictEqual(places.length, 2);
   assert.strictEqual(places[1].stage.x - attachedAt.stage.x, 300);
+});
+
+test('release discards an old pending placement before the replacement attach', async () => {
+  const panel = movablePanel({ left: 0, top: 0, width: 640, height: 360 });
+  const places = [];
+  let finishFirst;
+  const firstPlace = new Promise((resolve) => {
+    finishFirst = resolve;
+  });
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 1,
+    }),
+    wrap: panel.element,
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackRelease: async () => {},
+      playbackVisible: async () => {},
+      playbackPlace: async (place) => {
+        places.push(place);
+        if (places.length === 1) await firstPlace;
+      },
+    },
+  });
+
+  await monitor.attach();
+  panel.moveTo(100, 0);
+  monitor.place();
+  panel.moveTo(200, 0);
+  monitor.place();
+
+  await monitor.release();
+  panel.moveTo(300, 0);
+  await monitor.attach();
+  finishFirst();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(places.length, 1);
 });
 
 test('the placement keeps the project shape as the panel changes', async () => {
@@ -331,7 +463,47 @@ test('a panel dragged shut takes the view off screen, and reopening puts it back
 
   panel.resizeTo(640, 360);
   monitor.place();
+  await new Promise((resolve) => setImmediate(resolve));
   assert.deepStrictEqual(visibility, [true, false, true]);
+});
+
+test('a stale visibility command is corrected on the replacement session', async () => {
+  let finishHidden;
+  const hiddenAnswer = new Promise((resolve) => {
+    finishHidden = resolve;
+  });
+  let delayedHidden = true;
+  const visibility = [];
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 1,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackRelease: async () => {},
+      playbackVisible: (visible) => {
+        visibility.push(visible);
+        if (!visible && delayedHidden) {
+          delayedHidden = false;
+          return hiddenAnswer;
+        }
+        return Promise.resolve();
+      },
+    },
+  });
+
+  await monitor.attach();
+  monitor.setVisible(false);
+  await monitor.release();
+  await monitor.attach();
+  finishHidden();
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.place();
+
+  assert.deepStrictEqual(visibility, [true, false, true, true]);
 });
 
 // A panel with no room in it used to be a permanent fallback to the media
@@ -367,6 +539,1097 @@ test('an attach with no room to draw in is finished once there is', async () => 
   panel.resizeTo(640, 360);
   assert.strictEqual(await monitor.attach(), true);
   assert.strictEqual(attached, 1);
+});
+
+test('release invalidates a late native attach answer', async () => {
+  let answerAttach;
+  const attachAnswer = new Promise((resolve) => {
+    answerAttach = resolve;
+  });
+  const mediaCalls = [];
+  const notices = [];
+  const monitor = createMonitor({
+    preview: {
+      mode: () => 'timeline',
+      total: () => 1,
+      pause: () => mediaCalls.push('pause'),
+      clear: () => mediaCalls.push('clear'),
+      clearExact: () => mediaCalls.push('clearExact'),
+    },
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: () => attachAnswer,
+      playbackRelease: async () => {},
+      playbackVisible: async () => {},
+    },
+    onNotice: (notice) => notices.push(notice),
+  });
+
+  const pendingAttach = monitor.attach();
+  await monitor.release();
+  answerAttach({ engine: 'native', fellBack: 'late answer' });
+
+  assert.strictEqual(await pendingAttach, false);
+  assert.strictEqual(monitor.usesNativeMonitor(), false);
+  assert.deepStrictEqual(mediaCalls, []);
+  assert.deepStrictEqual(notices, []);
+});
+
+test('concurrent releases share one backend release before a new attach', async () => {
+  let finishRelease;
+  const releaseAnswer = new Promise((resolve) => {
+    finishRelease = resolve;
+  });
+  let attached = 0;
+  let released = 0;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 1,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => {
+        attached += 1;
+        return { engine: 'native' };
+      },
+      playbackRelease: () => {
+        released += 1;
+        return releaseAnswer;
+      },
+      playbackVisible: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  const first = monitor.release();
+  const second = monitor.release();
+  assert.strictEqual(released, 1);
+  finishRelease();
+  await Promise.all([first, second]);
+  await monitor.attach();
+
+  assert.strictEqual(attached, 2);
+  assert.strictEqual(monitor.usesNativeMonitor(), true);
+});
+
+test('an idempotent native attach adopts backend status when no input raced it', async () => {
+  let attaches = 0;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => 0,
+      isPlaying: () => false,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => {
+        attaches += 1;
+        return attaches === 1
+          ? { engine: 'native', status: { position: 12, playing: true } }
+          : { engine: 'native', status: { position: 19, playing: false } };
+      },
+      playbackVisible: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  assert.strictEqual(monitor.position(), 12);
+  assert.strictEqual(monitor.isPlaying(), true);
+  await monitor.attach();
+  assert.strictEqual(monitor.position(), 19);
+  assert.strictEqual(monitor.isPlaying(), false);
+});
+
+test('a rejected idempotent attach keeps the existing native session as the only owner', async () => {
+  let attaches = 0;
+  const mediaSeeks = [];
+  let mediaPlays = 0;
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => 0,
+      isPlaying: () => false,
+      seek: (target) => mediaSeeks.push(target),
+      play: () => {
+        mediaPlays += 1;
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => {
+        attaches += 1;
+        if (attaches === 2) throw new Error('placement request failed');
+        return { engine: 'native', status: { ...backend } };
+      },
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => {
+        backend.position = target;
+        return { ...backend };
+      },
+      playbackPlay: async () => {
+        backend.playing = true;
+        return { ...backend };
+      },
+    },
+  });
+
+  await monitor.attach();
+  await monitor.seek(42);
+  await monitor.play();
+
+  assert.strictEqual(await monitor.attach(), true);
+  assert.strictEqual(monitor.usesNativeMonitor(), true);
+  assert.strictEqual(monitor.position(), 42);
+  assert.strictEqual(monitor.isPlaying(), true);
+  assert.deepStrictEqual(mediaSeeks, []);
+  assert.strictEqual(mediaPlays, 0);
+});
+
+test('an idempotent timeline attach does not stop the asset preview', async () => {
+  let mode = 'timeline';
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => mode,
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      seek: (target) => {
+        mediaPosition = target;
+      },
+      play: () => {
+        mediaPlaying = true;
+      },
+      pause: () => {
+        mediaPlaying = false;
+      },
+      clear: () => {
+        mediaPosition = 0;
+        mediaPlaying = false;
+      },
+      showAsset: () => {
+        mode = 'asset';
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({
+        engine: 'native',
+        status: { position: 0, playing: false },
+      }),
+      playbackVisible: async () => {},
+      playbackPause: async () => ({ position: 0, playing: false }),
+    },
+  });
+
+  await monitor.attach();
+  monitor.showAsset({ id: 'asset' });
+  monitor.seek(37);
+  monitor.play();
+  await monitor.attach();
+
+  assert.strictEqual(monitor.position(), 37);
+  assert.strictEqual(monitor.isPlaying(), true);
+  assert.deepStrictEqual({ position: mediaPosition, playing: mediaPlaying }, {
+    position: 37,
+    playing: true,
+  });
+});
+
+test('an asset preview cannot restart a paused fallback timeline during native attach', async () => {
+  let mode = 'timeline';
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  let attaches = 0;
+  let clearedTimeline = 0;
+  const calls = [];
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => mode,
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      seek: (target) => {
+        mediaPosition = target;
+      },
+      play: () => {
+        mediaPlaying = true;
+      },
+      pause: () => {
+        mediaPlaying = false;
+      },
+      showAsset: () => {
+        mediaPlaying = false;
+        mediaPosition = 0;
+        mode = 'asset';
+      },
+      clearTimeline: () => {
+        clearedTimeline += 1;
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async (_place, frame) => {
+        attaches += 1;
+        if (attaches === 1) return { engine: 'media-element' };
+        backend.position = frame;
+        backend.playing = false;
+        return { engine: 'native', status: { ...backend } };
+      },
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => {
+        calls.push(`seek:${target}`);
+        backend.position = target;
+        return { ...backend };
+      },
+      playbackPlay: async () => {
+        calls.push('play');
+        backend.playing = true;
+        return { ...backend };
+      },
+      playbackPause: async () => {
+        calls.push('pause');
+        backend.playing = false;
+        return { ...backend };
+      },
+    },
+  });
+
+  assert.strictEqual(await monitor.attach(), false);
+  monitor.seek(12);
+  monitor.play();
+  monitor.showAsset({ id: 'asset' });
+  assert.strictEqual(await monitor.attach(), true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(calls, ['seek:12', 'pause']);
+  assert.deepStrictEqual(backend, { position: 12, playing: false });
+  assert.strictEqual(mediaPlaying, false);
+  assert.strictEqual(clearedTimeline, 1);
+});
+
+test('returning from an asset resets the native timeline before it plays', async () => {
+  let mode = 'timeline';
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  const calls = [];
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => mode,
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      pause: () => {
+        mediaPlaying = false;
+      },
+      clear: () => {
+        mediaPosition = 0;
+        mediaPlaying = false;
+      },
+      showAsset: () => {
+        mode = 'asset';
+        mediaPosition = 0;
+        mediaPlaying = false;
+      },
+      showTimeline: () => {
+        mode = 'timeline';
+        mediaPosition = 0;
+        mediaPlaying = false;
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({
+        engine: 'native',
+        status: { ...backend },
+      }),
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => {
+        calls.push(`seek:${target}`);
+        backend.position = target;
+        return { ...backend };
+      },
+      playbackPlay: async () => {
+        calls.push('play');
+        backend.playing = true;
+        return { ...backend };
+      },
+      playbackPause: async () => {
+        calls.push('pause');
+        backend.playing = false;
+        return { ...backend };
+      },
+    },
+  });
+
+  await monitor.attach();
+  await monitor.seek(42);
+  monitor.showAsset({ id: 'asset' });
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.showTimeline();
+  await new Promise((resolve) => setImmediate(resolve));
+  await monitor.play();
+
+  assert.deepStrictEqual(calls, ['seek:42', 'pause', 'seek:0', 'pause', 'play']);
+  assert.deepStrictEqual(backend, { position: 0, playing: true });
+  assert.strictEqual(monitor.position(), 0);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('returning from an asset queues its reset behind an in-flight native seek', async () => {
+  let mode = 'timeline';
+  let answerOldSeek;
+  const oldSeekAnswer = new Promise((resolve) => {
+    answerOldSeek = resolve;
+  });
+  const calls = [];
+  let seekCalls = 0;
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => mode,
+      total: () => 100,
+      showAsset: () => {
+        mode = 'asset';
+      },
+      showTimeline: () => {
+        mode = 'timeline';
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native', status: { ...backend } }),
+      playbackVisible: async () => {},
+      playbackSeek: (target) => {
+        calls.push(`seek:${target}`);
+        seekCalls += 1;
+        if (seekCalls === 1) return oldSeekAnswer;
+        backend.position = target;
+        return Promise.resolve({ ...backend });
+      },
+      playbackPause: async () => {
+        calls.push('pause');
+        backend.playing = false;
+        return { ...backend };
+      },
+    },
+  });
+
+  await monitor.attach();
+  const oldSeek = monitor.seek(42);
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.showAsset({ id: 'asset' });
+  monitor.showTimeline();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepStrictEqual(calls, ['seek:42']);
+
+  backend.position = 42;
+  answerOldSeek({ ...backend });
+  await oldSeek;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(calls, ['seek:42', 'pause', 'seek:0', 'pause']);
+  assert.deepStrictEqual(backend, { position: 0, playing: false });
+  assert.strictEqual(monitor.position(), 0);
+  assert.strictEqual(monitor.isPlaying(), false);
+});
+
+test('release for a replacement keeps the native playhead instead of the cleared preview', async () => {
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  const attachedFrames = [];
+  const replacementCalls = [];
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      seek: (target) => { mediaPosition = target; },
+      play: () => { mediaPlaying = true; },
+      pause: () => { mediaPlaying = false; },
+      clear: () => {
+        mediaPosition = 0;
+        mediaPlaying = false;
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async (_place, frame) => {
+        attachedFrames.push(frame);
+        backend.position = frame;
+        backend.playing = false;
+        return { engine: 'native', status: { ...backend } };
+      },
+      playbackRelease: async () => {},
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => {
+        replacementCalls.push(`seek:${target}`);
+        backend.position = target;
+        return { ...backend };
+      },
+      playbackPlay: async () => {
+        replacementCalls.push('play');
+        backend.playing = true;
+        return { ...backend };
+      },
+    },
+  });
+
+  await monitor.attach();
+  await monitor.seek(42);
+  await monitor.play();
+  replacementCalls.length = 0;
+  await monitor.release();
+  assert.strictEqual(monitor.position(), 42);
+  assert.strictEqual(monitor.isPlaying(), true);
+  await monitor.attach();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(attachedFrames, [0, 42]);
+  assert.deepStrictEqual(replacementCalls, ['seek:42', 'play']);
+  assert.deepStrictEqual(backend, { position: 42, playing: true });
+});
+
+test('a pending seek cannot make a replacement forget that playback was running', async () => {
+  let answerOldSeek;
+  const oldSeekAnswer = new Promise((resolve) => {
+    answerOldSeek = resolve;
+  });
+  const calls = [];
+  let seekCalls = 0;
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => 0,
+      isPlaying: () => false,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async (_place, frame) => {
+        calls.push(`attach:${frame}`);
+        backend.position = frame;
+        backend.playing = false;
+        return { engine: 'native', status: { ...backend } };
+      },
+      playbackRelease: async () => {
+        calls.push('release');
+        backend.playing = false;
+      },
+      playbackVisible: async () => {},
+      playbackSeek: (target) => {
+        calls.push(`seek:${target}`);
+        seekCalls += 1;
+        if (seekCalls === 1) return oldSeekAnswer;
+        backend.position = target;
+        return Promise.resolve({ ...backend });
+      },
+      playbackPlay: async () => {
+        calls.push('play');
+        backend.playing = true;
+        return { ...backend };
+      },
+      playbackPause: async () => {
+        calls.push('pause');
+        backend.playing = false;
+        return { ...backend };
+      },
+    },
+  });
+
+  await monitor.attach();
+  await monitor.play();
+  const pendingSeek = monitor.seek(42);
+  await new Promise((resolve) => setImmediate(resolve));
+  await monitor.release();
+  await monitor.attach();
+  answerOldSeek({ position: 42, playing: true });
+  await pendingSeek;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(calls, [
+    'attach:0',
+    'play',
+    'seek:42',
+    'release',
+    'attach:42',
+    'seek:42',
+    'play',
+  ]);
+  assert.deepStrictEqual(backend, { position: 42, playing: true });
+  assert.strictEqual(monitor.position(), 42);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('a paused replacement applies only the newest rapid seek', async () => {
+  let answerOldSeek;
+  const oldSeekAnswer = new Promise((resolve) => {
+    answerOldSeek = resolve;
+  });
+  const calls = [];
+  let seekCalls = 0;
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async (_place, frame) => {
+        calls.push(`attach:${frame}`);
+        backend.position = frame;
+        backend.playing = false;
+        return { engine: 'native', status: { ...backend } };
+      },
+      playbackRelease: async () => {
+        calls.push('release');
+      },
+      playbackVisible: async () => {},
+      playbackSeek: (target) => {
+        calls.push(`seek:${target}`);
+        seekCalls += 1;
+        if (seekCalls === 1) return oldSeekAnswer;
+        backend.position = target;
+        return Promise.resolve({ ...backend });
+      },
+      playbackPause: async () => {
+        calls.push('pause');
+        backend.playing = false;
+        return { ...backend };
+      },
+    },
+  });
+
+  await monitor.attach();
+  const oldSeek = monitor.seek(10);
+  const latestSeek = monitor.seek(20);
+  await new Promise((resolve) => setImmediate(resolve));
+  await monitor.release();
+  await monitor.attach();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(calls, [
+    'attach:0',
+    'seek:10',
+    'release',
+    'attach:20',
+    'seek:20',
+    'pause',
+  ]);
+  assert.deepStrictEqual(backend, { position: 20, playing: false });
+
+  answerOldSeek({ position: 10, playing: false });
+  await Promise.all([oldSeek, latestSeek]);
+  assert.deepStrictEqual(backend, { position: 20, playing: false });
+  assert.strictEqual(monitor.position(), 20);
+  assert.strictEqual(monitor.isPlaying(), false);
+});
+
+test('a rejected replacement attach hands the preserved native state to the preview', async () => {
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  let attaches = 0;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      seek: (target) => { mediaPosition = target; },
+      play: () => { mediaPlaying = true; },
+      pause: () => { mediaPlaying = false; },
+      clear: () => {
+        mediaPosition = 0;
+        mediaPlaying = false;
+      },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => {
+        attaches += 1;
+        if (attaches === 2) throw new Error('native surface unavailable');
+        return { engine: 'native', status: { position: 0, playing: false } };
+      },
+      playbackRelease: async () => {},
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => ({ position: target, playing: false }),
+      playbackPlay: async () => ({ position: 42, playing: true }),
+    },
+  });
+
+  await monitor.attach();
+  await monitor.seek(42);
+  await monitor.play();
+  await monitor.release();
+  assert.strictEqual(await monitor.attach(), false);
+
+  assert.deepStrictEqual({ position: mediaPosition, playing: mediaPlaying }, {
+    position: 42,
+    playing: true,
+  });
+  assert.strictEqual(monitor.position(), 42);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('timeline input and playback progress during attach are reasserted natively', async () => {
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  let answerAttach;
+  const attachAnswer = new Promise((resolve) => {
+    answerAttach = resolve;
+  });
+  const calls = [];
+  const backend = { position: 0, playing: false };
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      play: () => { mediaPlaying = true; },
+      pause: () => { mediaPlaying = false; },
+      seek: (target) => { mediaPosition = target; },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: (_place, frame) => {
+        calls.push(`attach:${frame}`);
+        return attachAnswer;
+      },
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => {
+        calls.push(`seek:${target}`);
+        backend.position = target;
+        return { ...backend };
+      },
+      playbackPlay: async () => {
+        calls.push('play');
+        backend.playing = true;
+        return { ...backend };
+      },
+      playbackPause: async () => {
+        calls.push('pause');
+        backend.playing = false;
+        return { ...backend };
+      },
+    },
+  });
+
+  const attaching = monitor.attach();
+  monitor.play();
+  monitor.seek(42);
+  assert.deepStrictEqual({ position: mediaPosition, playing: mediaPlaying }, {
+    position: 42,
+    playing: true,
+  });
+  mediaPosition = 57;
+
+  answerAttach({ engine: 'native', status: { position: 0, playing: false } });
+  assert.strictEqual(await attaching, true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(calls, ['attach:0', 'seek:57', 'play']);
+  assert.deepStrictEqual(backend, { position: 57, playing: true });
+  assert.strictEqual(monitor.position(), 57);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('fallback playback progress becomes the next native attach snapshot', async () => {
+  let mediaPosition = 0;
+  let mediaPlaying = false;
+  const attachedFrames = [];
+  const calls = [];
+  let attaches = 0;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+      position: () => mediaPosition,
+      isPlaying: () => mediaPlaying,
+      play: () => { mediaPlaying = true; },
+      pause: () => { mediaPlaying = false; },
+      seek: (target) => { mediaPosition = target; },
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async (_place, frame) => {
+        attachedFrames.push(frame);
+        attaches += 1;
+        return attaches === 1
+          ? { engine: 'media-element', status: null }
+          : { engine: 'native', status: { position: frame, playing: false } };
+      },
+      playbackVisible: async () => {},
+      playbackSeek: async (target) => {
+        calls.push(`seek:${target}`);
+        return { position: target, playing: false };
+      },
+      playbackPlay: async () => {
+        calls.push('play');
+        return { position: mediaPosition, playing: true };
+      },
+      playbackPause: async () => ({ position: mediaPosition, playing: false }),
+    },
+  });
+
+  assert.strictEqual(await monitor.attach(), false);
+  monitor.seek(42);
+  monitor.play();
+  mediaPosition = 57;
+  assert.strictEqual(await monitor.attach(), true);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(attachedFrames, [0, 57]);
+  assert.deepStrictEqual(calls, ['seek:57', 'play']);
+  assert.strictEqual(monitor.position(), 57);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('a late transport answer cannot overwrite a newly attached session', async () => {
+  let answerPause;
+  const pauseAnswer = new Promise((resolve) => {
+    answerPause = resolve;
+  });
+  let pauses = 0;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackRelease: async () => {},
+      playbackPause: () => {
+        pauses += 1;
+        return pauses === 1
+          ? pauseAnswer
+          : Promise.resolve({ position: 5, playing: false });
+      },
+      playbackSeek: async () => {},
+      playbackVisible: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  const oldPause = monitor.pause();
+  await monitor.release();
+  await monitor.attach();
+  const newSeek = monitor.seek(5);
+  answerPause({ position: 77, playing: false });
+  await Promise.all([oldPause, newSeek]);
+
+  assert.strictEqual(monitor.position(), 5);
+});
+
+test('a stale seek command is corrected to the replacement playhead', async () => {
+  let answerOldSeek;
+  const oldSeekAnswer = new Promise((resolve) => {
+    answerOldSeek = resolve;
+  });
+  const seeks = [];
+  const ticks = [];
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackRelease: async () => {},
+      playbackSeek: (target) => {
+        seeks.push(target);
+        if (seeks.length === 1) return oldSeekAnswer;
+        if (seeks.length === 3) {
+          return Promise.resolve({ position: 20, playing: false });
+        }
+        return Promise.resolve({ position: target, playing: false });
+      },
+      playbackVisible: async () => {},
+    },
+    onTick: (position, playing) => ticks.push([position, playing]),
+  });
+
+  await monitor.attach();
+  const oldSeek = monitor.seek(77);
+  await new Promise((resolve) => setImmediate(resolve));
+  monitor.clear();
+  await monitor.release();
+  await monitor.attach();
+  const newSeek = monitor.seek(5);
+  answerOldSeek({ position: 77, playing: false });
+  await Promise.all([oldSeek, newSeek]);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepStrictEqual(seeks, [77, 5]);
+  assert.strictEqual(monitor.position(), 5);
+  assert.ok(!ticks.some(([position]) => position === 20));
+});
+
+test('a newer seek wins while an old session correction is queued', async () => {
+  let answerOldSeek;
+  const oldSeekAnswer = new Promise((resolve) => {
+    answerOldSeek = resolve;
+  });
+  const seeks = [];
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackRelease: async () => {},
+      playbackSeek: (target) => {
+        seeks.push(target);
+        return seeks.length === 1
+          ? oldSeekAnswer
+          : Promise.resolve({ position: target, playing: false });
+      },
+      playbackVisible: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  const oldSeek = monitor.seek(77);
+  await new Promise((resolve) => setImmediate(resolve));
+  await monitor.release();
+  await monitor.attach();
+  const latestSeek = monitor.seek(9);
+  answerOldSeek({ position: 77, playing: false });
+  await Promise.all([oldSeek, latestSeek]);
+
+  assert.deepStrictEqual(seeks, [77, 77, 9]);
+  assert.strictEqual(monitor.position(), 9);
+});
+
+test('a rejected old play is reasserted on the replacement session', async () => {
+  let rejectOldPlay;
+  const oldPlayAnswer = new Promise((_resolve, reject) => {
+    rejectOldPlay = reject;
+  });
+  let plays = 0;
+  let backendPlaying = false;
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackRelease: async () => {},
+      playbackPlay: () => {
+        plays += 1;
+        if (plays === 1) return oldPlayAnswer;
+        backendPlaying = true;
+        return Promise.resolve({ position: 0, playing: true });
+      },
+      playbackVisible: async () => {},
+    },
+  });
+
+  await monitor.attach();
+  const oldPlay = monitor.play();
+  await new Promise((resolve) => setImmediate(resolve));
+  await monitor.release();
+  await monitor.attach();
+  rejectOldPlay(new Error('old session stopped'));
+  await oldPlay;
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(plays, 2);
+  assert.strictEqual(backendPlaying, true);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('acknowledged native commands confirm the optimistic transport state', async () => {
+  const ticks = [];
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async () => {},
+      playbackSeek: async () => ({ position: 40, playing: false }),
+      playbackPlay: async () => ({ position: 40, playing: true }),
+      playbackPause: async () => ({ position: 40, playing: false }),
+    },
+    onTick: (position, playing) => ticks.push([position, playing]),
+  });
+
+  await monitor.attach();
+  await monitor.seek(40);
+  assert.deepStrictEqual(ticks.at(-1), [40, false]);
+  assert.strictEqual(monitor.position(), 40);
+
+  await monitor.play();
+  assert.deepStrictEqual(ticks.at(-1), [40, true]);
+  assert.strictEqual(monitor.isPlaying(), true);
+
+  await monitor.pause();
+  assert.deepStrictEqual(ticks.at(-1), [40, false]);
+  assert.strictEqual(monitor.isPlaying(), false);
+});
+
+test('a same-turn seek is applied before the following play', async () => {
+  let answerSeek;
+  const seekAnswer = new Promise((resolve) => {
+    answerSeek = resolve;
+  });
+  const calls = [];
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: async () => ({ engine: 'native' }),
+      playbackVisible: async () => {},
+      playbackSeek: (target) => {
+        calls.push(`seek:${target}`);
+        return seekAnswer;
+      },
+      playbackPlay: async () => {
+        calls.push('play');
+        return { position: 40, playing: true };
+      },
+    },
+  });
+
+  await monitor.attach();
+  const seeking = monitor.seek(40);
+  const playing = monitor.play();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepStrictEqual(calls, ['seek:40']);
+
+  answerSeek({ position: 40, playing: false });
+  await Promise.all([seeking, playing]);
+  assert.deepStrictEqual(calls, ['seek:40', 'play']);
+  assert.strictEqual(monitor.position(), 40);
+  assert.strictEqual(monitor.isPlaying(), true);
+});
+
+test('a status poll started before a seek cannot rewind the new intent', async () => {
+  const previousAnimationFrame = global.requestAnimationFrame;
+  let nextFrame;
+  global.requestAnimationFrame = (callback) => {
+    nextFrame = callback;
+  };
+  let answerStatus;
+  const statusAnswer = new Promise((resolve) => {
+    answerStatus = resolve;
+  });
+
+  try {
+    const monitor = createMonitor({
+      preview: strictPreviewStub({
+        mode: () => 'timeline',
+        total: () => 100,
+      }),
+      wrap: panelStub(),
+      api: {
+        available: true,
+        playbackAttach: async () => ({ engine: 'native' }),
+        playbackVisible: async () => {},
+        playbackStatus: () => statusAnswer,
+        playbackSeek: async () => ({ position: 40, playing: false }),
+      },
+    });
+
+    await monitor.attach();
+    nextFrame();
+    await monitor.seek(40);
+    answerStatus({ position: 3, playing: false });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(monitor.position(), 40);
+  } finally {
+    if (previousAnimationFrame === undefined) delete global.requestAnimationFrame;
+    else global.requestAnimationFrame = previousAnimationFrame;
+  }
+});
+
+test('a status poll cannot outrun an unacknowledged seek command', async () => {
+  const previousAnimationFrame = global.requestAnimationFrame;
+  let nextFrame;
+  global.requestAnimationFrame = (callback) => {
+    nextFrame = callback;
+  };
+  let answerStatus;
+  let answerSeek;
+  const statusAnswer = new Promise((resolve) => {
+    answerStatus = resolve;
+  });
+  const seekAnswer = new Promise((resolve) => {
+    answerSeek = resolve;
+  });
+
+  try {
+    const monitor = createMonitor({
+      preview: strictPreviewStub({
+        mode: () => 'timeline',
+        total: () => 100,
+      }),
+      wrap: panelStub(),
+      api: {
+        available: true,
+        playbackAttach: async () => ({ engine: 'native' }),
+        playbackVisible: async () => {},
+        playbackStatus: () => statusAnswer,
+        playbackSeek: () => seekAnswer,
+      },
+    });
+
+    await monitor.attach();
+    const seeking = monitor.seek(40);
+    nextFrame();
+    answerStatus({ position: 3, playing: false });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(monitor.position(), 40);
+
+    answerSeek({ position: 40, playing: false });
+    await seeking;
+  } finally {
+    if (previousAnimationFrame === undefined) delete global.requestAnimationFrame;
+    else global.requestAnimationFrame = previousAnimationFrame;
+  }
 });
 
 test('a native monitor is used and reports nothing', () => {
@@ -422,8 +1685,9 @@ test('the router answers everything the page asks a preview for', () => {
   assert.deepStrictEqual(missing, []);
 });
 
-test('a ready proxy waits for playback to stop before replacing the native session', async () => {
+test('a ready proxy refreshes a playing native session without replacing it', async () => {
   const calls = [];
+  const ticks = [];
   const preview = {
     mode: () => 'timeline',
     total: () => 100,
@@ -440,6 +1704,10 @@ test('a ready proxy waits for playback to stop before replacing the native sessi
       return { engine: 'native' };
     },
     playbackRelease: async () => calls.push('release'),
+    playbackRefresh: async () => {
+      calls.push('refresh');
+      return { position: 12, playing: true };
+    },
     playbackVisible: async () => {},
     playbackPlay: async () => ({ position: 0, playing: true }),
     playbackPause: async () => {
@@ -452,15 +1720,59 @@ test('a ready proxy waits for playback to stop before replacing the native sessi
     wrap: panelStub(),
     api,
     getProject: () => ({ settings: { rate: { numerator: 30, denominator: 1 } } }),
+    onTick: (position, playing) => ticks.push([position, playing]),
   });
 
   await monitor.attach();
   await monitor.play();
   await monitor.refreshMedia();
-  assert.deepStrictEqual(calls, ['attach']);
+  assert.deepStrictEqual(calls, ['attach', 'refresh']);
+  assert.strictEqual(monitor.position(), 12);
+  assert.strictEqual(monitor.isPlaying(), true);
+  assert.deepStrictEqual(ticks.at(-1), [12, true]);
 
   await monitor.pause();
-  assert.deepStrictEqual(calls, ['attach', 'pause', 'release', 'attach']);
+  assert.deepStrictEqual(calls, ['attach', 'refresh', 'pause']);
+});
+
+test('a proxy ready during attach still reaches the backend session gate', async () => {
+  let answerAttach;
+  let answerRefresh;
+  const attachAnswer = new Promise((resolve) => {
+    answerAttach = resolve;
+  });
+  const refreshAnswer = new Promise((resolve) => {
+    answerRefresh = resolve;
+  });
+  const calls = [];
+  const monitor = createMonitor({
+    preview: strictPreviewStub({
+      mode: () => 'timeline',
+      total: () => 100,
+    }),
+    wrap: panelStub(),
+    api: {
+      available: true,
+      playbackAttach: () => {
+        calls.push('attach');
+        return attachAnswer;
+      },
+      playbackRefresh: () => {
+        calls.push('refresh');
+        return refreshAnswer;
+      },
+      playbackVisible: async () => {},
+    },
+  });
+
+  const attaching = monitor.attach();
+  const refreshing = monitor.refreshMedia();
+  assert.deepStrictEqual(calls, ['attach', 'refresh']);
+
+  answerAttach({ engine: 'native' });
+  answerRefresh({ position: 0, playing: false });
+  assert.strictEqual(await attaching, true);
+  await refreshing;
 });
 
 // Every method createPreview actually returns, and nothing else. A stub that
@@ -469,7 +1781,7 @@ test('a ready proxy waits for playback to stop before replacing the native sessi
 // front of a user opening a project.
 const PREVIEW_API = [
   'layout', 'play', 'pause', 'toggle', 'isPlaying', 'seek', 'position', 'total',
-  'mode', 'prune', 'clear', 'showAsset', 'showTimeline', 'setQuality',
+  'mode', 'prune', 'clearTimeline', 'clear', 'showAsset', 'showTimeline', 'setQuality',
   'setScrubbing', 'setMuteWhileScrubbing', 'showExact', 'clearExact', 'isExact',
 ];
 
@@ -490,8 +1802,8 @@ test('a ready proxy refreshes media elements without calling anything they do no
   });
   const monitor = createMonitor({ preview, stage: null, api: { available: false } });
 
-  // Playing: deferred. Stopped: taken. Neither may reach for a method that is
-  // not on the object, which on a real preview is a TypeError.
+  // A media element notices its changed path in the animation pass. The router
+  // must not reach for a method that is not on the real preview object.
   await monitor.refreshMedia();
   await monitor.pause();
 });

--- a/product/akbun-makevideo/workspace/test/preview.test.js
+++ b/product/akbun-makevideo/workspace/test/preview.test.js
@@ -226,3 +226,85 @@ test('an asset measured after it was shown still gets its own shape', async (con
   assert.strictEqual(stage.style.width, '600px', 'the square asset fills the height');
   assert.strictEqual(stage.style.height, '600px');
 });
+
+test('clearing the timeline pool keeps the asset preview alive', (context) => {
+  const original = {
+    document: global.document,
+    window: global.window,
+    timelineLib: global.timelineLib,
+    requestAnimationFrame: global.requestAnimationFrame,
+    performance: global.performance,
+  };
+  context.after(() => Object.assign(global, original));
+
+  const elements = [];
+  global.requestAnimationFrame = () => 0;
+  global.performance = { now: () => 0 };
+  global.document = {
+    createElement(tagName) {
+      const element = fakeMedia(tagName.toUpperCase(), () => Promise.resolve());
+      element.removed = false;
+      element.sourceRemoved = false;
+      element.remove = () => {
+        element.removed = true;
+      };
+      element.removeAttribute = (name) => {
+        if (name === 'src') element.sourceRemoved = true;
+      };
+      elements.push(element);
+      return element;
+    },
+  };
+  global.window = { api: { fileUrl: (path) => path } };
+
+  const timelineAsset = { id: 'timeline', path: '/timeline.mp4', kind: 'video' };
+  const shownAsset = { id: 'shown', path: '/shown.mp4', kind: 'video' };
+  const track = {
+    id: 'v1',
+    kind: 'video',
+    hidden: false,
+    muted: false,
+    clips: [{
+      id: 'c1',
+      assetId: timelineAsset.id,
+      start: 0,
+      in: 0,
+      out: 30,
+      opacity: 1,
+      volume: 1,
+    }],
+  };
+  const project = {
+    settings: { width: 1920, height: 1080, rate: T.fps(30) },
+    tracks: [track],
+    assets: [timelineAsset, shownAsset],
+  };
+  global.timelineLib = {
+    tracksOf: (value, kind) => value.tracks.filter((item) => item.kind === kind),
+    clipsAt: (_value, frame) => frame < 30
+      ? [{ track, clip: track.clips[0], sourceFrame: frame }]
+      : [],
+    findAsset: (_value, assetId) => project.assets.find((asset) => asset.id === assetId),
+    projectDurationFrames: () => 30,
+  };
+
+  const preview = require('../src/preview.js').createPreview({
+    stage: { style: {} },
+    inner: { style: {}, appendChild() {} },
+    wrap: null,
+    exactCanvas: null,
+    getProject: () => project,
+    onTick: () => {},
+  });
+
+  preview.seek(0);
+  preview.showAsset(shownAsset);
+  const [timelineElement, assetElement] = elements;
+  preview.clearTimeline();
+
+  assert.strictEqual(timelineElement.removed, true);
+  assert.strictEqual(timelineElement.sourceRemoved, true);
+  assert.strictEqual(assetElement.removed, false);
+  assert.strictEqual(assetElement.sourceRemoved, false);
+  assert.strictEqual(preview.mode(), 'asset');
+});

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -10,7 +10,7 @@ test('classic page scripts do not leak conflicting declarations', () => {
   const context = vm.createContext({});
   const names = [
     'time.js', 'geometry.js', 'timeline.js', 'shortcuts.js', 'quality.js',
-    'preview.js', 'transform.js', 'guides.js', 'monitor.js', 'panel.js',
+    'preview.js', 'transform.js', 'guides.js', 'monitor.js', 'panel.js', 'latest.js',
   ];
   for (const name of names) {
     const file = path.join(__dirname, '..', 'src', name);
@@ -25,6 +25,7 @@ test('classic page scripts do not leak conflicting declarations', () => {
   assert.ok(context.previewLib);
   assert.ok(context.monitorLib);
   assert.ok(context.panelLib);
+  assert.ok(context.latestLib);
 });
 
 // Each of these is loaded with a `<script>` tag and reached through its one
@@ -44,6 +45,7 @@ test('every library the page loads is a script tag on the page', () => {
   assert.ok(loaded.indexOf('geometry.js') < loaded.indexOf('preview.js'));
   assert.ok(loaded.indexOf('geometry.js') < loaded.indexOf('monitor.js'));
   assert.ok(loaded.indexOf('preview.js') < loaded.indexOf('renderer.js'));
+  assert.ok(loaded.indexOf('latest.js') < loaded.indexOf('renderer.js'));
 });
 
 test('the editor exposes one toggleable selected panel from the title bar', () => {


### PR DESCRIPTION
# 구현

재생 중 설정 후보 인계와 seek 디코더 재사용 구현
- JavaScript 170개, Rust 225개, 1080p 30fps 최대 4트랙 supply-soak와 present-soak 전부 통과

# 어려웠던 점

이전·후보 재생 경로가 공존하는 동안 화면·오디오·명령 소유권 경쟁 정리
- 후보 첫 프레임을 commit 지점으로 고정하고 설정 latest-wins, transport FIFO, 탐색 세대 검증으로 해결

# 리스크

설정 교체 준비 중 이전·후보 디코더가 잠시 함께 살아 메모리 증가
- live reconfiguration peak 58,060,800 bytes, 허용 상한 149,299,200 bytes 이내

Issue #1121
Issue #1122
