### PR TITLE
feat: Paint 모델과 오버레이 트랙 추가

### DIFF
--- a/product/akbun-makevideo/adr/2026-08-common-visual-item-model.md
+++ b/product/akbun-makevideo/adr/2026-08-common-visual-item-model.md
@@ -7,6 +7,10 @@
 - Store start and duration as frame counts on the project rate
 - Place items on video tracks and order them by track position first, then item `zIndex`
 - Keep selection outlines, handles and guides outside the project model
+- Give text and shapes one shared style: bottom-to-top paint fills, optional stroke and optional shadow
+- Store media paints by asset id and keep solid and gradient paints self-contained
+- Add clicked text and shapes to a clip-free top video track; reuse it until the four-track limit, then use the existing top video track
+- Apply top-track creation and item creation as one edit command and one undo step
 
 ## Reason
 
@@ -14,8 +18,11 @@
 - Selection and Inspector can edit one transform regardless of content kind
 - Frame-based time follows the same exact timebase as clips
 - Editor-only decorations cannot leak into an exported frame
+- A shared style keeps Inspector, migration and rasterization from implementing the same visual properties twice
+- A dedicated top track makes overlays visible without changing an explicitly dragged target track
 
 ## Tradeoffs
 
 - Content-specific properties arrive with each content feature rather than expanding the common transform
 - Items may overlap in time, so ordering must stay explicit and deterministic
+- A video paint cannot use the static filter-graph overlay optimization and takes the per-frame composited route

--- a/product/akbun-makevideo/knowledge/decisions/2026-08-graph-render-overlays-rasterized-stills.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-graph-render-overlays-rasterized-stills.md
@@ -1,22 +1,24 @@
 ---
 type: Decision
-title: filter graph 렌더는 rasterize한 still을 overlay로 굽는다
-description: CPU 렌더와 폴백에서 text/shape가 조용히 빠지던 것을 drawtext도 소프트웨어 합성도 아닌 자체 raster + overlay로 해결한 결정.
-tags: [makevideo, render, ffmpeg, text]
+title: filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다
+description: 정적 text/shape는 자체 raster를 overlay하고 video paint는 프레임 합성 경로로 보내는 결정.
+tags: [makevideo, render, ffmpeg, text, paint]
 timestamp: 2026-08-10T00:00:00Z
 ---
 
-# filter graph 렌더는 rasterize한 still을 overlay로 굽는다
+# filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다
 
 ## 결정
 
-* compositor의 text/shape rasterizer가 item당 still 하나(PAM)를 출력 해상도로 만들고, filter graph가 overlay와 enable 구간으로 굽는다
+* 정적 text/shape는 rasterizer가 item당 still 하나(PAM)를 출력 해상도로 만들고, filter graph가 overlay와 enable 구간으로 굽는다
+* video paint가 하나라도 있으면 CPU 설정도 프레임 합성 경로를 사용하고 filter graph fallback을 만들지 않음
 * drawtext 필터 생성과 전체 소프트웨어 합성은 둘 다 선택하지 않음
 
 ## 이유
 
 * filter graph 경로(compositor cpu 설정, composited 렌더 실패 폴백)는 drawtext가 없어 preview에 보이던 레이어가 결과 파일에서 조용히 사라졌음
-* drawtext는 폰트 지정과 도형 표현이 rasterizer와 달라 preview와 렌더가 다른 그림이 되고, 전체 소프트웨어 합성은 filter graph가 분 단위로 끝내는 일을 시간 단위로 만들어 기존 결정([그래픽 장치 축](2026-08-one-axis-for-the-graphics-device.md))의 이유를 무너뜨림. still overlay는 픽셀은 compositor 것, 합성 속도는 ffmpeg 것
+* drawtext는 폰트 지정과 도형 표현이 rasterizer와 달라 preview와 렌더가 다른 그림이 됨. 정적 still overlay는 픽셀은 compositor 것, 합성 속도는 ffmpeg 것으로 유지함
+* video paint를 still로 넘기면 첫 프레임으로 굳은 잘못된 결과가 성공함. 이 경우는 느린 CPU 합성도 허용하고 잘못된 fallback은 금지하는 편이 안전함
 
 ## Citations
 

--- a/product/akbun-makevideo/knowledge/decisions/2026-08-graph-render-overlays-rasterized-stills.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-08-graph-render-overlays-rasterized-stills.md
@@ -12,6 +12,7 @@ timestamp: 2026-08-10T00:00:00Z
 
 * 정적 text/shape는 rasterizer가 item당 still 하나(PAM)를 출력 해상도로 만들고, filter graph가 overlay와 enable 구간으로 굽는다
 * video paint가 하나라도 있으면 CPU 설정도 프레임 합성 경로를 사용하고 filter graph fallback을 만들지 않음
+* video paint는 visual item과 fill layer마다 장기 decoder 하나를 두고 순차 프레임에서 재사용하며 seek에서만 재시작
 * drawtext 필터 생성과 전체 소프트웨어 합성은 둘 다 선택하지 않음
 
 ## 이유
@@ -19,6 +20,7 @@ timestamp: 2026-08-10T00:00:00Z
 * filter graph 경로(compositor cpu 설정, composited 렌더 실패 폴백)는 drawtext가 없어 preview에 보이던 레이어가 결과 파일에서 조용히 사라졌음
 * drawtext는 폰트 지정과 도형 표현이 rasterizer와 달라 preview와 렌더가 다른 그림이 됨. 정적 still overlay는 픽셀은 compositor 것, 합성 속도는 ffmpeg 것으로 유지함
 * video paint를 still로 넘기면 첫 프레임으로 굳은 잘못된 결과가 성공함. 이 경우는 느린 CPU 합성도 허용하고 잘못된 fallback은 금지하는 편이 안전함
+* 프레임마다 ffmpeg 프로세스를 만들면 재생과 렌더가 process spawn 비용에 묶임. decoder 수를 여덟 개로 제한해 자원 상한도 유지함
 
 ## Citations
 

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -7,7 +7,7 @@
 * [native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다](2026-08-native-monitor-is-a-window-overlay.md) - GPU surface를 WebKit hierarchy에서 분리하고 실제 view 사이 좌표 변환을 AppKit에 맡긴 결정.
 * [첫 영상은 빈 기본 프로젝트의 canvas 비율을 정한다](2026-08-first-video-defines-default-canvas-shape.md) - 첫 영상 비율을 채택하되 기본 긴 변 해상도를 유지하는 결정.
 * [native view 좌표는 superview에게 원점을 물어본다](2026-08-native-view-asks-its-superview-for-the-origin.md) - WKWebView가 flipped view라 bottom-left 가정이 monitor를 뒤집힌 위치에 놓은 뒤 정한 규칙.
-* [filter graph 렌더는 rasterize한 still을 overlay로 굽는다](2026-08-graph-render-overlays-rasterized-stills.md) - CPU 렌더와 폴백에서 text/shape가 빠지던 것을 자체 raster + overlay로 해결한 결정.
+* [filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다](2026-08-graph-render-overlays-rasterized-stills.md) - 정적 text/shape는 자체 raster를 overlay하고 video paint는 프레임 합성 경로로 보내는 결정.
 * [그래픽 장치를 쓰는지 하나로 preview와 playback과 render를 함께 정한다](2026-08-one-axis-for-the-graphics-device.md) - compositor 설정을 GPU와 CPU 둘로 줄이고 playback 설정을 없앤 결정.
 * [재생 끊김은 경로별 계측으로 원인을 분리](2026-08-playback-stutter-is-measured-by-stage.md) - 공급과 표시와 A/V 지연을 따로 보고 구조 교체를 미룬 결정.
 * [경계 stub은 실제 API 이름만 가진다](2026-08-seam-stubs-carry-only-real-api-names.md) - 무엇에나 답하는 Proxy stub이 없는 메서드 호출을 숨긴 뒤 정한 규칙.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,9 @@
 # Knowledge Update Log
 
+## 2026-09-02
+
+* [filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다](decisions/2026-08-graph-render-overlays-rasterized-stills.md) 결정 갱신. video paint가 정적 overlay로 굳지 않도록 CPU 설정에서도 프레임 합성 경로를 사용함.
+
 ## 2026-09-01
 
 * [프록시는 해상도뿐 아니라 decode와 seek 비용을 줄인다](decisions/2026-09-proxy-targets-decode-and-seek-cost.md) 결정 기록. 1080p 비직접 재생 코덱과 긴 GOP 원본을 판정 대상에 넣고 프록시에 0.5초 키프레임을 강제함.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -2,7 +2,7 @@
 
 ## 2026-09-02
 
-* [filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다](decisions/2026-08-graph-render-overlays-rasterized-stills.md) 결정 갱신. video paint가 정적 overlay로 굳지 않도록 CPU 설정에서도 프레임 합성 경로를 사용함.
+* [filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다](decisions/2026-08-graph-render-overlays-rasterized-stills.md) 결정 갱신. video paint가 정적 overlay로 굳지 않도록 CPU 설정에서도 프레임 합성 경로를 사용하고 장기 decoder를 재사용함.
 
 ## 2026-09-01
 

--- a/product/akbun-makevideo/wiki/architecture/compositor.md
+++ b/product/akbun-makevideo/wiki/architecture/compositor.md
@@ -101,6 +101,7 @@ stdin. Closing that stdin is what tells ffmpeg the video is over. See
 - GPU and CPU composition receive identical RGBA pixels.
 - Static visual items become one PAM still per item on the filter graph route.
 - A video paint changes every frame and always takes the composited route, including under the CPU setting.
+- Each video paint keeps one decoder per visual item and fill layer; sequential frames reuse it and a seek restarts it.
 - A video-paint render does not fall back to a graph that would freeze the paint.
 
 The render differs from playback in one thing only: when a frame is not ready

--- a/product/akbun-makevideo/wiki/architecture/compositor.md
+++ b/product/akbun-makevideo/wiki/architecture/compositor.md
@@ -96,6 +96,13 @@ render takes a frame, composes it, and writes the result to the encoder's
 stdin. Closing that stdin is what tells ffmpeg the video is over. See
 [frame-source.md](./frame-source.md).
 
+- Text and shapes become raster layers before either backend receives them.
+- One rasterizer calculates paint stacks, media paints, stroke, shadow and shape geometry.
+- GPU and CPU composition receive identical RGBA pixels.
+- Static visual items become one PAM still per item on the filter graph route.
+- A video paint changes every frame and always takes the composited route, including under the CPU setting.
+- A video-paint render does not fall back to a graph that would freeze the paint.
+
 The render differs from playback in one thing only: when a frame is not ready
 it waits, because a file has no deadline. It waits in short spans so Cancel is
 still answered promptly.

--- a/product/akbun-makevideo/wiki/architecture/project-model.md
+++ b/product/akbun-makevideo/wiki/architecture/project-model.md
@@ -4,7 +4,7 @@ One JSON object, written to a `.akbunvideo` file and read back by both sides.
 
 ```text
 project
-  version                                  the storage format, 2 today
+  version                                  the storage format, 3 today
   settings { width, height, rate }         the canvas, and the timebase
     rate   { num, den }                    frames per second, 30000/1001 for 29.97
   assets[] { id, path, name, kind,         kind is video | audio | image
@@ -22,14 +22,17 @@ project
 - Video tracks composite in array order: track 1 is the bottom layer. The timeline draws them reversed so V1 sits at the bottom of the screen, which is where every other editor puts it.
 - Visual items belong to video tracks. Their coordinates and size are project pixels, not Program Monitor pixels. Items on one track draw by ascending `zIndex`, then `id`; track array order remains the primary layer order.
 - `content.kind` is `text`, `shape`, `image` or `videoOverlay`. Image and video overlay content names an asset; content-specific fields stay inside `content`, not beside the shared transform.
+- Text and shape content share `fills[]`, `stroke` and `shadow`. Fills paint bottom to top and each paint is solid, linear gradient, radial gradient, image or video.
+- Rectangle, rounded rectangle, ellipse, line, polygon and star use the same transform and visual style. Rounded rectangle alone reads `cornerRadius`; line alone reads its arrow flags.
+- Clicking Text or Shape creates or reuses a clip-free top video track. At the four-video-track limit it uses the existing top video track instead. Track creation and item creation are one undo step.
 - Selection borders, transform handles and guides are editor state and never appear in `visualItems`.
 - `hidden` on a video track removes it from the preview, the render **and** the timeline length. `muted` silences a track but keeps its picture.
 
 ## Versions
 
-Version 1 was the first format: every time in whole milliseconds (`startMs`, `inMs`, `outMs`) and `settings.fps` as a single integer. Version 2 is the shape above.
+Version 1 stored every time in whole milliseconds (`startMs`, `inMs`, `outMs`) and `settings.fps` as a single integer. Version 2 introduced frame counts and visual items. Version 3 is the shape above: text and shapes use paint stacks and shared stroke and shadow objects.
 
-A version 1 file still opens. `crates/edit/src/migrate.rs` converts it once as it is read, and what gets written back is version 2 only, with the millisecond keys gone rather than carried along beside the frame counts that replaced them. Which format a clip is in is read off the clip rather than taken from the header, because the two use different keys and a header can be wrong. A version 2 track without `visualItems` opens with an empty list.
+Version 1 and 2 files still open. `crates/edit/src/migrate.rs` converts timeline fields as they are read. The visual-content deserializer converts legacy `color`, `fill`, `strokeColor`, `strokeWidth` and shadow fields into the version 3 style. Saving writes version 3 fields only. Which time format a clip uses is read off the clip rather than trusted from the header, because the keys differ and a header can be wrong. A track without `visualItems` opens with an empty list.
 
 A version 1 file whose `fps` says `29.97` opens on 30000/1001, because that is what the number meant. Believing the decimal is how the approximation gets back in.
 

--- a/product/akbun-makevideo/wiki/architecture/render.md
+++ b/product/akbun-makevideo/wiki/architecture/render.md
@@ -23,6 +23,11 @@ there is a test asserting they are identical.
 
 One input per clip rather than per asset. That costs an extra decoder when the same file is used twice, and buys input level seeking (`-ss` before `-i`, so ffmpeg skips to the in point instead of decoding everything before it) and a uniform way to give a still a length.
 
+- Static text and shapes add one alpha-capable PAM input per visual item.
+- The shared visual rasterizer creates the pixels.
+- `overlay` enables each input only for its frame range.
+- A project with a video paint bypasses this graph and uses per-frame composition.
+
 The graph:
 
 ```text

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/pipeline.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/pipeline.rs
@@ -136,6 +136,7 @@ where
     F: FnMut(u64, u64),
 {
     let project = options.project;
+    crate::text::set_ffmpeg_path(options.ffmpeg);
     let rate = project.rate();
     // The progress bar is the only thing here that still speaks milliseconds,
     // because that is what a progress bar is for.
@@ -273,6 +274,7 @@ pub fn preview_frame(
     width: u32,
     height: u32,
 ) -> Result<Vec<u8>, String> {
+    crate::text::set_ffmpeg_path(ffmpeg_path);
     let rate = project.rate();
     let layers = layout::layers_at(project, frame, width, height);
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -1462,7 +1462,9 @@ mod tests {
     /// text visible *during* playback rather than only on the paused still.
     #[test]
     fn a_visual_item_rides_on_the_frames_it_covers() {
-        use makevideo_render::{ShapeKind, VisualContent, VisualItem, VisualTransform};
+        use makevideo_render::{
+            Paint, ShapeKind, Stroke, VisualContent, VisualItem, VisualStyle, VisualTransform,
+        };
         let mut with_shape = one_clip();
         with_shape.tracks[0].visual_items.push(VisualItem {
             id: "s1".into(),
@@ -1479,9 +1481,14 @@ mod tests {
             },
             content: VisualContent::Shape {
                 shape: ShapeKind::Rectangle,
-                fill: "#ff0000".into(),
-                stroke: "#ffffff".into(),
-                stroke_width: 1.0,
+                visual_style: VisualStyle {
+                    fills: vec![Paint::solid("#ff0000")],
+                    stroke: Some(Stroke {
+                        color: "#ffffff".into(),
+                        width: 1.0,
+                    }),
+                    shadow: None,
+                },
                 corner_radius: 0.0,
                 start_arrow: false,
                 end_arrow: false,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -6,9 +6,11 @@ use crate::Placement;
 use fontdb::{Database, Family, Query};
 use fontdue::layout::{CoordinateSystem, Layout, LayoutSettings, TextStyle as LayoutTextStyle};
 use fontdue::{Font, FontSettings};
-use makevideo_render::{Project, ShapeKind, TextAlign, TextStyle, VisualContent};
+use makevideo_render::{
+    GradientStop, Paint, Project, ShapeKind, TextAlign, TextStyle, VisualContent, VisualStyle,
+};
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 const CACHE_LIMIT_BYTES: usize = 64 * 1024 * 1024;
 
@@ -28,6 +30,16 @@ struct RasterCache {
 static CACHE: OnceLock<Mutex<RasterCache>> = OnceLock::new();
 static FONT_DATABASE: OnceLock<Database> = OnceLock::new();
 static FONTS: OnceLock<Mutex<HashMap<String, Font>>> = OnceLock::new();
+static FFMPEG: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+/// Keep media paints on the same ffmpeg executable as the decoder pipeline.
+/// Settings can replace it while the app is running, so this is updateable.
+pub fn set_ffmpeg_path(path: &str) {
+    *FFMPEG
+        .get_or_init(|| RwLock::new(None))
+        .write()
+        .unwrap() = Some(path.to_string());
+}
 
 /// One item's raster at the output size, with where it sits and the frames it
 /// covers. The pixels are the same ones `layers_at` composites — an item is
@@ -138,28 +150,48 @@ fn each_visual_item(
             let pixels = match &item.content {
                 VisualContent::Text { text, style } => {
                     let style = track.subtitle_style.as_ref().unwrap_or(style);
-                    let key = format!(
-                        "text\u{0}{text}\u{0}{style:?}\u{0}{item_width}x{item_height}\u{0}{scale:.4}"
+                    let paint_frame = at.unwrap_or(item.start);
+                    let relative_frame = paint_frame - item.start;
+                    let media = resolve_media_paints(
+                        project,
+                        &style.visual_style,
+                        relative_frame,
+                        item_width,
+                        item_height,
                     );
-                    cached(&key, || rasterize(text, style, item_width, item_height, scale))
+                    let key = format!(
+                        "text\u{0}{text}\u{0}{style:?}\u{0}{item_width}x{item_height}\u{0}{scale:.4}\u{0}{}",
+                        media_cache_token(project, &style.visual_style, relative_frame)
+                    );
+                    cached(&key, || {
+                        rasterize(text, style, item_width, item_height, scale, &media)
+                    })
                 }
                 VisualContent::Shape {
                     shape,
-                    fill,
-                    stroke,
-                    stroke_width,
+                    visual_style,
                     corner_radius,
                     start_arrow,
                     end_arrow,
                 } => {
+                    let paint_frame = at.unwrap_or(item.start);
+                    let relative_frame = paint_frame - item.start;
+                    let media = resolve_media_paints(
+                        project,
+                        visual_style,
+                        relative_frame,
+                        item_width,
+                        item_height,
+                    );
                     let key = format!(
-                        "shape\u{0}{shape:?}\u{0}{fill}\u{0}{stroke}\u{0}{stroke_width}\u{0}{corner_radius}\u{0}{start_arrow}\u{0}{end_arrow}\u{0}{item_width}x{item_height}\u{0}{scale:.4}"
+                        "shape\u{0}{shape:?}\u{0}{visual_style:?}\u{0}{corner_radius}\u{0}{start_arrow}\u{0}{end_arrow}\u{0}{item_width}x{item_height}\u{0}{scale:.4}\u{0}{}",
+                        media_cache_token(project, visual_style, relative_frame)
                     );
                     cached(&key, || rasterize_shape(
                         *shape,
-                        fill,
-                        stroke,
-                        *stroke_width * scale,
+                        visual_style,
+                        &media,
+                        scale,
                         *corner_radius * scale,
                         *start_arrow,
                         *end_arrow,
@@ -233,12 +265,117 @@ pub fn write_pam(
     file.flush()
 }
 
+fn media_cache_token(project: &Project, style: &VisualStyle, frame: i64) -> String {
+    style
+        .fills
+        .iter()
+        .filter_map(|paint| {
+            let asset = project.asset(paint.asset_id()?)?;
+            let frame = if matches!(paint, Paint::Video { .. }) {
+                frame.max(0) % asset.duration_frames(project.rate()).max(1)
+            } else {
+                0
+            };
+            Some(format!("{}:{frame}", asset.path))
+        })
+        .collect::<Vec<_>>()
+        .join("\u{0}")
+}
+
+fn resolve_media_paints(
+    project: &Project,
+    style: &VisualStyle,
+    relative_frame: i64,
+    width: u32,
+    height: u32,
+) -> Vec<Option<Arc<[u8]>>> {
+    style
+        .fills
+        .iter()
+        .map(|paint| {
+            let asset_id = paint.asset_id()?;
+            let asset = project.asset(asset_id)?;
+            let frame = match paint {
+                Paint::Image { .. } => 0,
+                Paint::Video { .. } => {
+                    let duration = asset.duration_frames(project.rate()).max(1);
+                    relative_frame.max(0) % duration
+                }
+                _ => return None,
+            };
+            let key = format!(
+                "paint-media\u{0}{}\u{0}{frame}\u{0}{width}x{height}",
+                asset.path
+            );
+            let pixels = cached(&key, || {
+                decode_paint_frame(&asset.path, asset.kind, frame, project, width, height)
+                    .unwrap_or_default()
+            });
+            (!pixels.is_empty()).then_some(pixels)
+        })
+        .collect()
+}
+
+fn decode_paint_frame(
+    path: &str,
+    kind: makevideo_render::AssetKind,
+    frame: i64,
+    project: &Project,
+    width: u32,
+    height: u32,
+) -> Option<Vec<u8>> {
+    let ffmpeg = ffmpeg_path()?;
+    let mut args = vec!["-hide_banner".to_string(), "-loglevel".into(), "error".into()];
+    if kind == makevideo_render::AssetKind::Video {
+        args.extend([
+            "-ss".into(),
+            format!("{:.9}", frame as f64 / project.rate().as_f64()),
+        ]);
+    }
+    args.extend([
+        "-i".into(),
+        path.into(),
+        "-frames:v".into(),
+        "1".into(),
+        "-vf".into(),
+        format!(
+            "scale={width}:{height}:force_original_aspect_ratio=increase,crop={width}:{height}"
+        ),
+        "-pix_fmt".into(),
+        "rgba".into(),
+        "-f".into(),
+        "rawvideo".into(),
+        "pipe:1".into(),
+    ]);
+    let output = std::process::Command::new(&ffmpeg)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    let expected = width as usize * height as usize * 4;
+    (output.status.success() && output.stdout.len() >= expected)
+        .then(|| output.stdout[..expected].to_vec())
+}
+
+fn ffmpeg_path() -> Option<String> {
+    let configured = FFMPEG.get_or_init(|| RwLock::new(None));
+    if let Some(path) = configured.read().unwrap().clone() {
+        return Some(path);
+    }
+    let path = std::env::var("PATH").unwrap_or_default();
+    let home = std::env::var("HOME").unwrap_or_default();
+    makevideo_render::tools::candidate_paths("ffmpeg", "", &path, &home)
+        .into_iter()
+        .find(|candidate| std::path::Path::new(candidate).is_file())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn rasterize_shape(
     shape: ShapeKind,
-    fill: &str,
-    stroke: &str,
-    stroke_width: f32,
+    style: &VisualStyle,
+    media: &[Option<Arc<[u8]>>],
+    scale: f32,
     corner_radius: f32,
     start_arrow: bool,
     end_arrow: bool,
@@ -246,23 +383,86 @@ fn rasterize_shape(
     height: u32,
 ) -> Vec<u8> {
     let mut pixels = vec![0; width as usize * height as usize * 4];
-    let fill = colour(fill, [79, 140, 255, 204]);
-    let stroke = colour(stroke, [255, 255, 255, 255]);
+    let stroke_width = style.stroke.as_ref().map(|stroke| stroke.width).unwrap_or(0.0) * scale;
     let edge = stroke_width.max(0.0) / 2.0;
+    let mask = shape_mask(
+        shape,
+        corner_radius,
+        edge,
+        start_arrow,
+        end_arrow,
+        width,
+        height,
+    );
+    if let Some(shadow) = &style.shadow {
+        draw_shadow(&mut pixels, &mask, width, height, shadow, scale);
+    }
     for y in 0..height {
         for x in 0..width {
-            let point = (x as f32 + 0.5, y as f32 + 0.5);
-            let (inside, outlined) = match shape {
-                ShapeKind::Rectangle => rounded_rectangle(point, width as f32, height as f32, corner_radius, edge),
-                ShapeKind::Ellipse => ellipse(point, width as f32, height as f32, edge),
-                ShapeKind::Line => line(point, width as f32, height as f32, edge, start_arrow, end_arrow),
-            };
+            let (inside, outlined) = mask[(y * width + x) as usize];
             if inside {
-                put_pixel(&mut pixels, width, x, y, if outlined { stroke } else { fill });
+                let color = if shape == ShapeKind::Line || outlined {
+                    style
+                        .stroke
+                        .as_ref()
+                        .map(|stroke| colour(&stroke.color, [0, 0, 0, 0]))
+                        .unwrap_or([0, 0, 0, 0])
+                } else {
+                    paint_stack(
+                        &style.fills,
+                        media,
+                        x as f32 + 0.5,
+                        y as f32 + 0.5,
+                        width,
+                        height,
+                    )
+                };
+                blend_at(&mut pixels, width, x, y, color);
             }
         }
     }
     pixels
+}
+
+fn shape_mask(
+    shape: ShapeKind,
+    corner_radius: f32,
+    edge: f32,
+    start_arrow: bool,
+    end_arrow: bool,
+    width: u32,
+    height: u32,
+) -> Vec<(bool, bool)> {
+    let mut mask = Vec::with_capacity(width as usize * height as usize);
+    for y in 0..height {
+        for x in 0..width {
+            let point = (x as f32 + 0.5, y as f32 + 0.5);
+            mask.push(match shape {
+                ShapeKind::Rectangle => {
+                    rounded_rectangle(point, width as f32, height as f32, 0.0, edge)
+                }
+                ShapeKind::RoundedRectangle => rounded_rectangle(
+                    point,
+                    width as f32,
+                    height as f32,
+                    corner_radius,
+                    edge,
+                ),
+                ShapeKind::Ellipse => ellipse(point, width as f32, height as f32, edge),
+                ShapeKind::Line => line(
+                    point,
+                    width as f32,
+                    height as f32,
+                    edge,
+                    start_arrow,
+                    end_arrow,
+                ),
+                ShapeKind::Polygon => polygon(point, width as f32, height as f32, 6, 1.0, edge),
+                ShapeKind::Star => polygon(point, width as f32, height as f32, 10, 0.45, edge),
+            });
+        }
+    }
+    mask
 }
 
 fn rounded_rectangle(point: (f32, f32), width: f32, height: f32, radius: f32, edge: f32) -> (bool, bool) {
@@ -295,9 +495,224 @@ fn line(point: (f32, f32), width: f32, height: f32, radius: f32, start_arrow: bo
     (body || (start_arrow && arrow(0.0, false)) || (end_arrow && arrow(width, true)), true)
 }
 
-fn put_pixel(pixels: &mut [u8], width: u32, x: u32, y: u32, color: [u8; 4]) {
+fn polygon(
+    point: (f32, f32),
+    width: f32,
+    height: f32,
+    vertices: usize,
+    inner_ratio: f32,
+    edge: f32,
+) -> (bool, bool) {
+    let outer = width.min(height) / 2.0;
+    let center = (width / 2.0, height / 2.0);
+    let points: Vec<(f32, f32)> = (0..vertices)
+        .map(|index| {
+            let angle = -std::f32::consts::FRAC_PI_2
+                + index as f32 * std::f32::consts::TAU / vertices as f32;
+            let radius = if vertices > 6 && index % 2 == 1 {
+                outer * inner_ratio
+            } else {
+                outer
+            };
+            (center.0 + angle.cos() * radius, center.1 + angle.sin() * radius)
+        })
+        .collect();
+    let mut inside = false;
+    let mut distance = f32::MAX;
+    for index in 0..points.len() {
+        let a = points[index];
+        let b = points[(index + 1) % points.len()];
+        if (a.1 > point.1) != (b.1 > point.1)
+            && point.0 < (b.0 - a.0) * (point.1 - a.1) / (b.1 - a.1) + a.0
+        {
+            inside = !inside;
+        }
+        distance = distance.min(segment_distance(point, a, b));
+    }
+    (inside, inside && distance <= edge)
+}
+
+fn segment_distance(point: (f32, f32), a: (f32, f32), b: (f32, f32)) -> f32 {
+    let delta = (b.0 - a.0, b.1 - a.1);
+    let length = delta.0 * delta.0 + delta.1 * delta.1;
+    if length <= f32::EPSILON {
+        return (point.0 - a.0).hypot(point.1 - a.1);
+    }
+    let amount = (((point.0 - a.0) * delta.0 + (point.1 - a.1) * delta.1) / length)
+        .clamp(0.0, 1.0);
+    (point.0 - (a.0 + delta.0 * amount)).hypot(point.1 - (a.1 + delta.1 * amount))
+}
+
+fn draw_shadow(
+    pixels: &mut [u8],
+    mask: &[(bool, bool)],
+    width: u32,
+    height: u32,
+    shadow: &makevideo_render::Shadow,
+    scale: f32,
+) {
+    let color = colour(&shadow.color, [0, 0, 0, 0]);
+    if color[3] == 0 {
+        return;
+    }
+    let offset_x = (shadow.x * scale).round() as i32;
+    let offset_y = (shadow.y * scale).round() as i32;
+    let blur = (shadow.blur * scale).round().clamp(0.0, 32.0) as i32;
+    for y in 0..height as i32 {
+        for x in 0..width as i32 {
+            let source_x = x - offset_x;
+            let source_y = y - offset_y;
+            let mut covered = 0u32;
+            let mut samples = 0u32;
+            for dy in -blur..=blur {
+                for dx in -blur..=blur {
+                    samples += 1;
+                    let sx = source_x + dx;
+                    let sy = source_y + dy;
+                    if sx >= 0
+                        && sy >= 0
+                        && sx < width as i32
+                        && sy < height as i32
+                        && mask[(sy as u32 * width + sx as u32) as usize].0
+                    {
+                        covered += 1;
+                    }
+                }
+            }
+            if covered == 0 {
+                continue;
+            }
+            let mut sampled = color;
+            sampled[3] = ((color[3] as u32 * covered + samples / 2) / samples) as u8;
+            blend_at(pixels, width, x as u32, y as u32, sampled);
+        }
+    }
+}
+
+fn paint_stack(
+    paints: &[Paint],
+    media: &[Option<Arc<[u8]>>],
+    x: f32,
+    y: f32,
+    width: u32,
+    height: u32,
+) -> [u8; 4] {
+    let mut result = [0, 0, 0, 0];
+    for (index, paint) in paints.iter().enumerate() {
+        blend(
+            &mut result,
+            sample_paint(
+                paint,
+                media.get(index).and_then(Option::as_deref),
+                x,
+                y,
+                width,
+                height,
+            ),
+        );
+    }
+    result
+}
+
+fn sample_paint(
+    paint: &Paint,
+    media: Option<&[u8]>,
+    x: f32,
+    y: f32,
+    width: u32,
+    height: u32,
+) -> [u8; 4] {
+    match paint {
+        Paint::Solid { color } => colour(color, [0, 0, 0, 0]),
+        Paint::LinearGradient { start, end, stops } => {
+            let start = (start.x * width as f32, start.y * height as f32);
+            let end = (end.x * width as f32, end.y * height as f32);
+            let delta = (end.0 - start.0, end.1 - start.1);
+            let length = delta.0 * delta.0 + delta.1 * delta.1;
+            let position = if length <= f32::EPSILON {
+                0.0
+            } else {
+                ((x - start.0) * delta.0 + (y - start.1) * delta.1) / length
+            };
+            gradient(stops, position)
+        }
+        Paint::RadialGradient {
+            center,
+            radius,
+            stops,
+        } => {
+            let center = (center.x * width as f32, center.y * height as f32);
+            let radius = radius.max(0.001) * width.max(height) as f32;
+            gradient(stops, (x - center.0).hypot(y - center.1) / radius)
+        }
+        Paint::Image { .. } | Paint::Video { .. } => media
+            .and_then(|pixels| {
+                let x = x.floor().clamp(0.0, width.saturating_sub(1) as f32) as u32;
+                let y = y.floor().clamp(0.0, height.saturating_sub(1) as f32) as u32;
+                let index = ((y * width + x) * 4) as usize;
+                pixels
+                    .get(index..index + 4)
+                    .map(|pixel| [pixel[0], pixel[1], pixel[2], pixel[3]])
+            })
+            .unwrap_or([0, 0, 0, 0]),
+    }
+}
+
+fn gradient(stops: &[GradientStop], position: f32) -> [u8; 4] {
+    if stops.is_empty() {
+        return [0, 0, 0, 0];
+    }
+    let mut stops: Vec<_> = stops.iter().collect();
+    stops.sort_by(|left, right| left.position.total_cmp(&right.position));
+    let position = position.clamp(0.0, 1.0);
+    let first = stops[0];
+    if position <= first.position {
+        return colour(&first.color, [0, 0, 0, 0]);
+    }
+    for pair in stops.windows(2) {
+        if position <= pair[1].position {
+            let span = (pair[1].position - pair[0].position).max(f32::EPSILON);
+            let amount = ((position - pair[0].position) / span).clamp(0.0, 1.0);
+            let from = colour(&pair[0].color, [0, 0, 0, 0]);
+            let to = colour(&pair[1].color, [0, 0, 0, 0]);
+            let mut result = [0; 4];
+            for channel in 0..4 {
+                result[channel] = (from[channel] as f32
+                    + (to[channel] as f32 - from[channel] as f32) * amount)
+                    .round() as u8;
+            }
+            return result;
+        }
+    }
+    colour(&stops.last().unwrap().color, [0, 0, 0, 0])
+}
+
+fn blend_at(pixels: &mut [u8], width: u32, x: u32, y: u32, color: [u8; 4]) {
     let index = ((y * width + x) * 4) as usize;
-    pixels[index..index + 4].copy_from_slice(&color);
+    blend(&mut pixels[index..index + 4], color);
+}
+
+fn blend(destination: &mut [u8], source: [u8; 4]) {
+    let source_alpha = source[3] as f32 / 255.0;
+    if source_alpha <= 0.0 {
+        return;
+    }
+    let destination_alpha = destination[3] as f32 / 255.0;
+    let output_alpha = source_alpha + destination_alpha * (1.0 - source_alpha);
+    for channel in 0..3 {
+        destination[channel] = if output_alpha <= f32::EPSILON {
+            0
+        } else {
+            ((source[channel] as f32 * source_alpha
+                + destination[channel] as f32
+                    * destination_alpha
+                    * (1.0 - source_alpha))
+                / output_alpha)
+                .round()
+                .clamp(0.0, 255.0) as u8
+        };
+    }
+    destination[3] = (output_alpha * 255.0).round().clamp(0.0, 255.0) as u8;
 }
 
 fn cached(key: &str, build: impl FnOnce() -> Vec<u8>) -> Arc<[u8]> {
@@ -336,7 +751,14 @@ fn cached(key: &str, build: impl FnOnce() -> Vec<u8>) -> Arc<[u8]> {
     pixels
 }
 
-fn rasterize(text: &str, style: &TextStyle, width: u32, height: u32, scale: f32) -> Vec<u8> {
+fn rasterize(
+    text: &str,
+    style: &TextStyle,
+    width: u32,
+    height: u32,
+    scale: f32,
+    media: &[Option<Arc<[u8]>>],
+) -> Vec<u8> {
     let mut pixels = vec![0; width as usize * height as usize * 4];
     let Some(font) = load_font(&style.font_family) else {
         return pixels;
@@ -358,19 +780,54 @@ fn rasterize(text: &str, style: &TextStyle, width: u32, height: u32, scale: f32)
         &[font.clone()],
         &LayoutTextStyle::new(text, (style.font_size * scale).max(1.0), 0),
     );
-    let color = colour(&style.color, [255, 255, 255, 255]);
-    let shadow = colour(&style.shadow_color, [0, 0, 0, 0]);
-    let stroke = colour(&style.stroke_color, [0, 0, 0, 0]);
-    let stroke_radius = (style.stroke_width * scale).round().max(0.0) as i32;
-    let shadow_x = (style.shadow_x * scale).round() as i32;
-    let shadow_y = (style.shadow_y * scale).round() as i32;
+    let visual_style = &style.visual_style;
+    let shadow = visual_style
+        .shadow
+        .as_ref()
+        .map(|shadow| colour(&shadow.color, [0, 0, 0, 0]))
+        .unwrap_or([0, 0, 0, 0]);
+    let stroke = visual_style
+        .stroke
+        .as_ref()
+        .map(|stroke| colour(&stroke.color, [0, 0, 0, 0]))
+        .unwrap_or([0, 0, 0, 0]);
+    let stroke_radius = visual_style
+        .stroke
+        .as_ref()
+        .map(|stroke| (stroke.width * scale).round().max(0.0) as i32)
+        .unwrap_or(0);
+    let shadow_x = visual_style
+        .shadow
+        .as_ref()
+        .map(|shadow| (shadow.x * scale).round() as i32)
+        .unwrap_or(0);
+    let shadow_y = visual_style
+        .shadow
+        .as_ref()
+        .map(|shadow| (shadow.y * scale).round() as i32)
+        .unwrap_or(0);
+    let shadow_blur = visual_style
+        .shadow
+        .as_ref()
+        .map(|shadow| (shadow.blur * scale).round().clamp(0.0, 32.0) as i32)
+        .unwrap_or(0);
 
     for glyph in layout.glyphs() {
         let (metrics, bitmap) = font.rasterize_config(glyph.key);
         let x = glyph.x.round() as i32;
         let y = glyph.y.round() as i32;
         if shadow[3] > 0 {
-            draw_bitmap(&mut pixels, width, height, x + shadow_x, y + shadow_y, &metrics, &bitmap, shadow);
+            draw_bitmap_shadow(
+                &mut pixels,
+                width,
+                height,
+                x + shadow_x,
+                y + shadow_y,
+                &metrics,
+                &bitmap,
+                shadow,
+                shadow_blur,
+            );
         }
         if stroke_radius > 0 && stroke[3] > 0 {
             for offset_y in -stroke_radius..=stroke_radius {
@@ -381,7 +838,19 @@ fn rasterize(text: &str, style: &TextStyle, width: u32, height: u32, scale: f32)
                 }
             }
         }
-        draw_bitmap(&mut pixels, width, height, x, y, &metrics, &bitmap, color);
+        for (paint_index, paint) in visual_style.fills.iter().enumerate() {
+            draw_bitmap_paint(
+                &mut pixels,
+                width,
+                height,
+                x,
+                y,
+                &metrics,
+                &bitmap,
+                paint,
+                media.get(paint_index).and_then(Option::as_deref),
+            );
+        }
     }
     pixels
 }
@@ -492,13 +961,103 @@ fn draw_bitmap(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn draw_bitmap_shadow(
+    pixels: &mut [u8],
+    width: u32,
+    height: u32,
+    x: i32,
+    y: i32,
+    metrics: &fontdue::Metrics,
+    bitmap: &[u8],
+    color: [u8; 4],
+    blur: i32,
+) {
+    if blur == 0 {
+        draw_bitmap(pixels, width, height, x, y, metrics, bitmap, color);
+        return;
+    }
+    let diameter = (blur * 2 + 1) as u32;
+    let samples = diameter * diameter;
+    let mut sample = color;
+    sample[3] = ((color[3] as u32 + samples / 2) / samples).max(1) as u8;
+    for offset_y in -blur..=blur {
+        for offset_x in -blur..=blur {
+            draw_bitmap(
+                pixels,
+                width,
+                height,
+                x + offset_x,
+                y + offset_y,
+                metrics,
+                bitmap,
+                sample,
+            );
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_bitmap_paint(
+    pixels: &mut [u8],
+    width: u32,
+    height: u32,
+    x: i32,
+    y: i32,
+    metrics: &fontdue::Metrics,
+    bitmap: &[u8],
+    paint: &Paint,
+    media: Option<&[u8]>,
+) {
+    for row in 0..metrics.height as i32 {
+        for column in 0..metrics.width as i32 {
+            let target_x = x + column;
+            let target_y = y + row;
+            if target_x < 0 || target_y < 0 || target_x >= width as i32 || target_y >= height as i32 {
+                continue;
+            }
+            let coverage = bitmap[(row as usize) * metrics.width + column as usize] as u16;
+            if coverage == 0 {
+                continue;
+            }
+            let mut color = sample_paint(
+                paint,
+                media,
+                target_x as f32 + 0.5,
+                target_y as f32 + 0.5,
+                width,
+                height,
+            );
+            color[3] = (color[3] as u16 * coverage / 255) as u8;
+            blend_at(
+                pixels,
+                width,
+                target_x as u32,
+                target_y as u32,
+                color,
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use makevideo_render::{
-        Project, ProjectSettings, Rate, ShapeKind as Shape, Track, TrackKind, VisualContent as Content,
-        VisualItem, VisualTransform, FORMAT_VERSION,
+        Paint, Project, ProjectSettings, Rate, ShapeKind as Shape, Stroke, Track, TrackKind,
+        VisualContent as Content, VisualItem, VisualStyle, VisualTransform, FORMAT_VERSION,
     };
+
+    fn shape_style(fill: &str, stroke: &str, width: f32) -> VisualStyle {
+        VisualStyle {
+            fills: vec![Paint::solid(fill)],
+            stroke: (width > 0.0).then(|| Stroke {
+                color: stroke.into(),
+                width,
+            }),
+            shadow: None,
+        }
+    }
 
     fn project_with_shape() -> Project {
         Project {
@@ -530,9 +1089,7 @@ mod tests {
                     },
                     content: Content::Shape {
                         shape: Shape::Rectangle,
-                        fill: "#ff0000".into(),
-                        stroke: "#ffffff".into(),
-                        stroke_width: 1.0,
+                        visual_style: shape_style("#ff0000", "#ffffff", 1.0),
                         corner_radius: 0.0,
                         start_arrow: false,
                         end_arrow: false,
@@ -583,9 +1140,9 @@ mod tests {
         let width = 40;
         let pixels = rasterize_shape(
             ShapeKind::Rectangle,
-            "#00000000",
-            "#ff0000",
-            8.0,
+            &shape_style("#00000000", "#ff0000", 8.0),
+            &[],
+            1.0,
             0.0,
             false,
             false,
@@ -607,9 +1164,9 @@ mod tests {
     fn shapes_rasterize_fill_outline_and_line_arrows() {
         let rectangle = rasterize_shape(
             ShapeKind::Rectangle,
-            "#112233",
-            "#ffffff",
-            2.0,
+            &shape_style("#112233", "#ffffff", 2.0),
+            &[],
+            1.0,
             4.0,
             false,
             false,
@@ -621,9 +1178,9 @@ mod tests {
 
         let line = rasterize_shape(
             ShapeKind::Line,
-            "#00000000",
-            "#ff0000",
-            3.0,
+            &shape_style("#00000000", "#ff0000", 3.0),
+            &[],
+            1.0,
             0.0,
             true,
             true,
@@ -635,9 +1192,9 @@ mod tests {
 
         let no_stroke = rasterize_shape(
             ShapeKind::Line,
-            "#00000000",
-            "#ff0000",
-            0.0,
+            &shape_style("#00000000", "#ff0000", 0.0),
+            &[],
+            1.0,
             0.0,
             true,
             true,
@@ -645,5 +1202,55 @@ mod tests {
             12,
         );
         assert!(no_stroke.chunks_exact(4).all(|pixel| pixel[3] == 0));
+    }
+
+    #[test]
+    fn gradients_interpolate_and_multiple_fills_stack_bottom_to_top() {
+        let gradient = Paint::LinearGradient {
+            start: makevideo_render::PaintPoint { x: 0.0, y: 0.5 },
+            end: makevideo_render::PaintPoint { x: 1.0, y: 0.5 },
+            stops: vec![
+                GradientStop {
+                    position: 0.0,
+                    color: "#ff0000".into(),
+                },
+                GradientStop {
+                    position: 1.0,
+                    color: "#0000ff".into(),
+                },
+            ],
+        };
+        assert_eq!(sample_paint(&gradient, None, 0.0, 5.0, 10, 10), [255, 0, 0, 255]);
+        let middle = sample_paint(&gradient, None, 5.0, 5.0, 10, 10);
+        assert!((middle[0] as i16 - middle[2] as i16).abs() <= 1, "{middle:?}");
+
+        let paints = [Paint::solid("#ff0000"), Paint::solid("#0000ff80")];
+        let stacked = paint_stack(&paints, &[], 5.0, 5.0, 10, 10);
+        assert!(stacked[0] >= 126 && stacked[0] <= 128, "{stacked:?}");
+        assert!(stacked[2] >= 127 && stacked[2] <= 129, "{stacked:?}");
+        assert_eq!(stacked[3], 255);
+    }
+
+    #[test]
+    fn polygon_star_and_rounded_rectangle_have_distinct_geometry() {
+        let style = shape_style("#ffffff", "#000000", 0.0);
+        for shape in [ShapeKind::Polygon, ShapeKind::Star, ShapeKind::RoundedRectangle] {
+            let pixels = rasterize_shape(shape, &style, &[], 1.0, 5.0, false, false, 30, 30);
+            assert_eq!(&pixels[(15 * 30 + 15) * 4..(15 * 30 + 15) * 4 + 4], &[255; 4]);
+            assert_eq!(pixels[3], 0, "{shape:?} keeps its corner transparent");
+        }
+    }
+
+    #[test]
+    fn a_media_paint_samples_the_decoded_rgba_frame() {
+        let paint = Paint::Image {
+            asset_id: "image".into(),
+        };
+        let pixels = [
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 255, 255,
+        ];
+        assert_eq!(sample_paint(&paint, Some(&pixels), 1.5, 0.5, 2, 2), [0, 255, 0, 255]);
+        assert_eq!(sample_paint(&paint, Some(&pixels), 0.5, 1.5, 2, 2), [0, 0, 255, 255]);
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -31,6 +31,41 @@ static CACHE: OnceLock<Mutex<RasterCache>> = OnceLock::new();
 static FONT_DATABASE: OnceLock<Database> = OnceLock::new();
 static FONTS: OnceLock<Mutex<HashMap<String, Font>>> = OnceLock::new();
 static FFMPEG: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+static VIDEO_DECODERS: OnceLock<Mutex<PaintVideoDecoderCache>> = OnceLock::new();
+
+const VIDEO_DECODER_LIMIT: usize = 8;
+
+struct PaintVideoDecoder {
+    child: std::process::Child,
+    stdout: std::process::ChildStdout,
+    next_frame: i64,
+    frame_bytes: usize,
+}
+
+impl PaintVideoDecoder {
+    fn read(&mut self, frame: i64) -> Option<Vec<u8>> {
+        use std::io::Read;
+        if frame != self.next_frame {
+            return None;
+        }
+        let mut pixels = vec![0; self.frame_bytes];
+        self.stdout.read_exact(&mut pixels).ok()?;
+        self.next_frame += 1;
+        Some(pixels)
+    }
+}
+
+impl Drop for PaintVideoDecoder {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+struct PaintVideoDecoderCache {
+    entries: HashMap<String, PaintVideoDecoder>,
+    oldest: VecDeque<String>,
+}
 
 /// Keep media paints on the same ffmpeg executable as the decoder pipeline.
 /// Settings can replace it while the app is running, so this is updateable.
@@ -152,18 +187,19 @@ fn each_visual_item(
                     let style = track.subtitle_style.as_ref().unwrap_or(style);
                     let paint_frame = at.unwrap_or(item.start);
                     let relative_frame = paint_frame - item.start;
-                    let media = resolve_media_paints(
-                        project,
-                        &style.visual_style,
-                        relative_frame,
-                        item_width,
-                        item_height,
-                    );
                     let key = format!(
                         "text\u{0}{text}\u{0}{style:?}\u{0}{item_width}x{item_height}\u{0}{scale:.4}\u{0}{}",
                         media_cache_token(project, &style.visual_style, relative_frame)
                     );
                     cached(&key, || {
+                        let media = resolve_media_paints(
+                            project,
+                            &style.visual_style,
+                            &item.id,
+                            relative_frame,
+                            item_width,
+                            item_height,
+                        );
                         rasterize(text, style, item_width, item_height, scale, &media)
                     })
                 }
@@ -176,28 +212,31 @@ fn each_visual_item(
                 } => {
                     let paint_frame = at.unwrap_or(item.start);
                     let relative_frame = paint_frame - item.start;
-                    let media = resolve_media_paints(
-                        project,
-                        visual_style,
-                        relative_frame,
-                        item_width,
-                        item_height,
-                    );
                     let key = format!(
                         "shape\u{0}{shape:?}\u{0}{visual_style:?}\u{0}{corner_radius}\u{0}{start_arrow}\u{0}{end_arrow}\u{0}{item_width}x{item_height}\u{0}{scale:.4}\u{0}{}",
                         media_cache_token(project, visual_style, relative_frame)
                     );
-                    cached(&key, || rasterize_shape(
-                        *shape,
-                        visual_style,
-                        &media,
-                        scale,
-                        *corner_radius * scale,
-                        *start_arrow,
-                        *end_arrow,
-                        item_width,
-                        item_height,
-                    ))
+                    cached(&key, || {
+                        let media = resolve_media_paints(
+                            project,
+                            visual_style,
+                            &item.id,
+                            relative_frame,
+                            item_width,
+                            item_height,
+                        );
+                        rasterize_shape(
+                            *shape,
+                            visual_style,
+                            &media,
+                            scale,
+                            *corner_radius * scale,
+                            *start_arrow,
+                            *end_arrow,
+                            item_width,
+                            item_height,
+                        )
+                    })
                 }
                 VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => continue,
             };
@@ -285,6 +324,7 @@ fn media_cache_token(project: &Project, style: &VisualStyle, frame: i64) -> Stri
 fn resolve_media_paints(
     project: &Project,
     style: &VisualStyle,
+    item_id: &str,
     relative_frame: i64,
     width: u32,
     height: u32,
@@ -292,7 +332,8 @@ fn resolve_media_paints(
     style
         .fills
         .iter()
-        .map(|paint| {
+        .enumerate()
+        .map(|(paint_index, paint)| {
             let asset_id = paint.asset_id()?;
             let asset = project.asset(asset_id)?;
             let frame = match paint {
@@ -308,8 +349,17 @@ fn resolve_media_paints(
                 asset.path
             );
             let pixels = cached(&key, || {
-                decode_paint_frame(&asset.path, asset.kind, frame, project, width, height)
-                    .unwrap_or_default()
+                decode_paint_frame(
+                    &asset.path,
+                    asset.kind,
+                    item_id,
+                    paint_index,
+                    frame,
+                    project,
+                    width,
+                    height,
+                )
+                .unwrap_or_default()
             });
             (!pixels.is_empty()).then_some(pixels)
         })
@@ -319,19 +369,27 @@ fn resolve_media_paints(
 fn decode_paint_frame(
     path: &str,
     kind: makevideo_render::AssetKind,
+    item_id: &str,
+    paint_index: usize,
     frame: i64,
     project: &Project,
     width: u32,
     height: u32,
 ) -> Option<Vec<u8>> {
     let ffmpeg = ffmpeg_path()?;
-    let mut args = vec!["-hide_banner".to_string(), "-loglevel".into(), "error".into()];
     if kind == makevideo_render::AssetKind::Video {
-        args.extend([
-            "-ss".into(),
-            format!("{:.9}", frame as f64 / project.rate().as_f64()),
-        ]);
+        return decode_video_paint_frame(
+            &ffmpeg,
+            path,
+            item_id,
+            paint_index,
+            frame,
+            project,
+            width,
+            height,
+        );
     }
+    let mut args = vec!["-hide_banner".to_string(), "-loglevel".into(), "error".into()];
     args.extend([
         "-i".into(),
         path.into(),
@@ -356,6 +414,95 @@ fn decode_paint_frame(
     let expected = width as usize * height as usize * 4;
     (output.status.success() && output.stdout.len() >= expected)
         .then(|| output.stdout[..expected].to_vec())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn decode_video_paint_frame(
+    ffmpeg: &str,
+    path: &str,
+    item_id: &str,
+    paint_index: usize,
+    frame: i64,
+    project: &Project,
+    width: u32,
+    height: u32,
+) -> Option<Vec<u8>> {
+    let rate = project.rate();
+    let key = format!(
+        "{ffmpeg}\u{0}{path}\u{0}{item_id}\u{0}{paint_index}\u{0}{width}x{height}\u{0}{}/{}",
+        rate.num(),
+        rate.den()
+    );
+    let cache = VIDEO_DECODERS.get_or_init(|| {
+        Mutex::new(PaintVideoDecoderCache {
+            entries: HashMap::new(),
+            oldest: VecDeque::new(),
+        })
+    });
+    let mut cache = cache.lock().unwrap();
+    if let Some(decoder) = cache.entries.get_mut(&key) {
+        if let Some(pixels) = decoder.read(frame) {
+            return Some(pixels);
+        }
+    }
+    cache.entries.remove(&key);
+    cache.oldest.retain(|entry| entry != &key);
+    while cache.entries.len() >= VIDEO_DECODER_LIMIT {
+        let oldest = cache.oldest.pop_front()?;
+        cache.entries.remove(&oldest);
+    }
+    let mut decoder = spawn_video_paint_decoder(ffmpeg, path, frame, project, width, height)?;
+    let pixels = decoder.read(frame)?;
+    cache.oldest.push_back(key.clone());
+    cache.entries.insert(key, decoder);
+    Some(pixels)
+}
+
+fn spawn_video_paint_decoder(
+    ffmpeg: &str,
+    path: &str,
+    frame: i64,
+    project: &Project,
+    width: u32,
+    height: u32,
+) -> Option<PaintVideoDecoder> {
+    let rate = project.rate();
+    let mut args = vec!["-hide_banner".to_string(), "-loglevel".into(), "error".into()];
+    if frame > 0 {
+        args.extend([
+            "-ss".into(),
+            format!("{:.9}", frame as f64 / rate.as_f64()),
+        ]);
+    }
+    args.extend([
+        "-i".into(),
+        path.into(),
+        "-vf".into(),
+        format!(
+            "fps={}/{},scale={width}:{height}:force_original_aspect_ratio=increase,crop={width}:{height}",
+            rate.num(),
+            rate.den()
+        ),
+        "-pix_fmt".into(),
+        "rgba".into(),
+        "-f".into(),
+        "rawvideo".into(),
+        "pipe:1".into(),
+    ]);
+    let mut child = std::process::Command::new(ffmpeg)
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    let stdout = child.stdout.take()?;
+    Some(PaintVideoDecoder {
+        child,
+        stdout,
+        next_frame: frame,
+        frame_bytes: width as usize * height as usize * 4,
+    })
 }
 
 fn ffmpeg_path() -> Option<String> {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -250,6 +250,19 @@ pub enum Command {
         #[serde(default)]
         id: Option<String>,
     },
+    /// Add text or a shape above the picture. A clip-free top video track is
+    /// reused; otherwise a new top track and the item are one undo step. At
+    /// the track limit the existing top video track is the fallback.
+    #[serde(rename_all = "camelCase")]
+    AddOverlayVisualItem {
+        content: VisualContent,
+        start: i64,
+        duration: i64,
+        transform: VisualTransform,
+        z_index: i32,
+        #[serde(default)]
+        id: Option<String>,
+    },
     #[serde(rename_all = "camelCase")]
     SetVisualTransform {
         item_id: String,
@@ -445,6 +458,7 @@ impl Command {
             Command::SetClipGain { .. } => "Clip levels",
             Command::SetClipLut { .. } => "Clip LUT",
             Command::AddVisualItem { .. } => "Add visual item",
+            Command::AddOverlayVisualItem { .. } => "Add visual item",
             Command::SetVisualTransform { .. } => "Transform visual item",
             Command::SetVisualTiming { .. } => "Time visual item",
             Command::SetVisualZIndex { .. } => "Reorder visual item",
@@ -590,6 +604,16 @@ impl Command {
             } => add_visual_item(
                 project, ids, track_id, content, start, duration, transform, z_index, id,
             ),
+            Command::AddOverlayVisualItem {
+                content,
+                start,
+                duration,
+                transform,
+                z_index,
+                id,
+            } => add_overlay_visual_item(
+                project, ids, content, start, duration, transform, z_index, id,
+            ),
             Command::SetVisualTransform { item_id, transform } => {
                 set_visual_transform(project, item_id, transform)
             }
@@ -714,7 +738,7 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
         }
         track.clips.retain(|clip| clip.asset_id != asset_id);
         for item in &track.visual_items {
-            if item.content.asset_id() == Some(asset_id.as_str()) {
+            if item.content.references_asset(&asset_id) {
                 orphan_items.push(VisualItemAt {
                     track_id: track.id.clone(),
                     item: item.clone(),
@@ -723,7 +747,7 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
         }
         track
             .visual_items
-            .retain(|item| item.content.asset_id() != Some(asset_id.as_str()));
+            .retain(|item| !item.content.references_asset(&asset_id));
     }
     Ok(Applied {
         resolved: Command::RemoveAsset { asset_id },
@@ -1982,6 +2006,76 @@ fn add_visual_item(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+fn add_overlay_visual_item(
+    project: &mut Project,
+    ids: &mut Ids,
+    content: VisualContent,
+    start: i64,
+    duration: i64,
+    transform: VisualTransform,
+    z_index: i32,
+    id: Option<String>,
+) -> Result<Applied, String> {
+    if !matches!(content, VisualContent::Text { .. } | VisualContent::Shape { .. }) {
+        return Err("only text and shapes use an overlay track".into());
+    }
+    let videos: Vec<_> = project
+        .tracks
+        .iter()
+        .filter(|track| track.kind == TrackKind::Video)
+        .collect();
+    let reusable = videos.last().filter(|track| {
+        track.clips.is_empty()
+            && track.visual_items.iter().all(|item| {
+                matches!(item.content, VisualContent::Text { .. } | VisualContent::Shape { .. })
+            })
+    });
+    if let Some(track) = reusable {
+        return add_visual_item(
+            project,
+            ids,
+            track.id.clone(),
+            content,
+            start,
+            duration,
+            transform,
+            z_index,
+            id,
+        );
+    }
+    if videos.len() >= crate::MAX_TRACKS_PER_KIND {
+        let track_id = videos
+            .last()
+            .map(|track| track.id.clone())
+            .ok_or("there is no video track for that visual item")?;
+        return add_visual_item(
+            project, ids, track_id, content, start, duration, transform, z_index, id,
+        );
+    }
+
+    let track_id = ids.make('t');
+    transaction(
+        project,
+        ids,
+        vec![
+            Command::AddTrack {
+                track_kind: TrackKind::Video,
+                id: Some(track_id.clone()),
+            },
+            Command::AddVisualItem {
+                track_id,
+                content,
+                start,
+                duration,
+                transform,
+                z_index,
+                id,
+            },
+        ],
+    )
+}
+
 fn set_visual_transform(
     project: &mut Project,
     item_id: String,
@@ -2078,21 +2172,47 @@ fn set_visual_content(
 }
 
 fn validate_visual_content(project: &Project, content: &VisualContent) -> Result<(), String> {
-    let Some(asset_id) = content.asset_id() else {
-        return Ok(());
-    };
-    let asset = project
-        .asset(asset_id)
-        .ok_or("that visual item asset is not in this project")?;
-    match (content, asset.kind) {
-        (VisualContent::Image { .. }, crate::AssetKind::Image)
-        | (VisualContent::VideoOverlay { .. }, crate::AssetKind::Video) => Ok(()),
-        (VisualContent::Image { .. }, _) => Err("an image item needs an image asset".into()),
-        (VisualContent::VideoOverlay { .. }, _) => {
-            Err("a video overlay needs a video asset".into())
+    if let Some(asset_id) = content.asset_id() {
+        let asset = project
+            .asset(asset_id)
+            .ok_or("that visual item asset is not in this project")?;
+        match (content, asset.kind) {
+            (VisualContent::Image { .. }, crate::AssetKind::Image)
+            | (VisualContent::VideoOverlay { .. }, crate::AssetKind::Video)
+            | (VisualContent::Text { .. } | VisualContent::Shape { .. }, _) => {}
+            (VisualContent::Image { .. }, _) => {
+                return Err("an image item needs an image asset".into())
+            }
+            (VisualContent::VideoOverlay { .. }, _) => {
+                return Err("a video overlay needs a video asset".into())
+            }
         }
-        (VisualContent::Text { .. } | VisualContent::Shape { .. }, _) => Ok(()),
     }
+    let style = match content {
+        VisualContent::Text { style, .. } => Some(&style.visual_style),
+        VisualContent::Shape { visual_style, .. } => Some(visual_style),
+        VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => None,
+    };
+    for paint in style.into_iter().flat_map(|style| &style.fills) {
+        let Some(asset_id) = paint.asset_id() else {
+            continue;
+        };
+        let asset = project
+            .asset(asset_id)
+            .ok_or("that paint asset is not in this project")?;
+        match (paint, asset.kind) {
+            (crate::Paint::Image { .. }, crate::AssetKind::Image)
+            | (crate::Paint::Video { .. }, crate::AssetKind::Video) => {}
+            (crate::Paint::Image { .. }, _) => {
+                return Err("an image paint needs an image asset".into())
+            }
+            (crate::Paint::Video { .. }, _) => {
+                return Err("a video paint needs a video asset".into())
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 fn remove_visual_item(project: &mut Project, item_id: String) -> Result<Applied, String> {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -2193,6 +2193,9 @@ fn validate_visual_content(project: &Project, content: &VisualContent) -> Result
         VisualContent::Shape { visual_style, .. } => Some(visual_style),
         VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => None,
     };
+    if let Some(style) = style {
+        style.validate().map_err(str::to_string)?;
+    }
     for paint in style.into_iter().flat_map(|style| &style.fills) {
         let Some(asset_id) = paint.asset_id() else {
             continue;

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -1277,7 +1277,7 @@ mod tests {
                 track_id: video_track(&document),
                 content: VisualContent::Shape {
                     shape: Default::default(),
-                    visual_style: Default::default(),
+                    visual_style: VisualStyle::shape_default(),
                     corner_radius: 0.0,
                     start_arrow: false,
                     end_arrow: false,
@@ -1301,6 +1301,37 @@ mod tests {
     }
 
     #[test]
+    fn a_visual_style_without_a_fill_is_rejected_before_it_changes_the_project() {
+        let mut document = document();
+        let error = document
+            .apply(Command::AddVisualItem {
+                track_id: video_track(&document),
+                content: VisualContent::Shape {
+                    shape: Default::default(),
+                    visual_style: VisualStyle::default(),
+                    corner_radius: 0.0,
+                    start_arrow: false,
+                    end_arrow: false,
+                },
+                start: 0,
+                duration: 30,
+                transform: VisualTransform {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 100.0,
+                    rotation: 0.0,
+                    opacity: 1.0,
+                },
+                z_index: 0,
+                id: None,
+            })
+            .unwrap_err();
+        assert!(error.contains("no fills"), "{error}");
+        assert!(document.project().tracks[0].visual_items.is_empty());
+    }
+
+    #[test]
     fn duplicate_visual_item_ids_are_rejected_without_changing_the_project() {
         let mut document = document();
         let track_id = video_track(&document);
@@ -1308,7 +1339,7 @@ mod tests {
             track_id,
             content: VisualContent::Shape {
                 shape: Default::default(),
-                visual_style: Default::default(),
+                visual_style: VisualStyle::shape_default(),
                 corner_radius: 0.0,
                 start_arrow: false,
                 end_arrow: false,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -256,8 +256,8 @@ impl Document {
 mod tests {
     use super::*;
     use crate::{
-        Asset, AssetKind, Clip, Command, Edge, ProjectSettings, Rate, TrackKind, VisualContent,
-        TextStyle, VisualTransform,
+        Asset, AssetKind, Clip, Command, Edge, Paint, ProjectSettings, Rate, TrackKind,
+        VisualContent, VisualStyle, TextStyle, VisualTransform,
     };
 
     fn asset(id: &str, kind: AssetKind, duration_ms: u64) -> Asset {
@@ -771,16 +771,48 @@ mod tests {
         add(&mut document, 0);
         add(&mut document, 300);
         document
+            .apply(Command::AddVisualItem {
+                track_id: video_track(&document),
+                content: VisualContent::Shape {
+                    shape: Default::default(),
+                    visual_style: VisualStyle {
+                        fills: vec![Paint::Video {
+                            asset_id: "v".into(),
+                        }],
+                        stroke: None,
+                        shadow: None,
+                    },
+                    corner_radius: 0.0,
+                    start_arrow: false,
+                    end_arrow: false,
+                },
+                start: 0,
+                duration: 30,
+                transform: VisualTransform {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 100.0,
+                    rotation: 0.0,
+                    opacity: 1.0,
+                },
+                z_index: 0,
+                id: None,
+            })
+            .unwrap();
+        document
             .apply(Command::RemoveAsset {
                 asset_id: "v".into(),
             })
             .unwrap();
         assert!(document.project().assets.is_empty());
         assert!(clips(&document).is_empty());
+        assert!(document.project().tracks[0].visual_items.is_empty());
 
         document.undo().unwrap();
         assert_eq!(document.project().assets.len(), 1);
         assert_eq!(clips(&document).len(), 2);
+        assert_eq!(document.project().tracks[0].visual_items.len(), 1);
     }
 
     #[test]
@@ -1245,9 +1277,7 @@ mod tests {
                 track_id: video_track(&document),
                 content: VisualContent::Shape {
                     shape: Default::default(),
-                    fill: "#4f8cffcc".into(),
-                    stroke: "#ffffff".into(),
-                    stroke_width: 4.0,
+                    visual_style: Default::default(),
                     corner_radius: 0.0,
                     start_arrow: false,
                     end_arrow: false,
@@ -1278,9 +1308,7 @@ mod tests {
             track_id,
             content: VisualContent::Shape {
                 shape: Default::default(),
-                fill: "#4f8cffcc".into(),
-                stroke: "#ffffff".into(),
-                stroke_width: 4.0,
+                visual_style: Default::default(),
                 corner_radius: 0.0,
                 start_arrow: false,
                 end_arrow: false,
@@ -1304,6 +1332,112 @@ mod tests {
 
         assert!(error.contains("already in this project"), "{error}");
         assert_eq!(document.project().tracks[0].visual_items.len(), 1);
+    }
+
+    fn overlay_command(text: &str) -> Command {
+        Command::AddOverlayVisualItem {
+            content: VisualContent::Text {
+                text: text.into(),
+                style: TextStyle::default(),
+            },
+            start: 0,
+            duration: 30,
+            transform: VisualTransform {
+                x: 10.0,
+                y: 10.0,
+                width: 100.0,
+                height: 40.0,
+                rotation: 0.0,
+                opacity: 1.0,
+            },
+            z_index: 0,
+            id: None,
+        }
+    }
+
+    #[test]
+    fn an_overlay_gets_a_top_track_and_one_undo_removes_both() {
+        let mut document = document();
+        add(&mut document, 0);
+
+        document.apply(overlay_command("title")).unwrap();
+
+        let videos: Vec<_> = document
+            .project()
+            .tracks_of(TrackKind::Video)
+            .collect();
+        assert_eq!(videos.len(), 2);
+        assert_eq!(videos[0].clips.len(), 1);
+        assert!(videos[1].clips.is_empty());
+        assert_eq!(videos[1].visual_items.len(), 1);
+        let item_id = videos[1].visual_items[0].id.clone();
+
+        document.undo().unwrap();
+        assert_eq!(document.project().tracks_of(TrackKind::Video).count(), 1);
+        assert!(document.project().visual_item(&item_id).is_none());
+        assert_eq!(document.project().tracks[0].clips.len(), 1);
+
+        document.redo().unwrap();
+        let videos: Vec<_> = document
+            .project()
+            .tracks_of(TrackKind::Video)
+            .collect();
+        assert_eq!(videos.len(), 2);
+        assert_eq!(videos[1].visual_items[0].id, item_id);
+    }
+
+    #[test]
+    fn consecutive_overlays_reuse_the_clip_free_top_track() {
+        let mut document = document();
+        add(&mut document, 0);
+        document.apply(overlay_command("one")).unwrap();
+        document.apply(overlay_command("two")).unwrap();
+
+        let videos: Vec<_> = document
+            .project()
+            .tracks_of(TrackKind::Video)
+            .collect();
+        assert_eq!(videos.len(), 2);
+        assert_eq!(videos[1].visual_items.len(), 2);
+    }
+
+    #[test]
+    fn the_track_limit_falls_back_to_the_top_video_track() {
+        let mut document = document();
+        add(&mut document, 0);
+        for _ in 1..crate::MAX_TRACKS_PER_KIND {
+            document
+                .apply(Command::AddTrack {
+                    track_kind: TrackKind::Video,
+                    id: None,
+                })
+                .unwrap();
+            let top = document
+                .project()
+                .tracks_of(TrackKind::Video)
+                .last()
+                .unwrap()
+                .id
+                .clone();
+            document
+                .apply(Command::AddClip {
+                    track_id: top,
+                    asset_id: "v".into(),
+                    start: 0,
+                    id: None,
+                    link_group: None,
+                })
+                .unwrap();
+        }
+
+        document.apply(overlay_command("top")).unwrap();
+
+        let videos: Vec<_> = document
+            .project()
+            .tracks_of(TrackKind::Video)
+            .collect();
+        assert_eq!(videos.len(), crate::MAX_TRACKS_PER_KIND);
+        assert_eq!(videos.last().unwrap().visual_items.len(), 1);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -34,7 +34,7 @@ use std::collections::{HashMap, HashSet};
 /// What `version` a project file written today holds. Version 1 measured
 /// everything in whole milliseconds; `migrate` turns one of those into this on
 /// the way in, so a project saved before this existed still opens.
-pub const FORMAT_VERSION: u32 = 2;
+pub const FORMAT_VERSION: u32 = 3;
 
 /// Four of each is as many as the timeline header has room to name, and a
 /// timeline that needs a fifth video track is asking for a different app.
@@ -319,10 +319,6 @@ fn default_font_size() -> f32 {
     64.0
 }
 
-fn default_text_color() -> String {
-    "#ffffff".into()
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TextAlign {
@@ -337,27 +333,17 @@ impl Default for TextAlign {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TextStyle {
     #[serde(default = "default_font_family")]
     pub font_family: String,
     #[serde(default = "default_font_size")]
     pub font_size: f32,
-    #[serde(default = "default_text_color")]
-    pub color: String,
     #[serde(default)]
     pub align: TextAlign,
-    #[serde(default)]
-    pub stroke_color: String,
-    #[serde(default)]
-    pub stroke_width: f32,
-    #[serde(default)]
-    pub shadow_color: String,
-    #[serde(default)]
-    pub shadow_x: f32,
-    #[serde(default)]
-    pub shadow_y: f32,
+    #[serde(flatten)]
+    pub visual_style: VisualStyle,
 }
 
 impl Default for TextStyle {
@@ -365,18 +351,277 @@ impl Default for TextStyle {
         TextStyle {
             font_family: default_font_family(),
             font_size: default_font_size(),
-            color: default_text_color(),
             align: TextAlign::default(),
-            stroke_color: String::new(),
-            stroke_width: 0.0,
-            shadow_color: "#00000080".into(),
-            shadow_x: 2.0,
-            shadow_y: 2.0,
+            visual_style: default_text_visual_style(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaintPoint {
+    pub x: f32,
+    pub y: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GradientStop {
+    pub position: f32,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum Paint {
+    Solid {
+        color: String,
+    },
+    LinearGradient {
+        #[serde(default = "default_linear_start")]
+        start: PaintPoint,
+        #[serde(default = "default_linear_end")]
+        end: PaintPoint,
+        #[serde(default = "default_gradient_stops")]
+        stops: Vec<GradientStop>,
+    },
+    RadialGradient {
+        #[serde(default = "default_radial_center")]
+        center: PaintPoint,
+        #[serde(default = "default_radial_radius")]
+        radius: f32,
+        #[serde(default = "default_gradient_stops")]
+        stops: Vec<GradientStop>,
+    },
+    Image {
+        asset_id: String,
+    },
+    Video {
+        asset_id: String,
+    },
+}
+
+impl Paint {
+    pub fn solid(color: impl Into<String>) -> Paint {
+        Paint::Solid {
+            color: color.into(),
+        }
+    }
+
+    pub fn asset_id(&self) -> Option<&str> {
+        match self {
+            Paint::Image { asset_id } | Paint::Video { asset_id } => Some(asset_id),
+            Paint::Solid { .. }
+            | Paint::LinearGradient { .. }
+            | Paint::RadialGradient { .. } => None,
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Stroke {
+    pub color: String,
+    #[serde(default)]
+    pub width: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Shadow {
+    pub color: String,
+    #[serde(default)]
+    pub x: f32,
+    #[serde(default)]
+    pub y: f32,
+    #[serde(default)]
+    pub blur: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualStyle {
+    #[serde(default)]
+    pub fills: Vec<Paint>,
+    #[serde(default)]
+    pub stroke: Option<Stroke>,
+    #[serde(default)]
+    pub shadow: Option<Shadow>,
+}
+
+impl VisualStyle {
+    pub fn shape_default() -> VisualStyle {
+        VisualStyle {
+            fills: vec![Paint::solid("#4f8cffcc")],
+            stroke: Some(Stroke {
+                color: "#ffffff".into(),
+                width: 4.0,
+            }),
+            shadow: None,
+        }
+    }
+
+    fn validate(&self) -> Result<(), &'static str> {
+        for paint in &self.fills {
+            match paint {
+                Paint::LinearGradient { start, end, stops } => {
+                    if ![start.x, start.y, end.x, end.y].into_iter().all(f32::is_finite) {
+                        return Err("has a non-finite linear gradient");
+                    }
+                    validate_stops(stops)?;
+                }
+                Paint::RadialGradient {
+                    center,
+                    radius,
+                    stops,
+                } => {
+                    if ![center.x, center.y, *radius].into_iter().all(f32::is_finite)
+                        || *radius <= 0.0
+                    {
+                        return Err("has an invalid radial gradient");
+                    }
+                    validate_stops(stops)?;
+                }
+                Paint::Image { asset_id } | Paint::Video { asset_id } if asset_id.is_empty() => {
+                    return Err("has a paint without an asset")
+                }
+                Paint::Solid { .. } | Paint::Image { .. } | Paint::Video { .. } => {}
+            }
+        }
+        if self
+            .stroke
+            .as_ref()
+            .is_some_and(|stroke| !stroke.width.is_finite() || stroke.width < 0.0)
+        {
+            return Err("has an invalid stroke");
+        }
+        if self.shadow.as_ref().is_some_and(|shadow| {
+            ![shadow.x, shadow.y, shadow.blur]
+                .into_iter()
+                .all(f32::is_finite)
+                || shadow.blur < 0.0
+        }) {
+            return Err("has an invalid shadow");
+        }
+        Ok(())
+    }
+}
+
+fn validate_stops(stops: &[GradientStop]) -> Result<(), &'static str> {
+    if stops.is_empty()
+        || stops
+            .iter()
+            .any(|stop| !stop.position.is_finite() || !(0.0..=1.0).contains(&stop.position))
+    {
+        return Err("has invalid gradient stops");
+    }
+    Ok(())
+}
+
+fn default_linear_start() -> PaintPoint {
+    PaintPoint { x: 0.0, y: 0.5 }
+}
+
+fn default_linear_end() -> PaintPoint {
+    PaintPoint { x: 1.0, y: 0.5 }
+}
+
+fn default_radial_center() -> PaintPoint {
+    PaintPoint { x: 0.5, y: 0.5 }
+}
+
+fn default_radial_radius() -> f32 {
+    0.5
+}
+
+fn default_gradient_stops() -> Vec<GradientStop> {
+    vec![
+        GradientStop {
+            position: 0.0,
+            color: "#ffffff".into(),
+        },
+        GradientStop {
+            position: 1.0,
+            color: "#000000".into(),
+        },
+    ]
+}
+
+fn default_text_visual_style() -> VisualStyle {
+    VisualStyle {
+        fills: vec![Paint::solid("#ffffff")],
+        stroke: None,
+        shadow: Some(Shadow {
+            color: "#00000080".into(),
+            x: 2.0,
+            y: 2.0,
+            blur: 0.0,
+        }),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireTextStyle {
+    #[serde(default = "default_font_family")]
+    font_family: String,
+    #[serde(default = "default_font_size")]
+    font_size: f32,
+    #[serde(default)]
+    align: TextAlign,
+    fills: Option<Vec<Paint>>,
+    stroke: Option<Stroke>,
+    shadow: Option<Shadow>,
+    color: Option<String>,
+    stroke_color: Option<String>,
+    stroke_width: Option<f32>,
+    shadow_color: Option<String>,
+    shadow_x: Option<f32>,
+    shadow_y: Option<f32>,
+}
+
+impl<'de> Deserialize<'de> for TextStyle {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = WireTextStyle::deserialize(deserializer)?;
+        let visual_style = if let Some(fills) = wire.fills {
+            VisualStyle {
+                fills,
+                stroke: wire.stroke,
+                shadow: wire.shadow,
+            }
+        } else {
+            VisualStyle {
+                fills: vec![Paint::solid(wire.color.unwrap_or_else(|| "#ffffff".into()))],
+                stroke: wire
+                    .stroke_width
+                    .filter(|width| *width > 0.0)
+                    .map(|width| Stroke {
+                        color: wire.stroke_color.unwrap_or_else(|| "#000000".into()),
+                        width,
+                    }),
+                shadow: wire.shadow_color.and_then(|color| {
+                    (!color.is_empty()).then_some(Shadow {
+                        color,
+                        x: wire.shadow_x.unwrap_or(2.0),
+                        y: wire.shadow_y.unwrap_or(2.0),
+                        blur: 0.0,
+                    })
+                }),
+            }
+        };
+        Ok(TextStyle {
+            font_family: wire.font_family,
+            font_size: wire.font_size,
+            align: wire.align,
+            visual_style,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(
     tag = "kind",
     rename_all = "camelCase",
@@ -391,12 +636,8 @@ pub enum VisualContent {
     Shape {
         #[serde(default)]
         shape: ShapeKind,
-        #[serde(default = "default_shape_fill")]
-        fill: String,
-        #[serde(default = "default_shape_stroke")]
-        stroke: String,
-        #[serde(default = "default_shape_stroke_width")]
-        stroke_width: f32,
+        #[serde(flatten)]
+        visual_style: VisualStyle,
         #[serde(default)]
         corner_radius: f32,
         #[serde(default)]
@@ -417,6 +658,37 @@ impl VisualContent {
             VisualContent::Text { .. } | VisualContent::Shape { .. } => None,
         }
     }
+
+    pub fn references_asset(&self, wanted: &str) -> bool {
+        if self.asset_id() == Some(wanted) {
+            return true;
+        }
+        let style = match self {
+            VisualContent::Text { style, .. } => Some(&style.visual_style),
+            VisualContent::Shape { visual_style, .. } => Some(visual_style),
+            VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => None,
+        };
+        style.is_some_and(|style| {
+            style
+                .fills
+                .iter()
+                .any(|paint| paint.asset_id() == Some(wanted))
+        })
+    }
+
+    pub fn uses_video_paint(&self) -> bool {
+        let style = match self {
+            VisualContent::Text { style, .. } => Some(&style.visual_style),
+            VisualContent::Shape { visual_style, .. } => Some(visual_style),
+            VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => None,
+        };
+        style.is_some_and(|style| {
+            style
+                .fills
+                .iter()
+                .any(|paint| matches!(paint, Paint::Video { .. }))
+        })
+    }
 }
 
 /// The primitive drawn inside a shape item's shared transform rectangle.
@@ -424,8 +696,11 @@ impl VisualContent {
 #[serde(rename_all = "camelCase")]
 pub enum ShapeKind {
     Rectangle,
+    RoundedRectangle,
     Ellipse,
     Line,
+    Polygon,
+    Star,
 }
 
 impl Default for ShapeKind {
@@ -434,16 +709,105 @@ impl Default for ShapeKind {
     }
 }
 
-fn default_shape_fill() -> String {
-    "#4f8cffcc".into()
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+enum WireVisualContent {
+    Text {
+        text: String,
+        #[serde(default)]
+        style: TextStyle,
+    },
+    Shape {
+        #[serde(default)]
+        shape: ShapeKind,
+        fills: Option<Vec<Paint>>,
+        shadow: Option<Shadow>,
+        fill: Option<String>,
+        stroke: Option<WireStroke>,
+        stroke_width: Option<f32>,
+        #[serde(default)]
+        corner_radius: f32,
+        #[serde(default)]
+        start_arrow: bool,
+        #[serde(default)]
+        end_arrow: bool,
+    },
+    Image { asset_id: String },
+    VideoOverlay { asset_id: String },
 }
 
-fn default_shape_stroke() -> String {
-    "#ffffff".into()
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum WireStroke {
+    Legacy(String),
+    Current(Stroke),
 }
 
-fn default_shape_stroke_width() -> f32 {
-    4.0
+impl<'de> Deserialize<'de> for VisualContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match WireVisualContent::deserialize(deserializer)? {
+            WireVisualContent::Text { text, style } => Ok(VisualContent::Text { text, style }),
+            WireVisualContent::Shape {
+                shape,
+                fills,
+                shadow,
+                fill,
+                stroke,
+                stroke_width,
+                corner_radius,
+                start_arrow,
+                end_arrow,
+            } => {
+                let legacy = fills.is_none();
+                let visual_style = if let Some(fills) = fills {
+                    VisualStyle {
+                        fills,
+                        stroke: stroke.and_then(|value| match value {
+                            WireStroke::Current(stroke) => Some(stroke),
+                            WireStroke::Legacy(_) => None,
+                        }),
+                        shadow,
+                    }
+                } else {
+                    let width = stroke_width.unwrap_or(4.0);
+                    VisualStyle {
+                        fills: vec![Paint::solid(
+                            fill.unwrap_or_else(|| "#4f8cffcc".into()),
+                        )],
+                        stroke: (width > 0.0).then(|| Stroke {
+                            color: stroke
+                                .and_then(|value| match value {
+                                    WireStroke::Legacy(color) => Some(color),
+                                    WireStroke::Current(_) => None,
+                                })
+                                .unwrap_or_else(|| "#ffffff".into()),
+                            width,
+                        }),
+                        shadow: None,
+                    }
+                };
+                let shape = if legacy && shape == ShapeKind::Rectangle && corner_radius > 0.0 {
+                    ShapeKind::RoundedRectangle
+                } else {
+                    shape
+                };
+                Ok(VisualContent::Shape {
+                    shape,
+                    visual_style,
+                    corner_radius,
+                    start_arrow,
+                    end_arrow,
+                })
+            }
+            WireVisualContent::Image { asset_id } => Ok(VisualContent::Image { asset_id }),
+            WireVisualContent::VideoOverlay { asset_id } => {
+                Ok(VisualContent::VideoOverlay { asset_id })
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -574,6 +938,15 @@ impl Project {
 
     pub fn asset_index(&self, id: &str) -> Option<usize> {
         self.assets.iter().position(|asset| asset.id == id)
+    }
+
+    pub fn uses_video_paint(&self) -> bool {
+        self.tracks.iter().filter(|track| track.contributes()).any(|track| {
+            track
+                .visual_items
+                .iter()
+                .any(|item| item.content.uses_video_paint())
+        })
     }
 
     pub fn track(&self, id: &str) -> Option<&Track> {
@@ -834,6 +1207,14 @@ impl Project {
                         "visual item {name} has opacity outside 0 through 1"
                     ));
                 }
+                let style = match &item.content {
+                    VisualContent::Text { style, .. } => Some(&style.visual_style),
+                    VisualContent::Shape { visual_style, .. } => Some(visual_style),
+                    VisualContent::Image { .. } | VisualContent::VideoOverlay { .. } => None,
+                };
+                if let Some(error) = style.and_then(|style| style.validate().err()) {
+                    return Err(format!("visual item {name} {error}"));
+                }
             }
         }
         for (group, entries) in links {
@@ -1022,9 +1403,7 @@ mod tests {
             z_index,
             content: VisualContent::Shape {
                 shape: ShapeKind::Rectangle,
-                fill: default_shape_fill(),
-                stroke: default_shape_stroke(),
-                stroke_width: default_shape_stroke_width(),
+                visual_style: VisualStyle::shape_default(),
                 corner_radius: 0.0,
                 start_arrow: false,
                 end_arrow: false,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -462,6 +462,9 @@ impl VisualStyle {
     }
 
     fn validate(&self) -> Result<(), &'static str> {
+        if self.fills.is_empty() {
+            return Err("has no fills");
+        }
         for paint in &self.fills {
             match paint {
                 Paint::LinearGradient { start, end, stops } => {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
@@ -253,11 +253,51 @@ mod tests {
     #[test]
     fn an_early_shape_without_style_opens_with_editable_defaults() {
         let content: crate::VisualContent = serde_json::from_str(r#"{"kind":"shape"}"#).unwrap();
-        assert!(matches!(content, crate::VisualContent::Shape {
-            shape: crate::ShapeKind::Rectangle,
-            stroke_width: 4.0,
+        let crate::VisualContent::Shape {
+            shape,
+            visual_style,
             ..
-        }));
+        } = content else {
+            panic!("expected a shape");
+        };
+        assert_eq!(shape, crate::ShapeKind::Rectangle);
+        assert_eq!(visual_style.stroke.unwrap().width, 4.0);
+    }
+
+    #[test]
+    fn legacy_shape_and_text_colours_become_paints_and_old_fields_are_not_written() {
+        let shape: crate::VisualContent = serde_json::from_str(
+            r##"{"kind":"shape","shape":"rectangle","fill":"#112233","stroke":"#445566","strokeWidth":7,"cornerRadius":12}"##,
+        )
+        .unwrap();
+        let crate::VisualContent::Shape {
+            shape: kind,
+            visual_style,
+            ..
+        } = &shape else {
+            panic!("expected a shape");
+        };
+        assert_eq!(*kind, crate::ShapeKind::RoundedRectangle);
+        assert_eq!(visual_style.fills, vec![crate::Paint::solid("#112233")]);
+        assert_eq!(visual_style.stroke.as_ref().unwrap().width, 7.0);
+        let written = serde_json::to_string(&shape).unwrap();
+        assert!(written.contains(r##""fills":[{"kind":"solid","color":"#112233"}]"##));
+        assert!(!written.contains(r##""fill":"#112233""##));
+        assert!(!written.contains("strokeWidth"));
+
+        let text: crate::VisualContent = serde_json::from_str(
+            r##"{"kind":"text","text":"title","style":{"color":"#abcdef","strokeColor":"#010203","strokeWidth":2,"shadowColor":"#00000080","shadowX":3,"shadowY":4}}"##,
+        )
+        .unwrap();
+        let crate::VisualContent::Text { style, .. } = &text else {
+            panic!("expected text");
+        };
+        assert_eq!(style.visual_style.fills, vec![crate::Paint::solid("#abcdef")]);
+        assert_eq!(style.visual_style.stroke.as_ref().unwrap().width, 2.0);
+        assert_eq!(style.visual_style.shadow.as_ref().unwrap().x, 3.0);
+        let written = serde_json::to_string(&text).unwrap();
+        assert!(!written.contains("strokeColor"));
+        assert!(!written.contains("shadowColor"));
     }
 
     #[test]
@@ -271,7 +311,7 @@ mod tests {
         }"#;
         let project: Project = serde_json::from_str(text).unwrap();
         let written = serde_json::to_string(&project).unwrap();
-        assert!(written.contains(r#""version":2"#), "{written}");
+        assert!(written.contains(r#""version":3"#), "{written}");
         assert!(
             written.contains(r#""rate":{"num":60,"den":1}"#),
             "{written}"

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
@@ -18,7 +18,8 @@ pub mod tools;
 pub mod workspace;
 
 pub use makevideo_edit::{
-    asset_id, Asset, AssetKind, Clip, Project, ProjectSettings, TextAlign, TextStyle, Track,
-    ShapeKind, TrackKind, VisualContent, VisualItem, VisualTransform, FORMAT_VERSION,
+    asset_id, Asset, AssetKind, Clip, GradientStop, Paint, PaintPoint, Project, ProjectSettings,
+    Shadow, ShapeKind, Stroke, TextAlign, TextStyle, Track, TrackKind, VisualContent, VisualItem,
+    VisualStyle, VisualTransform, FORMAT_VERSION,
 };
 pub use makevideo_time::{RationalTime, Rate};

--- a/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/commands.rs
@@ -2390,12 +2390,17 @@ pub fn start_render(
         .as_ref()
         .map(|hardware| hardware.label.clone())
         .unwrap_or_else(|| "CPU".into());
-    // On the CPU setting the filter graph draws. Not the software compositor:
-    // it is there so a preview frame can be drawn without a graphics device,
-    // and putting every frame of a whole render through it would take hours to
-    // produce what ffmpeg composites in minutes.
+    let dynamic_paint = project.uses_video_paint();
+    // On the CPU setting the filter graph normally draws, because putting a
+    // whole render through the software compositor is much slower. A video
+    // paint is different: it changes every frame, so it must use that
+    // compositor instead of turning one raster into a frozen overlay still.
     let gpu = if stays_on_cpu(&settings) {
-        None
+        if dynamic_paint {
+            Some(strict_compositor(&state, Backend::Cpu, None)?)
+        } else {
+            None
+        }
     } else {
         Some(settings_compositor(&state, &settings))
     };
@@ -2405,7 +2410,12 @@ pub fn start_render(
     // graph as an overlay input. Written even when the composited route goes
     // first: the fallback runs after a failure, which is the wrong moment to
     // start writing files.
-    let visual_dir = write_visual_stills(&project, preset)?;
+    makevideo_compositor::text::set_ffmpeg_path(&program);
+    let visual_dir = if dynamic_paint {
+        None
+    } else {
+        write_visual_stills(&project, preset)?
+    };
     let visuals = visual_dir
         .as_ref()
         .map(|prepared| prepared.inputs.clone())
@@ -2426,11 +2436,15 @@ pub fn start_render(
                 args: ffmpeg::build_args(&project, &path, preset, Some(hardware), &visuals)?,
             });
         }
-        let plain = ffmpeg::build_args(&project, &path, preset, None, &visuals)?;
-        routes.push(Route::Graph {
-            label: "ffmpeg filter graph, CPU encoder".into(),
-            args: plain,
-        });
+        // A filter graph only accepts static visual rasters. Do not turn a
+        // failed dynamic render into a successful export with frozen paint.
+        if !dynamic_paint {
+            let plain = ffmpeg::build_args(&project, &path, preset, None, &visuals)?;
+            routes.push(Route::Graph {
+                label: "ffmpeg filter graph, CPU encoder".into(),
+                args: plain,
+            });
+        }
         Ok(())
     })();
     if let Err(error) = built {

--- a/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/playback.rs
@@ -292,6 +292,7 @@ pub struct Config {
 
 impl Config {
     pub fn new(compositor: Arc<Compositor>, ffmpeg: String, width: u32, height: u32) -> Config {
+        makevideo_compositor::text::set_ffmpeg_path(&ffmpeg);
         Config {
             presenter: Arc::clone(&compositor),
             compositor,

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -39,7 +39,7 @@ if (!window.__TAURI__) {
   };
   const emptyDocument = () => ({
     project: {
-      version: 2,
+      version: 3,
       settings: { width: 1920, height: 1080, rate: { num: 30, den: 1 } },
       assets: [],
       markers: [],

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -266,21 +266,36 @@
               <label class="row">Text <input id="text-value" type="text" /></label>
               <label class="row">Font <input id="text-font" type="text" list="font-options" placeholder="sans-serif" /></label>
               <label class="row">Size <input id="text-size" type="number" min="8" max="512" /></label>
-              <label class="row">Color <input id="text-color" type="color" /></label>
+              <label class="row">Fill <select id="text-fill-kind"><option value="solid">Solid</option><option value="linearGradient">Linear gradient</option><option value="radialGradient">Radial gradient</option><option value="image">Image</option><option value="video">Video</option></select></label>
+              <label class="row">Fill color <input id="text-color" type="color" /></label>
+              <label class="row">Fill end <input id="text-fill-end-color" type="color" /></label>
+              <label class="row">Fill media <select id="text-fill-asset"></select></label>
+              <div class="field-pair"><button id="text-add-fill" class="small" type="button">+ Fill layer</button><button id="text-remove-fill" class="small" type="button">Remove top fill</button></div>
               <label class="row">Align <select id="text-align"><option value="left">Left</option><option value="center">Center</option><option value="right">Right</option></select></label>
               <label class="row">Outline <input id="text-stroke-color" type="color" /></label>
               <label class="row">Outline width <input id="text-stroke-width" type="number" min="0" max="32" step="1" /></label>
-              <label class="row">Shadow <input id="text-shadow-color" type="color" /></label>
+              <label class="row check"><input id="text-shadow-enabled" type="checkbox" /> Shadow</label>
+              <label class="row">Shadow color <input id="text-shadow-color" type="color" /></label>
+              <div class="field-pair"><label>Shadow X <input id="text-shadow-x" type="number" step="1" /></label><label>Shadow Y <input id="text-shadow-y" type="number" step="1" /></label></div>
+              <label class="row">Shadow blur <input id="text-shadow-blur" type="number" min="0" step="1" /></label>
             </div>
           </div>
           <div id="shape-panel" hidden>
             <h3>Shape</h3>
             <div id="shape-inspector">
-              <label class="row">Type <select id="shape-kind"><option value="rectangle">Rectangle</option><option value="ellipse">Ellipse</option><option value="line">Line / Arrow</option></select></label>
-              <label class="row">Fill <input id="shape-fill" type="color" /></label>
+              <label class="row">Type <select id="shape-kind"><option value="rectangle">Rectangle</option><option value="roundedRectangle">Rounded rectangle</option><option value="ellipse">Ellipse</option><option value="line">Line / Arrow</option><option value="polygon">Polygon</option><option value="star">Star</option></select></label>
+              <label class="row">Fill <select id="shape-fill-kind"><option value="solid">Solid</option><option value="linearGradient">Linear gradient</option><option value="radialGradient">Radial gradient</option><option value="image">Image</option><option value="video">Video</option></select></label>
+              <label class="row">Fill color <input id="shape-fill" type="color" /></label>
+              <label class="row">Fill end <input id="shape-fill-end-color" type="color" /></label>
+              <label class="row">Fill media <select id="shape-fill-asset"></select></label>
+              <div class="field-pair"><button id="shape-add-fill" class="small" type="button">+ Fill layer</button><button id="shape-remove-fill" class="small" type="button">Remove top fill</button></div>
               <label class="row">Outline <input id="shape-stroke" type="color" /></label>
               <label class="row">Outline width <input id="shape-stroke-width" type="number" min="0" max="128" step="1" /></label>
               <label class="row">Corner radius <input id="shape-corner-radius" type="number" min="0" max="2048" step="1" /></label>
+              <label class="row check"><input id="shape-shadow-enabled" type="checkbox" /> Shadow</label>
+              <label class="row">Shadow color <input id="shape-shadow-color" type="color" /></label>
+              <div class="field-pair"><label>Shadow X <input id="shape-shadow-x" type="number" step="1" /></label><label>Shadow Y <input id="shape-shadow-y" type="number" step="1" /></label></div>
+              <label class="row">Shadow blur <input id="shape-shadow-blur" type="number" min="0" step="1" /></label>
               <label class="row check"><input id="shape-start-arrow" type="checkbox" /> Start arrow</label>
               <label class="row check"><input id="shape-end-arrow" type="checkbox" /> End arrow</label>
             </div>

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -162,17 +162,36 @@ const dom = {
   textValue: el('text-value'),
   textFont: el('text-font'),
   textSize: el('text-size'),
+  textFillKind: el('text-fill-kind'),
   textColor: el('text-color'),
+  textFillEndColor: el('text-fill-end-color'),
+  textFillAsset: el('text-fill-asset'),
+  textAddFill: el('text-add-fill'),
+  textRemoveFill: el('text-remove-fill'),
   textAlign: el('text-align'),
   textStrokeColor: el('text-stroke-color'),
   textStrokeWidth: el('text-stroke-width'),
   textShadowColor: el('text-shadow-color'),
+  textShadowEnabled: el('text-shadow-enabled'),
+  textShadowX: el('text-shadow-x'),
+  textShadowY: el('text-shadow-y'),
+  textShadowBlur: el('text-shadow-blur'),
   shapePanel: el('shape-panel'),
   shapeKind: el('shape-kind'),
+  shapeFillKind: el('shape-fill-kind'),
   shapeFill: el('shape-fill'),
+  shapeFillEndColor: el('shape-fill-end-color'),
+  shapeFillAsset: el('shape-fill-asset'),
+  shapeAddFill: el('shape-add-fill'),
+  shapeRemoveFill: el('shape-remove-fill'),
   shapeStroke: el('shape-stroke'),
   shapeStrokeWidth: el('shape-stroke-width'),
   shapeCornerRadius: el('shape-corner-radius'),
+  shapeShadowEnabled: el('shape-shadow-enabled'),
+  shapeShadowColor: el('shape-shadow-color'),
+  shapeShadowX: el('shape-shadow-x'),
+  shapeShadowY: el('shape-shadow-y'),
+  shapeShadowBlur: el('shape-shadow-blur'),
   shapeStartArrow: el('shape-start-arrow'),
   shapeEndArrow: el('shape-end-arrow'),
   subtitlePanel: el('subtitle-panel'),
@@ -1457,37 +1476,151 @@ function drawTextContent(context, text, style, width, height, scale) {
   context.textAlign = align === 'left' ? 'left' : align === 'right' ? 'right' : 'center';
   context.textBaseline = 'alphabetic';
   const anchorX = align === 'left' ? 0 : align === 'right' ? width : width / 2;
-  const strokeWidth = Math.max(0, (style.strokeWidth || 0) * scale);
-  const shadowColor = style.shadowColor || '';
+  const stroke = style.stroke || null;
+  const strokeWidth = Math.max(0, ((stroke && stroke.width) || 0) * scale);
+  const shadow = style.shadow || null;
+  const fills = style.fills && style.fills.length
+    ? style.fills
+    : [{ kind: 'solid', color: '#ffffff' }];
   const lines = wrapVisualText(context, text, width);
   for (let index = 0; index < lines.length; index += 1) {
     const baseline = index * size * 1.2 + size;
     if (baseline - size > height) break;
-    if (shadowColor) {
-      context.shadowColor = shadowColor;
-      context.shadowOffsetX = (style.shadowX ?? 2) * scale;
-      context.shadowOffsetY = (style.shadowY ?? 2) * scale;
+    if (shadow) {
+      context.shadowColor = shadow.color || 'transparent';
+      context.shadowOffsetX = (shadow.x || 0) * scale;
+      context.shadowOffsetY = (shadow.y || 0) * scale;
+      context.shadowBlur = Math.max(0, shadow.blur || 0) * scale;
     }
-    if (strokeWidth > 0 && style.strokeColor) {
+    if (strokeWidth > 0 && stroke.color) {
       // The Rust pass dilates by the radius, so the visible rim is the radius
       // wide; a canvas stroke straddles the edge, so it is doubled to match.
       context.lineWidth = strokeWidth * 2;
       context.lineJoin = 'round';
-      context.strokeStyle = style.strokeColor;
+      context.strokeStyle = stroke.color;
       context.strokeText(lines[index], anchorX, baseline);
     }
-    context.fillStyle = style.color || '#ffffff';
-    context.fillText(lines[index], anchorX, baseline);
+    for (const fill of fills) {
+      context.fillStyle = canvasPaint(context, fill, width, height);
+      context.fillText(lines[index], anchorX, baseline);
+      context.shadowColor = 'transparent';
+    }
     context.shadowColor = 'transparent';
     context.shadowOffsetX = 0;
     context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
   }
 }
 
+function orderedStops(stops) {
+  const values = stops && stops.length ? stops : [
+    { position: 0, color: '#ffffff' },
+    { position: 1, color: '#000000' },
+  ];
+  return [...values].sort((a, b) => a.position - b.position);
+}
+
+const fillMediaElements = new Map();
+
+function mediaPaintPattern(context, paint, width, height) {
+  const asset = L.findAsset(state.project, paint.assetId);
+  if (!asset || asset.kind !== paint.kind) return '#00000000';
+  const key = `${paint.kind}:${asset.id}`;
+  let media = fillMediaElements.get(key);
+  if (!media) {
+    media = paint.kind === 'video' ? document.createElement('video') : new Image();
+    media.src = window.api.fileUrl(asset.path);
+    if (paint.kind === 'video') {
+      media.muted = true;
+      media.preload = 'auto';
+      media.playsInline = true;
+    }
+    media.addEventListener('loadeddata', drawStageVisuals);
+    media.addEventListener('load', drawStageVisuals);
+    fillMediaElements.set(key, media);
+  }
+  const sourceWidth = media.videoWidth || media.naturalWidth || 0;
+  const sourceHeight = media.videoHeight || media.naturalHeight || 0;
+  if (paint.kind === 'video' && media.readyState >= 1 && Number.isFinite(media.duration) && media.duration > 0) {
+    const time = (preview.position() / T.rateToNumber(rate())) % media.duration;
+    if (Math.abs(media.currentTime - time) > 0.05) media.currentTime = time;
+  }
+  if (!sourceWidth || !sourceHeight) return '#00000000';
+  const pattern = context.createPattern(media, 'no-repeat');
+  if (!pattern) return '#00000000';
+  if (pattern.setTransform && typeof DOMMatrix !== 'undefined') {
+    pattern.setTransform(new DOMMatrix().scale(width / sourceWidth, height / sourceHeight));
+  }
+  return pattern;
+}
+
+function canvasPaint(context, paint, width, height) {
+  if (!paint || paint.kind === 'solid') return (paint && paint.color) || '#00000000';
+  if (paint.kind === 'linearGradient') {
+    const start = paint.start || { x: 0, y: 0.5 };
+    const end = paint.end || { x: 1, y: 0.5 };
+    const gradient = context.createLinearGradient(
+      start.x * width, start.y * height, end.x * width, end.y * height,
+    );
+    for (const stop of orderedStops(paint.stops)) {
+      gradient.addColorStop(Math.max(0, Math.min(1, stop.position)), stop.color);
+    }
+    return gradient;
+  }
+  if (paint.kind === 'radialGradient') {
+    const center = paint.center || { x: 0.5, y: 0.5 };
+    const radius = Math.max(0.001, paint.radius || 0.5) * Math.max(width, height);
+    const gradient = context.createRadialGradient(
+      center.x * width, center.y * height, 0,
+      center.x * width, center.y * height, radius,
+    );
+    for (const stop of orderedStops(paint.stops)) {
+      gradient.addColorStop(Math.max(0, Math.min(1, stop.position)), stop.color);
+    }
+    return gradient;
+  }
+  if (paint.kind === 'image' || paint.kind === 'video') {
+    return mediaPaintPattern(context, paint, width, height);
+  }
+  return '#00000000';
+}
+
+function beginShapePath(context, kind, width, height, radius) {
+  context.beginPath();
+  if (kind === 'ellipse') {
+    context.ellipse(width / 2, height / 2, width / 2, height / 2, 0, 0, Math.PI * 2);
+    return;
+  }
+  if (kind === 'polygon' || kind === 'star') {
+    const points = kind === 'star' ? 10 : 6;
+    const outer = Math.min(width, height) / 2;
+    const inner = kind === 'star' ? outer * 0.45 : outer;
+    for (let index = 0; index < points; index += 1) {
+      const angle = -Math.PI / 2 + index * Math.PI * 2 / points;
+      const distance = kind === 'star' && index % 2 ? inner : outer;
+      const x = width / 2 + Math.cos(angle) * distance;
+      const y = height / 2 + Math.sin(angle) * distance;
+      if (index === 0) context.moveTo(x, y);
+      else context.lineTo(x, y);
+    }
+    context.closePath();
+    return;
+  }
+  if (kind === 'roundedRectangle') context.roundRect(0, 0, width, height, radius);
+  else context.rect(0, 0, width, height);
+}
+
 function drawShapeContent(context, content, width, height, scale) {
-  const stroke = content.stroke || '#ffffff';
-  const strokeWidth = Math.max(0, (content.strokeWidth ?? 4) * scale);
+  const stroke = content.stroke || null;
+  const strokeWidth = Math.max(0, ((stroke && stroke.width) || 0) * scale);
   const kind = content.shape || 'rectangle';
+  const shadow = content.shadow || null;
+  if (shadow) {
+    context.shadowColor = shadow.color || 'transparent';
+    context.shadowOffsetX = (shadow.x || 0) * scale;
+    context.shadowOffsetY = (shadow.y || 0) * scale;
+    context.shadowBlur = Math.max(0, shadow.blur || 0) * scale;
+  }
   if (kind === 'line') {
     // A line is all stroke: a bar through the middle, plus the arrow heads.
     // Nothing is drawn at width zero, the same rule the Rust rasterizer has.
@@ -1495,7 +1628,7 @@ function drawShapeContent(context, content, width, height, scale) {
     const middle = height / 2;
     const half = strokeWidth / 2;
     const arrow = Math.max(strokeWidth * 1.5, 8);
-    context.fillStyle = stroke;
+    context.fillStyle = stroke.color;
     context.fillRect(half, middle - half, Math.max(0, width - strokeWidth), strokeWidth);
     const head = (tipX, direction) => {
       context.beginPath();
@@ -1507,28 +1640,41 @@ function drawShapeContent(context, content, width, height, scale) {
     };
     if (content.startArrow) head(0, 1);
     if (content.endArrow) head(width, -1);
+    context.shadowColor = 'transparent';
+    context.shadowOffsetX = 0;
+    context.shadowOffsetY = 0;
+    context.shadowBlur = 0;
     return;
   }
-  context.beginPath();
-  if (kind === 'ellipse') {
-    context.ellipse(width / 2, height / 2, width / 2, height / 2, 0, 0, Math.PI * 2);
-  } else {
-    const radius = Math.min(Math.max(0, (content.cornerRadius ?? 0) * scale), Math.min(width, height) / 2);
-    context.roundRect(0, 0, width, height, radius);
+  const radius = Math.min(
+    Math.max(0, (content.cornerRadius ?? 0) * scale),
+    Math.min(width, height) / 2,
+  );
+  const fills = content.fills && content.fills.length
+    ? content.fills
+    : [{ kind: 'solid', color: '#4f8cffcc' }];
+  for (const fill of fills) {
+    beginShapePath(context, kind, width, height, radius);
+    context.fillStyle = canvasPaint(context, fill, width, height);
+    context.fill();
+    context.shadowColor = 'transparent';
   }
-  context.fillStyle = content.fill || '#4f8cffcc';
-  context.fill();
   if (strokeWidth > 0) {
     // The Rust outline is a band half the width lying inside the edge, so the
     // stroke is clipped to the shape — which throws away its outer half and
     // leaves the same half-width rim.
     context.save();
+    beginShapePath(context, kind, width, height, radius);
     context.clip();
     context.lineWidth = strokeWidth;
-    context.strokeStyle = stroke;
+    context.strokeStyle = stroke.color;
     context.stroke();
     context.restore();
   }
+  context.shadowColor = 'transparent';
+  context.shadowOffsetX = 0;
+  context.shadowOffsetY = 0;
+  context.shadowBlur = 0;
 }
 
 function beginVisualDrag(event) {
@@ -1670,36 +1816,52 @@ function addMarker(frame = Math.round(preview.position())) {
   return edit({ op: 'addMarker', frame, name: '', color: '#e6a700' });
 }
 
-/** The video track a new text or shape lands on: the one it was dropped on,
- *  else the targeted track, else the first video track. */
+/** A drag names its destination. A click does not: Rust then reuses a
+ *  clip-free top overlay track, creates one, or falls back at the track cap. */
 function visualTargetTrack(placement) {
-  if (placement) {
-    const track = L.findTrack(state.project, placement.trackId);
-    return track && track.kind === 'video' ? track : null;
-  }
-  const target = state.targetTrackId && L.findTrack(state.project, state.targetTrackId);
-  return target && target.kind === 'video' ? target : L.tracksOf(state.project, 'video')[0];
+  if (!placement) return null;
+  const track = L.findTrack(state.project, placement.trackId);
+  return track && track.kind === 'video' ? track : null;
 }
 
 /** Add a visual item and select what Rust made of it. `placement` is
- *  `{ trackId, frame }` from a drop; without one the item lands on the
- *  targeted track at the playhead. */
+ *  `{ trackId, frame }` from a drop; without one Rust chooses the top overlay
+ *  track at the playhead. */
 async function addVisualItem(placement, content, transform) {
   const track = visualTargetTrack(placement);
-  if (!track) return;
-  const known = new Set((track.visualItems || []).map((item) => item.id));
-  await edit({
-    op: 'addVisualItem',
-    trackId: track.id,
+  if (placement && !track) return;
+  const known = new Set();
+  for (const candidate of state.project.tracks) {
+    for (const item of candidate.visualItems || []) known.add(item.id);
+  }
+  const videos = L.tracksOf(state.project, 'video');
+  const top = videos[videos.length - 1];
+  const reusable = top && !top.clips.length && (top.visualItems || []).every((item) =>
+    item.content && (item.content.kind === 'text' || item.content.kind === 'shape'));
+  const atLimit = !placement && videos.length >= L.MAX_TRACKS_PER_KIND && !reusable;
+  const command = {
+    op: placement ? 'addVisualItem' : 'addOverlayVisualItem',
+    ...(placement ? { trackId: track.id } : {}),
     content,
     start: placement ? Math.round(placement.frame) : Math.round(preview.position()),
     duration: L.defaultVisualItemFrames(rate()),
     transform: { ...transform, rotation: 0, opacity: 1 },
     zIndex: 0,
-  });
-  const liveTrack = L.findTrack(state.project, track.id);
-  const item = (liveTrack && liveTrack.visualItems || []).find((entry) => !known.has(entry.id));
+  };
+  const done = await edit(command);
+  if (done === null) return;
+  let item = null;
+  for (const candidate of state.project.tracks) {
+    item = (candidate.visualItems || []).find((entry) => !known.has(entry.id));
+    if (item) break;
+  }
   if (item) selectVisualItem(item.id);
+  if (atLimit) {
+    await window.api.message(
+      `The ${L.MAX_TRACKS_PER_KIND}-video-track limit was reached. The layer was added to the top video track.`,
+      { title: 'Layer added to existing track', kind: 'warning' },
+    );
+  }
 }
 
 function addText(placement) {
@@ -1707,8 +1869,10 @@ function addText(placement) {
     kind: 'text',
     text: 'Title',
     style: {
-      fontFamily: 'sans-serif', fontSize: 64, color: '#ffffff', align: 'center',
-      strokeColor: '', strokeWidth: 0, shadowColor: '#00000080', shadowX: 2, shadowY: 2,
+      fontFamily: 'sans-serif', fontSize: 64, align: 'center',
+      fills: [{ kind: 'solid', color: '#ffffff' }],
+      stroke: null,
+      shadow: { color: '#00000080', x: 2, y: 2, blur: 0 },
     },
   }, {
     x: state.project.settings.width * 0.1,
@@ -1720,8 +1884,10 @@ function addText(placement) {
 
 function addShape(placement) {
   return addVisualItem(placement, {
-    kind: 'shape', shape: 'rectangle', fill: '#4f8cffcc', stroke: '#ffffff',
-    strokeWidth: 4, cornerRadius: 20, startArrow: false, endArrow: false,
+    kind: 'shape', shape: 'roundedRectangle',
+    fills: [{ kind: 'solid', color: '#4f8cffcc' }],
+    stroke: { color: '#ffffff', width: 4 }, shadow: null,
+    cornerRadius: 20, startArrow: false, endArrow: false,
   }, {
     x: state.project.settings.width * 0.3,
     y: state.project.settings.height * 0.3,
@@ -1774,6 +1940,74 @@ function hexColor(value, fallback) {
 function preserveAlpha(color, previous) {
   const alpha = /^#[0-9a-fA-F]{8}$/.test(previous || '') ? previous.slice(7) : '';
   return `${color}${alpha}`;
+}
+
+function topPaint(style, fallback) {
+  return style && style.fills && style.fills.length
+    ? style.fills[style.fills.length - 1]
+    : { kind: 'solid', color: fallback };
+}
+
+function paintColors(paint, fallback) {
+  if (!paint || paint.kind === 'solid') return [(paint && paint.color) || fallback, fallback];
+  const stops = orderedStops(paint.stops);
+  return [stops[0].color, stops[stops.length - 1].color];
+}
+
+function fillAssetOptions(select, kind, selected) {
+  select.textContent = '';
+  const wanted = kind === 'video' ? 'video' : 'image';
+  for (const asset of state.project.assets.filter((entry) => entry.kind === wanted)) {
+    const option = document.createElement('option');
+    option.value = asset.id;
+    option.textContent = asset.name || baseName(asset.path);
+    option.selected = asset.id === selected;
+    select.appendChild(option);
+  }
+  select.disabled = kind !== 'image' && kind !== 'video';
+}
+
+function showFillEditor(kindInput, colorInput, endInput, assetInput, style, fallback) {
+  const paint = topPaint(style, fallback);
+  const [start, end] = paintColors(paint, fallback);
+  kindInput.value = paint.kind;
+  colorInput.value = hexColor(start, fallback.slice(0, 7));
+  endInput.value = hexColor(end, '#000000');
+  const assetId = paint.assetId || '';
+  fillAssetOptions(assetInput, paint.kind, assetId);
+  endInput.disabled = paint.kind !== 'linearGradient' && paint.kind !== 'radialGradient';
+  colorInput.disabled = paint.kind === 'image' || paint.kind === 'video';
+}
+
+function paintFromEditor(kind, color, endColor, assetId, previous) {
+  if (kind === 'image' || kind === 'video') {
+    const asset = state.project.assets.find((entry) => entry.id === assetId && entry.kind === kind)
+      || state.project.assets.find((entry) => entry.kind === kind);
+    return { kind, assetId: asset ? asset.id : '' };
+  }
+  if (kind === 'linearGradient') {
+    return {
+      kind,
+      start: (previous && previous.kind === kind && previous.start) || { x: 0, y: 0.5 },
+      end: (previous && previous.kind === kind && previous.end) || { x: 1, y: 0.5 },
+      stops: [
+        { position: 0, color: preserveAlpha(color, paintColors(previous, color)[0]) },
+        { position: 1, color: preserveAlpha(endColor, paintColors(previous, endColor)[1]) },
+      ],
+    };
+  }
+  if (kind === 'radialGradient') {
+    return {
+      kind,
+      center: (previous && previous.kind === kind && previous.center) || { x: 0.5, y: 0.5 },
+      radius: (previous && previous.kind === kind && previous.radius) || 0.5,
+      stops: [
+        { position: 0, color: preserveAlpha(color, paintColors(previous, color)[0]) },
+        { position: 1, color: preserveAlpha(endColor, paintColors(previous, endColor)[1]) },
+      ],
+    };
+  }
+  return { kind: 'solid', color: preserveAlpha(color, paintColors(previous, color)[0]) };
 }
 
 function inspectorMessage(tab, item, clipTargets) {
@@ -1845,12 +2079,21 @@ function renderInspector() {
   }
   if (shape) {
     dom.shapeKind.value = shape.shape || 'rectangle';
-    dom.shapeFill.value = hexColor(shape.fill, '#4f8cff');
-    dom.shapeStroke.value = hexColor(shape.stroke, '#ffffff');
-    dom.shapeStrokeWidth.value = shape.strokeWidth ?? 4;
+    showFillEditor(
+      dom.shapeFillKind, dom.shapeFill, dom.shapeFillEndColor, dom.shapeFillAsset,
+      shape, '#4f8cffcc',
+    );
+    dom.shapeRemoveFill.disabled = !shape.fills || shape.fills.length <= 1;
+    dom.shapeStroke.value = hexColor(shape.stroke && shape.stroke.color, '#ffffff');
+    dom.shapeStrokeWidth.value = shape.stroke ? shape.stroke.width : 0;
     dom.shapeCornerRadius.value = shape.cornerRadius ?? 0;
     dom.shapeStartArrow.checked = Boolean(shape.startArrow);
     dom.shapeEndArrow.checked = Boolean(shape.endArrow);
+    dom.shapeShadowEnabled.checked = Boolean(shape.shadow);
+    dom.shapeShadowColor.value = hexColor(shape.shadow && shape.shadow.color, '#000000');
+    dom.shapeShadowX.value = shape.shadow ? shape.shadow.x : 0;
+    dom.shapeShadowY.value = shape.shadow ? shape.shadow.y : 0;
+    dom.shapeShadowBlur.value = shape.shadow ? shape.shadow.blur : 0;
   }
   if (!text) return;
   if (subtitle) {
@@ -1860,18 +2103,26 @@ function renderInspector() {
     const subtitleStyle = track.subtitleStyle || {};
     dom.subtitleFont.value = subtitleStyle.fontFamily || 'sans-serif';
     dom.subtitleSize.value = subtitleStyle.fontSize || 64;
-    dom.subtitleColor.value = hexColor(subtitleStyle.color, '#ffffff');
+    dom.subtitleColor.value = hexColor(paintColors(topPaint(subtitleStyle, '#ffffff'), '#ffffff')[0], '#ffffff');
     return;
   }
   const style = text.style || {};
   dom.textValue.value = text.text || '';
   dom.textFont.value = style.fontFamily || 'sans-serif';
   dom.textSize.value = style.fontSize || 64;
-  dom.textColor.value = hexColor(style.color, '#ffffff');
+  showFillEditor(
+    dom.textFillKind, dom.textColor, dom.textFillEndColor, dom.textFillAsset,
+    style, '#ffffff',
+  );
+  dom.textRemoveFill.disabled = !style.fills || style.fills.length <= 1;
   dom.textAlign.value = style.align || 'center';
-  dom.textStrokeColor.value = hexColor(style.strokeColor, '#000000');
-  dom.textStrokeWidth.value = style.strokeWidth || 0;
-  dom.textShadowColor.value = hexColor(style.shadowColor, '#000000');
+  dom.textStrokeColor.value = hexColor(style.stroke && style.stroke.color, '#000000');
+  dom.textStrokeWidth.value = style.stroke ? style.stroke.width : 0;
+  dom.textShadowEnabled.checked = Boolean(style.shadow);
+  dom.textShadowColor.value = hexColor(style.shadow && style.shadow.color, '#000000');
+  dom.textShadowX.value = style.shadow ? style.shadow.x : 0;
+  dom.textShadowY.value = style.shadow ? style.shadow.y : 0;
+  dom.textShadowBlur.value = style.shadow ? style.shadow.blur : 0;
 }
 
 function updateSelectedTransform(event) {
@@ -1898,12 +2149,39 @@ function updateSelectedTransform(event) {
 function updateSelectedShape() {
   const item = selectedVisualItem();
   if (!item || item.content.kind !== 'shape') return;
+  const fills = [...(item.content.fills || [])];
+  const first = topPaint(item.content, '#4f8cffcc');
+  const paint = paintFromEditor(
+    dom.shapeFillKind.value,
+    dom.shapeFill.value,
+    dom.shapeFillEndColor.value,
+    dom.shapeFillAsset.value,
+    first,
+  );
+  if ((paint.kind === 'image' || paint.kind === 'video') && !paint.assetId) {
+    window.api.message(`Import a matching ${paint.kind} asset before using that fill.`, {
+      title: 'Fill media unavailable', kind: 'warning',
+    });
+    renderInspector();
+    return;
+  }
+  fills[Math.max(0, fills.length - 1)] = paint;
+  const strokeWidth = Math.max(0, Number(dom.shapeStrokeWidth.value) || 0);
+  const previousShadow = item.content.shadow || {};
   const content = {
     kind: 'shape',
     shape: dom.shapeKind.value,
-    fill: preserveAlpha(dom.shapeFill.value, item.content.fill),
-    stroke: preserveAlpha(dom.shapeStroke.value, item.content.stroke),
-    strokeWidth: Math.max(0, Number(dom.shapeStrokeWidth.value) || 0),
+    fills,
+    stroke: strokeWidth > 0 ? {
+      color: preserveAlpha(dom.shapeStroke.value, item.content.stroke && item.content.stroke.color),
+      width: strokeWidth,
+    } : null,
+    shadow: dom.shapeShadowEnabled.checked ? {
+      color: preserveAlpha(dom.shapeShadowColor.value, previousShadow.color),
+      x: Number(dom.shapeShadowX.value) || 0,
+      y: Number(dom.shapeShadowY.value) || 0,
+      blur: Math.max(0, Number(dom.shapeShadowBlur.value) || 0),
+    } : null,
     cornerRadius: Math.max(0, Number(dom.shapeCornerRadius.value) || 0),
     startArrow: dom.shapeStartArrow.checked,
     endArrow: dom.shapeEndArrow.checked,
@@ -1911,6 +2189,21 @@ function updateSelectedShape() {
   edit({ op: 'setVisualContent', itemId: item.id, content })
     .then(() => selectVisualItem(item.id))
     .catch((error) => reportError(error, 'shape:edit'));
+}
+
+function changeSelectedFillLayers(kind, add) {
+  const item = selectedVisualItem();
+  if (!item || item.content.kind !== kind) return;
+  const owner = kind === 'text' ? (item.content.style || {}) : item.content;
+  const fills = [...(owner.fills || [])];
+  if (add) fills.push({ kind: 'solid', color: kind === 'text' ? '#ffffff80' : '#4f8cff80' });
+  else if (fills.length > 1) fills.pop();
+  const content = kind === 'text'
+    ? { ...item.content, style: { ...owner, fills } }
+    : { ...item.content, fills };
+  edit({ op: 'setVisualContent', itemId: item.id, content })
+    .then(() => selectVisualItem(item.id))
+    .catch((error) => reportError(error, `${kind}:fills`));
 }
 
 function updateSelectedSubtitle() {
@@ -1932,7 +2225,13 @@ function updateSubtitleStyle() {
     ...(track.subtitleStyle || {}),
     fontFamily: dom.subtitleFont.value || 'sans-serif',
     fontSize: Math.max(8, Number(dom.subtitleSize.value) || 64),
-    color: dom.subtitleColor.value,
+    fills: [{
+      kind: 'solid',
+      color: preserveAlpha(
+        dom.subtitleColor.value,
+        paintColors(topPaint(track.subtitleStyle, '#ffffff'), '#ffffff')[0],
+      ),
+    }],
   };
   edit({ op: 'setSubtitleStyle', trackId: track.id, style }).catch((error) => reportError(error, 'subtitle:style'));
 }
@@ -1940,15 +2239,42 @@ function updateSubtitleStyle() {
 function updateSelectedText() {
   const item = selectedVisualItem();
   if (!item || item.content.kind !== 'text') return;
+  const previousStyle = item.content.style || {};
+  const fills = [...(previousStyle.fills || [])];
+  const first = topPaint(previousStyle, '#ffffff');
+  const paint = paintFromEditor(
+    dom.textFillKind.value,
+    dom.textColor.value,
+    dom.textFillEndColor.value,
+    dom.textFillAsset.value,
+    first,
+  );
+  if ((paint.kind === 'image' || paint.kind === 'video') && !paint.assetId) {
+    window.api.message(`Import a matching ${paint.kind} asset before using that fill.`, {
+      title: 'Fill media unavailable', kind: 'warning',
+    });
+    renderInspector();
+    return;
+  }
+  fills[Math.max(0, fills.length - 1)] = paint;
+  const strokeWidth = Math.max(0, Number(dom.textStrokeWidth.value) || 0);
+  const previousShadow = previousStyle.shadow || {};
   const style = {
     ...(item.content.style || {}),
     fontFamily: dom.textFont.value || 'sans-serif',
     fontSize: Math.max(8, Number(dom.textSize.value) || 64),
-    color: dom.textColor.value,
+    fills,
     align: dom.textAlign.value,
-    strokeColor: Number(dom.textStrokeWidth.value) > 0 ? dom.textStrokeColor.value : '',
-    strokeWidth: Math.max(0, Number(dom.textStrokeWidth.value) || 0),
-    shadowColor: preserveAlpha(dom.textShadowColor.value, item.content.style && item.content.style.shadowColor),
+    stroke: strokeWidth > 0 ? {
+      color: preserveAlpha(dom.textStrokeColor.value, previousStyle.stroke && previousStyle.stroke.color),
+      width: strokeWidth,
+    } : null,
+    shadow: dom.textShadowEnabled.checked ? {
+      color: preserveAlpha(dom.textShadowColor.value, previousShadow.color),
+      x: Number(dom.textShadowX.value) || 0,
+      y: Number(dom.textShadowY.value) || 0,
+      blur: Math.max(0, Number(dom.textShadowBlur.value) || 0),
+    } : null,
   };
   Promise.resolve(window.api.fontAvailable(style.fontFamily))
     .then((available) => {
@@ -3350,14 +3676,19 @@ function wireTimeline() {
     }
   });
   for (const input of [
-    dom.textValue, dom.textFont, dom.textSize, dom.textColor, dom.textAlign,
-    dom.textStrokeColor, dom.textStrokeWidth, dom.textShadowColor,
+    dom.textValue, dom.textFont, dom.textSize, dom.textFillKind, dom.textColor,
+    dom.textFillEndColor, dom.textFillAsset, dom.textAlign, dom.textStrokeColor,
+    dom.textStrokeWidth, dom.textShadowEnabled, dom.textShadowColor,
+    dom.textShadowX, dom.textShadowY, dom.textShadowBlur,
   ]) {
     input.addEventListener('change', updateSelectedText);
   }
   for (const input of [
-    dom.shapeKind, dom.shapeFill, dom.shapeStroke, dom.shapeStrokeWidth,
-    dom.shapeCornerRadius, dom.shapeStartArrow, dom.shapeEndArrow,
+    dom.shapeKind, dom.shapeFillKind, dom.shapeFill, dom.shapeFillEndColor,
+    dom.shapeFillAsset, dom.shapeStroke, dom.shapeStrokeWidth,
+    dom.shapeCornerRadius, dom.shapeShadowEnabled, dom.shapeShadowColor,
+    dom.shapeShadowX, dom.shapeShadowY, dom.shapeShadowBlur,
+    dom.shapeStartArrow, dom.shapeEndArrow,
   ]) {
     input.addEventListener('change', updateSelectedShape);
   }
@@ -3369,6 +3700,10 @@ function wireTimeline() {
   }
   dom.clipOpacity.addEventListener('change', updateSelectedVideoOpacity);
   dom.clipVolume.addEventListener('change', updateSelectedAudioVolume);
+  dom.textAddFill.addEventListener('click', () => changeSelectedFillLayers('text', true));
+  dom.textRemoveFill.addEventListener('click', () => changeSelectedFillLayers('text', false));
+  dom.shapeAddFill.addEventListener('click', () => changeSelectedFillLayers('shape', true));
+  dom.shapeRemoveFill.addEventListener('click', () => changeSelectedFillLayers('shape', false));
   for (const input of [
     dom.transformX, dom.transformY, dom.transformWidth, dom.transformHeight,
     dom.transformRotation, dom.transformOpacity, dom.transformOpacityValue,

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1614,6 +1614,7 @@ function drawShapeContent(context, content, width, height, scale) {
   const stroke = content.stroke || null;
   const strokeWidth = Math.max(0, ((stroke && stroke.width) || 0) * scale);
   const kind = content.shape || 'rectangle';
+  if (kind === 'line' && strokeWidth <= 0) return;
   const shadow = content.shadow || null;
   if (shadow) {
     context.shadowColor = shadow.color || 'transparent';
@@ -1624,7 +1625,6 @@ function drawShapeContent(context, content, width, height, scale) {
   if (kind === 'line') {
     // A line is all stroke: a bar through the middle, plus the arrow heads.
     // Nothing is drawn at width zero, the same rule the Rust rasterizer has.
-    if (strokeWidth <= 0) return;
     const middle = height / 2;
     const half = strokeWidth / 2;
     const arrow = Math.max(strokeWidth * 1.5, 8);

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -331,7 +331,7 @@ function tickStepFrames(pxPerSecond, rate) {
  *  over the real one. Nothing is edited through it. */
 function blankProject() {
   return {
-    version: 2,
+    version: 3,
     settings: { width: 1920, height: 1080, rate: T.fps(30) },
     assets: [],
     tracks: [],


### PR DESCRIPTION
# 구현

도형·텍스트 공통 Paint fill 스택과 전용 최상단 오버레이 트랙 추가
- project format 3 마이그레이션, 다각형·별·둥근 사각형, image·video paint, 원자적 undo, CPU·GPU 렌더 검증 포함

# 어려웠던 점

정적 filter graph에서 video paint가 첫 프레임으로 고정되는 문제
- video paint만 프레임 합성 경로로 제한하고 설정된 ffmpeg 경로를 rasterizer와 공유

# 리스크

CPU 설정의 video paint 렌더 속도 저하
- 잘못된 정적 결과보다 정확성을 우선하며 정적 visual은 기존 PAM overlay 고속 경로 유지

Issue #1125
Issue #1130