### PR TITLE
fix: akbun-makevideo 프로젝트 열기 오류 수정

### DIFF
--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/src/program-monitor-ui.js
+++ b/product/akbun-makevideo/workspace/src/program-monitor-ui.js
@@ -63,6 +63,17 @@
     let exactTimer = null;
     let exactToken = 0;
 
+    function resetDocumentUi() {
+      if (exactTimer !== null) window.clearTimeout(exactTimer);
+      exactTimer = null;
+      exactToken += 1;
+      visualDrag = null;
+      editorOverlayActive = false;
+      dom.stage.classList.remove('editing');
+      const preview = getPreview();
+      if (preview) preview.setEditing(false);
+    }
+
     function setStageMode(mode) {
       if (!dom.stageMode) return;
       // The badge exists to say which of two pictures is on screen. On the native
@@ -696,6 +707,7 @@
       exitFullscreen,
       orderedStops,
       renderStageOverlay,
+      resetDocumentUi,
       scheduleExactFrame,
       selectClip,
       selectedVisualItem,

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -1603,10 +1603,7 @@ async function confirmDiscard(what) {
  *  page keeps alongside it. The history belongs to the document, so opening a
  *  project starts with nothing to undo. */
 function loadDocument(doc, path) {
-  if (preview) preview.setEditing(false);
-  editorOverlayActive = false;
-  dom.stage.classList.remove('editing');
-  visualDrag = null;
+  stageController.resetDocumentUi();
   adopt(doc);
   state.path = path || null;
   state.savedRevision = doc.revision;

--- a/product/akbun-makevideo/workspace/test/program-monitor-ui.test.js
+++ b/product/akbun-makevideo/workspace/test/program-monitor-ui.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { visualTransformFor } = require('../src/program-monitor-ui.js');
+const { createProgramMonitorUi, visualTransformFor } = require('../src/program-monitor-ui.js');
 
 test('a drag preview leaves the project transform untouched', () => {
   const item = {
@@ -21,4 +21,27 @@ test('a drag preview leaves the project transform untouched', () => {
     opacity: 1,
   });
   assert.strictEqual(visualTransformFor(item, null), item.transform);
+});
+
+test('loading a document resets program monitor editing state through its controller', () => {
+  const calls = [];
+  const controller = createProgramMonitorUi({
+    dom: {
+      stage: {
+        classList: {
+          remove: (name) => calls.push(['remove', name]),
+        },
+      },
+    },
+    getPreview: () => ({
+      setEditing: (active) => calls.push(['setEditing', active]),
+    }),
+  });
+
+  controller.resetDocumentUi();
+
+  assert.deepStrictEqual(calls, [
+    ['remove', 'editing'],
+    ['setEditing', false],
+  ]);
 });

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -35,7 +35,7 @@ test('classic page scripts do not leak conflicting declarations', () => {
   assert.ok(context.appInitLib);
 });
 
-test('renderer reaches program monitor private state through its controller', () => {
+test('renderer resets program monitor state only through its controller', () => {
   const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer.js'), 'utf8');
 
   assert.doesNotMatch(source, /\beditorOverlayActive\b/);

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -35,6 +35,14 @@ test('classic page scripts do not leak conflicting declarations', () => {
   assert.ok(context.appInitLib);
 });
 
+test('renderer reaches program monitor private state through its controller', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'src', 'renderer.js'), 'utf8');
+
+  assert.doesNotMatch(source, /\beditorOverlayActive\b/);
+  assert.doesNotMatch(source, /\bvisualDrag\b/);
+  assert.match(source, /stageController\.resetDocumentUi\(\)/);
+});
+
 // Each of these is loaded with a `<script>` tag and reached through its one
 // global. A file left out of index.html is a global that is not there when the
 // file needing it runs, which is a TypeError on the first frame and a dead


### PR DESCRIPTION
# 구현

문서 전환 시 Program Monitor 전용 초기화 API로 overlay, drag, exact frame 상태 초기화 및 0.39.1 patch 버전 갱신
- JavaScript 테스트 180개 통과, 정적 페이지 초기화 확인

# 어려웠던 점

controller 분리 후 renderer에 남은 내부 상태 직접 참조 탐지
- editorOverlayActive와 visualDrag 재유입을 막는 source boundary 회귀 테스트 추가

Issue #1155
