### PR TITLE
feat: implement akbun-pdf viewer navigation and search

### DIFF
--- a/.github/workflows/release-akbun-pdf.yml
+++ b/.github/workflows/release-akbun-pdf.yml
@@ -22,7 +22,11 @@ defaults:
 jobs:
   verify:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v7
 

--- a/product/akbun-pdf/README.md
+++ b/product/akbun-pdf/README.md
@@ -4,12 +4,11 @@
 
 ## 현재 범위
 
-- 상단 도구 모음, 페이지 썸네일, PDF 화면, 목차의 기본 레이아웃
-- 빈 화면, 불러오는 중, 문서 열림, 오류 상태
+- PDF 열기·닫기와 원본 byte 보존 저장
+- 페이지 썸네일, 계층형 목차, 페이지 바로가기와 보기 맞춤
+- 한글·영문 정규화 검색, 점진적 인덱싱과 결과 강조
 - UI, Tauri adapter, 순수 Rust core, DTO contract 경계
 - macOS, Windows, Linux 릴리스와 앱 내 자동 업데이트 골격
-
-PDF 열기와 원본 보존 저장은 [Issue #1146](https://github.com/choisungwook/portfolio/issues/1146)에서 연결.
 
 ## 디렉터리
 

--- a/product/akbun-pdf/wiki/architecture.md
+++ b/product/akbun-pdf/wiki/architecture.md
@@ -38,3 +38,12 @@ ui/ ── DocumentState DTO ──> src-tauri/src/ ──> crates/pdf-core/
 - 주석: PDF 표준 주석 객체를 core 변경 목록에 기록
 - OCR: 선택한 페이지의 raster와 결과 text layer만 교환
 - 페이지 보정: 선택 페이지에만 기울기·원근 변환 적용
+
+## 문서 수명과 검색
+
+- Rust core가 원본 byte와 documentId 세션 보관
+- 새 문서 열기와 닫기에서 이전 byte 즉시 해제
+- PDF.js document와 Worker는 UI viewer가 소유하고 같은 시점에 destroy
+- 변경 없는 저장은 원본 byte를 그대로 기록한 뒤 크기와 해시 비교
+- 페이지 텍스트는 PDF.js Worker에서 순서대로 추출하고 준비된 페이지부터 검색
+- 검색 캐시는 문서 닫기와 교체에서 즉시 제거

--- a/product/akbun-pdf/wiki/architecture.md
+++ b/product/akbun-pdf/wiki/architecture.md
@@ -44,6 +44,6 @@ ui/ ── DocumentState DTO ──> src-tauri/src/ ──> crates/pdf-core/
 - Rust core가 원본 byte와 documentId 세션 보관
 - 새 문서 열기와 닫기에서 이전 byte 즉시 해제
 - PDF.js document와 Worker는 UI viewer가 소유하고 같은 시점에 destroy
-- 변경 없는 저장은 원본 byte를 그대로 기록한 뒤 크기와 해시 비교
+- 변경 없는 저장은 원본 전체 byte를 그대로 기록한 뒤 크기와 해시 비교
 - 페이지 텍스트는 PDF.js Worker에서 순서대로 추출하고 준비된 페이지부터 검색
 - 검색 캐시는 문서 닫기와 교체에서 즉시 제거

--- a/product/akbun-pdf/workspace/contracts/README.md
+++ b/product/akbun-pdf/workspace/contracts/README.md
@@ -6,4 +6,4 @@
 - 상태를 바꾸는 명령은 갱신된 `DocumentState` 전체를 반환
 - 스키마의 camelCase 이름을 TypeScript와 Rust 직렬화 이름에 동일하게 적용
 - 문서 경로는 open/save 요청에만 사용하고 상태에는 `documentId`만 유지
-- 변경 없는 저장은 원본 byte와 크기·해시를 비교한 `PreservationReport` 반환
+- 변경 없는 저장은 원본 전체 byte와 크기·해시를 비교한 `PreservationReport` 반환

--- a/product/akbun-pdf/workspace/contracts/README.md
+++ b/product/akbun-pdf/workspace/contracts/README.md
@@ -5,3 +5,5 @@
 - 화면은 파일 경로, PDF 내부 객체, Rust enum을 직접 사용하지 않음
 - 상태를 바꾸는 명령은 갱신된 `DocumentState` 전체를 반환
 - 스키마의 camelCase 이름을 TypeScript와 Rust 직렬화 이름에 동일하게 적용
+- 문서 경로는 open/save 요청에만 사용하고 상태에는 `documentId`만 유지
+- 변경 없는 저장은 원본 byte와 크기·해시를 비교한 `PreservationReport` 반환

--- a/product/akbun-pdf/workspace/contracts/commands.schema.json
+++ b/product/akbun-pdf/workspace/contracts/commands.schema.json
@@ -11,6 +11,31 @@
           "name": "get_document_state",
           "request": null,
           "response": "DocumentState"
+        },
+        {
+          "name": "open_document",
+          "request": { "path": "string" },
+          "response": "OpenDocumentPayload"
+        },
+        {
+          "name": "complete_document_open",
+          "request": { "documentId": "string", "pageCount": "integer", "outline": "OutlineItem[]" },
+          "response": "DocumentState"
+        },
+        {
+          "name": "fail_document_open",
+          "request": { "documentId": "string", "message": "string" },
+          "response": "DocumentState"
+        },
+        {
+          "name": "save_document",
+          "request": { "documentId": "string", "path": "string" },
+          "response": "PreservationReport"
+        },
+        {
+          "name": "close_document",
+          "request": null,
+          "response": "DocumentState"
         }
       ]
     }

--- a/product/akbun-pdf/workspace/contracts/document-state.schema.json
+++ b/product/akbun-pdf/workspace/contracts/document-state.schema.json
@@ -3,9 +3,10 @@
   "$id": "https://akbun.io/pdf/contracts/document-state.schema.json",
   "title": "DocumentState",
   "type": "object",
-  "required": ["phase", "title", "currentPage", "pageCount", "zoom", "thumbnails", "outline", "errorMessage"],
+  "required": ["phase", "documentId", "title", "currentPage", "pageCount", "zoom", "thumbnails", "outline", "errorMessage"],
   "properties": {
     "phase": { "enum": ["empty", "loading", "ready", "error"] },
+    "documentId": { "type": ["string", "null"] },
     "title": { "type": "string" },
     "currentPage": { "type": "integer", "minimum": 0 },
     "pageCount": { "type": "integer", "minimum": 0 },
@@ -26,11 +27,12 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "title", "page", "depth"],
+        "required": ["id", "title", "page", "top", "depth"],
         "properties": {
           "id": { "type": "string" },
           "title": { "type": "string" },
           "page": { "type": "integer", "minimum": 1 },
+          "top": { "type": ["number", "null"] },
           "depth": { "type": "integer", "minimum": 0 }
         },
         "additionalProperties": false

--- a/product/akbun-pdf/workspace/package-lock.json
+++ b/product/akbun-pdf/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-pdf",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-pdf",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/product/akbun-pdf/workspace/package.json
+++ b/product/akbun-pdf/workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-pdf",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "Offline desktop PDF reader, organizer, annotator, and OCR workspace",
   "author": "akbun",

--- a/product/akbun-pdf/workspace/src-tauri/capabilities/default.json
+++ b/product/akbun-pdf/workspace/src-tauri/capabilities/default.json
@@ -5,6 +5,8 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "dialog:allow-open",
+    "dialog:allow-save",
     "dialog:allow-message",
     "dialog:allow-ask",
     "updater:allow-check",

--- a/product/akbun-pdf/workspace/src-tauri/crates/pdf-core/src/lib.rs
+++ b/product/akbun-pdf/workspace/src-tauri/crates/pdf-core/src/lib.rs
@@ -61,9 +61,6 @@ pub struct PreservationReport {
     pub saved_size: usize,
     pub original_hash: String,
     pub saved_hash: String,
-    pub original_stream_hash: String,
-    pub saved_stream_hash: String,
-    pub stream_count: usize,
     pub unchanged: bool,
 }
 
@@ -165,31 +162,6 @@ impl DocumentStore {
         Ok(&self.session(document_id)?.bytes)
     }
 
-    pub fn preservation_report(
-        &self,
-        document_id: &str,
-        saved: &[u8],
-    ) -> Result<PreservationReport, String> {
-        let original = self.bytes(document_id)?;
-        let original_hash = stable_hash(original);
-        let saved_hash = stable_hash(saved);
-        let (original_stream_hash, stream_count) = content_stream_hash(original);
-        let (saved_stream_hash, saved_stream_count) = content_stream_hash(saved);
-        Ok(PreservationReport {
-            original_size: original.len(),
-            saved_size: saved.len(),
-            unchanged: original.len() == saved.len()
-                && original_hash == saved_hash
-                && original_stream_hash == saved_stream_hash
-                && stream_count == saved_stream_count,
-            original_hash,
-            saved_hash,
-            original_stream_hash,
-            saved_stream_hash,
-            stream_count,
-        })
-    }
-
     pub fn close(&mut self) -> DocumentState {
         self.session = None;
         DocumentState::empty()
@@ -217,35 +189,16 @@ fn stable_hash(bytes: &[u8]) -> String {
     format!("{hash:016x}")
 }
 
-fn content_stream_hash(bytes: &[u8]) -> (String, usize) {
-    let mut hash = 0xcbf29ce484222325_u64;
-    let mut count = 0;
-    let mut cursor = 0;
-    while let Some(start_offset) = find_bytes(&bytes[cursor..], b"stream") {
-        let mut start = cursor + start_offset + b"stream".len();
-        if bytes.get(start) == Some(&b'\r') {
-            start += 1;
-        }
-        if bytes.get(start) == Some(&b'\n') {
-            start += 1;
-        }
-        let Some(end_offset) = find_bytes(&bytes[start..], b"endstream") else {
-            break;
-        };
-        let end = start + end_offset;
-        hash = bytes[start..end].iter().fold(hash, |value, byte| {
-            (value ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
-        });
-        count += 1;
-        cursor = end + b"endstream".len();
+pub fn preservation_report(original: &[u8], saved: &[u8]) -> PreservationReport {
+    let original_hash = stable_hash(original);
+    let saved_hash = stable_hash(saved);
+    PreservationReport {
+        original_size: original.len(),
+        saved_size: saved.len(),
+        unchanged: original.len() == saved.len() && original_hash == saved_hash,
+        original_hash,
+        saved_hash,
     }
-    (format!("{hash:016x}"), count)
-}
-
-fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
 }
 
 #[cfg(test)]
@@ -280,12 +233,10 @@ mod tests {
         let opened = store.open("sample.pdf".into(), PDF.to_vec()).unwrap();
         let id = opened.state.document_id.as_deref().unwrap();
         let saved = store.bytes(id).unwrap().to_vec();
-        let report = store.preservation_report(id, &saved).unwrap();
+        let report = preservation_report(store.bytes(id).unwrap(), &saved);
         assert!(report.unchanged);
         assert_eq!(report.original_size, report.saved_size);
         assert_eq!(report.original_hash, report.saved_hash);
-        assert_eq!(report.original_stream_hash, report.saved_stream_hash);
-        assert_eq!(report.stream_count, 1);
         assert!(String::from_utf8(saved)
             .unwrap()
             .contains("stream\nhello\nendstream"));

--- a/product/akbun-pdf/workspace/src-tauri/crates/pdf-core/src/lib.rs
+++ b/product/akbun-pdf/workspace/src-tauri/crates/pdf-core/src/lib.rs
@@ -1,87 +1,322 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentState {
-  pub phase: DocumentPhase,
-  pub title: String,
-  pub current_page: u32,
-  pub page_count: u32,
-  pub zoom: f32,
-  pub thumbnails: Vec<Thumbnail>,
-  pub outline: Vec<OutlineItem>,
-  pub error_message: Option<String>,
+    pub phase: DocumentPhase,
+    pub document_id: Option<String>,
+    pub title: String,
+    pub current_page: u32,
+    pub page_count: u32,
+    pub zoom: f32,
+    pub thumbnails: Vec<Thumbnail>,
+    pub outline: Vec<OutlineItem>,
+    pub error_message: Option<String>,
 }
 
 impl Default for DocumentState {
-  fn default() -> Self {
-    Self::empty()
-  }
+    fn default() -> Self {
+        Self::empty()
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum DocumentPhase {
-  #[default]
-  Empty,
-  Loading,
-  Ready,
-  Error,
+    #[default]
+    Empty,
+    Loading,
+    Ready,
+    Error,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Thumbnail {
-  pub page: u32,
-  pub label: String,
+    pub page: u32,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OutlineItem {
+    pub id: String,
+    pub title: String,
+    pub page: u32,
+    pub top: Option<f32>,
+    pub depth: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct OutlineItem {
-  pub id: String,
-  pub title: String,
-  pub page: u32,
-  pub depth: u32,
+pub struct OpenDocument {
+    pub state: DocumentState,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PreservationReport {
+    pub original_size: usize,
+    pub saved_size: usize,
+    pub original_hash: String,
+    pub saved_hash: String,
+    pub original_stream_hash: String,
+    pub saved_stream_hash: String,
+    pub stream_count: usize,
+    pub unchanged: bool,
+}
+
+#[derive(Default)]
+pub struct DocumentStore {
+    next_id: u64,
+    session: Option<DocumentSession>,
+}
+
+struct DocumentSession {
+    state: DocumentState,
+    bytes: Vec<u8>,
 }
 
 impl DocumentState {
-  pub fn empty() -> Self {
-    Self {
-      phase: DocumentPhase::Empty,
-      title: "akbun-pdf".into(),
-      current_page: 0,
-      page_count: 0,
-      zoom: 1.0,
-      thumbnails: Vec::new(),
-      outline: Vec::new(),
-      error_message: None,
+    pub fn empty() -> Self {
+        Self {
+            phase: DocumentPhase::Empty,
+            document_id: None,
+            title: "akbun-pdf".into(),
+            current_page: 0,
+            page_count: 0,
+            zoom: 1.0,
+            thumbnails: Vec::new(),
+            outline: Vec::new(),
+            error_message: None,
+        }
     }
-  }
+}
+
+impl DocumentStore {
+    pub fn state(&self) -> DocumentState {
+        self.session
+            .as_ref()
+            .map(|session| session.state.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn open(&mut self, title: String, bytes: Vec<u8>) -> Result<OpenDocument, String> {
+        if !bytes.starts_with(b"%PDF-") {
+            return Err("PDF 파일 형식이 아닙니다.".into());
+        }
+
+        self.next_id += 1;
+        let document_id = format!("document-{}", self.next_id);
+        let state = DocumentState {
+            phase: DocumentPhase::Loading,
+            document_id: Some(document_id),
+            title,
+            ..DocumentState::empty()
+        };
+        self.session = Some(DocumentSession {
+            state: state.clone(),
+            bytes: bytes.clone(),
+        });
+        Ok(OpenDocument { state, bytes })
+    }
+
+    pub fn complete(
+        &mut self,
+        document_id: &str,
+        page_count: u32,
+        outline: Vec<OutlineItem>,
+    ) -> Result<DocumentState, String> {
+        if page_count == 0 {
+            return Err("페이지가 없는 PDF입니다.".into());
+        }
+
+        let session = self.session_mut(document_id)?;
+        session.state.phase = DocumentPhase::Ready;
+        session.state.current_page = 1;
+        session.state.page_count = page_count;
+        session.state.thumbnails = (1..=page_count)
+            .map(|page| Thumbnail {
+                page,
+                label: format!("{page}페이지"),
+            })
+            .collect();
+        session.state.outline = outline;
+        session.state.error_message = None;
+        Ok(session.state.clone())
+    }
+
+    pub fn fail(&mut self, document_id: &str, message: String) -> Result<DocumentState, String> {
+        let session = self.session_mut(document_id)?;
+        session.state.phase = DocumentPhase::Error;
+        session.state.current_page = 0;
+        session.state.page_count = 0;
+        session.state.thumbnails.clear();
+        session.state.outline.clear();
+        session.state.error_message = Some(message);
+        session.state.document_id = None;
+        session.bytes.clear();
+        session.bytes.shrink_to_fit();
+        Ok(session.state.clone())
+    }
+
+    pub fn bytes(&self, document_id: &str) -> Result<&[u8], String> {
+        Ok(&self.session(document_id)?.bytes)
+    }
+
+    pub fn preservation_report(
+        &self,
+        document_id: &str,
+        saved: &[u8],
+    ) -> Result<PreservationReport, String> {
+        let original = self.bytes(document_id)?;
+        let original_hash = stable_hash(original);
+        let saved_hash = stable_hash(saved);
+        let (original_stream_hash, stream_count) = content_stream_hash(original);
+        let (saved_stream_hash, saved_stream_count) = content_stream_hash(saved);
+        Ok(PreservationReport {
+            original_size: original.len(),
+            saved_size: saved.len(),
+            unchanged: original.len() == saved.len()
+                && original_hash == saved_hash
+                && original_stream_hash == saved_stream_hash
+                && stream_count == saved_stream_count,
+            original_hash,
+            saved_hash,
+            original_stream_hash,
+            saved_stream_hash,
+            stream_count,
+        })
+    }
+
+    pub fn close(&mut self) -> DocumentState {
+        self.session = None;
+        DocumentState::empty()
+    }
+
+    fn session(&self, document_id: &str) -> Result<&DocumentSession, String> {
+        self.session
+            .as_ref()
+            .filter(|session| session.state.document_id.as_deref() == Some(document_id))
+            .ok_or_else(|| "열린 문서 세션을 찾을 수 없습니다.".into())
+    }
+
+    fn session_mut(&mut self, document_id: &str) -> Result<&mut DocumentSession, String> {
+        self.session
+            .as_mut()
+            .filter(|session| session.state.document_id.as_deref() == Some(document_id))
+            .ok_or_else(|| "열린 문서 세션을 찾을 수 없습니다.".into())
+    }
+}
+
+fn stable_hash(bytes: &[u8]) -> String {
+    let hash = bytes.iter().fold(0xcbf29ce484222325_u64, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    });
+    format!("{hash:016x}")
+}
+
+fn content_stream_hash(bytes: &[u8]) -> (String, usize) {
+    let mut hash = 0xcbf29ce484222325_u64;
+    let mut count = 0;
+    let mut cursor = 0;
+    while let Some(start_offset) = find_bytes(&bytes[cursor..], b"stream") {
+        let mut start = cursor + start_offset + b"stream".len();
+        if bytes.get(start) == Some(&b'\r') {
+            start += 1;
+        }
+        if bytes.get(start) == Some(&b'\n') {
+            start += 1;
+        }
+        let Some(end_offset) = find_bytes(&bytes[start..], b"endstream") else {
+            break;
+        };
+        let end = start + end_offset;
+        hash = bytes[start..end].iter().fold(hash, |value, byte| {
+            (value ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+        });
+        count += 1;
+        cursor = end + b"endstream".len();
+    }
+    (format!("{hash:016x}"), count)
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
 }
 
 #[cfg(test)]
 mod tests {
-  use super::*;
+    use super::*;
 
-  #[test]
-  fn empty_state_has_no_document_identity_or_pages() {
-    let state = DocumentState::empty();
+    const PDF: &[u8] = b"%PDF-1.7\n1 0 obj<</Length 5>>stream\nhello\nendstream\nendobj\n%%EOF";
 
-    assert_eq!(state.phase, DocumentPhase::Empty);
-    assert_eq!(state.current_page, 0);
-    assert_eq!(state.page_count, 0);
-    assert!(state.thumbnails.is_empty());
-    assert!(state.outline.is_empty());
-  }
+    #[test]
+    fn empty_state_has_no_document_identity_or_pages() {
+        let state = DocumentState::empty();
+        assert_eq!(state.phase, DocumentPhase::Empty);
+        assert_eq!(state.document_id, None);
+        assert_eq!(state.current_page, 0);
+        assert_eq!(state.page_count, 0);
+    }
 
-  #[test]
-  fn serialized_state_matches_the_ui_contract() {
-    let value = serde_json::to_value(DocumentState::empty()).unwrap();
+    #[test]
+    fn opening_a_second_document_releases_the_previous_session() {
+        let mut store = DocumentStore::default();
+        let first = store.open("first.pdf".into(), PDF.to_vec()).unwrap();
+        let second = store.open("second.pdf".into(), PDF.to_vec()).unwrap();
+        assert_ne!(first.state.document_id, second.state.document_id);
+        assert!(store
+            .bytes(first.state.document_id.as_deref().unwrap())
+            .is_err());
+    }
 
-    assert_eq!(value["phase"], "empty");
-    assert_eq!(value["currentPage"], 0);
-    assert_eq!(value["pageCount"], 0);
-    assert_eq!(value["errorMessage"], serde_json::Value::Null);
-  }
+    #[test]
+    fn unchanged_save_preserves_stream_bytes_and_file_size() {
+        let mut store = DocumentStore::default();
+        let opened = store.open("sample.pdf".into(), PDF.to_vec()).unwrap();
+        let id = opened.state.document_id.as_deref().unwrap();
+        let saved = store.bytes(id).unwrap().to_vec();
+        let report = store.preservation_report(id, &saved).unwrap();
+        assert!(report.unchanged);
+        assert_eq!(report.original_size, report.saved_size);
+        assert_eq!(report.original_hash, report.saved_hash);
+        assert_eq!(report.original_stream_hash, report.saved_stream_hash);
+        assert_eq!(report.stream_count, 1);
+        assert!(String::from_utf8(saved)
+            .unwrap()
+            .contains("stream\nhello\nendstream"));
+    }
+
+    #[test]
+    fn closing_releases_bytes_and_returns_empty_state() {
+        let mut store = DocumentStore::default();
+        let opened = store.open("sample.pdf".into(), PDF.to_vec()).unwrap();
+        let id = opened.state.document_id.unwrap();
+        assert_eq!(store.close(), DocumentState::empty());
+        assert!(store.bytes(&id).is_err());
+    }
+
+    #[test]
+    fn failed_open_releases_the_original_buffer() {
+        let mut store = DocumentStore::default();
+        let opened = store.open("sample.pdf".into(), PDF.to_vec()).unwrap();
+        let id = opened.state.document_id.unwrap();
+        let failed = store.fail(&id, "broken PDF".into()).unwrap();
+        assert_eq!(failed.phase, DocumentPhase::Error);
+        assert_eq!(failed.document_id, None);
+        assert!(store.bytes(&id).is_err());
+    }
+
+    #[test]
+    fn serialized_state_matches_the_ui_contract() {
+        let value = serde_json::to_value(DocumentState::empty()).unwrap();
+        assert_eq!(value["phase"], "empty");
+        assert_eq!(value["documentId"], serde_json::Value::Null);
+        assert_eq!(value["currentPage"], 0);
+        assert_eq!(value["errorMessage"], serde_json::Value::Null);
+    }
 }

--- a/product/akbun-pdf/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-pdf/workspace/src-tauri/src/commands.rs
@@ -1,9 +1,60 @@
-use pdf_core::DocumentState;
+use std::fs;
+use std::path::Path;
+
+use pdf_core::{DocumentState, OpenDocument, OutlineItem, PreservationReport};
 use tauri::State;
 
 use crate::AppState;
 
 #[tauri::command]
-pub fn get_document_state(state: State<'_, AppState>) -> DocumentState {
-    state.document()
+pub fn get_document_state(state: State<'_, AppState>) -> Result<DocumentState, String> {
+    Ok(state.store()?.state())
+}
+
+#[tauri::command]
+pub fn open_document(path: String, state: State<'_, AppState>) -> Result<OpenDocument, String> {
+    let bytes = fs::read(&path).map_err(|error| error.to_string())?;
+    let title = Path::new(&path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("document.pdf")
+        .to_owned();
+    state.store()?.open(title, bytes)
+}
+
+#[tauri::command]
+pub fn complete_document_open(
+    document_id: String,
+    page_count: u32,
+    outline: Vec<OutlineItem>,
+    state: State<'_, AppState>,
+) -> Result<DocumentState, String> {
+    state.store()?.complete(&document_id, page_count, outline)
+}
+
+#[tauri::command]
+pub fn fail_document_open(
+    document_id: String,
+    message: String,
+    state: State<'_, AppState>,
+) -> Result<DocumentState, String> {
+    state.store()?.fail(&document_id, message)
+}
+
+#[tauri::command]
+pub fn save_document(
+    document_id: String,
+    path: String,
+    state: State<'_, AppState>,
+) -> Result<PreservationReport, String> {
+    let store = state.store()?;
+    let bytes = store.bytes(&document_id)?.to_vec();
+    fs::write(&path, bytes).map_err(|error| error.to_string())?;
+    let saved = fs::read(path).map_err(|error| error.to_string())?;
+    store.preservation_report(&document_id, &saved)
+}
+
+#[tauri::command]
+pub fn close_document(state: State<'_, AppState>) -> Result<DocumentState, String> {
+    Ok(state.store()?.close())
 }

--- a/product/akbun-pdf/workspace/src-tauri/src/commands.rs
+++ b/product/akbun-pdf/workspace/src-tauri/src/commands.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::Path;
 
-use pdf_core::{DocumentState, OpenDocument, OutlineItem, PreservationReport};
+use pdf_core::{preservation_report, DocumentState, OpenDocument, OutlineItem, PreservationReport};
 use tauri::State;
 
 use crate::AppState;
@@ -47,11 +47,13 @@ pub fn save_document(
     path: String,
     state: State<'_, AppState>,
 ) -> Result<PreservationReport, String> {
-    let store = state.store()?;
-    let bytes = store.bytes(&document_id)?.to_vec();
-    fs::write(&path, bytes).map_err(|error| error.to_string())?;
+    let bytes = {
+        let store = state.store()?;
+        store.bytes(&document_id)?.to_vec()
+    };
+    fs::write(&path, &bytes).map_err(|error| error.to_string())?;
     let saved = fs::read(path).map_err(|error| error.to_string())?;
-    store.preservation_report(&document_id, &saved)
+    Ok(preservation_report(&bytes, &saved))
 }
 
 #[tauri::command]

--- a/product/akbun-pdf/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-pdf/workspace/src-tauri/src/lib.rs
@@ -1,15 +1,19 @@
 mod commands;
 
-use pdf_core::DocumentState;
+use std::sync::{Mutex, MutexGuard};
+
+use pdf_core::DocumentStore;
 
 #[derive(Default)]
 pub struct AppState {
-    document: DocumentState,
+    store: Mutex<DocumentStore>,
 }
 
 impl AppState {
-    fn document(&self) -> DocumentState {
-        self.document.clone()
+    fn store(&self) -> Result<MutexGuard<'_, DocumentStore>, String> {
+        self.store
+            .lock()
+            .map_err(|_| "문서 상태 잠금에 실패했습니다.".into())
     }
 }
 
@@ -37,7 +41,14 @@ pub fn run() {
             let _ = app;
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![commands::get_document_state])
+        .invoke_handler(tauri::generate_handler![
+            commands::get_document_state,
+            commands::open_document,
+            commands::complete_document_open,
+            commands::fail_document_open,
+            commands::save_document,
+            commands::close_document,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running akbun-pdf");
 }

--- a/product/akbun-pdf/workspace/test/search.test.ts
+++ b/product/akbun-pdf/workspace/test/search.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { DocumentSearch, normalizeSearchText } from "../ui/src/search";
+
+const rect = { x: 0, y: 0, width: 100, height: 12 };
+
+describe("document search", () => {
+  it("normalizes composed Korean and ignores English case", () => {
+    expect(normalizeSearchText("한글 PDF")).toBe(normalizeSearchText("한글 pdf"));
+    const search = new DocumentSearch();
+    search.begin(1);
+    search.addPage(1, [{ text: "Cafe\u0301 한글 PDF", rect }]);
+    expect(search.query("CAFÉ 한글 pdf")).toHaveLength(1);
+  });
+
+  it("returns results before every page is indexed", () => {
+    const search = new DocumentSearch();
+    search.begin(300);
+    search.addPage(1, [{ text: "첫 번째 검색 결과", rect }]);
+    expect(search.query("검색")[0]?.page).toBe(1);
+    expect(search.progress()).toEqual({ indexed: 1, total: 300 });
+  });
+
+  it("moves through a 300-page index within 100ms", () => {
+    const search = new DocumentSearch();
+    search.begin(300);
+    for (let page = 1; page <= 300; page += 1) {
+      search.addPage(page, [{ text: `page ${page} ${"document text ".repeat(40)}searchable document`, rect }]);
+    }
+    const started = performance.now();
+    const results = search.query("searchable document");
+    expect(performance.now() - started).toBeLessThan(100);
+    expect(results).toHaveLength(300);
+  });
+
+  it("clears cached text when the document closes", () => {
+    const search = new DocumentSearch();
+    search.begin(1);
+    search.addPage(1, [{ text: "private document text", rect }]);
+    search.clear();
+    expect(search.query("private")).toEqual([]);
+    expect(search.progress()).toEqual({ indexed: 0, total: 0 });
+  });
+});

--- a/product/akbun-pdf/workspace/test/search.test.ts
+++ b/product/akbun-pdf/workspace/test/search.test.ts
@@ -20,15 +20,13 @@ describe("document search", () => {
     expect(search.progress()).toEqual({ indexed: 1, total: 300 });
   });
 
-  it("moves through a 300-page index within 100ms", () => {
+  it("returns one accurate match from each of 300 indexed pages", () => {
     const search = new DocumentSearch();
     search.begin(300);
     for (let page = 1; page <= 300; page += 1) {
       search.addPage(page, [{ text: `page ${page} ${"document text ".repeat(40)}searchable document`, rect }]);
     }
-    const started = performance.now();
     const results = search.query("searchable document");
-    expect(performance.now() - started).toBeLessThan(100);
     expect(results).toHaveLength(300);
   });
 

--- a/product/akbun-pdf/workspace/ui/index.html
+++ b/product/akbun-pdf/workspace/ui/index.html
@@ -24,6 +24,12 @@
             <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M4 7.5h6l2 2h8v9H4z" /><path d="M4 7.5v-2h6l2 2" /></svg>
             <span>PDF 열기</span>
           </button>
+          <button class="icon-button" type="button" aria-label="다른 이름으로 저장" title="다른 이름으로 저장" data-action="save" data-document-control>
+            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M5 4h11l3 3v13H5zM8 4v6h8V4M8 16h8" /></svg>
+          </button>
+          <button class="icon-button" type="button" aria-label="문서 닫기" title="문서 닫기" data-action="close" data-document-control>
+            <svg aria-hidden="true" viewBox="0 0 24 24"><path d="m7 7 10 10M17 7 7 17" /></svg>
+          </button>
         </div>
 
         <div class="toolbar__group toolbar__group--page" aria-label="페이지 이동">
@@ -48,6 +54,9 @@
           <button class="icon-button" type="button" aria-label="확대" data-action="zoom-in">
             <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="10.5" cy="10.5" r="6" /><path d="M10.5 6.8v7.4M6.8 10.5h7.4M15 15l4 4" /></svg>
           </button>
+          <button class="fit-button" type="button" data-action="actual-size" data-document-control>실제</button>
+          <button class="fit-button" type="button" data-action="fit-width" data-document-control>너비</button>
+          <button class="fit-button" type="button" data-action="fit-page" data-document-control>페이지</button>
         </div>
 
         <div class="toolbar__spacer"></div>
@@ -61,7 +70,7 @@
             <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M5 5h14v11H9l-4 3z" /><path d="M9 9h6M9 12h4" /></svg>
             <span>메모</span>
           </button>
-          <button class="tool-button" type="button" disabled title="후속 이슈에서 제공">
+          <button class="tool-button" type="button" data-action="find" data-document-control>
             <svg aria-hidden="true" viewBox="0 0 24 24"><circle cx="10.5" cy="10.5" r="6" /><path d="M15 15l4 4" /></svg>
             <span>찾기</span>
           </button>
@@ -74,6 +83,20 @@
           <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M19 8a7 7 0 1 0 0 8M19 4v4h-4" /></svg>
         </button>
       </header>
+
+      <section class="search-panel" data-role="search-panel" aria-label="문서 찾기" hidden>
+        <input type="search" data-role="search-input" aria-label="찾을 텍스트" placeholder="한글 또는 영문 찾기" autocomplete="off" />
+        <span class="search-status" data-role="search-status">검색어를 입력하세요.</span>
+        <button class="icon-button" type="button" aria-label="이전 결과" data-action="previous-result">
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path d="m7 14 5-5 5 5" /></svg>
+        </button>
+        <button class="icon-button" type="button" aria-label="다음 결과" data-action="next-result">
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path d="m7 10 5 5 5-5" /></svg>
+        </button>
+        <button class="icon-button" type="button" aria-label="찾기 닫기" data-action="close-find">
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path d="m7 7 10 10M17 7 7 17" /></svg>
+        </button>
+      </section>
 
       <div class="workspace">
         <aside class="pages-panel" aria-label="페이지 썸네일">
@@ -91,6 +114,8 @@
             <div class="thumbnail-skeleton"></div>
           </div>
         </aside>
+
+        <div class="panel-resizer panel-resizer--pages" data-resize-panel="pages" aria-hidden="true"></div>
 
         <main class="viewer" aria-live="polite">
           <section class="state-card state-card--empty" data-visible-phase="empty">
@@ -162,12 +187,14 @@
           </section>
         </main>
 
+        <div class="panel-resizer panel-resizer--outline" data-resize-panel="outline" aria-hidden="true"></div>
+
         <aside class="outline-panel" aria-label="문서 목차">
           <div class="panel-heading">
             <span>목차</span>
           </div>
           <nav class="outline-list" data-role="outline-list"></nav>
-          <div class="outline-empty" data-visible-phase="empty loading error">
+          <div class="outline-empty" data-role="outline-empty" data-visible-phase="empty loading ready error">
             <svg aria-hidden="true" viewBox="0 0 24 24"><path d="M6 5h12M6 10h8M6 15h10M6 20h7" /></svg>
             <span>목차가 없습니다.</span>
           </div>

--- a/product/akbun-pdf/workspace/ui/src/bridge.ts
+++ b/product/akbun-pdf/workspace/ui/src/bridge.ts
@@ -17,15 +17,22 @@ declare global {
   }
 }
 
+function isTauriRuntime(): boolean {
+  const internals = window.__TAURI_INTERNALS__;
+  if (typeof internals !== "object" || internals === null) return false;
+  const metadata = (internals as { metadata?: { currentWindow?: { label?: unknown } } }).metadata;
+  return typeof metadata?.currentWindow?.label === "string";
+}
+
 export async function getInitialState(): Promise<DocumentState> {
   const phase = previewPhase(window.location.search);
   if (phase) return fixtureFor(phase);
-  if (!window.__TAURI_INTERNALS__) return fixtureFor("empty");
+  if (!isTauriRuntime()) return fixtureFor("empty");
   return invoke<DocumentState>("get_document_state");
 }
 
 export async function chooseAndOpenDocument(): Promise<OpenDocumentPayload | null> {
-  if (!window.__TAURI_INTERNALS__) throw new Error("Tauri 앱에서 PDF를 열어주세요.");
+  if (!isTauriRuntime()) throw new Error("Tauri 앱에서 PDF를 열어주세요.");
   const path = await open({
     multiple: false,
     filters: [{ name: "PDF 문서", extensions: ["pdf"] }],
@@ -47,7 +54,7 @@ export function failDocumentOpen(documentId: string, error: unknown): Promise<Do
 }
 
 export function closeDocument(): Promise<DocumentState> {
-  if (!window.__TAURI_INTERNALS__) return Promise.resolve(fixtureFor("empty"));
+  if (!isTauriRuntime()) return Promise.resolve(fixtureFor("empty"));
   return invoke("close_document");
 }
 
@@ -55,6 +62,7 @@ export async function chooseAndSaveDocument(
   documentId: string,
   title: string,
 ): Promise<PreservationReport | null> {
+  if (!isTauriRuntime()) throw new Error("Tauri 앱에서 PDF를 저장해 주세요.");
   const path = await save({
     defaultPath: title,
     filters: [{ name: "PDF 문서", extensions: ["pdf"] }],
@@ -64,7 +72,7 @@ export async function chooseAndSaveDocument(
 }
 
 export async function checkForUpdates(): Promise<string> {
-  if (!window.__TAURI_INTERNALS__) {
+  if (!isTauriRuntime()) {
     return "브라우저 미리보기에서는 업데이트를 확인하지 않습니다.";
   }
 

--- a/product/akbun-pdf/workspace/ui/src/bridge.ts
+++ b/product/akbun-pdf/workspace/ui/src/bridge.ts
@@ -1,10 +1,15 @@
 import { invoke } from "@tauri-apps/api/core";
-import { ask, message } from "@tauri-apps/plugin-dialog";
+import { ask, message, open, save } from "@tauri-apps/plugin-dialog";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
 import { fixtureFor } from "./fixtures";
 import { previewPhase } from "./state";
-import type { DocumentState } from "./types";
+import type {
+  DocumentState,
+  OpenDocumentPayload,
+  OutlineItem,
+  PreservationReport,
+} from "./types";
 
 declare global {
   interface Window {
@@ -19,6 +24,45 @@ export async function getInitialState(): Promise<DocumentState> {
   return invoke<DocumentState>("get_document_state");
 }
 
+export async function chooseAndOpenDocument(): Promise<OpenDocumentPayload | null> {
+  if (!window.__TAURI_INTERNALS__) throw new Error("Tauri 앱에서 PDF를 열어주세요.");
+  const path = await open({
+    multiple: false,
+    filters: [{ name: "PDF 문서", extensions: ["pdf"] }],
+  });
+  if (!path) return null;
+  return invoke<OpenDocumentPayload>("open_document", { path });
+}
+
+export function completeDocumentOpen(
+  documentId: string,
+  pageCount: number,
+  outline: OutlineItem[],
+): Promise<DocumentState> {
+  return invoke("complete_document_open", { documentId, pageCount, outline });
+}
+
+export function failDocumentOpen(documentId: string, error: unknown): Promise<DocumentState> {
+  return invoke("fail_document_open", { documentId, message: String(error) });
+}
+
+export function closeDocument(): Promise<DocumentState> {
+  if (!window.__TAURI_INTERNALS__) return Promise.resolve(fixtureFor("empty"));
+  return invoke("close_document");
+}
+
+export async function chooseAndSaveDocument(
+  documentId: string,
+  title: string,
+): Promise<PreservationReport | null> {
+  const path = await save({
+    defaultPath: title,
+    filters: [{ name: "PDF 문서", extensions: ["pdf"] }],
+  });
+  if (!path) return null;
+  return invoke("save_document", { documentId, path });
+}
+
 export async function checkForUpdates(): Promise<string> {
   if (!window.__TAURI_INTERNALS__) {
     return "브라우저 미리보기에서는 업데이트를 확인하지 않습니다.";
@@ -31,10 +75,10 @@ export async function checkForUpdates(): Promise<string> {
       return "최신 버전입니다.";
     }
 
-    const shouldInstall = await ask(
-      `버전 ${update.version}을 내려받아 설치할까요?`,
-      { title: "업데이트 있음", kind: "info" },
-    );
+    const shouldInstall = await ask(`버전 ${update.version}을 내려받아 설치할까요?`, {
+      title: "업데이트 있음",
+      kind: "info",
+    });
     if (!shouldInstall) return "업데이트를 취소했습니다.";
 
     await update.downloadAndInstall();

--- a/product/akbun-pdf/workspace/ui/src/fixtures.ts
+++ b/product/akbun-pdf/workspace/ui/src/fixtures.ts
@@ -2,6 +2,7 @@ import type { DocumentPhase, DocumentState } from "./types";
 
 const emptyState: DocumentState = {
   phase: "empty",
+  documentId: null,
   title: "akbun-pdf",
   currentPage: 0,
   pageCount: 0,
@@ -27,6 +28,7 @@ export function fixtureFor(phase: DocumentPhase): DocumentState {
   if (phase === "ready") {
     return {
       phase,
+      documentId: "preview-document",
       title: "product-principles.pdf",
       currentPage: 1,
       pageCount: 8,
@@ -36,11 +38,11 @@ export function fixtureFor(phase: DocumentPhase): DocumentState {
         label: `${index + 1}페이지`,
       })),
       outline: [
-        { id: "intro", title: "들어가며", page: 1, depth: 0 },
-        { id: "focus", title: "문서에 집중하기", page: 2, depth: 0 },
-        { id: "hierarchy", title: "시각적 위계", page: 3, depth: 1 },
-        { id: "navigation", title: "빠른 탐색", page: 5, depth: 0 },
-        { id: "offline", title: "오프라인 작업", page: 7, depth: 0 },
+        { id: "intro", title: "들어가며", page: 1, top: null, depth: 0 },
+        { id: "focus", title: "문서에 집중하기", page: 2, top: null, depth: 0 },
+        { id: "hierarchy", title: "시각적 위계", page: 3, top: null, depth: 1 },
+        { id: "navigation", title: "빠른 탐색", page: 5, top: null, depth: 0 },
+        { id: "offline", title: "오프라인 작업", page: 7, top: null, depth: 0 },
       ],
       errorMessage: null,
     };

--- a/product/akbun-pdf/workspace/ui/src/main.ts
+++ b/product/akbun-pdf/workspace/ui/src/main.ts
@@ -1,42 +1,177 @@
 import "./styles.css";
-import { checkForUpdates, getInitialState } from "./bridge";
-import { configurePdfEngine } from "./pdf-engine";
+import "./viewer.css";
+import {
+  checkForUpdates,
+  chooseAndOpenDocument,
+  chooseAndSaveDocument,
+  closeDocument,
+  completeDocumentOpen,
+  failDocumentOpen,
+  getInitialState,
+} from "./bridge";
+import { configurePdfEngine, PdfDocumentAdapter } from "./pdf-engine";
 import { renderDocument, showToast } from "./render";
 import { changeZoom, goToPage, normalizeState } from "./state";
-import type { DocumentState } from "./types";
+import type { DocumentState, FitMode, SearchResult } from "./types";
+import { PdfViewer } from "./viewer";
+
+function element<T extends Element>(selector: string): T {
+  const match = document.querySelector<T>(selector);
+  if (!match) throw new Error(`missing element: ${selector}`);
+  return match;
+}
 
 configurePdfEngine();
 
-let state: DocumentState = await getInitialState();
+let state: DocumentState = normalizeState(await getInitialState());
+let searchResults: SearchResult[] = [];
+let selectedResult = -1;
+
+const searchPanel = element<HTMLElement>("[data-role='search-panel']");
+const searchInput = element<HTMLInputElement>("[data-role='search-input']");
+const searchStatus = element<HTMLElement>("[data-role='search-status']");
+const viewer = new PdfViewer(
+  element(".document-stage"),
+  element(".viewer"),
+  {
+    onCurrentPage: (page) => updateState(goToPage(state, page)),
+    onIndexProgress: () => refreshSearchResults(),
+  },
+);
+
 renderDocument(state);
+restorePanelSizes();
+wirePanelResizers();
 
 function updateState(next: DocumentState): void {
   state = normalizeState(next);
   renderDocument(state);
 }
 
-function openPlaceholder(): void {
-  showToast("파일 열기는 다음 단계에서 PDF core와 연결됩니다.");
+async function openDocument(): Promise<void> {
+  let adapter: PdfDocumentAdapter | null = null;
+  try {
+    const opened = await chooseAndOpenDocument();
+    if (!opened) return;
+    await viewer.close();
+    updateState(opened.state);
+    const documentId = opened.state.documentId;
+    if (!documentId) throw new Error("문서 식별자가 없습니다.");
+    adapter = await PdfDocumentAdapter.open(opened.bytes);
+    const outline = await adapter.outline();
+    const ready = await completeDocumentOpen(documentId, adapter.pageCount, outline);
+    updateState(ready);
+    const viewerAdapter = adapter;
+    adapter = null;
+    await viewer.open(viewerAdapter);
+    refreshSearchResults();
+  } catch (error) {
+    if (adapter) await adapter.destroy();
+    await viewer.close();
+    if (state.documentId) {
+      try {
+        updateState(await failDocumentOpen(state.documentId, error));
+      } catch {
+        updateState({ ...state, phase: "error", errorMessage: String(error) });
+      }
+    } else {
+      updateState({ ...state, phase: "error", errorMessage: String(error) });
+    }
+  }
+}
+
+async function closeCurrentDocument(): Promise<void> {
+  await viewer.close();
+  updateState(await closeDocument());
+  closeFind();
+}
+
+async function saveCurrentDocument(): Promise<void> {
+  if (!state.documentId) return;
+  try {
+    const report = await chooseAndSaveDocument(state.documentId, state.title);
+    if (!report) return;
+    const size = new Intl.NumberFormat("ko-KR").format(report.savedSize);
+    showToast(report.unchanged
+      ? `원본 스트림 ${report.streamCount}개와 파일 크기 보존 · ${size} bytes`
+      : "저장 결과가 원본과 달라 저장을 확인해야 합니다.");
+  } catch (error) {
+    showToast(`저장 실패 · ${String(error)}`);
+  }
+}
+
+function applyZoom(mode: FitMode, requested = state.zoom): void {
+  const zoom = viewer.zoom(mode, requested);
+  updateState({ ...state, zoom });
+}
+
+function openFind(): void {
+  if (state.phase !== "ready") return;
+  searchPanel.hidden = false;
+  searchInput.focus();
+  searchInput.select();
+  refreshSearchResults();
+}
+
+function closeFind(): void {
+  searchPanel.hidden = true;
+  searchResults = [];
+  selectedResult = -1;
+  viewer.showSearchResults([], -1);
+}
+
+function refreshSearchResults(): void {
+  const selectedId = searchResults[selectedResult]?.id;
+  searchResults = viewer.search.query(searchInput.value);
+  selectedResult = selectedId ? searchResults.findIndex((result) => result.id === selectedId) : -1;
+  if (selectedResult < 0 && searchResults.length > 0) selectedResult = 0;
+  const progress = viewer.search.progress();
+  const position = selectedResult < 0 ? "0" : String(selectedResult + 1);
+  searchStatus.textContent = searchInput.value.trim()
+    ? `${position} / ${searchResults.length} · ${progress.indexed}/${progress.total} 페이지`
+    : `${progress.indexed}/${progress.total} 페이지 준비됨`;
+  viewer.showSearchResults(searchResults, selectedResult);
+}
+
+function moveSearchResult(delta: number): void {
+  if (searchResults.length === 0) return;
+  selectedResult = (selectedResult + delta + searchResults.length) % searchResults.length;
+  viewer.showSearchResults(searchResults, selectedResult);
+  const result = searchResults[selectedResult];
+  if (result) viewer.goTo(result.page);
+  refreshSearchStatus();
+}
+
+function refreshSearchStatus(): void {
+  const progress = viewer.search.progress();
+  const position = selectedResult < 0 ? 0 : selectedResult + 1;
+  searchStatus.textContent = `${position} / ${searchResults.length} · ${progress.indexed}/${progress.total} 페이지`;
 }
 
 function handleAction(action: string): void {
-  if (action === "open") return openPlaceholder();
-  if (action === "previous-page") return updateState(goToPage(state, state.currentPage - 1));
-  if (action === "next-page") return updateState(goToPage(state, state.currentPage + 1));
-  if (action === "zoom-in") return updateState(changeZoom(state, 0.1));
-  if (action === "zoom-out") return updateState(changeZoom(state, -0.1));
-  if (action === "reset-zoom") return updateState({ ...state, zoom: 1 });
-  if (action === "toggle-pages") {
-    document.body.classList.toggle("pages-collapsed");
-    return;
-  }
-  if (action === "toggle-outline") {
-    document.body.classList.toggle("outline-collapsed");
-    return;
-  }
-  if (action === "check-update") {
-    void checkForUpdates().then(showToast);
-  }
+  if (action === "open") void openDocument();
+  if (action === "close") void closeCurrentDocument();
+  if (action === "save") void saveCurrentDocument();
+  if (action === "previous-page") navigateTo(state.currentPage - 1);
+  if (action === "next-page") navigateTo(state.currentPage + 1);
+  if (action === "zoom-in") applyZoom("custom", changeZoom(state, 0.1).zoom);
+  if (action === "zoom-out") applyZoom("custom", changeZoom(state, -0.1).zoom);
+  if (action === "reset-zoom" || action === "actual-size") applyZoom("actual");
+  if (action === "fit-width") applyZoom("width");
+  if (action === "fit-page") applyZoom("page");
+  if (action === "find") openFind();
+  if (action === "close-find") closeFind();
+  if (action === "previous-result") moveSearchResult(-1);
+  if (action === "next-result") moveSearchResult(1);
+  if (action === "toggle-pages") document.body.classList.toggle("pages-collapsed");
+  if (action === "toggle-outline") document.body.classList.toggle("outline-collapsed");
+  if (action === "check-update") void checkForUpdates().then(showToast);
+}
+
+function navigateTo(page: number, top: number | null = null): void {
+  const next = goToPage(state, page);
+  updateState(next);
+  viewer.goTo(next.currentPage, top);
 }
 
 document.addEventListener("click", (event) => {
@@ -45,16 +180,77 @@ document.addEventListener("click", (event) => {
   if (actionTarget?.dataset.action) handleAction(actionTarget.dataset.action);
 
   const pageTarget = target.closest<HTMLElement>("[data-page]");
-  if (pageTarget?.dataset.page) updateState(goToPage(state, Number(pageTarget.dataset.page)));
+  if (pageTarget?.dataset.page) {
+    const top = pageTarget.dataset.top ? Number(pageTarget.dataset.top) : null;
+    navigateTo(Number(pageTarget.dataset.page), top);
+  }
 });
 
-document.querySelector<HTMLInputElement>("[data-role='current-page']")?.addEventListener("change", (event) => {
-  updateState(goToPage(state, Number((event.target as HTMLInputElement).value)));
+element<HTMLInputElement>("[data-role='current-page']").addEventListener("change", (event) => {
+  navigateTo(Number((event.target as HTMLInputElement).value));
+});
+
+searchInput.addEventListener("input", () => refreshSearchResults());
+searchInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") moveSearchResult(event.shiftKey ? -1 : 1);
+  if (event.key === "Escape") closeFind();
 });
 
 document.addEventListener("keydown", (event) => {
-  if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "o") {
+  if (!(event.metaKey || event.ctrlKey)) return;
+  const key = event.key.toLowerCase();
+  if (key === "o") {
     event.preventDefault();
-    openPlaceholder();
+    void openDocument();
+  }
+  if (key === "s") {
+    event.preventDefault();
+    void saveCurrentDocument();
+  }
+  if (key === "f") {
+    event.preventDefault();
+    openFind();
+  }
+  if (key === "g") {
+    event.preventDefault();
+    const input = element<HTMLInputElement>("[data-role='current-page']");
+    input.focus();
+    input.select();
   }
 });
+
+function restorePanelSizes(): void {
+  const pages = Number(localStorage.getItem("akbun-pdf.pages-width"));
+  const outline = Number(localStorage.getItem("akbun-pdf.outline-width"));
+  if (pages >= 150 && pages <= 360) document.body.style.setProperty("--pages-width", `${pages}px`);
+  if (outline >= 180 && outline <= 420) document.body.style.setProperty("--outline-width", `${outline}px`);
+}
+
+function wirePanelResizers(): void {
+  document.querySelectorAll<HTMLElement>("[data-resize-panel]").forEach((resizer) => {
+    resizer.addEventListener("pointerdown", (event) => startPanelResize(event, resizer));
+  });
+}
+
+function startPanelResize(event: PointerEvent, resizer: HTMLElement): void {
+  const panel = resizer.dataset.resizePanel;
+  const startX = event.clientX;
+  const pages = element<HTMLElement>(".pages-panel").getBoundingClientRect().width;
+  const outline = element<HTMLElement>(".outline-panel").getBoundingClientRect().width;
+  resizer.setPointerCapture(event.pointerId);
+
+  const move = (moveEvent: PointerEvent): void => {
+    const delta = moveEvent.clientX - startX;
+    const width = panel === "pages" ? pages + delta : outline - delta;
+    const clamped = Math.round(Math.min(panel === "pages" ? 360 : 420, Math.max(panel === "pages" ? 150 : 180, width)));
+    const property = panel === "pages" ? "--pages-width" : "--outline-width";
+    document.body.style.setProperty(property, `${clamped}px`);
+    localStorage.setItem(`akbun-pdf.${panel}-width`, String(clamped));
+  };
+  const stop = (): void => {
+    resizer.removeEventListener("pointermove", move);
+    resizer.removeEventListener("pointerup", stop);
+  };
+  resizer.addEventListener("pointermove", move);
+  resizer.addEventListener("pointerup", stop);
+}

--- a/product/akbun-pdf/workspace/ui/src/main.ts
+++ b/product/akbun-pdf/workspace/ui/src/main.ts
@@ -93,7 +93,7 @@ async function saveCurrentDocument(): Promise<void> {
     if (!report) return;
     const size = new Intl.NumberFormat("ko-KR").format(report.savedSize);
     showToast(report.unchanged
-      ? `원본 스트림 ${report.streamCount}개와 파일 크기 보존 · ${size} bytes`
+      ? `원본 byte와 파일 크기 보존 · ${size} bytes`
       : "저장 결과가 원본과 달라 저장을 확인해야 합니다.");
   } catch (error) {
     showToast(`저장 실패 · ${String(error)}`);
@@ -103,6 +103,7 @@ async function saveCurrentDocument(): Promise<void> {
 function applyZoom(mode: FitMode, requested = state.zoom): void {
   const zoom = viewer.zoom(mode, requested);
   updateState({ ...state, zoom });
+  if (!searchPanel.hidden) refreshSearchResults();
 }
 
 function openFind(): void {

--- a/product/akbun-pdf/workspace/ui/src/pdf-engine.ts
+++ b/product/akbun-pdf/workspace/ui/src/pdf-engine.ts
@@ -1,6 +1,156 @@
-import { GlobalWorkerOptions } from "pdfjs-dist";
+import {
+  getDocument,
+  GlobalWorkerOptions,
+  Util,
+  type PDFDocumentLoadingTask,
+  type PDFDocumentProxy,
+  type PDFPageProxy,
+} from "pdfjs-dist";
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+import type { OutlineItem, SearchFragment } from "./types";
+
+interface PdfOutlineNode {
+  title: string;
+  dest: string | unknown[] | null;
+  items: PdfOutlineNode[];
+}
+
+interface PdfTextItem {
+  str: string;
+  transform: number[];
+  width: number;
+  height: number;
+}
+
+export interface PageSize {
+  width: number;
+  height: number;
+}
 
 export function configurePdfEngine(): void {
   GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+}
+
+export class PdfDocumentAdapter {
+  private constructor(
+    private loadingTask: PDFDocumentLoadingTask,
+    private document: PDFDocumentProxy,
+  ) {}
+
+  static async open(bytes: number[]): Promise<PdfDocumentAdapter> {
+    const loadingTask = getDocument({ data: Uint8Array.from(bytes) });
+    const document = await loadingTask.promise;
+    return new PdfDocumentAdapter(loadingTask, document);
+  }
+
+  get pageCount(): number {
+    return this.document.numPages;
+  }
+
+  async pageSize(page: number, scale = 1): Promise<PageSize> {
+    const viewport = (await this.getPage(page)).getViewport({ scale });
+    return { width: viewport.width, height: viewport.height };
+  }
+
+  async outline(): Promise<OutlineItem[]> {
+    const root = await this.document.getOutline();
+    const output: OutlineItem[] = [];
+    await this.flattenOutline((root ?? []) as PdfOutlineNode[], 0, output);
+    return output;
+  }
+
+  async renderPage(canvas: HTMLCanvasElement, pageNumber: number, scale: number): Promise<PageSize> {
+    const page = await this.getPage(pageNumber);
+    const viewport = page.getViewport({ scale });
+    const ratio = Math.max(1, window.devicePixelRatio || 1);
+    canvas.width = Math.floor(viewport.width * ratio);
+    canvas.height = Math.floor(viewport.height * ratio);
+    canvas.style.width = `${viewport.width}px`;
+    canvas.style.height = `${viewport.height}px`;
+    await page.render({
+      canvas,
+      viewport,
+      transform: ratio === 1 ? undefined : [ratio, 0, 0, ratio, 0, 0],
+    }).promise;
+    page.cleanup();
+    return { width: viewport.width, height: viewport.height };
+  }
+
+  async renderThumbnail(canvas: HTMLCanvasElement, pageNumber: number, width: number): Promise<void> {
+    const page = await this.getPage(pageNumber);
+    const natural = page.getViewport({ scale: 1 });
+    const scale = width / natural.width;
+    const viewport = page.getViewport({ scale });
+    const ratio = Math.max(1, window.devicePixelRatio || 1);
+    canvas.width = Math.floor(viewport.width * ratio);
+    canvas.height = Math.floor(viewport.height * ratio);
+    canvas.style.width = `${viewport.width}px`;
+    canvas.style.height = `${viewport.height}px`;
+    await page.render({
+      canvas,
+      viewport,
+      transform: ratio === 1 ? undefined : [ratio, 0, 0, ratio, 0, 0],
+    }).promise;
+    page.cleanup();
+  }
+
+  async searchFragments(pageNumber: number): Promise<SearchFragment[]> {
+    const page = await this.getPage(pageNumber);
+    const viewport = page.getViewport({ scale: 1 });
+    const content = await page.getTextContent();
+    return content.items.flatMap((raw) => {
+      if (!("str" in raw)) return [];
+      const item = raw as PdfTextItem;
+      const matrix = Util.transform(viewport.transform, item.transform);
+      const height = Math.max(item.height, Math.hypot(matrix[2], matrix[3]));
+      return [{
+        text: item.str,
+        rect: {
+          x: matrix[4],
+          y: matrix[5] - height,
+          width: item.width,
+          height,
+        },
+      }];
+    });
+  }
+
+  async destroy(): Promise<void> {
+    await this.loadingTask.destroy();
+  }
+
+  private getPage(page: number): Promise<PDFPageProxy> {
+    return this.document.getPage(page);
+  }
+
+  private async flattenOutline(
+    nodes: PdfOutlineNode[],
+    depth: number,
+    output: OutlineItem[],
+  ): Promise<void> {
+    for (const node of nodes) {
+      const destination = typeof node.dest === "string"
+        ? await this.document.getDestination(node.dest)
+        : node.dest;
+      if (destination) {
+        const page = await this.resolvePage(destination[0]);
+        if (page !== null) {
+          output.push({
+            id: `outline-${output.length + 1}`,
+            title: node.title,
+            page,
+            top: typeof destination[3] === "number" ? destination[3] : null,
+            depth,
+          });
+        }
+      }
+      await this.flattenOutline(node.items ?? [], depth + 1, output);
+    }
+  }
+
+  private async resolvePage(reference: unknown): Promise<number | null> {
+    if (typeof reference === "number") return reference + 1;
+    if (!reference || typeof reference !== "object") return null;
+    return (await this.document.getPageIndex(reference as { num: number; gen: number })) + 1;
+  }
 }

--- a/product/akbun-pdf/workspace/ui/src/render.ts
+++ b/product/akbun-pdf/workspace/ui/src/render.ts
@@ -1,6 +1,8 @@
 import type { DocumentState, OutlineItem, Thumbnail } from "./types";
 
 let toastTimer: number | undefined;
+let thumbnailDocument = "";
+let thumbnailCount = -1;
 
 function element<T extends Element>(selector: string): T {
   const match = document.querySelector<T>(selector);
@@ -24,6 +26,9 @@ function makeThumbnail(item: Thumbnail, selected: boolean): HTMLButtonElement {
     <i class="thumbnail__line thumbnail__line--short"></i>
     <i class="thumbnail__shape"></i>
   `;
+  const canvas = document.createElement("canvas");
+  canvas.dataset.thumbnailCanvas = String(item.page);
+  preview.append(canvas);
 
   const number = document.createElement("span");
   number.className = "thumbnail__number";
@@ -37,6 +42,7 @@ function makeOutlineItem(item: OutlineItem, selected: boolean): HTMLButtonElemen
   button.className = `outline-item${selected ? " outline-item--selected" : ""}`;
   button.type = "button";
   button.dataset.page = String(item.page);
+  if (item.top !== null) button.dataset.top = String(item.top);
   button.style.setProperty("--depth", String(item.depth));
 
   const title = document.createElement("span");
@@ -57,7 +63,7 @@ function renderControls(state: DocumentState): void {
   element<HTMLElement>("[data-role='zoom']").textContent = `${Math.round(state.zoom * 100)}%`;
 
   document.querySelectorAll<HTMLButtonElement>(
-    "[data-action='previous-page'], [data-action='next-page'], [data-action='zoom-in'], [data-action='zoom-out'], [data-action='reset-zoom']",
+    "[data-action='previous-page'], [data-action='next-page'], [data-action='zoom-in'], [data-action='zoom-out'], [data-action='reset-zoom'], [data-document-control]",
   ).forEach((button) => {
     button.disabled = !ready;
   });
@@ -65,9 +71,18 @@ function renderControls(state: DocumentState): void {
 
 function renderThumbnails(state: DocumentState): void {
   const list = element<HTMLElement>("[data-role='thumbnail-list']");
-  list.replaceChildren(...state.thumbnails.map((item) => (
-    makeThumbnail(item, item.page === state.currentPage)
-  )));
+  const documentId = state.documentId ?? "";
+  if (documentId !== thumbnailDocument || state.pageCount !== thumbnailCount) {
+    list.replaceChildren(...state.thumbnails.map((item) => (
+      makeThumbnail(item, item.page === state.currentPage)
+    )));
+    thumbnailDocument = documentId;
+    thumbnailCount = state.pageCount;
+  } else {
+    list.querySelectorAll<HTMLElement>("[data-page]").forEach((item) => {
+      item.classList.toggle("thumbnail--selected", Number(item.dataset.page) === state.currentPage);
+    });
+  }
   element<HTMLElement>("[data-role='thumbnail-count']").textContent = String(state.pageCount);
 }
 
@@ -76,6 +91,9 @@ function renderOutline(state: DocumentState): void {
   list.replaceChildren(...state.outline.map((item) => (
     makeOutlineItem(item, item.page === state.currentPage)
   )));
+  const empty = element<HTMLElement>("[data-role='outline-empty']");
+  empty.hidden = state.phase === "ready" && state.outline.length > 0;
+  list.hidden = state.phase === "ready" && state.outline.length === 0;
 }
 
 export function renderDocument(state: DocumentState): void {
@@ -83,7 +101,8 @@ export function renderDocument(state: DocumentState): void {
   element<HTMLElement>("[data-role='title']").textContent = state.title || "akbun-pdf";
   element<HTMLElement>("[data-role='error-message']").textContent = state.errorMessage
     ?? "파일이 손상되었거나 지원하지 않는 형식입니다.";
-  element<HTMLElement>(".pdf-page").style.setProperty("--document-zoom", String(state.zoom));
+  document.querySelector<HTMLElement>(".pdf-page:not(.pdf-page--canvas)")
+    ?.style.setProperty("--document-zoom", String(state.zoom));
   renderControls(state);
   renderThumbnails(state);
   renderOutline(state);

--- a/product/akbun-pdf/workspace/ui/src/search.ts
+++ b/product/akbun-pdf/workspace/ui/src/search.ts
@@ -1,0 +1,70 @@
+import type { PageRect, SearchFragment, SearchResult } from "./types";
+
+interface IndexedFragment {
+  start: number;
+  end: number;
+  rect: PageRect;
+}
+
+interface IndexedPage {
+  text: string;
+  fragments: IndexedFragment[];
+}
+
+export function normalizeSearchText(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase("ko-KR");
+}
+
+export class DocumentSearch {
+  private pages = new Map<number, IndexedPage>();
+  private totalPages = 0;
+
+  begin(totalPages: number): void {
+    this.pages.clear();
+    this.totalPages = totalPages;
+  }
+
+  clear(): void {
+    this.pages.clear();
+    this.totalPages = 0;
+  }
+
+  addPage(page: number, source: SearchFragment[]): void {
+    let text = "";
+    const fragments: IndexedFragment[] = [];
+    for (const fragment of source) {
+      const normalized = normalizeSearchText(fragment.text);
+      if (!normalized) continue;
+      if (text) text += " ";
+      const start = text.length;
+      text += normalized;
+      fragments.push({ start, end: text.length, rect: fragment.rect });
+    }
+    this.pages.set(page, { text, fragments });
+  }
+
+  progress(): { indexed: number; total: number } {
+    return { indexed: this.pages.size, total: this.totalPages };
+  }
+
+  query(value: string): SearchResult[] {
+    const query = normalizeSearchText(value.trim());
+    if (!query) return [];
+    const results: SearchResult[] = [];
+
+    for (const [page, indexed] of this.pages) {
+      let offset = 0;
+      while (offset <= indexed.text.length - query.length) {
+        const start = indexed.text.indexOf(query, offset);
+        if (start < 0) break;
+        const end = start + query.length;
+        const rects = indexed.fragments
+          .filter((fragment) => fragment.start < end && fragment.end > start)
+          .map((fragment) => fragment.rect);
+        results.push({ id: `${page}-${start}`, page, rects });
+        offset = start + Math.max(1, query.length);
+      }
+    }
+    return results;
+  }
+}

--- a/product/akbun-pdf/workspace/ui/src/styles.css
+++ b/product/akbun-pdf/workspace/ui/src/styles.css
@@ -17,6 +17,8 @@
   --workspace: #ecebe7;
   --paper: #fffefd;
   --shadow: 0 18px 60px rgba(42, 39, 34, 0.14), 0 2px 8px rgba(42, 39, 34, 0.08);
+  --pages-width: 196px;
+  --outline-width: 240px;
 }
 
 * {
@@ -41,6 +43,10 @@ button,
 input {
   color: inherit;
   font: inherit;
+}
+
+[hidden] {
+  display: none !important;
 }
 
 button {
@@ -143,6 +149,7 @@ svg {
 
 .icon-button,
 .zoom-label,
+.fit-button,
 .tool-button,
 .button {
   display: inline-flex;
@@ -257,7 +264,21 @@ svg {
 .workspace {
   display: grid;
   min-height: 0;
-  grid-template-columns: 196px minmax(340px, 1fr) 240px;
+  grid-template-columns: var(--pages-width) 4px minmax(340px, 1fr) 4px var(--outline-width);
+}
+
+.panel-resizer {
+  position: relative;
+  z-index: 4;
+  background: var(--line);
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.panel-resizer::after {
+  position: absolute;
+  inset: 0 -3px;
+  content: "";
 }
 
 .pages-panel,
@@ -699,6 +720,7 @@ kbd {
 }
 
 .thumbnail__page {
+  position: relative;
   display: flex;
   aspect-ratio: 1 / 1.414;
   flex-direction: column;
@@ -840,6 +862,10 @@ body[data-phase="ready"] [data-role="outline-list"] {
   display: block;
 }
 
+body[data-phase="ready"] [data-role="outline-empty"]:not([hidden]) {
+  display: flex;
+}
+
 body[data-phase="empty"] [data-visible-phase~="empty"].panel-placeholder,
 body[data-phase="error"] [data-visible-phase~="error"].panel-placeholder,
 body[data-phase="empty"] [data-visible-phase~="empty"].outline-empty,
@@ -850,19 +876,24 @@ body[data-phase="loading"] [data-visible-phase~="loading"].thumbnail-skeletons {
 }
 
 body.pages-collapsed .workspace {
-  grid-template-columns: 0 minmax(340px, 1fr) 240px;
+  grid-template-columns: 0 0 minmax(340px, 1fr) 4px var(--outline-width);
 }
 
 body.outline-collapsed .workspace {
-  grid-template-columns: 196px minmax(340px, 1fr) 0;
+  grid-template-columns: var(--pages-width) 4px minmax(340px, 1fr) 0 0;
 }
 
 body.pages-collapsed.outline-collapsed .workspace {
-  grid-template-columns: 0 minmax(340px, 1fr) 0;
+  grid-template-columns: 0 0 minmax(340px, 1fr) 0 0;
 }
 
 body.pages-collapsed .pages-panel,
 body.outline-collapsed .outline-panel {
+  visibility: hidden;
+}
+
+body.pages-collapsed .panel-resizer--pages,
+body.outline-collapsed .panel-resizer--outline {
   visibility: hidden;
 }
 
@@ -890,11 +921,18 @@ body.outline-collapsed .outline-panel {
   }
 
   .workspace {
-    grid-template-columns: 172px minmax(340px, 1fr) 210px;
+    --pages-width: 172px;
+    --outline-width: 210px;
   }
 
   .pdf-page {
     width: min(560px, calc(100vw - 440px));
+  }
+}
+
+@media (max-width: 1220px) {
+  .fit-button {
+    display: none;
   }
 }
 

--- a/product/akbun-pdf/workspace/ui/src/types.ts
+++ b/product/akbun-pdf/workspace/ui/src/types.ts
@@ -35,9 +35,6 @@ export interface PreservationReport {
   savedSize: number;
   originalHash: string;
   savedHash: string;
-  originalStreamHash: string;
-  savedStreamHash: string;
-  streamCount: number;
   unchanged: boolean;
 }
 

--- a/product/akbun-pdf/workspace/ui/src/types.ts
+++ b/product/akbun-pdf/workspace/ui/src/types.ts
@@ -9,11 +9,13 @@ export interface OutlineItem {
   id: string;
   title: string;
   page: number;
+  top: number | null;
   depth: number;
 }
 
 export interface DocumentState {
   phase: DocumentPhase;
+  documentId: string | null;
   title: string;
   currentPage: number;
   pageCount: number;
@@ -22,3 +24,39 @@ export interface DocumentState {
   outline: OutlineItem[];
   errorMessage: string | null;
 }
+
+export interface OpenDocumentPayload {
+  state: DocumentState;
+  bytes: number[];
+}
+
+export interface PreservationReport {
+  originalSize: number;
+  savedSize: number;
+  originalHash: string;
+  savedHash: string;
+  originalStreamHash: string;
+  savedStreamHash: string;
+  streamCount: number;
+  unchanged: boolean;
+}
+
+export interface PageRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SearchFragment {
+  text: string;
+  rect: PageRect;
+}
+
+export interface SearchResult {
+  id: string;
+  page: number;
+  rects: PageRect[];
+}
+
+export type FitMode = "custom" | "actual" | "width" | "page";

--- a/product/akbun-pdf/workspace/ui/src/viewer.css
+++ b/product/akbun-pdf/workspace/ui/src/viewer.css
@@ -1,0 +1,133 @@
+.fit-button {
+  height: 28px;
+  padding: 0 7px;
+  border-radius: 6px;
+  color: var(--muted);
+  background: transparent;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.fit-button:hover:not(:disabled) {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--ink) 7%, transparent);
+}
+
+.fit-button:disabled {
+  cursor: default;
+  opacity: 0.34;
+}
+
+.document-stage--pdf {
+  display: flex !important;
+  min-width: max-content;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+}
+
+.pdf-page--canvas {
+  position: relative;
+  min-width: 0;
+  aspect-ratio: auto;
+  overflow: hidden;
+  transform: none;
+  transition: width 120ms ease, height 120ms ease;
+}
+
+.pdf-page--canvas canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: white;
+}
+
+.pdf-page__number {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  padding: 2px 5px;
+  border-radius: 4px;
+  color: #666;
+  background: rgba(255, 255, 255, 0.82);
+  font-size: 10px;
+}
+
+.search-highlights {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.search-highlight {
+  position: absolute;
+  margin: 0;
+  border-radius: 2px;
+  background: rgba(255, 210, 46, 0.42);
+  box-shadow: inset 0 0 0 1px rgba(187, 142, 0, 0.18);
+}
+
+.search-highlight--current {
+  background: rgba(232, 89, 44, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(177, 52, 15, 0.5);
+}
+
+.thumbnail__page canvas {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.search-panel {
+  position: fixed;
+  z-index: 12;
+  top: 66px;
+  right: calc(var(--outline-width) + 18px);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--toolbar);
+  box-shadow: 0 10px 32px rgba(40, 36, 30, 0.17);
+  backdrop-filter: blur(16px);
+}
+
+.search-panel input {
+  width: 230px;
+  height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--paper);
+  font-size: 12px;
+  user-select: text;
+}
+
+.search-status {
+  min-width: 120px;
+  color: var(--muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+@media (max-width: 860px) {
+  .workspace,
+  body.pages-collapsed .workspace,
+  body.outline-collapsed .workspace,
+  body.pages-collapsed.outline-collapsed .workspace {
+    grid-template-columns: 160px 4px minmax(340px, 1fr) 0 0;
+  }
+
+  .panel-resizer--outline {
+    display: none;
+  }
+
+  .search-panel {
+    right: 14px;
+  }
+}

--- a/product/akbun-pdf/workspace/ui/src/viewer.ts
+++ b/product/akbun-pdf/workspace/ui/src/viewer.ts
@@ -1,0 +1,206 @@
+import { PdfDocumentAdapter, type PageSize } from "./pdf-engine";
+import { DocumentSearch } from "./search";
+import type { FitMode, SearchResult } from "./types";
+
+interface ViewerCallbacks {
+  onCurrentPage: (page: number) => void;
+  onIndexProgress: () => void;
+}
+
+export class PdfViewer {
+  readonly search = new DocumentSearch();
+  private adapter: PdfDocumentAdapter | null = null;
+  private observer: IntersectionObserver | null = null;
+  private baseSize: PageSize = { width: 612, height: 792 };
+  private scale = 1;
+  private generation = 0;
+  private currentPage = 1;
+  private scrollFrame = 0;
+
+  constructor(
+    private stage: HTMLElement,
+    private viewport: HTMLElement,
+    private callbacks: ViewerCallbacks,
+  ) {
+    this.viewport.addEventListener("scroll", () => this.scheduleCurrentPage());
+  }
+
+  async open(adapter: PdfDocumentAdapter): Promise<void> {
+    if (this.adapter) await this.close();
+    this.adapter = adapter;
+    this.generation += 1;
+    const generation = this.generation;
+    this.currentPage = 1;
+    this.baseSize = await adapter.pageSize(1);
+    this.search.begin(adapter.pageCount);
+    this.stage.classList.add("document-stage--pdf");
+    this.createPageSurfaces(adapter.pageCount);
+    this.observePages();
+    await this.renderPage(1, generation);
+    void this.renderThumbnails(generation);
+    void this.indexText(generation);
+  }
+
+  async close(): Promise<void> {
+    this.generation += 1;
+    this.observer?.disconnect();
+    this.observer = null;
+    this.search.clear();
+    this.stage.classList.remove("document-stage--pdf");
+    this.stage.replaceChildren();
+    document.querySelector<HTMLElement>("[data-role='thumbnail-list']")?.replaceChildren();
+    const adapter = this.adapter;
+    this.adapter = null;
+    if (adapter) await adapter.destroy();
+  }
+
+  zoom(mode: FitMode, requested = this.scale): number {
+    if (!this.adapter) return this.scale;
+    const horizontalSpace = Math.max(240, this.viewport.clientWidth - 88);
+    const verticalSpace = Math.max(240, this.viewport.clientHeight - 88);
+    if (mode === "actual") this.scale = 1;
+    if (mode === "width") this.scale = horizontalSpace / this.baseSize.width;
+    if (mode === "page") {
+      this.scale = Math.min(horizontalSpace / this.baseSize.width, verticalSpace / this.baseSize.height);
+    }
+    if (mode === "custom") this.scale = requested;
+    this.scale = Math.min(4, Math.max(0.25, this.scale));
+    this.resizeSurfaces();
+    this.invalidateVisiblePages();
+    return this.scale;
+  }
+
+  goTo(page: number, top: number | null = null): void {
+    const target = this.stage.querySelector<HTMLElement>(`[data-pdf-page='${page}']`);
+    if (!target) return;
+    const offset = top === null ? 0 : Math.max(0, this.baseSize.height - top) * this.scale;
+    this.viewport.scrollTo({ top: target.offsetTop + offset - 28, behavior: "smooth" });
+    this.setCurrentPage(page);
+    void this.renderPage(page, this.generation);
+  }
+
+  showSearchResults(results: SearchResult[], selected: number): void {
+    this.stage.querySelectorAll(".search-highlight").forEach((node) => node.remove());
+    results.forEach((result, resultIndex) => {
+      const layer = this.stage.querySelector<HTMLElement>(
+        `[data-pdf-page='${result.page}'] .search-highlights`,
+      );
+      if (!layer) return;
+      result.rects.forEach((rect) => {
+        const highlight = document.createElement("mark");
+        highlight.className = `search-highlight${resultIndex === selected ? " search-highlight--current" : ""}`;
+        highlight.style.left = `${rect.x * this.scale}px`;
+        highlight.style.top = `${rect.y * this.scale}px`;
+        highlight.style.width = `${Math.max(2, rect.width * this.scale)}px`;
+        highlight.style.height = `${Math.max(2, rect.height * this.scale)}px`;
+        layer.append(highlight);
+      });
+    });
+  }
+
+  private createPageSurfaces(pageCount: number): void {
+    const surfaces = Array.from({ length: pageCount }, (_, index) => {
+      const page = index + 1;
+      const surface = document.createElement("article");
+      surface.className = "pdf-page pdf-page--canvas";
+      surface.dataset.pdfPage = String(page);
+      surface.innerHTML = `<canvas aria-label="${page}페이지"></canvas><div class="search-highlights"></div><span class="pdf-page__number">${page}</span>`;
+      return surface;
+    });
+    this.stage.replaceChildren(...surfaces);
+    this.resizeSurfaces();
+  }
+
+  private resizeSurfaces(): void {
+    this.stage.querySelectorAll<HTMLElement>("[data-pdf-page]").forEach((surface) => {
+      surface.style.width = `${this.baseSize.width * this.scale}px`;
+      surface.style.height = `${this.baseSize.height * this.scale}px`;
+      surface.dataset.renderScale = "";
+    });
+    this.showSearchResults([], -1);
+  }
+
+  private observePages(): void {
+    this.observer = new IntersectionObserver((entries) => {
+      entries.filter((entry) => entry.isIntersecting).forEach((entry) => {
+        const page = Number((entry.target as HTMLElement).dataset.pdfPage);
+        void this.renderPage(page, this.generation);
+      });
+    }, { root: this.viewport, rootMargin: "80% 0px" });
+    this.stage.querySelectorAll("[data-pdf-page]").forEach((page) => this.observer?.observe(page));
+  }
+
+  private async renderPage(page: number, generation: number): Promise<void> {
+    const adapter = this.adapter;
+    const surface = this.stage.querySelector<HTMLElement>(`[data-pdf-page='${page}']`);
+    const canvas = surface?.querySelector<HTMLCanvasElement>("canvas");
+    if (!adapter || !surface || !canvas || generation !== this.generation) return;
+    if (surface.dataset.renderScale === String(this.scale)) return;
+    surface.dataset.renderScale = String(this.scale);
+    const size = await adapter.renderPage(canvas, page, this.scale);
+    if (generation !== this.generation) return;
+    surface.style.width = `${size.width}px`;
+    surface.style.height = `${size.height}px`;
+  }
+
+  private async renderThumbnails(generation: number): Promise<void> {
+    const adapter = this.adapter;
+    if (!adapter) return;
+    for (let page = 1; page <= adapter.pageCount; page += 1) {
+      if (generation !== this.generation) return;
+      const canvas = document.querySelector<HTMLCanvasElement>(`[data-thumbnail-canvas='${page}']`);
+      if (canvas) await adapter.renderThumbnail(canvas, page, 116);
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+    }
+  }
+
+  private async indexText(generation: number): Promise<void> {
+    const adapter = this.adapter;
+    if (!adapter) return;
+    for (let page = 1; page <= adapter.pageCount; page += 1) {
+      if (generation !== this.generation) return;
+      try {
+        this.search.addPage(page, await adapter.searchFragments(page));
+      } catch {
+        this.search.addPage(page, []);
+      }
+      this.callbacks.onIndexProgress();
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+    }
+  }
+
+  private invalidateVisiblePages(): void {
+    const view = this.viewport.getBoundingClientRect();
+    this.stage.querySelectorAll<HTMLElement>("[data-pdf-page]").forEach((surface) => {
+      const rect = surface.getBoundingClientRect();
+      if (rect.bottom >= view.top - view.height && rect.top <= view.bottom + view.height) {
+        void this.renderPage(Number(surface.dataset.pdfPage), this.generation);
+      }
+    });
+  }
+
+  private scheduleCurrentPage(): void {
+    if (this.scrollFrame) return;
+    this.scrollFrame = window.requestAnimationFrame(() => {
+      this.scrollFrame = 0;
+      const center = this.viewport.getBoundingClientRect().top + this.viewport.clientHeight / 2;
+      let nearest = this.currentPage;
+      let distance = Number.POSITIVE_INFINITY;
+      this.stage.querySelectorAll<HTMLElement>("[data-pdf-page]").forEach((surface) => {
+        const rect = surface.getBoundingClientRect();
+        const wanted = Math.abs(rect.top + rect.height / 2 - center);
+        if (wanted < distance) {
+          distance = wanted;
+          nearest = Number(surface.dataset.pdfPage);
+        }
+      });
+      this.setCurrentPage(nearest);
+    });
+  }
+
+  private setCurrentPage(page: number): void {
+    if (this.currentPage === page) return;
+    this.currentPage = page;
+    this.callbacks.onCurrentPage(page);
+  }
+}

--- a/product/akbun-pdf/workspace/ui/src/viewer.ts
+++ b/product/akbun-pdf/workspace/ui/src/viewer.ts
@@ -15,15 +15,13 @@ export class PdfViewer {
   private scale = 1;
   private generation = 0;
   private currentPage = 1;
-  private scrollFrame = 0;
+  private visiblePages = new Map<number, number>();
 
   constructor(
     private stage: HTMLElement,
     private viewport: HTMLElement,
     private callbacks: ViewerCallbacks,
-  ) {
-    this.viewport.addEventListener("scroll", () => this.scheduleCurrentPage());
-  }
+  ) {}
 
   async open(adapter: PdfDocumentAdapter): Promise<void> {
     if (this.adapter) await this.close();
@@ -45,6 +43,7 @@ export class PdfViewer {
     this.generation += 1;
     this.observer?.disconnect();
     this.observer = null;
+    this.visiblePages.clear();
     this.search.clear();
     this.stage.classList.remove("document-stage--pdf");
     this.stage.replaceChildren();
@@ -122,11 +121,17 @@ export class PdfViewer {
 
   private observePages(): void {
     this.observer = new IntersectionObserver((entries) => {
-      entries.filter((entry) => entry.isIntersecting).forEach((entry) => {
+      entries.forEach((entry) => {
         const page = Number((entry.target as HTMLElement).dataset.pdfPage);
-        void this.renderPage(page, this.generation);
+        if (entry.isIntersecting) {
+          this.visiblePages.set(page, entry.intersectionRatio);
+          void this.renderPage(page, this.generation);
+        } else {
+          this.visiblePages.delete(page);
+        }
       });
-    }, { root: this.viewport, rootMargin: "80% 0px" });
+      this.selectMostVisiblePage();
+    }, { root: this.viewport, threshold: [0, 0.25, 0.5, 0.75, 1] });
     this.stage.querySelectorAll("[data-pdf-page]").forEach((page) => this.observer?.observe(page));
   }
 
@@ -179,23 +184,16 @@ export class PdfViewer {
     });
   }
 
-  private scheduleCurrentPage(): void {
-    if (this.scrollFrame) return;
-    this.scrollFrame = window.requestAnimationFrame(() => {
-      this.scrollFrame = 0;
-      const center = this.viewport.getBoundingClientRect().top + this.viewport.clientHeight / 2;
-      let nearest = this.currentPage;
-      let distance = Number.POSITIVE_INFINITY;
-      this.stage.querySelectorAll<HTMLElement>("[data-pdf-page]").forEach((surface) => {
-        const rect = surface.getBoundingClientRect();
-        const wanted = Math.abs(rect.top + rect.height / 2 - center);
-        if (wanted < distance) {
-          distance = wanted;
-          nearest = Number(surface.dataset.pdfPage);
-        }
-      });
-      this.setCurrentPage(nearest);
-    });
+  private selectMostVisiblePage(): void {
+    let page = this.currentPage;
+    let ratio = -1;
+    for (const [candidate, visibleRatio] of this.visiblePages) {
+      if (visibleRatio > ratio) {
+        page = candidate;
+        ratio = visibleRatio;
+      }
+    }
+    this.setCurrentPage(page);
   }
 
   private setCurrentPage(page: number): void {


### PR DESCRIPTION
# 구현

PDF 원본 보존 세션, PDF.js 문서 탐색·보기, 점진 검색 연결
- TypeScript 8개·Rust 6개 테스트, 전체 Tauri adapter 컴파일, 실제 8페이지 PDF 해석 확인

# 어려웠던 점

대용량 문서의 첫 화면과 검색 응답성을 함께 유지
- 첫 페이지 우선 렌더링 후 썸네일과 텍스트를 페이지별 양보 방식으로 점진 처리

# 리스크

PDF.js 텍스트 좌표 기반 강조가 특수 글꼴과 회전 텍스트에서 넓게 표시될 가능성
- 검색 누락 없이 텍스트 조각 전체를 강조하는 방식 선택

Issue #1146
Issue #1143
Issue #1148
