### PR TITLE
fix: akbun-makevideo Source range와 clip drag 지연 수정

### DIFF
--- a/product/akbun-makevideo/knowledge/decisions/2026-09-source-monitor-range-is-playback-boundary.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-09-source-monitor-range-is-playback-boundary.md
@@ -1,0 +1,21 @@
+---
+type: Decision
+title: Source monitor의 in-out은 재생 경계다
+description: asset preview의 seek와 재생을 선택 구간 안으로 제한하고 구간 밖은 scrub bar에서 어둡게 표시한다.
+tags: [makevideo, source-monitor, playback]
+timestamp: 2026-09-04T00:00:00Z
+---
+
+# Source monitor의 in-out은 재생 경계다
+
+## 결정
+
+* asset preview의 seek 범위를 in부터 out까지로 제한
+* out 도달 시 in으로 되감지 않고 out에서 정지
+* in-out이 없거나 전체 구간이면 자산 전체를 재생
+* scrub bar의 선택 밖 구간을 어두운 음영으로 표시
+
+## 이유
+
+* 삽입 결과를 만들기 전에도 선택한 소스 구간을 그대로 확인할 수 있어야 함
+* 표식만으로는 어느 쪽이 선택 안과 밖인지 구분하기 어려움

--- a/product/akbun-makevideo/knowledge/decisions/2026-09-timeline-drag-defers-compositor.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-09-timeline-drag-defers-compositor.md
@@ -1,0 +1,21 @@
+---
+type: Decision
+title: 타임라인 드래그 중 compositor 상태 전환을 미룬다
+description: clip pointer-down은 선택만 바꾸고 exact frame 재합성과 레인 배치 읽기는 드래그 시작 경로에서 제외한다.
+tags: [makevideo, timeline, drag, diagnostics]
+timestamp: 2026-09-04T00:00:00Z
+---
+
+# 타임라인 드래그 중 compositor 상태 전환을 미룬다
+
+## 결정
+
+* clip drag가 시작되면 visual editor overlay 해제를 pointer-up까지 유예
+* 대상 레인은 pointer-down에서 측정한 세로 경계와 pointer 좌표로 판정
+* pointer-down 다음 frame과 첫 pointermove queue 지연을 Debug 패널에 last와 peak로 표시
+
+## 이유
+
+* overlay 해제는 exact frame 재합성을 요청해 첫 pointermove보다 비싼 작업이 먼저 실행될 수 있음
+* elementFromPoint는 매 pointermove에서 브라우저 배치 계산을 강제할 수 있음
+* 간헐적인 입력 지연은 화면 관찰보다 같은 경로의 수치로 회귀 여부를 판정해야 함

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,8 @@
 
 ## 목록
 
+* [Source monitor의 in-out은 재생 경계다](2026-09-source-monitor-range-is-playback-boundary.md) - asset preview를 선택 구간 안으로 제한하고 scrub bar에서 구간 밖을 구분한 결정.
+* [타임라인 드래그 중 compositor 상태 전환을 미룬다](2026-09-timeline-drag-defers-compositor.md) - drag 시작 경로에서 exact frame 재합성과 반복 배치 읽기를 제외한 결정.
 * [프록시는 해상도뿐 아니라 decode와 seek 비용을 줄인다](2026-09-proxy-targets-decode-and-seek-cost.md) - 코덱과 키프레임 간격을 해상도와 함께 판정하고 프록시에 짧은 GOP를 강제한 결정.
 * [Inspector는 타임라인에서 선택한 미디어 트랙을 따른다](2026-08-inspector-follows-timeline-media.md) - 연결된 clip의 속성을 Video와 Audio 탭으로 분리하고 선택한 트랙 탭을 먼저 보여 주는 결정.
 * [native monitor는 window overlay에서 AppKit 좌표 변환을 사용한다](2026-08-native-monitor-is-a-window-overlay.md) - GPU surface를 WebKit hierarchy에서 분리하고 실제 view 사이 좌표 변환을 AppKit에 맡긴 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -1,5 +1,10 @@
 # Knowledge Update Log
 
+## 2026-09-04
+
+* [Source monitor의 in-out은 재생 경계다](decisions/2026-09-source-monitor-range-is-playback-boundary.md) 결정 기록. 선택 범위를 asset preview의 seek와 재생 경계로 사용함.
+* [타임라인 드래그 중 compositor 상태 전환을 미룬다](decisions/2026-09-timeline-drag-defers-compositor.md) 결정 기록. pointer-down에서 exact frame 재합성과 반복 배치 읽기를 제외하고 지연 수치를 노출함.
+
 ## 2026-09-02
 
 * [filter graph 렌더는 정적 visual만 rasterize한 still로 굽는다](decisions/2026-08-graph-render-overlays-rasterized-stills.md) 결정 갱신. video paint가 정적 overlay로 굳지 않도록 CPU 설정에서도 프레임 합성 경로를 사용하고 장기 decoder를 재사용함.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.38.0",
+      "version": "0.38.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -180,6 +180,8 @@
             <div id="source-seek-wrap">
               <input id="source-seek" type="range" min="0" max="1" step="1" value="0" aria-label="Source position" />
               <div id="source-marker-layer" aria-hidden="true" hidden>
+                <span id="source-before-range" class="source-range-shade before"></span>
+                <span id="source-after-range" class="source-range-shade after"></span>
                 <span id="source-in-marker" class="source-boundary-marker in" data-label="IN"></span>
                 <span id="source-out-marker" class="source-boundary-marker out" data-label="OUT"></span>
               </div>

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -359,8 +359,16 @@ function createPreview(options) {
     } else {
       syncAsset();
       const bounds = assetPlaybackBounds();
-      if (positionFrames >= bounds.end && transportActive()) {
-        positionFrames = bounds.end;
+      const mediaPosition = positionFrames;
+      positionFrames = Math.max(bounds.start, Math.min(mediaPosition, bounds.end));
+      if (positionFrames !== mediaPosition && assetElement.currentTime !== undefined) {
+        try {
+          assetElement.currentTime = positionSeconds();
+        } catch (error) {
+          // Retried on the next frame.
+        }
+      }
+      if (mediaPosition >= bounds.end && transportActive()) {
         pause();
       }
     }

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -55,6 +55,14 @@ function clamp01(value) {
   return Math.min(1, Math.max(0, value));
 }
 
+function playbackBounds(total, requested) {
+  const end = Math.max(0, Number(total) || 0);
+  if (!requested) return { start: 0, end };
+  const start = Math.max(0, Math.min(Number(requested.start) || 0, end));
+  const selectedEnd = Math.max(start, Math.min(Number(requested.end) || 0, end));
+  return { start, end: selectedEnd };
+}
+
 function createPreview(options) {
   const { stage, inner, wrap, exactCanvas, getProject, onTick, qualityMonitor } = options;
   const playbackPath = options.playbackPath || ((asset) => asset.path);
@@ -307,6 +315,13 @@ function createPreview(options) {
     return project ? L.projectDurationFrames(project) : 0;
   }
 
+  function assetPlaybackBounds() {
+    const requested = typeof options.getAssetPlaybackRange === 'function'
+      ? options.getAssetPlaybackRange()
+      : null;
+    return playbackBounds(totalFrames(), requested);
+  }
+
   function transportActive() {
     return playing || starting;
   }
@@ -341,7 +356,14 @@ function createPreview(options) {
         clock = readyClock;
         clockOrigin = performance.now() - positionSeconds() * 1000;
       }
-    } else syncAsset();
+    } else {
+      syncAsset();
+      const bounds = assetPlaybackBounds();
+      if (positionFrames >= bounds.end && transportActive()) {
+        positionFrames = bounds.end;
+        pause();
+      }
+    }
 
     // Reported when it lands on a new frame, which is also how often the
     // playhead and the clock can actually change.
@@ -358,6 +380,15 @@ function createPreview(options) {
     if (totalFrames() <= 0) return;
     clearExact();
     if (mode === 'timeline' && positionFrames >= totalFrames()) positionFrames = 0;
+    if (mode === 'asset') {
+      const bounds = assetPlaybackBounds();
+      if (positionFrames < bounds.start || positionFrames >= bounds.end) {
+        positionFrames = bounds.start;
+        if (assetElement && assetElement.currentTime !== undefined) {
+          assetElement.currentTime = positionSeconds();
+        }
+      }
+    }
     if (qualityMonitor) qualityMonitor.playbackRequested();
     starting = true;
     if (onTick) onTick(positionFrames, transportActive());
@@ -405,7 +436,10 @@ function createPreview(options) {
    *  dragging the playhead does not feel notched. */
   function seek(frames) {
     if (qualityMonitor && qualityMonitor.isRunning()) qualityMonitor.discontinuity();
-    positionFrames = Math.max(0, Math.min(frames, Math.max(totalFrames(), 0)));
+    const bounds = mode === 'asset'
+      ? assetPlaybackBounds()
+      : { start: 0, end: Math.max(totalFrames(), 0) };
+    positionFrames = Math.max(bounds.start, Math.min(frames, bounds.end));
     clockOrigin = performance.now() - positionSeconds() * 1000;
     clock = null;
     timelineDiscontinuity = mode === 'timeline';
@@ -481,7 +515,8 @@ function createPreview(options) {
     assetElement.classList.add('on');
     assetElement.style.zIndex = '50';
     inner.appendChild(assetElement);
-    positionFrames = 0;
+    positionFrames = assetPlaybackBounds().start;
+    if (assetElement.currentTime !== undefined) assetElement.currentTime = positionSeconds();
     layout();
   }
 
@@ -576,6 +611,7 @@ if (typeof module !== 'undefined' && module.exports) {
     QUALITY,
     timelineTimeFromMedia,
     playbackRateForDrift,
+    playbackBounds,
     HARD_SYNC_THRESHOLD,
   };
 } else {

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -94,6 +94,8 @@ const dom = {
   sourceMarkOut: el('source-mark-out'),
   sourceSeek: el('source-seek'),
   sourceMarkerLayer: el('source-marker-layer'),
+  sourceBeforeRange: el('source-before-range'),
+  sourceAfterRange: el('source-after-range'),
   sourceInMarker: el('source-in-marker'),
   sourceOutMarker: el('source-out-marker'),
   sourceRange: el('source-range'),
@@ -550,6 +552,14 @@ function playbackDebugLines(status) {
   ];
 }
 
+function clipDragDebugLines() {
+  const text = (value) => Number.isFinite(value) ? `${value.toFixed(1)} ms` : 'not measured';
+  return [
+    `Timeline drag next frame: ${text(clipDragMetrics.nextFrameMs)} last, ${text(clipDragMetrics.peakNextFrameMs)} peak`,
+    `Timeline drag first move queue: ${text(clipDragMetrics.firstMoveQueueMs)} last, ${text(clipDragMetrics.peakFirstMoveQueueMs)} peak`,
+  ];
+}
+
 async function refreshDebug() {
   if (dom.debugPanel.hidden || debugRefreshInFlight) return;
   debugRefreshInFlight = true;
@@ -567,6 +577,7 @@ async function refreshDebug() {
       `Timeline: ${state.project.tracks.length} tracks, ${state.project.assets.length} assets`,
       `Proxy jobs: ${active.length} active, ${Object.keys(state.proxies).length} known`,
       `Compositor: ${state.settings.compositor || 'not read yet'}`,
+      ...clipDragDebugLines(),
       ...playbackDebugLines(playback),
       `IPC proxy updates: percentage-throttled`,
     ].join('\n');
@@ -727,6 +738,9 @@ function renderSourceMonitor() {
   if (selection) {
     dom.sourceInMarker.style.left = `${S.markerPercent(selection.inPoint, limit)}%`;
     dom.sourceOutMarker.style.left = `${S.markerPercent(selection.outPoint, limit)}%`;
+    const shade = S.rangeShade(selection, limit);
+    dom.sourceBeforeRange.style.width = `${shade.beforePercent}%`;
+    dom.sourceAfterRange.style.width = `${shade.afterPercent}%`;
   }
   dom.sourceRange.textContent = selection
     ? `${sourceTime(selection.inPoint)} – ${sourceTime(selection.outPoint)}`
@@ -1297,6 +1311,10 @@ function syncEditorOverlay() {
   const active = editorOverlayWanted();
   dom.stage.classList.toggle('editing', Boolean(state.selectedVisualItemId));
   if (active === editorOverlayActive) return;
+  if (drag) {
+    drag.syncOverlayAfterEnd = true;
+    return;
+  }
   editorOverlayActive = active;
   preview.setEditing(active);
   if (active) scheduleExactFrame();
@@ -2408,8 +2426,47 @@ function toggleSnap() {
 // --- dragging clips --------------------------------------------------------
 
 let drag = null;
+const clipDragMetrics = {
+  nextFrameMs: null,
+  peakNextFrameMs: null,
+  firstMoveQueueMs: null,
+  peakFirstMoveQueueMs: null,
+};
+
+function measureClipDragNextFrame(startedAt) {
+  window.requestAnimationFrame(() => {
+    const elapsed = Math.max(0, performance.now() - startedAt);
+    clipDragMetrics.nextFrameMs = elapsed;
+    clipDragMetrics.peakNextFrameMs = Math.max(clipDragMetrics.peakNextFrameMs || 0, elapsed);
+  });
+}
+
+function measureFirstClipMove(current, event) {
+  if (current.firstMoveMeasured) return;
+  current.firstMoveMeasured = true;
+  const handledAt = performance.now();
+  let queuedAt = Number(event.timeStamp);
+  if (queuedAt > handledAt && Number.isFinite(performance.timeOrigin)) {
+    queuedAt -= performance.timeOrigin;
+  }
+  if (!Number.isFinite(queuedAt) || queuedAt < 0 || queuedAt > handledAt) return;
+  const elapsed = handledAt - queuedAt;
+  clipDragMetrics.firstMoveQueueMs = elapsed;
+  clipDragMetrics.peakFirstMoveQueueMs = Math.max(
+    clipDragMetrics.peakFirstMoveQueueMs || 0,
+    elapsed,
+  );
+}
+
+function clipDragLanes() {
+  return [...dom.lanes.querySelectorAll('.lane')].map((node) => {
+    const box = node.getBoundingClientRect();
+    return { node, top: box.top, bottom: box.bottom };
+  });
+}
 
 function beginClipDrag(event, node) {
+  const startedAt = performance.now();
   const clipId = node.dataset.clipId;
   const found = L.findClip(state.project, clipId);
   if (!found) return;
@@ -2418,7 +2475,6 @@ function beginClipDrag(event, node) {
   const mode =
     offsetX <= HANDLE_PX ? 'trim-start' : offsetX >= box.width - HANDLE_PX ? 'trim-end' : 'move';
 
-  selectClip(clipId);
   drag = {
     mode,
     clipId,
@@ -2432,12 +2488,18 @@ function beginClipDrag(event, node) {
     nextStart: found.clip.start,
     nextEdge: found.clip.start,
     moved: false,
+    lanes: clipDragLanes(),
+    firstMoveMeasured: false,
+    syncOverlayAfterEnd: false,
   };
+  selectClip(clipId);
   document.body.classList.add(mode === 'move' ? 'dragging' : 'trimming');
+  measureClipDragNextFrame(startedAt);
   event.preventDefault();
 }
 
 function updateClipDrag(event) {
+  measureFirstClipMove(drag, event);
   const pointer = frameAtClientX(event.clientX);
   const tolerance = snapTolerance();
 
@@ -2451,12 +2513,12 @@ function updateClipDrag(event) {
 
     // The lane under the pointer decides the target track, but only if it can
     // play this asset; otherwise the clip stays where it came from.
-    const under = document.elementFromPoint(event.clientX, event.clientY);
-    const lane = under && under.closest ? under.closest('.lane') : null;
+    const laneIndex = L.laneIndexAtY(drag.lanes, event.clientY);
+    const lane = laneIndex >= 0 ? drag.lanes[laneIndex].node : null;
     const found = L.findClip(state.project, drag.clipId);
     const asset = found && L.findAsset(state.project, found.clip.assetId);
     const track = lane && L.findTrack(state.project, lane.dataset.trackId);
-    for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
+    for (const bound of drag.lanes) bound.node.classList.remove('drop-target');
     if (track && L.canAccept(track, asset)) {
       drag.targetTrackId = track.id;
       lane.classList.add('drop-target');
@@ -2486,31 +2548,35 @@ function updateClipDrag(event) {
  *  IPC boundary. Rust may put the clip somewhere other than where it is being
  *  drawn — pushed right past a clip it would have overlapped — and the redraw
  *  is what settles it. */
-function endClipDrag() {
+async function endClipDrag() {
   const current = drag;
   drag = null;
   document.body.classList.remove('dragging', 'trimming');
   for (const node of dom.lanes.querySelectorAll('.lane')) node.classList.remove('drop-target');
   if (!current) return;
-  if (!current.moved) {
-    renderTimeline();
-    return;
+  try {
+    if (!current.moved) {
+      renderTimeline();
+      return;
+    }
+    return await edit(
+      current.mode === 'move'
+        ? {
+            op: 'moveClip',
+            clipId: current.clipId,
+            trackId: current.targetTrackId,
+            start: current.nextStart,
+          }
+        : {
+            op: 'trimClip',
+            clipId: current.clipId,
+            edge: current.mode === 'trim-start' ? 'start' : 'end',
+            frame: current.nextEdge,
+          }
+    );
+  } finally {
+    if (current.syncOverlayAfterEnd) syncEditorOverlay();
   }
-  return edit(
-    current.mode === 'move'
-      ? {
-          op: 'moveClip',
-          clipId: current.clipId,
-          trackId: current.targetTrackId,
-          start: current.nextStart,
-        }
-      : {
-          op: 'trimClip',
-          clipId: current.clipId,
-          edge: current.mode === 'trim-start' ? 'start' : 'end',
-          frame: current.nextEdge,
-        }
-  );
 }
 
 // --- dragging text and shape layers on the timeline -------------------------
@@ -3769,7 +3835,7 @@ function wireTimeline() {
     else if (scrubbing) scrubTo(event.clientX);
   });
   window.addEventListener('pointerup', (event) => {
-    if (drag) endClipDrag();
+    if (drag) endClipDrag().catch((error) => reportError(error, 'clip:drag'));
     if (visualTimingDrag) endVisualItemDrag();
     if (toolDrag) {
       endToolDrag(event).catch((error) => reportError(error, 'tool-drop'));
@@ -4027,6 +4093,12 @@ async function boot() {
     inner: dom.sourceStageInner,
     wrap: dom.sourceStageWrap,
     getProject: () => state.project,
+    getAssetPlaybackRange: () => {
+      const asset = selectedSourceAsset();
+      return asset && state.sourceSelection
+        ? S.playbackRange(state.sourceSelection, S.sourceLimitFrames(asset, rate()))
+        : null;
+    },
     playbackPath,
     onTick: (frame, playing) => {
       dom.sourceClock.textContent = sourceTime(frame);

--- a/product/akbun-makevideo/workspace/src/source.js
+++ b/product/akbun-makevideo/workspace/src/source.js
@@ -39,6 +39,22 @@ function markerPercent(frame, limit) {
   return position / end * 100;
 }
 
+function playbackRange(selection, limit) {
+  const end = Math.max(0, Math.round(Number(limit) || 0));
+  if (!selection || end === 0) return { start: 0, end };
+  const start = Math.max(0, Math.min(Math.round(selection.inPoint), end));
+  const selectedEnd = Math.max(start, Math.min(Math.round(selection.outPoint), end));
+  return { start, end: selectedEnd };
+}
+
+function rangeShade(selection, limit) {
+  const range = playbackRange(selection, limit);
+  return {
+    beforePercent: markerPercent(range.start, limit),
+    afterPercent: 100 - markerPercent(range.end, limit),
+  };
+}
+
 function targetTrack(project, kind, preferredId) {
   const preferred = project.tracks.find(
     (track) => track.id === preferredId && track.kind === kind
@@ -75,6 +91,8 @@ const exported = {
   markIn,
   markOut,
   markerPercent,
+  playbackRange,
+  rangeShade,
   targetTrack,
   commandFor,
 };

--- a/product/akbun-makevideo/workspace/src/style.css
+++ b/product/akbun-makevideo/workspace/src/style.css
@@ -596,6 +596,22 @@ select {
   pointer-events: none;
 }
 
+.source-range-shade {
+  position: absolute;
+  top: 12px;
+  bottom: 1px;
+  background: color-mix(in srgb, var(--stage) 62%, transparent);
+  border-radius: 2px;
+}
+
+.source-range-shade.before {
+  left: 0;
+}
+
+.source-range-shade.after {
+  right: 0;
+}
+
 .source-boundary-marker {
   position: absolute;
   top: 0;

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -296,6 +296,10 @@ function pxToFrames(px, rate, pxPerSecond) {
   return T.secondsToFrames(px / pxPerSecond, rate);
 }
 
+function laneIndexAtY(bounds, y) {
+  return bounds.findIndex((bound) => y >= bound.top && y < bound.bottom);
+}
+
 function waveformBucketRange(clip, rate, bucketsPerSecond) {
   const secondsPerFrame = rate.den / rate.num;
   return {
@@ -370,6 +374,7 @@ const exported = {
   snapClipStart,
   framesToPx,
   pxToFrames,
+  laneIndexAtY,
   waveformBucketRange,
   formatTimecode,
   formatRulerLabel,

--- a/product/akbun-makevideo/workspace/test/preview.test.js
+++ b/product/akbun-makevideo/workspace/test/preview.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert');
 const {
   timelineTimeFromMedia,
   playbackRateForDrift,
+  playbackBounds,
   HARD_SYNC_THRESHOLD,
 } = require('../src/preview.js');
 const T = require('../src/time.js');
@@ -35,6 +36,65 @@ test('follower drift is corrected without large playback rate changes', () => {
   assert.strictEqual(playbackRateForDrift(10), 1.05);
   assert.strictEqual(playbackRateForDrift(-10), 0.95);
   assert.strictEqual(HARD_SYNC_THRESHOLD, 1);
+});
+
+test('asset playback bounds treat no range and the full range alike', () => {
+  assert.deepStrictEqual(playbackBounds(300, null), { start: 0, end: 300 });
+  assert.deepStrictEqual(playbackBounds(300, { start: 0, end: 300 }), { start: 0, end: 300 });
+  assert.deepStrictEqual(playbackBounds(300, { start: 60, end: 240 }), { start: 60, end: 240 });
+});
+
+test('asset seek and playback stay inside the selected range', async (context) => {
+  const original = {
+    document: global.document,
+    window: global.window,
+    timelineLib: global.timelineLib,
+    requestAnimationFrame: global.requestAnimationFrame,
+    performance: global.performance,
+  };
+  context.after(() => Object.assign(global, original));
+
+  const frames = [];
+  let media;
+  global.document = {
+    createElement(tagName) {
+      media = fakeMedia(tagName.toUpperCase(), () => Promise.resolve());
+      return media;
+    },
+  };
+  global.window = { api: { fileUrl: (path) => path } };
+  global.timelineLib = { tracksOf: () => [], clipsAt: () => [], projectDurationFrames: () => 0 };
+  global.requestAnimationFrame = (callback) => frames.push(callback);
+  global.performance = { now: () => 0 };
+
+  const project = {
+    settings: { width: 1920, height: 1080, rate: T.fps(30) },
+    tracks: [],
+    assets: [],
+  };
+  const preview = require('../src/preview.js').createPreview({
+    stage: { style: {} },
+    inner: { style: {}, appendChild() {} },
+    wrap: null,
+    getProject: () => project,
+    getAssetPlaybackRange: () => ({ start: 60, end: 240 }),
+    onTick: () => {},
+  });
+  preview.showAsset({ id: 'v', kind: 'video', path: '/v.mp4', durationMs: 10000 });
+
+  preview.seek(0);
+  assert.strictEqual(preview.position(), 60);
+  assert.strictEqual(media.currentTime, 2);
+  preview.seek(300);
+  assert.strictEqual(preview.position(), 240);
+  assert.strictEqual(media.currentTime, 8);
+
+  await preview.play();
+  assert.strictEqual(preview.position(), 60, 'play at out restarts from in');
+  media.currentTime = 8;
+  frames.shift()();
+  assert.strictEqual(preview.position(), 240);
+  assert.strictEqual(preview.isPlaying(), false, 'out pauses without rewinding');
 });
 
 class FakeClassList {

--- a/product/akbun-makevideo/workspace/test/preview.test.js
+++ b/product/akbun-makevideo/workspace/test/preview.test.js
@@ -72,12 +72,13 @@ test('asset seek and playback stay inside the selected range', async (context) =
     tracks: [],
     assets: [],
   };
+  let selectedRange = { start: 60, end: 240 };
   const preview = require('../src/preview.js').createPreview({
     stage: { style: {} },
     inner: { style: {}, appendChild() {} },
     wrap: null,
     getProject: () => project,
-    getAssetPlaybackRange: () => ({ start: 60, end: 240 }),
+    getAssetPlaybackRange: () => selectedRange,
     onTick: () => {},
   });
   preview.showAsset({ id: 'v', kind: 'video', path: '/v.mp4', durationMs: 10000 });
@@ -95,6 +96,12 @@ test('asset seek and playback stay inside the selected range', async (context) =
   frames.shift()();
   assert.strictEqual(preview.position(), 240);
   assert.strictEqual(preview.isPlaying(), false, 'out pauses without rewinding');
+
+  selectedRange = { start: 90, end: 180 };
+  media.currentTime = 9;
+  frames.shift()();
+  assert.strictEqual(preview.position(), 180, 'paused playhead stays inside a changed range');
+  assert.strictEqual(media.currentTime, 6, 'paused media seeks back inside a changed range');
 });
 
 class FakeClassList {

--- a/product/akbun-makevideo/workspace/test/source.test.js
+++ b/product/akbun-makevideo/workspace/test/source.test.js
@@ -51,6 +51,22 @@ test('source boundary markers stay on the seek range', () => {
   assert.strictEqual(S.markerPercent(400, 300), 100);
 });
 
+test('source playback and shade use the selected interval', () => {
+  assert.deepStrictEqual(S.playbackRange(null, 300), { start: 0, end: 300 });
+  assert.deepStrictEqual(
+    S.playbackRange({ inPoint: 0, outPoint: 300 }, 300),
+    { start: 0, end: 300 }
+  );
+  assert.deepStrictEqual(
+    S.playbackRange({ inPoint: 60, outPoint: 240 }, 300),
+    { start: 60, end: 240 }
+  );
+  assert.deepStrictEqual(
+    S.rangeShade({ inPoint: 60, outPoint: 240 }, 300),
+    { beforePercent: 20, afterPercent: 20 }
+  );
+});
+
 test('placement names a target per media kind and keeps the chosen range', () => {
   assert.deepStrictEqual(
     S.commandFor('insert', project, video, { inPoint: 30, outPoint: 120 }, {

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -310,6 +310,18 @@ test('pixels and frames convert both ways', () => {
   assert.strictEqual(L.pxToFrames(100, rate, 50), 60);
 });
 
+test('a drag finds its lane from cached vertical boundaries', () => {
+  const bounds = [
+    { top: 100, bottom: 164 },
+    { top: 164, bottom: 228 },
+  ];
+  assert.strictEqual(L.laneIndexAtY(bounds, 100), 0);
+  assert.strictEqual(L.laneIndexAtY(bounds, 163.9), 0);
+  assert.strictEqual(L.laneIndexAtY(bounds, 164), 1);
+  assert.strictEqual(L.laneIndexAtY(bounds, 99), -1);
+  assert.strictEqual(L.laneIndexAtY(bounds, 228), -1);
+});
+
 test('a trimmed clip reads only its source interval from the waveform', () => {
   const media = clip('c1', 'v', 900, 150, 450);
   assert.deepStrictEqual(L.waveformBucketRange(media, T.fps(30), 100), {


### PR DESCRIPTION
# 구현

Source Monitor 선택 구간 재생 제한과 타임라인 clip drag 시작 경로 경량화

- Node 테스트 174개 통과, 정적 브라우저에서 범위 음영과 Debug 계측 노출 확인

# 어려웠던 점

clip 선택 변경이 editor overlay 해제와 exact frame 재합성을 함께 시작하는 경로 분리

- overlay 전환을 pointer-up까지 유예하고 레인 경계를 pointer-down에서 한 번만 측정

# 리스크

Source Monitor out 정지는 브라우저 animation frame 주기의 media time 관찰에 의존

- foreground 재생에서는 다음 frame에 정지하며 background throttling에서는 반응이 늦을 수 있음

Issue #1128
Issue #1131
