### PR TITLE
feat: add makevideo transitions and PIP overlays

### DIFF
--- a/product/akbun-makevideo/adr/2026-09-dissolve-boundary-object.md
+++ b/product/akbun-makevideo/adr/2026-09-dissolve-boundary-object.md
@@ -1,0 +1,11 @@
+# A dissolve is a clip-boundary object
+
+## Decision
+
+A transition is stored separately from clips and names a track plus touching `from` and `to` clips. Clips remain non-overlapping. The first implementation supports dissolve only, and its duration must fit inside both adjacent clips.
+
+The transition interval is the final duration of the outgoing clip. Only that interval opens a second decoder for the incoming source. Available source frames before the incoming in-point are used as pre-roll; missing handles hold the first source frame.
+
+## Reason
+
+Keeping clips unchanged preserves the no-overlap timeline invariant and makes transition deletion lossless. A bounded synthetic placement gives preview and export the same source frames and opacity ramps without keeping two decoders alive outside the transition.

--- a/product/akbun-makevideo/adr/2026-09-pip-video-overlay.md
+++ b/product/akbun-makevideo/adr/2026-09-pip-video-overlay.md
@@ -1,0 +1,13 @@
+# PIP is a video visual item
+
+## Decision
+
+PIP uses `VisualItem` with `VideoOverlay` content. Timing, transform, opacity, z-order and animation remain common visual-item properties; the content stores source in-point, normalized crop, corner radius, border and audio enablement.
+
+The preview and composited export open the same video placement. PIP audio enters the existing audio-placement path only when enabled.
+
+## Reason
+
+A separate overlay timeline would duplicate selection, transform, undo and render ordering. Normalized crop survives project and output resolution changes, while corner radius and border remain project-pixel values.
+
+Four simultaneous video sources are the measured realtime boundary. Adding a PIP that exceeds it is allowed with a warning because machine capacity varies and export has no realtime deadline.

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -29,3 +29,5 @@
 | [2026-08-live-playback-reconfiguration.md](./2026-08-live-playback-reconfiguration.md) | Playback settings switch after the replacement picture is ready |
 | [2026-08-reusable-seek-decoder.md](./2026-08-reusable-seek-decoder.md) | Short forward seeks reuse a decoder and may show two earlier frames |
 | [2026-09-playback-speed-and-audio-curves.md](./2026-09-playback-speed-and-audio-curves.md) | Clip duration is derived from speed; pitch preservation defaults on and fades stay separate from keyframes |
+| [2026-09-pip-video-overlay.md](./2026-09-pip-video-overlay.md) | PIP uses the common visual-item model and warns beyond four simultaneous video sources |
+| [2026-09-dissolve-boundary-object.md](./2026-09-dissolve-boundary-object.md) | Dissolve is a separate adjacent-clip boundary object with interval-only dual decode |

--- a/product/akbun-makevideo/knowledge/decisions/2026-09-overlays-and-transitions-share-the-compositor.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-09-overlays-and-transitions-share-the-compositor.md
@@ -1,0 +1,25 @@
+---
+type: Decision
+title: PIP와 디졸브는 기존 compositor placement로 합성한다
+description: PIP는 VisualItem, 디졸브는 clip 경계 객체로 저장하고 둘 다 FrameSource placement로 변환한다.
+tags: [makevideo, pip, transition, compositor]
+timestamp: 2026-09-05T00:00:00Z
+---
+
+# PIP와 디졸브는 기존 compositor placement로 합성한다
+
+## 결정
+
+* PIP는 `VisualItem.VideoOverlay`로 저장함
+* crop은 해상도와 독립적인 정규화 좌표로 저장함
+* 디졸브는 인접한 두 clip을 가리키는 별도 경계 객체로 저장함
+* 디졸브 구간에만 incoming decoder placement를 추가함
+* incoming source handle이 부족하면 첫 프레임을 유지함
+* preview와 export는 같은 placement와 opacity 계산을 사용함
+* 동시 video source가 측정 기준 4개를 넘으면 경고하되 편집은 허용함
+
+## 이유
+
+* clip 비중첩 규칙을 유지함
+* 기존 transform, z-order, undo, audio 배치 경로를 재사용함
+* 실시간 제한이 내보내기 기능 제한으로 번지지 않음

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,7 @@
 
 ## 목록
 
+* [PIP와 디졸브는 기존 compositor placement로 합성한다](2026-09-overlays-and-transitions-share-the-compositor.md) - PIP와 디졸브를 기존 preview/export 합성 경로에 연결하는 결정.
 * [clip 속도는 source 범위를 바꾸지 않고 timeline 길이를 결정한다](2026-09-clip-speed-derives-duration.md) - source in-out을 유지하고 duration을 speed에서 파생하는 결정.
 * [Program Monitor 전체 화면은 편집 레이아웃을 숨겨 보존한다](2026-09-program-monitor-fullscreen-preserves-layout.md) - Cmd+F와 Esc가 layout 상태를 바꾸지 않고 Program Monitor 표시만 전환하는 결정.
 * [page controller는 의존성과 공개 경계를 선언한다](2026-09-page-controllers-declare-boundaries.md) - no-build classic script를 factory controller로 나누고 생성 시 의존성과 반환 API를 명시한 결정.

--- a/product/akbun-makevideo/quality/README.md
+++ b/product/akbun-makevideo/quality/README.md
@@ -30,7 +30,7 @@ media element 재생과 이후 엔진을 같은 수치로 비교하는 하네스
 - 생성물은 `/tmp/akbun-makevideo-quality`에 저장
 - 대용량 영상은 저장소에 저장하지 않음
 
-합성 영상과 4개 영상·오디오 트랙 프로젝트를 생성한다.
+합성 영상과 4개 영상·오디오 트랙 프로젝트를 생성한다. 첫 영상 트랙은 중앙 경계에 15프레임 디졸브가 있는 두 clip으로 나뉜다.
 
 ```bash
 cd product/akbun-makevideo/workspace
@@ -142,6 +142,15 @@ npm run quality:supply -- /tmp/akbun-makevideo-quality/project.akbunvideo --seco
 
 - 같은 binary로 연속 실행한 두 번이 늦은 프레임 8개와 49개로 갈리고, 4트랙은 아예 첫 프레임이 2초 안에 오지 않아 중단되기도 함
 - 1080p 디코더 4개가 4코어를 채우는 지점이라 측정 대상이 소스가 아니라 머신이 됨. 이 구간은 대상 머신에서 다시 재야 함
+
+### PIP와 디졸브 기준
+
+- PIP도 video track과 같은 decoder placement이므로 동시 video source 수로 제한을 판단함
+- macOS에서 1080p30 source 4개를 6초간 측정한 결과 late frame 0, frame interval p99 33.3 ms, startup delay p99 112.5 ms로 통과함
+- UI는 base clip과 PIP를 합쳐 4개를 넘을 때 실시간 재생 품질 경고를 표시함
+- 같은 실행의 1-track 프로젝트는 4초 경계의 15-frame dissolve를 포함함
+- dissolve 포함 continuous supply는 late frame 0/180, frame interval p99 33.3 ms, supply wait p99 2.3 ms, startup delay p99 58.1 ms로 통과함
+- 측정 명령: `npm run quality:supply -- /tmp/akbun-makevideo-transition-quality/project.akbunvideo --seconds 6`
 
 ## 오디오 엔진 계측
 

--- a/product/akbun-makevideo/wiki/architecture/frame-source.md
+++ b/product/akbun-makevideo/wiki/architecture/frame-source.md
@@ -18,6 +18,8 @@ Nothing here draws, and nothing here is connected to the window yet. It is drive
 | `FrameSource` | The timeline as frames. `take`, `take_by`, `seek` |
 | `Supply` | `Ready`, `Starved` or `End` |
 
+PIP video is another placement with its own normalized crop and overlay style. A dissolve adds a synthetic incoming placement only for the final transition frames of the outgoing clip. If the incoming clip has no earlier source handle, ffmpeg pads its first frame; outside that interval only the ordinary clip decoder remains.
+
 A decoder is opened **on its own thread**, not on the consumer's. Starting one is a process spawn and a file seek, which is tens of milliseconds; doing it on the caller's thread would be a stall on the playhead.
 
 ## A starved poll consumes nothing

--- a/product/akbun-makevideo/wiki/architecture/preview.md
+++ b/product/akbun-makevideo/wiki/architecture/preview.md
@@ -21,6 +21,8 @@ describes this one.
 5. A follower seeks only when it is at least one second from the reference.
 6. Everything not live is hidden and paused.
 
+PIP media elements use the visual item's project-space rectangle, crop, radius, border and optional audio. Dissolve playback duplicates the incoming element only during the boundary interval and applies the same opacity ramp and source pre-roll rule as the frame source.
+
 This is not the render. The differences are real and worth knowing:
 
 - The preview composites with CSS `object-fit: contain` and `opacity`; the render composites with `scale`, `pad` and `overlay`. They agree on framing and z-order, and they will not agree on colour management.

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.40.1",
+      "version": "0.41.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.40.1",
+  "version": "0.41.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",

--- a/product/akbun-makevideo/workspace/scripts/generate-quality-media.sh
+++ b/product/akbun-makevideo/workspace/scripts/generate-quality-media.sh
@@ -19,17 +19,22 @@ duration_ms=$((duration * 1000))
 # pattern above. The asset keeps a duration in milliseconds because that is a
 # fact about the file rather than about the timeline.
 duration_frames=$((duration * 30))
+cut_frame=$((duration_frames / 2))
 tracks=""
 for index in 1 2 3 4; do
   comma=""
   if [[ -n "$tracks" ]]; then comma=","; fi
+  video_clips="[{\"id\":\"quality-vc$index\",\"assetId\":\"quality-source\",\"start\":0,\"in\":0,\"out\":$duration_frames,\"volume\":1,\"opacity\":1}]"
+  if [[ $index -eq 1 ]]; then
+    video_clips="[{\"id\":\"quality-vc1a\",\"assetId\":\"quality-source\",\"start\":0,\"in\":0,\"out\":$cut_frame,\"volume\":1,\"opacity\":1},{\"id\":\"quality-vc1b\",\"assetId\":\"quality-source\",\"start\":$cut_frame,\"in\":$cut_frame,\"out\":$duration_frames,\"volume\":1,\"opacity\":1}]"
+  fi
   tracks+="$comma
-    {\"id\":\"quality-v$index\",\"kind\":\"video\",\"name\":\"V$index\",\"muted\":false,\"hidden\":$([[ $index -eq 1 ]] && echo false || echo true),\"clips\":[{\"id\":\"quality-vc$index\",\"assetId\":\"quality-source\",\"start\":0,\"in\":0,\"out\":$duration_frames,\"volume\":1,\"opacity\":1}]},
+    {\"id\":\"quality-v$index\",\"kind\":\"video\",\"name\":\"V$index\",\"muted\":false,\"hidden\":$([[ $index -eq 1 ]] && echo false || echo true),\"clips\":$video_clips},
     {\"id\":\"quality-a$index\",\"kind\":\"audio\",\"name\":\"A$index\",\"muted\":$([[ $index -eq 1 ]] && echo false || echo true),\"hidden\":false,\"clips\":[{\"id\":\"quality-ac$index\",\"assetId\":\"quality-source\",\"start\":0,\"in\":0,\"out\":$duration_frames,\"volume\":1,\"opacity\":1}]}"
 done
 
 printf '%s\n' "{
-  \"version\": 2,
+  \"version\": 5,
   \"settings\": {\"width\": 1920, \"height\": 1080, \"rate\": {\"num\": 30, \"den\": 1}},
   \"assets\": [{
     \"id\": \"quality-source\",
@@ -42,7 +47,8 @@ printf '%s\n' "{
     \"hasAudio\": true
   }],
   \"tracks\": [$tracks
-  ]
+  ],
+  \"transitions\": [{\"id\":\"quality-x1\",\"trackId\":\"quality-v1\",\"fromClipId\":\"quality-vc1a\",\"toClipId\":\"quality-vc1b\",\"duration\":15,\"kind\":\"dissolve\"}]
 }" > "$project"
 
 echo "$project"

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/mix.rs
@@ -200,6 +200,7 @@ mod tests {
             },
             assets,
             tracks,
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/src/source.rs
@@ -915,6 +915,7 @@ pub(crate) mod tests {
             },
             assets,
             tracks,
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/audio/tests/amix.rs
@@ -136,6 +136,7 @@ fn project(rate: Rate, a: &str, b: &str) -> Project {
             audio_track("A1", vec![clip("c1", "a1", 0, 15, 75, 0.333_5)]),
             audio_track("A2", vec![clip("c2", "a2", 23, 0, 60, 0.707_9)]),
         ],
+        transitions: Vec::new(),
         markers: Vec::new(),
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/pipeline.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/pipeline.rs
@@ -98,6 +98,8 @@ fn decode_layer(
         rate,
         speed: 1.0,
         hwaccel: None,
+        crop: layer.crop,
+        head_pad_frames: 0,
     });
     let output = Command::new(ffmpeg_path)
         .args(&args)
@@ -111,6 +113,9 @@ fn decode_layer(
     }
     let mut pixels = output.stdout;
     pixels.truncate(wanted);
+    if let Some(style) = &layer.overlay_style {
+        crate::source::apply_overlay_style(&mut pixels, layer.dst.w, layer.dst.h, style);
+    }
     Some(pixels)
 }
 

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/source.rs
@@ -122,6 +122,8 @@ pub struct Open {
     pub height: u32,
     pub rate: Rate,
     pub speed: f32,
+    pub crop: makevideo_render::Crop,
+    pub head_pad_frames: i64,
 }
 
 /// Opens the readers.
@@ -154,7 +156,9 @@ impl Readers for FfmpegReaders {
             kind: request.kind,
             in_time: RationalTime::new(request.in_frame, request.rate),
             duration: RationalTime::new(
-                (request.frames as f64 * request.speed as f64).ceil() as i64,
+                (((request.frames - request.head_pad_frames).max(1) as f64 * request.speed as f64)
+                    .ceil() as i64)
+                    .max(1),
                 request.rate,
             ),
             width: request.width,
@@ -167,6 +171,8 @@ impl Readers for FfmpegReaders {
             } else {
                 None
             },
+            crop: request.crop,
+            head_pad_frames: request.head_pad_frames,
         };
         let fallback = decode.hwaccel.map(|_| {
             let software = ffmpeg::decoder_args(&ffmpeg::Decode {
@@ -174,7 +180,10 @@ impl Readers for FfmpegReaders {
                 kind: request.kind,
                 in_time: RationalTime::new(request.in_frame, request.rate),
                 duration: RationalTime::new(
-                    (request.frames as f64 * request.speed as f64).ceil() as i64,
+                    (((request.frames - request.head_pad_frames).max(1) as f64
+                        * request.speed as f64)
+                        .ceil() as i64)
+                        .max(1),
                     request.rate,
                 ),
                 width: request.width,
@@ -182,6 +191,8 @@ impl Readers for FfmpegReaders {
                 rate: request.rate,
                 speed: request.speed,
                 hwaccel: None,
+                crop: request.crop,
+                head_pad_frames: request.head_pad_frames,
             });
             (self.ffmpeg.clone(), software)
         });
@@ -478,6 +489,7 @@ impl Supply {
 struct Stream {
     placement: Placement,
     track_order: usize,
+    visual: Option<(i32, makevideo_render::layout::OverlayStyle)>,
     lut: Option<Arc<Lut>>,
     frame_bytes: usize,
     receiver: Option<Receiver<DecodedFrame>>,
@@ -600,15 +612,41 @@ impl FrameSource {
         let streams = layout::placements(project, width, height)
             .into_iter()
             .map(|placement| {
+                let transition = placement
+                    .clip_id
+                    .strip_prefix("transition:")
+                    .and_then(|id| project.transition(id));
+                let source_clip_id = transition
+                    .map(|entry| entry.to_clip_id.as_str())
+                    .unwrap_or(placement.clip_id.as_str());
+                let visual = project.visual_item(&placement.clip_id).map(|item| {
+                    (
+                        item.z_index,
+                        placement
+                            .overlay_style
+                            .clone()
+                            .expect("a video visual has overlay styling"),
+                    )
+                });
                 let track_order = project
                     .tracks
                     .iter()
-                    .position(|track| track.clips.iter().any(|clip| clip.id == placement.clip_id))
+                    .position(|track| {
+                        track.id
+                            == transition
+                                .map(|entry| entry.track_id.as_str())
+                                .unwrap_or("")
+                            || track.clips.iter().any(|clip| clip.id == placement.clip_id)
+                            || track
+                                .visual_items
+                                .iter()
+                                .any(|item| item.id == placement.clip_id)
+                    })
                     .unwrap_or(0);
                 Stream {
                     frame_bytes: (placement.dst.w as usize) * (placement.dst.h as usize) * 4,
                     lut: project
-                        .clip(&placement.clip_id)
+                        .clip(source_clip_id)
                         .and_then(|clip| clip.lut_path.as_deref())
                         .and_then(|path| Lut::from_cube_file(path).ok())
                         .map(Arc::new),
@@ -622,6 +660,7 @@ impl FrameSource {
                     control: Arc::new(DecoderControl::new(0, 0)),
                     dead: false,
                     track_order,
+                    visual,
                 }
             })
             .collect();
@@ -990,27 +1029,54 @@ impl FrameSource {
             return Supply::Starved;
         }
 
-        let layers = self
-            .streams
-            .iter_mut()
-            .filter(|stream| stream.wants(frame))
-            .filter_map(|stream| {
-                stream.pending.take().map(|decoded| {
-                    stream.buffered.fetch_sub(1, Ordering::SeqCst);
-                    stream.control.notify();
-                    Layer {
-                        clip_id: stream.placement.clip_id.clone(),
-                        pixels: decoded.pixels,
+        let mut layers = Vec::new();
+        let mut visuals = Vec::new();
+        for stream in self.streams.iter_mut().filter(|stream| stream.wants(frame)) {
+            let Some(decoded) = stream.pending.take() else {
+                continue;
+            };
+            stream.buffered.fetch_sub(1, Ordering::SeqCst);
+            stream.control.notify();
+            if let Some((z_index, style)) = &stream.visual {
+                let mut pixels = decoded.pixels;
+                apply_overlay_style(
+                    &mut pixels,
+                    stream.placement.dst.w,
+                    stream.placement.dst.h,
+                    style,
+                );
+                visuals.push(crate::text::RasterLayer {
+                    pixels: pixels.into(),
+                    width: stream.placement.dst.w,
+                    height: stream.placement.dst.h,
+                    lut: None,
+                    placement: Draw {
                         dst: stream.placement.dst,
-                        opacity: stream.placement.opacity,
+                        opacity: stream.placement.opacity_at(frame),
                         blend_mode: stream.placement.blend_mode,
-                        lut: stream.lut.clone(),
-                        track_order: stream.track_order,
-                    }
-                })
-            })
-            .collect();
-        let visuals = crate::text::layers_at(&self.project, frame, self.width, self.height);
+                        adjustment: false,
+                    },
+                    track_order: stream.track_order,
+                    z_index: *z_index,
+                });
+            } else {
+                layers.push(Layer {
+                    clip_id: stream.placement.clip_id.clone(),
+                    pixels: decoded.pixels,
+                    dst: stream.placement.dst,
+                    opacity: stream.placement.opacity_at(frame),
+                    blend_mode: stream.placement.blend_mode,
+                    lut: stream.lut.clone(),
+                    track_order: stream.track_order,
+                });
+            }
+        }
+        visuals.extend(crate::text::layers_at(
+            &self.project,
+            frame,
+            self.width,
+            self.height,
+        ));
         Supply::Ready(Frame {
             frame,
             layers,
@@ -1095,13 +1161,14 @@ impl FrameSource {
         let request = Open {
             path: placement.path.clone(),
             kind: placement.kind,
-            in_frame: placement.in_frame
-                + ((first - placement.start_frame) as f64 * placement.speed as f64).floor() as i64,
+            in_frame: placement.source_frame_at(first),
             frames: wanted,
             width: placement.dst.w,
             height: placement.dst.h,
             rate,
             speed: placement.speed,
+            crop: placement.crop,
+            head_pad_frames: (placement.head_pad_frames - (first - placement.start_frame)).max(0),
         };
 
         let frame_bytes = stream.frame_bytes;
@@ -1241,6 +1308,82 @@ impl FrameSource {
             }
         }
     }
+}
+
+pub(crate) fn apply_overlay_style(
+    pixels: &mut [u8],
+    width: u32,
+    height: u32,
+    style: &makevideo_render::layout::OverlayStyle,
+) {
+    let radius = style
+        .corner_radius
+        .clamp(0.0, width.min(height) as f32 / 2.0);
+    let border_width = style
+        .border
+        .as_ref()
+        .map(|border| border.width.clamp(0.0, width.min(height) as f32 / 2.0))
+        .unwrap_or(0.0);
+    let border = style
+        .border
+        .as_ref()
+        .and_then(|stroke| parse_rgba(&stroke.color));
+    if radius <= 0.0 && border_width <= 0.0 {
+        return;
+    }
+    for y in 0..height {
+        for x in 0..width {
+            let index = ((y * width + x) * 4) as usize;
+            if !inside_rounded_rect(x as f32 + 0.5, y as f32 + 0.5, width, height, radius, 0.0) {
+                pixels[index + 3] = 0;
+                continue;
+            }
+            if border_width > 0.0
+                && !inside_rounded_rect(
+                    x as f32 + 0.5,
+                    y as f32 + 0.5,
+                    width,
+                    height,
+                    (radius - border_width).max(0.0),
+                    border_width,
+                )
+            {
+                if let Some(color) = border {
+                    pixels[index..index + 4].copy_from_slice(&color);
+                }
+            }
+        }
+    }
+}
+
+fn inside_rounded_rect(x: f32, y: f32, width: u32, height: u32, radius: f32, inset: f32) -> bool {
+    let left = inset;
+    let top = inset;
+    let right = width as f32 - inset;
+    let bottom = height as f32 - inset;
+    if x < left || y < top || x >= right || y >= bottom {
+        return false;
+    }
+    if radius <= 0.0 {
+        return true;
+    }
+    let cx = x.clamp(left + radius, right - radius);
+    let cy = y.clamp(top + radius, bottom - radius);
+    (x - cx).powi(2) + (y - cy).powi(2) <= radius.powi(2)
+}
+
+fn parse_rgba(value: &str) -> Option<[u8; 4]> {
+    let text = value.strip_prefix('#')?;
+    if text.len() != 6 && text.len() != 8 {
+        return None;
+    }
+    let channel = |at| u8::from_str_radix(&text[at..at + 2], 16).ok();
+    Some([
+        channel(0)?,
+        channel(2)?,
+        channel(4)?,
+        if text.len() == 8 { channel(6)? } else { 255 },
+    ])
 }
 
 impl Drop for FrameSource {
@@ -1442,6 +1585,7 @@ mod tests {
             },
             assets,
             tracks,
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }
@@ -2131,6 +2275,29 @@ mod tests {
             .map(|(source, _)| source.rgba[0])
             .collect();
         assert_eq!(order, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn overlay_style_masks_corners_and_paints_the_border() {
+        let mut pixels = vec![100; 4 * 4 * 4];
+        for alpha in pixels.iter_mut().skip(3).step_by(4) {
+            *alpha = 255;
+        }
+        let style = makevideo_render::layout::OverlayStyle {
+            corner_radius: 2.0,
+            border: Some(makevideo_render::Stroke {
+                color: "#ff0000".into(),
+                width: 1.0,
+            }),
+        };
+
+        apply_overlay_style(&mut pixels, 4, 4, &style);
+
+        assert_eq!(pixels[3], 0, "the rounded corner is transparent");
+        let top_middle = (1 * 4) as usize;
+        assert_eq!(&pixels[top_middle..top_middle + 4], &[255, 0, 0, 255]);
+        let centre = ((2 * 4 + 2) * 4) as usize;
+        assert_eq!(&pixels[centre..centre + 4], &[100, 100, 100, 255]);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/supply.rs
@@ -477,6 +477,7 @@ mod tests {
                 muted: false,
                 hidden: false,
             }],
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/src/text.rs
@@ -1309,6 +1309,7 @@ mod tests {
             },
             assets: Vec::new(),
             markers: Vec::new(),
+            transitions: Vec::new(),
             tracks: vec![Track {
                 id: "V1".into(),
                 kind: TrackKind::Video,

--- a/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/compositor/tests/render.rs
@@ -241,6 +241,7 @@ fn two_tracks_composite_the_way_the_timeline_says() {
             track("V1", TrackKind::Video, vec![clip("c1", "wide", 0, 60)]),
             track("V2", TrackKind::Video, vec![clip("c2", "narrow", 30, 60)]),
         ],
+        transitions: Vec::new(),
         markers: Vec::new(),
     };
     let output = temp_dir()
@@ -293,6 +294,7 @@ fn the_output_is_the_length_the_timeline_says_with_the_sound_on_it() {
             TrackKind::Video,
             vec![clip("c1", "wide", 0, 90)],
         )],
+        transitions: Vec::new(),
         markers: Vec::new(),
     };
     let output = temp_dir().join("length.mp4").to_string_lossy().to_string();
@@ -349,6 +351,7 @@ fn a_missing_source_leaves_a_hole_rather_than_an_error() {
             track("V1", TrackKind::Video, vec![clip("c1", "wide", 0, 60)]),
             track("V2", TrackKind::Video, vec![clip("c2", "gone", 0, 60)]),
         ],
+        transitions: Vec::new(),
         markers: Vec::new(),
     };
     let output = temp_dir().join("missing.mp4").to_string_lossy().to_string();
@@ -383,6 +386,7 @@ fn the_preview_frame_matches_the_rendered_frame() {
             track("V1", TrackKind::Video, vec![clip("c1", "wide", 0, 90)]),
             track("V2", TrackKind::Video, vec![clip("c2", "narrow", 30, 60)]),
         ],
+        transitions: Vec::new(),
         markers: Vec::new(),
     };
     let output = temp_dir().join("match.mp4").to_string_lossy().to_string();

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -29,7 +29,8 @@
 
 use crate::{
     min_clip_frames, Asset, BlendMode, Clip, Easing, Keyframe, Marker, Project, ProjectSettings,
-    Rate, TextStyle, Track, TrackKind, VisualContent, VisualItem, VisualProperty, VisualTransform,
+    Rate, TextStyle, Track, TrackKind, Transition, TransitionKind, VisualContent, VisualItem,
+    VisualProperty, VisualTransform,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -63,6 +64,13 @@ pub struct VisualItemAt {
 pub struct MarkerAt {
     pub index: usize,
     pub marker: Marker,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransitionAt {
+    pub index: usize,
+    pub transition: Transition,
 }
 
 /// An asset and where it sat in the library, so undoing an import does not
@@ -202,6 +210,23 @@ pub enum Command {
     #[serde(rename_all = "camelCase")]
     RemoveClip {
         clip_id: String,
+    },
+    #[serde(rename_all = "camelCase")]
+    AddTransition {
+        from_clip_id: String,
+        to_clip_id: String,
+        duration: i64,
+        #[serde(default)]
+        id: Option<String>,
+    },
+    #[serde(rename_all = "camelCase")]
+    SetTransitionDuration {
+        transition_id: String,
+        duration: i64,
+    },
+    #[serde(rename_all = "camelCase")]
+    RemoveTransition {
+        transition_id: String,
     },
     #[serde(rename_all = "camelCase")]
     LinkClips {
@@ -408,6 +433,12 @@ pub enum Command {
     DropMarkers {
         marker_ids: Vec<String>,
     },
+    RestoreTransitions {
+        entries: Vec<TransitionAt>,
+    },
+    DropTransitions {
+        transition_ids: Vec<String>,
+    },
 
     /// One undo step made of several commands, all or nothing.
     #[serde(rename_all = "camelCase")]
@@ -499,6 +530,11 @@ impl Command {
             Command::TrimClip { .. } => "Trim clip",
             Command::SplitAt { .. } => "Split",
             Command::RemoveClip { .. } | Command::DropClips { .. } => "Delete clip",
+            Command::AddTransition { .. } => "Add transition",
+            Command::SetTransitionDuration { .. } => "Edit transition",
+            Command::RemoveTransition { .. } | Command::DropTransitions { .. } => {
+                "Delete transition"
+            }
             Command::LinkClips { .. } => "Link clips",
             Command::UnlinkClips { .. } => "Unlink clips",
             Command::RippleDelete { .. } => "Ripple delete",
@@ -531,6 +567,7 @@ impl Command {
             Command::RestoreTracks { .. } => "Restore track",
             Command::RestoreVisualItems { .. } => "Restore visual items",
             Command::RestoreMarkers { .. } => "Restore markers",
+            Command::RestoreTransitions { .. } => "Restore transitions",
             Command::Transaction { commands } => commands
                 .iter()
                 .find(|command| !command.is_nothing())
@@ -634,6 +671,19 @@ impl Command {
                 link_groups,
             } => Ok(split_at(project, ids, frame, clip_id, given, link_groups)),
             Command::RemoveClip { clip_id } => remove_clip(project, clip_id),
+            Command::AddTransition {
+                from_clip_id,
+                to_clip_id,
+                duration,
+                id,
+            } => add_transition(project, ids, from_clip_id, to_clip_id, duration, id),
+            Command::SetTransitionDuration {
+                transition_id,
+                duration,
+            } => set_transition_duration(project, transition_id, duration),
+            Command::RemoveTransition { transition_id } => {
+                remove_transition(project, transition_id)
+            }
             Command::LinkClips {
                 clip_ids,
                 link_group,
@@ -743,6 +793,10 @@ impl Command {
             Command::DropVisualItems { item_ids } => Ok(drop_visual_items(project, item_ids)),
             Command::RestoreMarkers { entries } => Ok(restore_markers(project, entries)),
             Command::DropMarkers { marker_ids } => Ok(drop_markers(project, marker_ids)),
+            Command::RestoreTransitions { entries } => Ok(restore_transitions(project, entries)),
+            Command::DropTransitions { transition_ids } => {
+                Ok(drop_transitions(project, transition_ids))
+            }
             Command::Transaction { commands } => transaction(project, ids, commands),
         }
     }
@@ -839,6 +893,24 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
             .visual_items
             .retain(|item| !item.content.references_asset(&asset_id));
     }
+    let orphan_ids: Vec<&str> = orphans.iter().map(|entry| entry.clip.id.as_str()).collect();
+    let transitions: Vec<TransitionAt> = project
+        .transitions
+        .iter()
+        .enumerate()
+        .filter(|(_, transition)| {
+            orphan_ids.contains(&transition.from_clip_id.as_str())
+                || orphan_ids.contains(&transition.to_clip_id.as_str())
+        })
+        .map(|(index, transition)| TransitionAt {
+            index,
+            transition: transition.clone(),
+        })
+        .collect();
+    project.transitions.retain(|transition| {
+        !orphan_ids.contains(&transition.from_clip_id.as_str())
+            && !orphan_ids.contains(&transition.to_clip_id.as_str())
+    });
     Ok(Applied {
         resolved: Command::RemoveAsset { asset_id },
         inverse: Command::Transaction {
@@ -849,6 +921,9 @@ fn remove_asset(project: &mut Project, asset_id: String) -> Result<Applied, Stri
                 Command::RestoreClips { entries: orphans },
                 Command::RestoreVisualItems {
                     entries: orphan_items,
+                },
+                Command::RestoreTransitions {
+                    entries: transitions,
                 },
             ],
         },
@@ -908,10 +983,30 @@ fn remove_track(project: &mut Project, track_id: String) -> Result<Applied, Stri
         return Err("only the last track of a kind can be removed".into());
     }
     let track = project.tracks.remove(index);
+    let transitions: Vec<TransitionAt> = project
+        .transitions
+        .iter()
+        .enumerate()
+        .filter(|(_, transition)| transition.track_id == track_id)
+        .map(|(index, transition)| TransitionAt {
+            index,
+            transition: transition.clone(),
+        })
+        .collect();
+    project
+        .transitions
+        .retain(|transition| transition.track_id != track_id);
     Ok(Applied {
         resolved: Command::RemoveTrack { track_id },
-        inverse: Command::RestoreTracks {
-            entries: vec![TrackAt { index, track }],
+        inverse: Command::Transaction {
+            commands: vec![
+                Command::RestoreTracks {
+                    entries: vec![TrackAt { index, track }],
+                },
+                Command::RestoreTransitions {
+                    entries: transitions,
+                },
+            ],
         },
     })
 }
@@ -1838,12 +1933,133 @@ fn remove_clip(project: &mut Project, clip_id: String) -> Result<Applied, String
         return Err("that clip is not on the timeline".into());
     }
     let ids: Vec<&str> = entries.iter().map(|entry| entry.clip.id.as_str()).collect();
+    let transitions: Vec<TransitionAt> = project
+        .transitions
+        .iter()
+        .enumerate()
+        .filter(|(_, transition)| {
+            ids.contains(&transition.from_clip_id.as_str())
+                || ids.contains(&transition.to_clip_id.as_str())
+        })
+        .map(|(index, transition)| TransitionAt {
+            index,
+            transition: transition.clone(),
+        })
+        .collect();
+    let transition_ids: Vec<String> = transitions
+        .iter()
+        .map(|entry| entry.transition.id.clone())
+        .collect();
     for track in &mut project.tracks {
         track.clips.retain(|clip| !ids.contains(&clip.id.as_str()));
     }
+    project
+        .transitions
+        .retain(|transition| !transition_ids.contains(&transition.id));
     Ok(Applied {
         resolved: Command::RemoveClip { clip_id },
-        inverse: Command::RestoreClips { entries },
+        inverse: Command::Transaction {
+            commands: vec![
+                Command::RestoreClips { entries },
+                Command::RestoreTransitions {
+                    entries: transitions,
+                },
+            ],
+        },
+    })
+}
+
+fn add_transition(
+    project: &mut Project,
+    ids: &mut Ids,
+    from_clip_id: String,
+    to_clip_id: String,
+    duration: i64,
+    id: Option<String>,
+) -> Result<Applied, String> {
+    let (track_index, clip_index) = project
+        .locate(&from_clip_id)
+        .ok_or("the first transition clip is not on the timeline")?;
+    let track = &project.tracks[track_index];
+    if track.kind != TrackKind::Video
+        || track.clips.get(clip_index + 1).map(|clip| clip.id.as_str()) != Some(to_clip_id.as_str())
+        || track.clips[clip_index].end_frame() != track.clips[clip_index + 1].start
+    {
+        return Err("a transition needs touching adjacent video clips".into());
+    }
+    if project.transitions.iter().any(|transition| {
+        transition.from_clip_id == from_clip_id && transition.to_clip_id == to_clip_id
+    }) {
+        return Err("that clip boundary already has a transition".into());
+    }
+    let max_duration = track.clips[clip_index]
+        .duration_frames()
+        .min(track.clips[clip_index + 1].duration_frames());
+    if duration <= 0 || duration > max_duration {
+        return Err("the transition duration must fit inside both clips".into());
+    }
+    let id = id.unwrap_or_else(|| ids.make('x'));
+    if project.transition(&id).is_some() {
+        return Err("that transition already exists".into());
+    }
+    let transition = Transition {
+        id: id.clone(),
+        track_id: track.id.clone(),
+        from_clip_id: from_clip_id.clone(),
+        to_clip_id: to_clip_id.clone(),
+        duration,
+        kind: TransitionKind::Dissolve,
+    };
+    project.transitions.push(transition);
+    Ok(Applied {
+        resolved: Command::AddTransition {
+            from_clip_id,
+            to_clip_id,
+            duration,
+            id: Some(id.clone()),
+        },
+        inverse: Command::DropTransitions {
+            transition_ids: vec![id],
+        },
+    })
+}
+
+fn set_transition_duration(
+    project: &mut Project,
+    transition_id: String,
+    duration: i64,
+) -> Result<Applied, String> {
+    let transition = project
+        .transitions
+        .iter_mut()
+        .find(|transition| transition.id == transition_id)
+        .ok_or("that transition is not on the timeline")?;
+    let previous = transition.duration;
+    transition.duration = duration;
+    Ok(Applied {
+        resolved: Command::SetTransitionDuration {
+            transition_id: transition_id.clone(),
+            duration,
+        },
+        inverse: Command::SetTransitionDuration {
+            transition_id,
+            duration: previous,
+        },
+    })
+}
+
+fn remove_transition(project: &mut Project, transition_id: String) -> Result<Applied, String> {
+    let index = project
+        .transitions
+        .iter()
+        .position(|transition| transition.id == transition_id)
+        .ok_or("that transition is not on the timeline")?;
+    let transition = project.transitions.remove(index);
+    Ok(Applied {
+        resolved: Command::RemoveTransition { transition_id },
+        inverse: Command::RestoreTransitions {
+            entries: vec![TransitionAt { index, transition }],
+        },
     })
 }
 
@@ -2653,6 +2869,18 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
     let mut restore = Vec::new();
     let mut restore_items = Vec::new();
     let mut restore_markers = Vec::new();
+    let restore_transitions: Vec<TransitionAt> = project
+        .transitions
+        .iter()
+        .enumerate()
+        .map(|(index, transition)| TransitionAt {
+            index,
+            transition: transition.clone(),
+        })
+        .collect();
+    for transition in &mut project.transitions {
+        transition.duration = rescale(transition.duration, from, to).max(1);
+    }
     for (index, marker) in project.markers.iter_mut().enumerate() {
         restore_markers.push(MarkerAt {
             index,
@@ -2704,6 +2932,9 @@ fn set_settings(project: &mut Project, settings: ProjectSettings) -> Applied {
                 },
                 Command::RestoreMarkers {
                     entries: restore_markers,
+                },
+                Command::RestoreTransitions {
+                    entries: restore_transitions,
                 },
             ],
         },
@@ -3043,5 +3274,62 @@ fn drop_markers(project: &mut Project, marker_ids: Vec<String>) -> Applied {
     Applied {
         resolved: Command::DropMarkers { marker_ids },
         inverse: Command::RestoreMarkers { entries: previous },
+    }
+}
+
+fn restore_transitions(project: &mut Project, entries: Vec<TransitionAt>) -> Applied {
+    let mut previous = Vec::new();
+    let mut invented = Vec::new();
+    for entry in &entries {
+        if let Some(index) = project
+            .transitions
+            .iter()
+            .position(|transition| transition.id == entry.transition.id)
+        {
+            previous.push(TransitionAt {
+                index,
+                transition: project.transitions.remove(index),
+            });
+        } else {
+            invented.push(entry.transition.id.clone());
+        }
+        project.transitions.insert(
+            entry.index.min(project.transitions.len()),
+            entry.transition.clone(),
+        );
+    }
+    Applied {
+        resolved: Command::RestoreTransitions { entries },
+        inverse: Command::Transaction {
+            commands: vec![
+                Command::DropTransitions {
+                    transition_ids: invented,
+                },
+                Command::RestoreTransitions { entries: previous },
+            ],
+        },
+    }
+}
+
+fn drop_transitions(project: &mut Project, transition_ids: Vec<String>) -> Applied {
+    let previous = transition_ids
+        .iter()
+        .filter_map(|id| {
+            project
+                .transitions
+                .iter()
+                .position(|transition| transition.id == *id)
+                .map(|index| TransitionAt {
+                    index,
+                    transition: project.transitions[index].clone(),
+                })
+        })
+        .collect();
+    project
+        .transitions
+        .retain(|transition| !transition_ids.contains(&transition.id));
+    Applied {
+        resolved: Command::DropTransitions { transition_ids },
+        inverse: Command::RestoreTransitions { entries: previous },
     }
 }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/command.rs
@@ -2029,13 +2029,31 @@ fn set_transition_duration(
     transition_id: String,
     duration: i64,
 ) -> Result<Applied, String> {
-    let transition = project
+    let transition_index = project
         .transitions
-        .iter_mut()
-        .find(|transition| transition.id == transition_id)
+        .iter()
+        .position(|transition| transition.id == transition_id)
         .ok_or("that transition is not on the timeline")?;
+    let transition = &project.transitions[transition_index];
+    let (track_index, clip_index) = project
+        .locate(&transition.from_clip_id)
+        .ok_or("the first transition clip is not on the timeline")?;
+    let track = &project.tracks[track_index];
+    if track.kind != TrackKind::Video
+        || track.clips.get(clip_index + 1).map(|clip| clip.id.as_str())
+            != Some(transition.to_clip_id.as_str())
+        || track.clips[clip_index].end_frame() != track.clips[clip_index + 1].start
+    {
+        return Err("a transition needs touching adjacent video clips".into());
+    }
+    let max_duration = track.clips[clip_index]
+        .duration_frames()
+        .min(track.clips[clip_index + 1].duration_frames());
+    if duration <= 0 || duration > max_duration {
+        return Err("the transition duration must fit inside both clips".into());
+    }
     let previous = transition.duration;
-    transition.duration = duration;
+    project.transitions[transition_index].duration = duration;
     Ok(Applied {
         resolved: Command::SetTransitionDuration {
             transition_id: transition_id.clone(),

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -68,6 +68,9 @@ impl Document {
         for marker in &project.markers {
             ids.observe(&marker.id);
         }
+        for transition in &project.transitions {
+            ids.observe(&transition.id);
+        }
         for track in &project.tracks {
             ids.observe(&track.id);
             for clip in &track.clips {
@@ -256,8 +259,8 @@ impl Document {
 mod tests {
     use super::*;
     use crate::{
-        Asset, AssetKind, Clip, Command, Edge, Paint, ProjectSettings, Rate, TextStyle, TrackKind,
-        VisualContent, VisualStyle, VisualTransform,
+        Asset, AssetKind, Clip, Command, Crop, Edge, Paint, ProjectSettings, Rate, Stroke,
+        TextStyle, TrackKind, VisualContent, VisualStyle, VisualTransform,
     };
 
     fn asset(id: &str, kind: AssetKind, duration_ms: u64) -> Asset {
@@ -361,6 +364,36 @@ mod tests {
             (clips[0].start, clips[0].in_point, clips[0].out_point),
             (75, 0, 300)
         );
+    }
+
+    #[test]
+    fn a_dissolve_is_a_boundary_object_with_undo_and_clip_cleanup() {
+        let mut document = document();
+        let first = add(&mut document, 0);
+        let second = add(&mut document, 300);
+        document
+            .apply(Command::AddTransition {
+                from_clip_id: first.clone(),
+                to_clip_id: second.clone(),
+                duration: 15,
+                id: None,
+            })
+            .unwrap();
+        assert_eq!(document.project().transitions.len(), 1);
+        assert_eq!(document.project().transitions[0].duration, 15);
+
+        document.undo().unwrap();
+        assert!(document.project().transitions.is_empty());
+        document.redo().unwrap();
+        assert_eq!(document.project().transitions.len(), 1);
+
+        document
+            .apply(Command::RemoveClip { clip_id: second })
+            .unwrap();
+        assert!(document.project().transitions.is_empty());
+        document.undo().unwrap();
+        assert_eq!(document.project().transitions.len(), 1);
+        assert_eq!(clips(&document).len(), 2);
     }
 
     #[test]
@@ -1391,6 +1424,58 @@ mod tests {
 
         assert!(error.contains("already in this project"), "{error}");
         assert_eq!(document.project().tracks[0].visual_items.len(), 1);
+    }
+
+    #[test]
+    fn a_video_overlay_keeps_crop_border_and_audio_as_one_visual_item() {
+        let mut document = document();
+        let track_id = video_track(&document);
+        document
+            .apply(Command::AddVisualItem {
+                track_id,
+                content: VisualContent::VideoOverlay {
+                    asset_id: "v".into(),
+                    in_point: 30,
+                    crop: Crop {
+                        left: 0.1,
+                        top: 0.2,
+                        right: 0.1,
+                        bottom: 0.0,
+                    },
+                    corner_radius: 24.0,
+                    border: Some(Stroke {
+                        color: "#ffffff".into(),
+                        width: 4.0,
+                    }),
+                    audio_enabled: true,
+                },
+                start: 60,
+                duration: 90,
+                transform: VisualTransform {
+                    x: 100.0,
+                    y: 100.0,
+                    width: 640.0,
+                    height: 360.0,
+                    rotation: 0.0,
+                    opacity: 1.0,
+                },
+                z_index: 1,
+                id: None,
+            })
+            .unwrap();
+
+        let item = &document.project().tracks[0].visual_items[0];
+        assert!(matches!(
+            item.content,
+            VisualContent::VideoOverlay {
+                audio_enabled: true,
+                corner_radius: 24.0,
+                ..
+            }
+        ));
+        assert!(document.project().uses_video_paint());
+        document.undo().unwrap();
+        assert!(document.project().tracks[0].visual_items.is_empty());
     }
 
     fn overlay_command(text: &str) -> Command {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/document.rs
@@ -381,6 +381,15 @@ mod tests {
             .unwrap();
         assert_eq!(document.project().transitions.len(), 1);
         assert_eq!(document.project().transitions[0].duration, 15);
+        let transition_id = document.project().transitions[0].id.clone();
+        let error = document
+            .apply(Command::SetTransitionDuration {
+                transition_id,
+                duration: 301,
+            })
+            .unwrap_err();
+        assert!(error.contains("fit inside both clips"), "{error}");
+        assert_eq!(document.project().transitions[0].duration, 15);
 
         document.undo().unwrap();
         assert!(document.project().transitions.is_empty());

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/lib.rs
@@ -26,7 +26,7 @@ pub mod document;
 pub mod migrate;
 
 pub use animation::{Easing, Keyframe, KeyframeTrack, VisualAnimation, VisualProperty};
-pub use command::{ClipAt, Command, Edge, MarkerAt, VisualItemAt};
+pub use command::{ClipAt, Command, Edge, MarkerAt, TransitionAt, VisualItemAt};
 pub use document::{Document, DocumentState};
 pub use makevideo_time::{Rate, RationalTime};
 
@@ -36,7 +36,7 @@ use std::collections::{HashMap, HashSet};
 /// What `version` a project file written today holds. Version 1 measured
 /// everything in whole milliseconds; `migrate` turns one of those into this on
 /// the way in, so a project saved before this existed still opens.
-pub const FORMAT_VERSION: u32 = 4;
+pub const FORMAT_VERSION: u32 = 5;
 
 /// Four of each is as many as the timeline header has room to name, and a
 /// timeline that needs a fifth video track is asking for a different app.
@@ -99,6 +99,8 @@ pub struct Project {
     pub settings: ProjectSettings,
     pub assets: Vec<Asset>,
     pub tracks: Vec<Track>,
+    #[serde(default)]
+    pub transitions: Vec<Transition>,
     #[serde(default)]
     pub markers: Vec<Marker>,
 }
@@ -345,6 +347,33 @@ pub enum TextAlign {
 impl Default for TextAlign {
     fn default() -> Self {
         TextAlign::Center
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Crop {
+    #[serde(default)]
+    pub left: f32,
+    #[serde(default)]
+    pub top: f32,
+    #[serde(default)]
+    pub right: f32,
+    #[serde(default)]
+    pub bottom: f32,
+}
+
+impl Crop {
+    pub fn is_valid(self) -> bool {
+        [self.left, self.top, self.right, self.bottom]
+            .into_iter()
+            .all(|value| value.is_finite() && (0.0..1.0).contains(&value))
+            && self.left + self.right < 1.0
+            && self.top + self.bottom < 1.0
+    }
+
+    pub fn is_empty(self) -> bool {
+        self == Crop::default()
     }
 }
 
@@ -677,6 +706,16 @@ pub enum VisualContent {
     },
     VideoOverlay {
         asset_id: String,
+        #[serde(default)]
+        in_point: i64,
+        #[serde(default)]
+        crop: Crop,
+        #[serde(default)]
+        corner_radius: f32,
+        #[serde(default)]
+        border: Option<Stroke>,
+        #[serde(default)]
+        audio_enabled: bool,
     },
     Adjustment {
         lut_path: String,
@@ -686,7 +725,7 @@ pub enum VisualContent {
 impl VisualContent {
     pub fn asset_id(&self) -> Option<&str> {
         match self {
-            VisualContent::Image { asset_id } | VisualContent::VideoOverlay { asset_id } => {
+            VisualContent::Image { asset_id } | VisualContent::VideoOverlay { asset_id, .. } => {
                 Some(asset_id)
             }
             VisualContent::Text { .. }
@@ -715,6 +754,9 @@ impl VisualContent {
     }
 
     pub fn uses_video_paint(&self) -> bool {
+        if matches!(self, VisualContent::VideoOverlay { .. }) {
+            return true;
+        }
         let style = match self {
             VisualContent::Text { style, .. } => Some(&style.visual_style),
             VisualContent::Shape { visual_style, .. } => Some(visual_style),
@@ -780,6 +822,16 @@ enum WireVisualContent {
     },
     VideoOverlay {
         asset_id: String,
+        #[serde(default)]
+        in_point: i64,
+        #[serde(default)]
+        crop: Crop,
+        #[serde(default)]
+        corner_radius: f32,
+        #[serde(default)]
+        border: Option<Stroke>,
+        #[serde(default)]
+        audio_enabled: bool,
     },
     Adjustment {
         lut_path: String,
@@ -851,9 +903,21 @@ impl<'de> Deserialize<'de> for VisualContent {
                 })
             }
             WireVisualContent::Image { asset_id } => Ok(VisualContent::Image { asset_id }),
-            WireVisualContent::VideoOverlay { asset_id } => {
-                Ok(VisualContent::VideoOverlay { asset_id })
-            }
+            WireVisualContent::VideoOverlay {
+                asset_id,
+                in_point,
+                crop,
+                corner_radius,
+                border,
+                audio_enabled,
+            } => Ok(VisualContent::VideoOverlay {
+                asset_id,
+                in_point,
+                crop,
+                corner_radius,
+                border,
+                audio_enabled,
+            }),
             WireVisualContent::Adjustment { lut_path } => {
                 Ok(VisualContent::Adjustment { lut_path })
             }
@@ -938,6 +1002,25 @@ pub struct Clip {
     pub volume_keyframes: KeyframeTrack,
     #[serde(default)]
     pub blend_mode: BlendMode,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransitionKind {
+    #[default]
+    Dissolve,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Transition {
+    pub id: String,
+    pub track_id: String,
+    pub from_clip_id: String,
+    pub to_clip_id: String,
+    pub duration: i64,
+    #[serde(default)]
+    pub kind: TransitionKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1040,6 +1123,7 @@ impl Project {
                     hidden: false,
                 },
             ],
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }
@@ -1053,18 +1137,21 @@ impl Project {
     }
 
     pub fn uses_video_paint(&self) -> bool {
-        self.tracks
-            .iter()
-            .filter(|track| track.contributes())
-            .any(|track| {
-                track.clips.iter().any(|clip| {
-                    (clip.speed - 1.0).abs() > f32::EPSILON || clip.blend_mode != BlendMode::Normal
-                }) || track.visual_items.iter().any(|item| {
-                    item.content.uses_video_paint()
-                        || item.blend_mode != BlendMode::Normal
-                        || item.animation != VisualAnimation::default()
+        !self.transitions.is_empty()
+            || self
+                .tracks
+                .iter()
+                .filter(|track| track.contributes())
+                .any(|track| {
+                    track.clips.iter().any(|clip| {
+                        (clip.speed - 1.0).abs() > f32::EPSILON
+                            || clip.blend_mode != BlendMode::Normal
+                    }) || track.visual_items.iter().any(|item| {
+                        item.content.uses_video_paint()
+                            || item.blend_mode != BlendMode::Normal
+                            || item.animation != VisualAnimation::default()
+                    })
                 })
-            })
     }
 
     pub fn track(&self, id: &str) -> Option<&Track> {
@@ -1092,6 +1179,12 @@ impl Project {
     pub fn clip(&self, clip_id: &str) -> Option<&Clip> {
         let (track, clip) = self.locate(clip_id)?;
         Some(&self.tracks[track].clips[clip])
+    }
+
+    pub fn transition(&self, transition_id: &str) -> Option<&Transition> {
+        self.transitions
+            .iter()
+            .find(|transition| transition.id == transition_id)
     }
 
     pub fn locate_visual_item(&self, item_id: &str) -> Option<(usize, usize)> {
@@ -1346,6 +1439,40 @@ impl Project {
                         "visual item {name} has opacity outside 0 through 1"
                     ));
                 }
+                if let VisualContent::VideoOverlay {
+                    asset_id,
+                    in_point,
+                    crop,
+                    corner_radius,
+                    border,
+                    ..
+                } = &item.content
+                {
+                    let asset = self
+                        .asset(asset_id)
+                        .ok_or_else(|| format!("visual item {name} references a missing asset"))?;
+                    if asset.kind != AssetKind::Video {
+                        return Err(format!("visual item {name} needs a video asset"));
+                    }
+                    if *in_point < 0
+                        || asset
+                            .source_limit_frames(self.rate())
+                            .is_some_and(|limit| in_point.saturating_add(item.duration) > limit)
+                    {
+                        return Err(format!("visual item {name} reaches past its video source"));
+                    }
+                    if !crop.is_valid() {
+                        return Err(format!("visual item {name} has an invalid crop"));
+                    }
+                    if !corner_radius.is_finite() || *corner_radius < 0.0 {
+                        return Err(format!("visual item {name} has an invalid corner radius"));
+                    }
+                    if border.as_ref().is_some_and(|stroke| {
+                        !stroke.width.is_finite() || stroke.width < 0.0 || stroke.color.is_empty()
+                    }) {
+                        return Err(format!("visual item {name} has an invalid border"));
+                    }
+                }
                 let last_frame = item.end_frame().saturating_sub(1);
                 let unbounded = -f32::MAX..=f32::MAX;
                 for track in [
@@ -1397,6 +1524,47 @@ impl Project {
                 || first.out_point != second.out_point
             {
                 return Err(format!("link group {group} is out of sync"));
+            }
+        }
+        let mut transition_ids = HashSet::new();
+        for transition in &self.transitions {
+            if !transition_ids.insert(transition.id.as_str()) {
+                return Err(format!("transition {} is duplicated", transition.id));
+            }
+            let track = self.track(&transition.track_id).ok_or_else(|| {
+                format!("transition {} references a missing track", transition.id)
+            })?;
+            if track.kind != TrackKind::Video {
+                return Err(format!("transition {} needs a video track", transition.id));
+            }
+            let Some(index) = track
+                .clips
+                .iter()
+                .position(|clip| clip.id == transition.from_clip_id)
+            else {
+                return Err(format!(
+                    "transition {} references a missing clip",
+                    transition.id
+                ));
+            };
+            let Some(next) = track.clips.get(index + 1) else {
+                return Err(format!("transition {} needs adjacent clips", transition.id));
+            };
+            let from = &track.clips[index];
+            if next.id != transition.to_clip_id || from.end_frame() != next.start {
+                return Err(format!(
+                    "transition {} needs touching adjacent clips",
+                    transition.id
+                ));
+            }
+            if transition.duration <= 0
+                || transition.duration > from.duration_frames()
+                || transition.duration > next.duration_frames()
+            {
+                return Err(format!(
+                    "transition {} has an invalid duration",
+                    transition.id
+                ));
             }
         }
         Ok(())
@@ -1495,6 +1663,34 @@ impl Project {
                 }
             }
         }
+        let transitions = std::mem::take(&mut self.transitions);
+        let mut transition_ids = HashSet::new();
+        self.transitions = transitions
+            .into_iter()
+            .filter(|transition| {
+                if !transition_ids.insert(transition.id.clone()) {
+                    return false;
+                }
+                let Some(track) = self.track(&transition.track_id) else {
+                    return false;
+                };
+                let Some(index) = track
+                    .clips
+                    .iter()
+                    .position(|clip| clip.id == transition.from_clip_id)
+                else {
+                    return false;
+                };
+                let Some(next) = track.clips.get(index + 1) else {
+                    return false;
+                };
+                next.id == transition.to_clip_id
+                    && track.clips[index].end_frame() == next.start
+                    && transition.duration > 0
+                    && transition.duration <= track.clips[index].duration_frames()
+                    && transition.duration <= next.duration_frames()
+            })
+            .collect();
         let mut groups: HashMap<String, Vec<(TrackKind, String, i64, i64, i64)>> = HashMap::new();
         for track in &self.tracks {
             for clip in &track.clips {

--- a/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/edit/src/migrate.rs
@@ -13,7 +13,7 @@
 
 use crate::{
     Asset, BlendMode, Clip, KeyframeTrack, Marker, Project, ProjectSettings, Rate, RationalTime,
-    Track, TrackKind, VisualItem, FORMAT_VERSION,
+    Track, TrackKind, Transition, VisualItem, FORMAT_VERSION,
 };
 use serde::Deserialize;
 
@@ -32,6 +32,8 @@ pub struct WireProject {
     assets: Vec<Asset>,
     #[serde(default)]
     tracks: Vec<WireTrack>,
+    #[serde(default)]
+    transitions: Vec<Transition>,
     #[serde(default)]
     markers: Vec<Marker>,
 }
@@ -137,6 +139,7 @@ impl From<WireProject> for Project {
                 rate,
             },
             assets: wire.assets,
+            transitions: wire.transitions,
             markers: wire.markers,
             tracks: wire
                 .tracks
@@ -273,10 +276,18 @@ mod tests {
         assert_eq!(
             content,
             crate::VisualContent::VideoOverlay {
-                asset_id: "a1".into()
+                asset_id: "a1".into(),
+                in_point: 0,
+                crop: Default::default(),
+                corner_radius: 0.0,
+                border: None,
+                audio_enabled: false,
             }
         );
-        assert_eq!(serde_json::to_string(&content).unwrap(), text);
+        assert_eq!(
+            serde_json::to_string(&content).unwrap(),
+            r#"{"kind":"videoOverlay","assetId":"a1","inPoint":0,"crop":{"left":0.0,"top":0.0,"right":0.0,"bottom":0.0},"cornerRadius":0.0,"border":null,"audioEnabled":false}"#
+        );
     }
 
     #[test]
@@ -345,7 +356,7 @@ mod tests {
         }"#;
         let project: Project = serde_json::from_str(text).unwrap();
         let written = serde_json::to_string(&project).unwrap();
-        assert!(written.contains(r#""version":4"#), "{written}");
+        assert!(written.contains(r#""version":5"#), "{written}");
         assert!(
             written.contains(r#""rate":{"num":60,"den":1}"#),
             "{written}"

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/player.rs
@@ -913,6 +913,7 @@ mod tests {
                 hidden: false,
                 subtitle_style: None,
             }],
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/soak.rs
@@ -1090,6 +1090,7 @@ mod tests {
                 hidden: false,
                 subtitle_style: None,
             }],
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/present/src/transport.rs
@@ -808,6 +808,7 @@ mod tests {
                 hidden: false,
                 subtitle_style: None,
             }],
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }

--- a/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/proxy/src/lib.rs
@@ -334,6 +334,7 @@ mod tests {
             },
             assets: vec![original.clone()],
             tracks: Vec::new(),
+            transitions: Vec::new(),
             markers: Vec::new(),
         };
         let ready = HashMap::from([(original.id.clone(), "/project/proxies/as1.mp4".into())]);

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/ffmpeg.rs
@@ -11,7 +11,7 @@
 
 use crate::accel::Acceleration;
 use crate::layout;
-use crate::{AssetKind, Clip, Project, ProjectSettings, Rate, RationalTime, TrackKind};
+use crate::{AssetKind, Clip, Crop, Project, ProjectSettings, Rate, RationalTime, TrackKind};
 
 /// Everything is resampled to this on the way in, so a sample count means the
 /// same thing in every chain.
@@ -368,17 +368,37 @@ fn audio_chain(item: &Item, input: usize, rate: Rate) -> String {
 }
 
 fn volume_expression(clip: &Clip, rate: Rate) -> String {
-    let keys = &clip.volume_keyframes.keyframes;
+    volume_expression_for(
+        &clip.volume_keyframes,
+        clip.volume,
+        clip.fade_in,
+        clip.fade_out,
+        clip.start,
+        clip.duration_frames(),
+        rate,
+    )
+}
+
+fn volume_expression_for(
+    keyframes: &crate::KeyframeTrack,
+    volume: f32,
+    fade_in: i64,
+    fade_out: i64,
+    start_frame: i64,
+    duration_frames: i64,
+    rate: Rate,
+) -> String {
+    let keys = &keyframes.keyframes;
     let mut expression = if keys.is_empty() {
-        format!("{:.6}", clip.volume.clamp(0.0, 1.0))
+        format!("{:.6}", volume.clamp(0.0, 1.0))
     } else {
         let last = keys.last().expect("checked");
         let mut tail = format!("{:.6}", last.value.clamp(0.0, 1.0));
         for pair in keys.windows(2).rev() {
             let left = pair[0];
             let right = pair[1];
-            let left_time = RationalTime::new(left.frame - clip.start, rate).to_seconds();
-            let right_time = RationalTime::new(right.frame - clip.start, rate).to_seconds();
+            let left_time = RationalTime::new(left.frame - start_frame, rate).to_seconds();
+            let right_time = RationalTime::new(right.frame - start_frame, rate).to_seconds();
             let amount = format!(
                 "max(0,min(1,(t-{left_time:.9})/{:.9}))",
                 (right_time - left_time).max(1e-9)
@@ -398,20 +418,38 @@ fn volume_expression(clip: &Clip, rate: Rate) -> String {
             );
             tail = format!("if(lt(t,{right_time:.9}),{segment},{tail})");
         }
-        let first_time = RationalTime::new(keys[0].frame - clip.start, rate).to_seconds();
+        let first_time = RationalTime::new(keys[0].frame - start_frame, rate).to_seconds();
         format!("if(lt(t,{first_time:.9}),{:.6},{tail})", keys[0].value)
     };
-    if clip.fade_in > 0 {
-        let duration = RationalTime::new(clip.fade_in, rate).to_seconds();
+    if fade_in > 0 {
+        let duration = RationalTime::new(fade_in, rate).to_seconds();
         expression = format!("({expression})*min(1,max(0,t/{duration:.9}))");
     }
-    if clip.fade_out > 0 {
-        let start = RationalTime::new(clip.duration_frames() - clip.fade_out, rate).to_seconds();
-        let duration = RationalTime::new(clip.fade_out, rate).to_seconds();
+    if fade_out > 0 {
+        let start = RationalTime::new(duration_frames - fade_out, rate).to_seconds();
+        let duration = RationalTime::new(fade_out, rate).to_seconds();
         expression =
             format!("({expression})*min(1,max(0,({start:.9}+{duration:.9}-t)/{duration:.9}))");
     }
     expression
+}
+
+fn audio_placement_chain(item: &layout::AudioPlacement, input: usize, rate: Rate) -> String {
+    let speed = speed_audio_filter(item.speed, item.preserve_pitch);
+    let volume = volume_expression_for(
+        &item.volume_keyframes,
+        item.volume,
+        item.fade_in,
+        item.fade_out,
+        item.start_frame,
+        item.duration_frames,
+        rate,
+    );
+    format!(
+        "[{input}:a]aformat=sample_fmts=fltp:sample_rates={AUDIO_HZ}:channel_layouts=stereo\
+         {speed},asetpts=PTS-STARTPTS,volume='{volume}':eval=frame,adelay={}S:all=1[a{input}]",
+        RationalTime::new(item.start_frame, rate).to_samples(AUDIO_HZ)
+    )
 }
 
 /// normalize=0 keeps a single clip at its own level instead of dividing it by
@@ -501,6 +539,8 @@ pub struct Decode<'a> {
     pub rate: Rate,
     pub speed: f32,
     pub hwaccel: Option<&'a str>,
+    pub crop: Crop,
+    pub head_pad_frames: i64,
 }
 
 /// Decode one clip to raw RGBA at the project frame rate, already scaled to
@@ -521,6 +561,8 @@ pub fn decoder_args(request: &Decode<'_>) -> Vec<String> {
         rate,
         speed,
         hwaccel,
+        crop,
+        head_pad_frames,
     } = *request;
     let fps = rate.ratio_text();
     let mut args: Vec<String> = vec![
@@ -544,9 +586,28 @@ pub fn decoder_args(request: &Decode<'_>) -> Vec<String> {
     // fps= is what makes the frame count predictable: the reader takes exactly
     // one frame per output frame and a variable frame rate source would
     // otherwise drift out of step with the timeline.
+    let crop_filter = if crop.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "crop=iw*{:.6}:ih*{:.6}:iw*{:.6}:ih*{:.6},",
+            1.0 - crop.left - crop.right,
+            1.0 - crop.top - crop.bottom,
+            crop.left,
+            crop.top,
+        )
+    };
+    let pad_filter = if head_pad_frames > 0 {
+        format!(
+            "tpad=start_mode=clone:start_duration={:.9},",
+            RationalTime::new(head_pad_frames, rate).to_seconds()
+        )
+    } else {
+        String::new()
+    };
     args.extend([
         "-vf".into(),
-        format!("scale={width}:{height},setpts=PTS/{speed:.6},fps={fps}"),
+        format!("{crop_filter}scale={width}:{height},setpts=PTS/{speed:.6},{pad_filter}fps={fps}"),
         "-f".into(),
         "rawvideo".into(),
         "-pix_fmt".into(),
@@ -728,15 +789,17 @@ pub fn encoder_args(
         "pipe:0".into(),
     ];
 
-    let items = collect_items(project);
-    let audio: Vec<&Item> = items.iter().filter(|item| item.audio).collect();
+    let audio = layout::audio_placements(project);
     for item in &audio {
-        args.extend(["-ss".into(), secs(item.clip.in_time(rate))]);
+        args.extend(["-ss".into(), secs(item.in_time(rate))]);
         args.extend([
             "-t".into(),
-            secs(RationalTime::new(item.clip.source_duration_frames(), rate)),
+            secs(RationalTime::new(
+                (item.duration_frames as f64 * item.speed as f64).ceil() as i64,
+                rate,
+            )),
         ]);
-        args.extend(["-i".into(), item.path.to_string()]);
+        args.extend(["-i".into(), item.path.clone()]);
     }
 
     let has_audio = !audio.is_empty();
@@ -745,7 +808,7 @@ pub fn encoder_args(
         let mut labels = Vec::new();
         for (index, item) in audio.iter().enumerate() {
             let input = index + 1;
-            chains.push(audio_chain(item, input, rate));
+            chains.push(audio_placement_chain(item, input, rate));
             labels.push(format!("[a{input}]"));
         }
         chains.push(format!(
@@ -886,6 +949,7 @@ mod tests {
                 TrackKind::Video,
                 vec![clip("c1", "a1", 60, 30, 120)],
             )],
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }
@@ -909,6 +973,7 @@ mod tests {
             settings: settings(1920, 1080),
             assets: vec![],
             tracks: vec![track("V1", TrackKind::Video, vec![])],
+            transitions: Vec::new(),
             markers: Vec::new(),
         };
         assert!(build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).is_err());
@@ -1092,6 +1157,7 @@ mod tests {
                 track("V1", TrackKind::Video, vec![clip("c1", "a1", 0, 0, 120)]),
                 track("V2", TrackKind::Video, vec![clip("c2", "a2", 0, 0, 120)]),
             ],
+            transitions: Vec::new(),
             markers: Vec::new(),
         };
         let filter = filter_of(&build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap());
@@ -1127,6 +1193,7 @@ mod tests {
                 TrackKind::Audio,
                 vec![clip("c1", "a1", 15, 0, 90)],
             )],
+            transitions: Vec::new(),
             markers: Vec::new(),
         };
         let args = build_args(&project, "/out.mp4", Preset::Fhd, None, &[]).unwrap();
@@ -1299,6 +1366,8 @@ mod tests {
             rate,
             speed: 1.0,
             hwaccel: None,
+            crop: Crop::default(),
+            head_pad_frames: 0,
         })
         .join(" ");
         assert!(
@@ -1362,10 +1431,35 @@ mod tests {
             rate,
             speed: 1.0,
             hwaccel: None,
+            crop: Crop::default(),
+            head_pad_frames: 0,
         })
         .join(" ");
         assert!(args.contains("-ss 1.001000 -t 1.001000"), "{args}");
         assert!(args.contains("fps=24000/1001"), "{args}");
+    }
+
+    #[test]
+    fn a_transition_decoder_holds_the_first_frame_for_missing_handles() {
+        let rate = Rate::fps(30);
+        let args = decoder_args(&Decode {
+            path: "/m/a.mp4",
+            kind: AssetKind::Video,
+            in_time: RationalTime::zero(rate),
+            duration: RationalTime::new(1, rate),
+            width: 640,
+            height: 360,
+            rate,
+            speed: 1.0,
+            hwaccel: None,
+            crop: Crop::default(),
+            head_pad_frames: 15,
+        })
+        .join(" ");
+        assert!(
+            args.contains("tpad=start_mode=clone:start_duration=0.500000000"),
+            "{args}"
+        );
     }
 
     #[test]
@@ -1381,6 +1475,8 @@ mod tests {
             rate,
             speed: 1.0,
             hwaccel: None,
+            crop: Crop::default(),
+            head_pad_frames: 0,
         })
         .join(" ");
         assert!(args.contains("-loop 1 -framerate 25 -t 2.000000"), "{args}");
@@ -1401,6 +1497,8 @@ mod tests {
             rate,
             speed: 1.0,
             hwaccel: Some("videotoolbox"),
+            crop: Crop::default(),
+            head_pad_frames: 0,
         })
         .join(" ");
         assert!(args.contains("-hwaccel videotoolbox -ss"), "{args}");
@@ -1475,6 +1573,7 @@ mod tests {
             settings: settings(1920, 1080),
             assets: vec![],
             tracks: vec![],
+            transitions: Vec::new(),
             markers: Vec::new(),
         };
         assert!(encoder_args(&project, "/o.mp4", Preset::Fhd, None).is_err());
@@ -1549,6 +1648,7 @@ mod tests {
                 track("V1", TrackKind::Video, vec![clip("c1", "a1", 0, 0, 60)]),
                 track("A1", TrackKind::Audio, vec![clip("c2", "a2", 30, 0, 60)]),
             ],
+            transitions: Vec::new(),
             markers: Vec::new(),
         };
         let filter = filter_of(&mix_reference_args(&project, "/tmp/mix.f32").unwrap());

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/layout.rs
@@ -11,7 +11,8 @@
 //! differently, which is exactly the divergence this removes.
 
 use crate::{
-    Asset, AssetKind, BlendMode, Clip, KeyframeTrack, Project, Rate, RationalTime, Track, TrackKind,
+    Asset, AssetKind, BlendMode, Clip, Crop, KeyframeTrack, Project, Rate, RationalTime, Stroke,
+    Track, TrackKind, VisualContent,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,6 +41,17 @@ pub struct Placement {
     pub opacity: f32,
     pub speed: f32,
     pub blend_mode: BlendMode,
+    pub crop: Crop,
+    pub overlay_style: Option<OverlayStyle>,
+    pub fade_in: i64,
+    pub fade_out: i64,
+    pub head_pad_frames: i64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OverlayStyle {
+    pub corner_radius: f32,
+    pub border: Option<Stroke>,
 }
 
 impl Placement {
@@ -59,6 +71,27 @@ impl Placement {
 
     pub fn duration(&self, rate: Rate) -> RationalTime {
         RationalTime::new(self.duration_frames, rate)
+    }
+
+    pub fn opacity_at(&self, frame: i64) -> f32 {
+        let offset = frame.saturating_sub(self.start_frame);
+        let mut opacity = self.opacity;
+        if self.fade_in > 0 {
+            opacity *= ((offset + 1) as f32 / self.fade_in as f32).clamp(0.0, 1.0);
+        }
+        let remaining = self.end_frame().saturating_sub(frame);
+        if self.fade_out > 0 {
+            opacity *= (remaining as f32 / self.fade_out as f32).clamp(0.0, 1.0);
+        }
+        opacity.clamp(0.0, 1.0)
+    }
+
+    pub fn source_frame_at(&self, frame: i64) -> i64 {
+        let offset = frame.saturating_sub(self.start_frame);
+        if offset < self.head_pad_frames {
+            return self.in_frame;
+        }
+        self.in_frame + ((offset - self.head_pad_frames) as f64 * self.speed as f64).floor() as i64
     }
 }
 
@@ -200,6 +233,44 @@ pub fn audio_placements(project: &Project) -> Vec<AudioPlacement> {
             }
         }
     }
+    for track in project
+        .tracks
+        .iter()
+        .filter(|track| track.kind == TrackKind::Video && track.contributes())
+    {
+        for item in &track.visual_items {
+            let VisualContent::VideoOverlay {
+                asset_id,
+                in_point,
+                audio_enabled: true,
+                ..
+            } = &item.content
+            else {
+                continue;
+            };
+            let Some(asset) = project.asset(asset_id) else {
+                continue;
+            };
+            if !asset.has_audio || item.duration <= 0 {
+                continue;
+            }
+            placements.push(AudioPlacement {
+                clip_id: item.id.clone(),
+                asset_id: asset.id.clone(),
+                path: asset.path.clone(),
+                kind: asset.kind,
+                start_frame: item.start,
+                duration_frames: item.duration,
+                in_frame: *in_point,
+                volume: 1.0,
+                volume_keyframes: KeyframeTrack::default(),
+                fade_in: 0,
+                fade_out: 0,
+                speed: 1.0,
+                preserve_pitch: true,
+            });
+        }
+    }
     placements
 }
 
@@ -215,6 +286,8 @@ pub struct Layer {
     pub dst: Rect,
     pub opacity: f32,
     pub blend_mode: BlendMode,
+    pub crop: Crop,
+    pub overlay_style: Option<OverlayStyle>,
 }
 
 impl Layer {
@@ -280,6 +353,12 @@ pub fn placements(project: &Project, out_width: u32, out_height: u32) -> Vec<Pla
             if !matches!(asset.kind, AssetKind::Video | AssetKind::Image) {
                 continue;
             }
+            let fade_out = project
+                .transitions
+                .iter()
+                .find(|transition| transition.from_clip_id == clip.id)
+                .map(|transition| transition.duration)
+                .unwrap_or(0);
             placements.push(Placement {
                 clip_id: clip.id.clone(),
                 asset_id: asset.id.clone(),
@@ -292,6 +371,101 @@ pub fn placements(project: &Project, out_width: u32, out_height: u32) -> Vec<Pla
                 opacity: clip.opacity.clamp(0.0, 1.0),
                 speed: clip.speed,
                 blend_mode: clip.blend_mode,
+                crop: Crop::default(),
+                overlay_style: None,
+                fade_in: 0,
+                fade_out,
+                head_pad_frames: 0,
+            });
+        }
+        for transition in project
+            .transitions
+            .iter()
+            .filter(|transition| transition.track_id == track.id)
+        {
+            let Some(incoming) = track.clip(&transition.to_clip_id) else {
+                continue;
+            };
+            let Some(asset) = project.asset(&incoming.asset_id) else {
+                continue;
+            };
+            let source_span = (transition.duration as f64 * incoming.speed as f64).ceil() as i64;
+            let missing_source = (source_span - incoming.in_point).max(0);
+            let head_pad_frames =
+                (missing_source as f64 / incoming.speed.max(0.0001) as f64).ceil() as i64;
+            placements.push(Placement {
+                clip_id: format!("transition:{}", transition.id),
+                asset_id: asset.id.clone(),
+                path: asset.path.clone(),
+                kind: asset.kind,
+                start_frame: incoming.start - transition.duration,
+                duration_frames: transition.duration,
+                in_frame: incoming.in_point.saturating_sub(source_span).max(0),
+                dst: fit_rect(asset.width, asset.height, out_width, out_height),
+                opacity: incoming.opacity.clamp(0.0, 1.0),
+                speed: incoming.speed,
+                blend_mode: incoming.blend_mode,
+                crop: Crop::default(),
+                overlay_style: None,
+                fade_in: transition.duration,
+                fade_out: 0,
+                head_pad_frames,
+            });
+        }
+        let scale_x = out_width as f32 / project.settings.width.max(1) as f32;
+        let scale_y = out_height as f32 / project.settings.height.max(1) as f32;
+        let mut items: Vec<_> = track
+            .visual_items
+            .iter()
+            .filter(|item| matches!(item.content, VisualContent::VideoOverlay { .. }))
+            .collect();
+        items.sort_by_key(|item| item.z_index);
+        for item in items {
+            let VisualContent::VideoOverlay {
+                asset_id,
+                in_point,
+                crop,
+                corner_radius,
+                border,
+                ..
+            } = &item.content
+            else {
+                continue;
+            };
+            let Some(asset) = project.asset(asset_id) else {
+                continue;
+            };
+            let transform = item.transform_at(item.start);
+            let width = even((transform.width * scale_x) as f64).max(2);
+            let height = even((transform.height * scale_y) as f64).max(2);
+            placements.push(Placement {
+                clip_id: item.id.clone(),
+                asset_id: asset.id.clone(),
+                path: asset.path.clone(),
+                kind: asset.kind,
+                start_frame: item.start,
+                duration_frames: item.duration,
+                in_frame: *in_point,
+                dst: Rect {
+                    x: (transform.x * scale_x).round() as i32,
+                    y: (transform.y * scale_y).round() as i32,
+                    w: width,
+                    h: height,
+                },
+                opacity: transform.opacity.clamp(0.0, 1.0),
+                speed: 1.0,
+                blend_mode: item.blend_mode,
+                crop: *crop,
+                overlay_style: Some(OverlayStyle {
+                    corner_radius: *corner_radius * scale_x.min(scale_y),
+                    border: border.clone().map(|mut stroke| {
+                        stroke.width *= scale_x.min(scale_y);
+                        stroke
+                    }),
+                }),
+                fade_in: 0,
+                fade_out: 0,
+                head_pad_frames: 0,
             });
         }
     }
@@ -305,16 +479,21 @@ pub fn layers_at(project: &Project, frame: i64, out_width: u32, out_height: u32)
     placements(project, out_width, out_height)
         .into_iter()
         .filter(|placement| placement.covers(frame))
-        .map(|placement| Layer {
-            source_frame: placement.in_frame
-                + ((frame - placement.start_frame) as f64 * placement.speed as f64).floor() as i64,
-            clip_id: placement.clip_id,
-            asset_id: placement.asset_id,
-            path: placement.path,
-            kind: placement.kind,
-            dst: placement.dst,
-            opacity: placement.opacity,
-            blend_mode: placement.blend_mode,
+        .map(|placement| {
+            let source_frame = placement.source_frame_at(frame);
+            let opacity = placement.opacity_at(frame);
+            Layer {
+                source_frame,
+                clip_id: placement.clip_id,
+                asset_id: placement.asset_id,
+                path: placement.path,
+                kind: placement.kind,
+                dst: placement.dst,
+                opacity,
+                blend_mode: placement.blend_mode,
+                crop: placement.crop,
+                overlay_style: placement.overlay_style,
+            }
         })
         .collect()
 }
@@ -344,7 +523,7 @@ pub fn frame_time(index: i64, rate: Rate) -> RationalTime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Asset, Clip, ProjectSettings, Track};
+    use crate::{Asset, Clip, ProjectSettings, Track, Transition, TransitionKind};
 
     fn asset(id: &str, kind: AssetKind, width: u32, height: u32) -> Asset {
         Asset {
@@ -389,6 +568,7 @@ mod tests {
             },
             assets,
             tracks,
+            transitions: Vec::new(),
             markers: Vec::new(),
         }
     }
@@ -438,6 +618,69 @@ mod tests {
                 h: 1080
             }
         );
+    }
+
+    #[test]
+    fn a_dissolve_decodes_both_clips_only_before_the_boundary() {
+        let mut incoming = clip("c2", "a2", 60, 30, 90);
+        incoming.opacity = 0.8;
+        let mut project = project(
+            vec![video_track(
+                "V1",
+                vec![clip("c1", "a1", 0, 0, 60), incoming],
+            )],
+            vec![
+                asset("a1", AssetKind::Video, 1920, 1080),
+                asset("a2", AssetKind::Video, 1920, 1080),
+            ],
+        );
+        project.transitions.push(Transition {
+            id: "x1".into(),
+            track_id: "V1".into(),
+            from_clip_id: "c1".into(),
+            to_clip_id: "c2".into(),
+            duration: 15,
+            kind: TransitionKind::Dissolve,
+        });
+
+        assert_eq!(layers_at(&project, 44, 1920, 1080).len(), 1);
+        let start = layers_at(&project, 45, 1920, 1080);
+        assert_eq!(start.len(), 2);
+        assert_eq!(start[1].source_frame, 15);
+        assert!(start[0].opacity > start[1].opacity);
+        let end = layers_at(&project, 59, 1920, 1080);
+        assert_eq!(end.len(), 2);
+        assert_eq!(end[1].source_frame, 29);
+        assert!(end[0].opacity < end[1].opacity);
+        let after = layers_at(&project, 60, 1920, 1080);
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].clip_id, "c2");
+        assert!((after[0].opacity - 0.8).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn a_dissolve_without_source_handles_holds_the_first_incoming_frame() {
+        let mut project = project(
+            vec![video_track(
+                "V1",
+                vec![clip("c1", "a1", 0, 0, 60), clip("c2", "a2", 60, 0, 60)],
+            )],
+            vec![
+                asset("a1", AssetKind::Video, 1920, 1080),
+                asset("a2", AssetKind::Video, 1920, 1080),
+            ],
+        );
+        project.transitions.push(Transition {
+            id: "x1".into(),
+            track_id: "V1".into(),
+            from_clip_id: "c1".into(),
+            to_clip_id: "c2".into(),
+            duration: 15,
+            kind: TransitionKind::Dissolve,
+        });
+
+        assert_eq!(layers_at(&project, 45, 1920, 1080)[1].source_frame, 0);
+        assert_eq!(layers_at(&project, 59, 1920, 1080)[1].source_frame, 0);
     }
 
     #[test]

--- a/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/crates/render/src/lib.rs
@@ -18,9 +18,9 @@ pub mod tools;
 pub mod workspace;
 
 pub use makevideo_edit::{
-    asset_id, Asset, AssetKind, BlendMode, Clip, Easing, GradientStop, Keyframe, KeyframeTrack,
-    Paint, PaintPoint, Project, ProjectSettings, Shadow, ShapeKind, Stroke, TextAlign, TextStyle,
-    Track, TrackKind, VisualAnimation, VisualContent, VisualItem, VisualProperty, VisualStyle,
-    VisualTransform, FORMAT_VERSION,
+    asset_id, Asset, AssetKind, BlendMode, Clip, Crop, Easing, GradientStop, Keyframe,
+    KeyframeTrack, Paint, PaintPoint, Project, ProjectSettings, Shadow, ShapeKind, Stroke,
+    TextAlign, TextStyle, Track, TrackKind, Transition, TransitionKind, VisualAnimation,
+    VisualContent, VisualItem, VisualProperty, VisualStyle, VisualTransform, FORMAT_VERSION,
 };
 pub use makevideo_time::{Rate, RationalTime};

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -199,6 +199,7 @@
             <button id="source-insert">Insert</button>
             <button id="source-overwrite">Overwrite</button>
             <button id="source-append">Append</button>
+            <button id="source-pip" title="Place the selected video over the timeline at the playhead">Add PIP</button>
           </div>
         </section>
 
@@ -321,6 +322,20 @@
               <label class="row check"><input id="shape-start-arrow" type="checkbox" /> Start arrow</label>
               <label class="row check"><input id="shape-end-arrow" type="checkbox" /> End arrow</label>
             </div>
+          </div>
+          <div id="pip-panel" hidden>
+            <h3>Picture in Picture</h3>
+            <div class="field-pair"><label>Crop left % <input id="pip-crop-left" type="number" min="0" max="95" step="1" /></label><label>Crop right % <input id="pip-crop-right" type="number" min="0" max="95" step="1" /></label></div>
+            <div class="field-pair"><label>Crop top % <input id="pip-crop-top" type="number" min="0" max="95" step="1" /></label><label>Crop bottom % <input id="pip-crop-bottom" type="number" min="0" max="95" step="1" /></label></div>
+            <label class="row">Corner radius <input id="pip-corner-radius" type="number" min="0" step="1" /></label>
+            <label class="row">Border color <input id="pip-border-color" type="color" /></label>
+            <label class="row">Border width <input id="pip-border-width" type="number" min="0" step="1" /></label>
+            <label class="row check"><input id="pip-audio-enabled" type="checkbox" /> Play overlay audio</label>
+          </div>
+          <div id="transition-panel" hidden>
+            <h3>Dissolve</h3>
+            <label class="row">Duration (frames) <input id="transition-duration" type="number" min="1" step="1" /></label>
+            <button id="transition-remove" type="button">Remove transition</button>
           </div>
           <div id="subtitle-panel" hidden>
             <h3>Subtitle</h3>

--- a/product/akbun-makevideo/workspace/src/inspector-ui.js
+++ b/product/akbun-makevideo/workspace/src/inspector-ui.js
@@ -102,9 +102,9 @@
       return { kind: 'solid', color: preserveAlpha(color, paintColors(previous, color)[0]) };
     }
 
-    function inspectorMessage(tab, item, clipTargets) {
+    function inspectorMessage(tab, item, clipTargets, transition) {
       if (tab === 'effects') return 'No effect is selected.';
-      if (tab === 'transition') return 'No transition is selected.';
+      if (tab === 'transition') return transition ? '' : 'Select a clip beside a transition.';
       if (tab === 'image') {
         const asset = L.findAsset(state.project, state.selectedAssetId);
         return asset && asset.kind === 'image'
@@ -128,12 +128,17 @@
       const item = selectedVisualItem();
       const text = item && item.content && item.content.kind === 'text' ? item.content : null;
       const shape = item && item.content && item.content.kind === 'shape' ? item.content : null;
+      const pip = item && item.content && item.content.kind === 'videoOverlay' ? item.content : null;
       const track = item && state.project.tracks.find((candidate) => (candidate.visualItems || []).some((entry) => entry.id === item.id));
       const subtitle = track && track.kind === 'subtitle';
       const clipTargets = !item && liveSelection()
         ? I.clipTargets(state.project, liveSelection())
         : null;
       const clip = clipTargets && clipTargets.selected;
+      const transition = !item && liveSelection()
+        ? (state.project.transitions || []).find((entry) =>
+          entry.fromClipId === liveSelection() || entry.toClipId === liveSelection())
+        : null;
       const tab = state.inspectorTab || 'video';
       const video = tab === 'video';
       const audio = tab === 'audio';
@@ -143,11 +148,13 @@
       dom.textPanel.hidden = !video || !text || subtitle;
       dom.subtitlePanel.hidden = !video || !text || !subtitle;
       dom.shapePanel.hidden = !video || !shape;
+      dom.pipPanel.hidden = !video || !pip;
+      dom.transitionPanel.hidden = tab !== 'transition' || !transition;
       dom.clipPanel.hidden = !clip || (!video && !audio);
       dom.transformPanel.hidden = !video || !item;
       dom.keyframePanel.hidden = !selectedKeyframe;
-      dom.inspectorEmpty.hidden = hasProperties;
-      dom.inspectorEmpty.textContent = inspectorMessage(tab, item, clipTargets);
+      dom.inspectorEmpty.hidden = hasProperties || Boolean(transition);
+      dom.inspectorEmpty.textContent = inspectorMessage(tab, item, clipTargets, transition);
       for (const button of dom.panelTabBar.querySelectorAll('[data-inspector-tab]')) {
         const active = button.dataset.inspectorTab === tab;
         button.setAttribute('aria-pressed', String(active));
@@ -205,6 +212,18 @@
         dom.shapeShadowY.value = shape.shadow ? shape.shadow.y : 0;
         dom.shapeShadowBlur.value = shape.shadow ? shape.shadow.blur : 0;
       }
+      if (pip) {
+        const crop = pip.crop || {};
+        dom.pipCropLeft.value = Math.round((crop.left || 0) * 100);
+        dom.pipCropTop.value = Math.round((crop.top || 0) * 100);
+        dom.pipCropRight.value = Math.round((crop.right || 0) * 100);
+        dom.pipCropBottom.value = Math.round((crop.bottom || 0) * 100);
+        dom.pipCornerRadius.value = pip.cornerRadius || 0;
+        dom.pipBorderColor.value = hexColor(pip.border && pip.border.color, '#ffffff');
+        dom.pipBorderWidth.value = pip.border ? pip.border.width : 0;
+        dom.pipAudioEnabled.checked = Boolean(pip.audioEnabled);
+      }
+      if (transition) dom.transitionDuration.value = transition.duration;
       if (!text) return;
       if (subtitle) {
         dom.subtitleValue.value = text.text || '';
@@ -299,6 +318,57 @@
       edit({ op: 'setVisualContent', itemId: item.id, content })
         .then(() => selectVisualItem(item.id))
         .catch((error) => reportError(error, 'shape:edit'));
+    }
+
+    function updateSelectedPip() {
+      const item = selectedVisualItem();
+      if (!item || item.content.kind !== 'videoOverlay') return;
+      const percent = (input) => Math.max(0, Math.min(0.95, (Number(input.value) || 0) / 100));
+      const crop = {
+        left: percent(dom.pipCropLeft),
+        top: percent(dom.pipCropTop),
+        right: percent(dom.pipCropRight),
+        bottom: percent(dom.pipCropBottom),
+      };
+      if (crop.left + crop.right >= 1) crop.right = Math.max(0, 0.99 - crop.left);
+      if (crop.top + crop.bottom >= 1) crop.bottom = Math.max(0, 0.99 - crop.top);
+      const borderWidth = Math.max(0, Number(dom.pipBorderWidth.value) || 0);
+      const content = {
+        ...item.content,
+        crop,
+        cornerRadius: Math.max(0, Number(dom.pipCornerRadius.value) || 0),
+        border: borderWidth > 0 ? {
+          color: preserveAlpha(dom.pipBorderColor.value, item.content.border && item.content.border.color),
+          width: borderWidth,
+        } : null,
+        audioEnabled: dom.pipAudioEnabled.checked,
+      };
+      edit({ op: 'setVisualContent', itemId: item.id, content })
+        .then(() => selectVisualItem(item.id))
+        .catch((error) => reportError(error, 'pip:edit'));
+    }
+
+    function selectedTransition() {
+      const clipId = liveSelection();
+      return (state.project.transitions || []).find((entry) =>
+        entry.fromClipId === clipId || entry.toClipId === clipId) || null;
+    }
+
+    function updateSelectedTransition() {
+      const transition = selectedTransition();
+      if (!transition) return;
+      edit({
+        op: 'setTransitionDuration',
+        transitionId: transition.id,
+        duration: Math.max(1, Math.round(Number(dom.transitionDuration.value) || 1)),
+      }).catch((error) => reportError(error, 'transition:edit'));
+    }
+
+    function removeSelectedTransition() {
+      const transition = selectedTransition();
+      if (!transition) return;
+      edit({ op: 'removeTransition', transitionId: transition.id })
+        .catch((error) => reportError(error, 'transition:remove'));
     }
 
     function changeSelectedFillLayers(kind, add) {
@@ -573,6 +643,14 @@
       for (const input of [dom.subtitleFont, dom.subtitleSize, dom.subtitleColor]) {
         input.addEventListener('change', updateSubtitleStyle);
       }
+      for (const input of [
+        dom.pipCropLeft, dom.pipCropTop, dom.pipCropRight, dom.pipCropBottom,
+        dom.pipCornerRadius, dom.pipBorderColor, dom.pipBorderWidth, dom.pipAudioEnabled,
+      ]) {
+        input.addEventListener('change', updateSelectedPip);
+      }
+      dom.transitionDuration.addEventListener('change', updateSelectedTransition);
+      dom.transitionRemove.addEventListener('click', removeSelectedTransition);
       dom.clipOpacity.addEventListener('change', updateSelectedVideoOpacity);
       dom.clipVolume.addEventListener('change', updateSelectedAudioVolume);
       dom.visualBlendMode.addEventListener('change', () => {

--- a/product/akbun-makevideo/workspace/src/inspector-ui.js
+++ b/product/akbun-makevideo/workspace/src/inspector-ui.js
@@ -136,8 +136,7 @@
         : null;
       const clip = clipTargets && clipTargets.selected;
       const transition = !item && liveSelection()
-        ? (state.project.transitions || []).find((entry) =>
-          entry.fromClipId === liveSelection() || entry.toClipId === liveSelection())
+        ? L.transitionForClip(state.project, liveSelection(), getPreview().position())
         : null;
       const tab = state.inspectorTab || 'video';
       const video = tab === 'video';
@@ -223,7 +222,10 @@
         dom.pipBorderWidth.value = pip.border ? pip.border.width : 0;
         dom.pipAudioEnabled.checked = Boolean(pip.audioEnabled);
       }
-      if (transition) dom.transitionDuration.value = transition.duration;
+      if (transition) {
+        dom.transitionDuration.max = L.transitionMaxDuration(state.project, transition);
+        dom.transitionDuration.value = transition.duration;
+      }
       if (!text) return;
       if (subtitle) {
         dom.subtitleValue.value = text.text || '';
@@ -350,17 +352,20 @@
 
     function selectedTransition() {
       const clipId = liveSelection();
-      return (state.project.transitions || []).find((entry) =>
-        entry.fromClipId === clipId || entry.toClipId === clipId) || null;
+      return L.transitionForClip(state.project, clipId, getPreview().position());
     }
 
     function updateSelectedTransition() {
       const transition = selectedTransition();
       if (!transition) return;
+      const maxDuration = L.transitionMaxDuration(state.project, transition);
       edit({
         op: 'setTransitionDuration',
         transitionId: transition.id,
-        duration: Math.max(1, Math.round(Number(dom.transitionDuration.value) || 1)),
+        duration: Math.max(1, Math.min(
+          maxDuration,
+          Math.round(Number(dom.transitionDuration.value) || 1),
+        )),
       }).catch((error) => reportError(error, 'transition:edit'));
     }
 

--- a/product/akbun-makevideo/workspace/src/preview.js
+++ b/product/akbun-makevideo/workspace/src/preview.js
@@ -242,8 +242,12 @@ function createPreview(options) {
       live.add(clip.id);
       entry.element.classList.add('on');
       if (wantsPicture) {
-        entry.element.style.zIndex = String(videoTracks.indexOf(track) + 1);
-        entry.element.style.opacity = String(clamp01(clip.opacity));
+        entry.element.style.zIndex = String((videoTracks.indexOf(track) + 1) * 100);
+        const transition = (project.transitions || []).find((item) => item.fromClipId === clip.id);
+        const transitionOpacity = transition && positionFrames >= L.clipEnd(clip) - transition.duration
+          ? (L.clipEnd(clip) - positionFrames) / transition.duration
+          : 1;
+        entry.element.style.opacity = String(clamp01(clip.opacity * transitionOpacity));
       }
       if (entry.kind === 'image') continue;
 
@@ -251,11 +255,113 @@ function createPreview(options) {
       media.push({ entry, track, clip, target, wasLive });
     }
 
+    for (const track of videoTracks) {
+      if (track.hidden) continue;
+      for (const item of track.visualItems || []) {
+        if (!item.content || item.content.kind !== 'videoOverlay') continue;
+        if (positionFrames < item.start || positionFrames >= item.start + item.duration) continue;
+        const asset = L.findAsset(project, item.content.assetId);
+        if (!asset) continue;
+        const entry = entryFor(item, asset, true);
+        const wasLive = entry.element.classList.contains('on');
+        const transform = L.visualTransformAt(item, positionFrames);
+        const crop = item.content.crop || {};
+        const border = item.content.border;
+        live.add(item.id);
+        entry.element.classList.add('on');
+        Object.assign(entry.element.style, {
+          inset: 'auto',
+          left: `${(transform.x / project.settings.width) * 100}%`,
+          top: `${(transform.y / project.settings.height) * 100}%`,
+          width: `${(transform.width / project.settings.width) * 100}%`,
+          height: `${(transform.height / project.settings.height) * 100}%`,
+          objectFit: 'cover',
+          opacity: String(clamp01(transform.opacity)),
+          zIndex: String((videoTracks.indexOf(track) + 1) * 100 + 50 + (item.zIndex || 0)),
+          clipPath: `inset(${(crop.top || 0) * 100}% ${(crop.right || 0) * 100}% ${(crop.bottom || 0) * 100}% ${(crop.left || 0) * 100}% round ${item.content.cornerRadius || 0}px)`,
+          border: border ? `${border.width}px solid ${border.color}` : '0',
+          boxSizing: 'border-box',
+          borderRadius: `${item.content.cornerRadius || 0}px`,
+        });
+        const clip = {
+          id: item.id,
+          start: item.start,
+          in: item.content.inPoint || 0,
+          out: (item.content.inPoint || 0) + item.duration,
+          speed: 1,
+          preservePitch: true,
+          volume: 1,
+        };
+        const target = T.framesToSeconds(clip.in + positionFrames - item.start, rate());
+        media.push({
+          entry,
+          track,
+          clip,
+          target,
+          wasLive,
+          overlayAudioEnabled: Boolean(item.content.audioEnabled),
+        });
+      }
+    }
+
+    for (const transition of project.transitions || []) {
+      const from = L.findClip(project, transition.fromClipId);
+      const to = L.findClip(project, transition.toClipId);
+      if (!from || !to || from.track.hidden) continue;
+      const start = to.clip.start - transition.duration;
+      if (positionFrames < start || positionFrames >= to.clip.start) continue;
+      const asset = L.findAsset(project, to.clip.assetId);
+      if (!asset) continue;
+      const proxy = { id: `transition:${transition.id}` };
+      const entry = entryFor(proxy, asset, true);
+      const wasLive = entry.element.classList.contains('on');
+      const offset = positionFrames - start;
+      const speed = to.clip.speed || 1;
+      const sourceSpan = Math.ceil(transition.duration * speed);
+      const missingSource = Math.max(0, sourceSpan - to.clip.in);
+      const headPad = Math.ceil(missingSource / speed);
+      const sourceFrame = offset < headPad
+        ? 0
+        : Math.max(0, to.clip.in - sourceSpan) + Math.floor((offset - headPad) * speed);
+      live.add(proxy.id);
+      entry.element.classList.add('on');
+      Object.assign(entry.element.style, {
+        inset: '0',
+        left: '0',
+        top: '0',
+        width: '100%',
+        height: '100%',
+        objectFit: 'contain',
+        opacity: String(clamp01((to.clip.opacity ?? 1) * ((offset + 1) / transition.duration))),
+        zIndex: String((videoTracks.indexOf(to.track) + 1) * 100 + 1),
+        clipPath: 'none',
+        border: '0',
+        borderRadius: '0',
+      });
+      const clip = {
+        id: proxy.id,
+        start,
+        in: Math.max(0, to.clip.in - sourceSpan),
+        out: to.clip.in,
+        speed,
+        preservePitch: true,
+        volume: 0,
+      };
+      media.push({
+        entry,
+        track: to.track,
+        clip,
+        target: T.framesToSeconds(sourceFrame, rate()),
+        wasLive,
+        overlayAudioEnabled: false,
+      });
+    }
+
     const reference =
       media.find(({ clip }) => clock && clip.id === clock.clip.id) || media[0] || null;
 
     for (const item of media) {
-      const { entry, track, clip, target, wasLive } = item;
+      const { entry, track, clip, target, wasLive, overlayAudioEnabled } = item;
       const drift = target - entry.element.currentTime;
       const isReference = item === reference;
       const needsInitialSeek =
@@ -284,7 +390,9 @@ function createPreview(options) {
           : clip.volume
       );
       entry.element.muted =
-        (track.kind === 'video' && track.muted) || (scrubbing && muteWhileScrubbing);
+        overlayAudioEnabled === false ||
+        (track.kind === 'video' && track.muted) ||
+        (scrubbing && muteWhileScrubbing);
       if (
         qualityMonitor &&
         (playing || starting) &&

--- a/product/akbun-makevideo/workspace/src/renderer-assets-ui.js
+++ b/product/akbun-makevideo/workspace/src/renderer-assets-ui.js
@@ -362,6 +362,7 @@
       for (const button of [dom.sourceInsert, dom.sourceOverwrite, dom.sourceAppend]) {
         button.disabled = !command;
       }
+      dom.sourcePip.disabled = !asset || asset.kind !== 'video' || !selection;
     }
 
     function setSourceMark(which) {

--- a/product/akbun-makevideo/workspace/src/renderer-timeline-ui.js
+++ b/product/akbun-makevideo/workspace/src/renderer-timeline-ui.js
@@ -156,7 +156,13 @@
       // A project should always contain content, but keep an incomplete saved
       // visual item from taking down the whole timeline while it is repaired.
       const content = item.content || {};
-      const kind = content.kind === 'shape' ? 'shape' : content.kind === 'adjustment' ? 'adjustment' : 'text';
+      const kind = content.kind === 'shape'
+        ? 'shape'
+        : content.kind === 'adjustment'
+          ? 'adjustment'
+          : content.kind === 'videoOverlay'
+            ? 'pip'
+            : 'text';
       node.className = track.kind === 'subtitle' ? 'clip subtitle' : `clip visual ${kind}`;
       node.dataset.visualItemId = item.id;
       node.style.left = `${L.framesToPx(item.start, rate(), state.pxPerSecond)}px`;
@@ -168,6 +174,8 @@
         ? `Shape — ${content.shape || 'rectangle'}`
         : kind === 'adjustment'
           ? `Adjustment — ${baseName(content.lutPath || '')}`
+          : kind === 'pip'
+            ? `PIP — ${(L.findAsset(state.project, content.assetId) || {}).name || 'Video'}`
           : content.text || (track.kind === 'subtitle' ? 'Subtitle' : 'Text');
       const left = document.createElement('span');
       left.className = 'handle left';
@@ -181,6 +189,19 @@
           node.appendChild(keyframeDot('visual', item.id, property, key, item.start, parseFloat(node.style.width), row));
         }
       }
+      return node;
+    }
+
+    function transitionElement(transition) {
+      const incoming = L.findClip(state.project, transition.toClipId);
+      if (!incoming) return null;
+      const node = document.createElement('div');
+      node.className = 'timeline-transition';
+      node.dataset.transitionId = transition.id;
+      node.style.left = `${L.framesToPx(incoming.clip.start - transition.duration, rate(), state.pxPerSecond)}px`;
+      node.style.width = `${Math.max(4, L.framesToPx(transition.duration, rate(), state.pxPerSecond))}px`;
+      node.title = `Dissolve · ${transition.duration} frames`;
+      node.textContent = 'Dissolve';
       return node;
     }
 
@@ -234,6 +255,10 @@
           for (const item of track.visualItems || []) lane.appendChild(visualElement(track, item));
         } else {
           for (const clip of track.clips) lane.appendChild(clipElement(track, clip));
+          for (const transition of (state.project.transitions || []).filter((entry) => entry.trackId === track.id)) {
+            const node = transitionElement(transition);
+            if (node) lane.appendChild(node);
+          }
           // Text and shape layers ride on video tracks beside the clips. Without
           // an element here they exist only on the stage, which is how a layer
           // ends up impossible to move, trim or delete.
@@ -496,7 +521,7 @@
     /** Add a visual item and select what Rust made of it. `placement` is
      *  `{ trackId, frame }` from a drop; without one Rust chooses the top overlay
      *  track at the playhead. */
-    async function addVisualItem(placement, content, transform) {
+    async function addVisualItem(placement, content, transform, duration = L.defaultVisualItemFrames(rate())) {
       const track = visualTargetTrack(placement);
       if (placement && !track) return;
       const known = new Set();
@@ -513,7 +538,7 @@
         ...(placement ? { trackId: track.id } : {}),
         content,
         start: placement ? Math.round(placement.frame) : Math.round(preview.position()),
-        duration: L.defaultVisualItemFrames(rate()),
+        duration,
         transform: { ...transform, rotation: 0, opacity: 1 },
         zIndex: 0,
       };
@@ -529,6 +554,35 @@
         await window.api.message(
           `The ${L.MAX_TRACKS_PER_KIND}-video-track limit was reached. The layer was added to the top video track.`,
           { title: 'Layer added to existing track', kind: 'warning' },
+        );
+      }
+    }
+
+    async function addPip() {
+      const asset = L.findAsset(state.project, state.selectedAssetId);
+      const selection = state.sourceSelection;
+      if (!asset || asset.kind !== 'video' || !selection) return;
+      const width = state.project.settings.width * 0.32;
+      const height = width * (asset.height || 9) / (asset.width || 16);
+      await addVisualItem(null, {
+        kind: 'videoOverlay',
+        assetId: asset.id,
+        inPoint: selection.inPoint,
+        crop: { left: 0, top: 0, right: 0, bottom: 0 },
+        cornerRadius: 24,
+        border: { color: '#ffffff', width: 4 },
+        audioEnabled: Boolean(dom.sourceAudio.checked && asset.hasAudio),
+      }, {
+        x: state.project.settings.width - width - state.project.settings.width * 0.05,
+        y: state.project.settings.height - height - state.project.settings.height * 0.05,
+        width,
+        height,
+      }, Math.max(1, selection.outPoint - selection.inPoint));
+      const item = stageController.selectedVisualItem();
+      if (item && L.videoSourceCountAt(state.project, item.start) > L.MAX_REALTIME_VIDEO_SOURCES) {
+        await window.api.message(
+          `More than ${L.MAX_REALTIME_VIDEO_SOURCES} video sources overlap here. Preview may drop frames; export remains exact.`,
+          { title: 'Playback budget exceeded', kind: 'warning' },
         );
       }
     }
@@ -689,7 +743,7 @@
       inspectorController.render();
     }
 
-    return { setRuntime, renderHeads, clipElement, keyframeDot, visualElement, drawWaveform, renderLanes, renderRuler, renderMarkerList, updateHistoryUi, updateMonitorZoomUi, renderTimeline, checkLutFiles, refresh, updatePlayhead, seekPreviousEdit, seekNextEdit, seekTimelineStart, seekTimelineEnd, seekTimelineOffset, followPlayhead, closeTimelineContextMenu, openTimelineContextMenu, updateLinkUi, selectAsset, liveSelection, splitAtPlayhead, addMarker, visualTargetTrack, addVisualItem, addText, shapeTransform, addShape, addSubtitle, importSrt, exportSrt, deleteSelected, toggleClipLink, setClipLut, addAdjustmentLayer, addVisualKeyframesAt, addVolumeKeyframeAt };
+    return { setRuntime, renderHeads, clipElement, keyframeDot, visualElement, drawWaveform, renderLanes, renderRuler, renderMarkerList, updateHistoryUi, updateMonitorZoomUi, renderTimeline, checkLutFiles, refresh, updatePlayhead, seekPreviousEdit, seekNextEdit, seekTimelineStart, seekTimelineEnd, seekTimelineOffset, followPlayhead, closeTimelineContextMenu, openTimelineContextMenu, updateLinkUi, selectAsset, liveSelection, splitAtPlayhead, addMarker, visualTargetTrack, addVisualItem, addPip, addText, shapeTransform, addShape, addSubtitle, importSrt, exportSrt, deleteSelected, toggleClipLink, setClipLut, addAdjustmentLayer, addVisualKeyframesAt, addVolumeKeyframeAt };
   }
 
   return { createRendererTimelineUi };

--- a/product/akbun-makevideo/workspace/src/renderer-wiring.js
+++ b/product/akbun-makevideo/workspace/src/renderer-wiring.js
@@ -65,6 +65,7 @@
       addVolumeKeyframeAt,
       setClipLut,
       addAdjustmentLayer,
+      addPip,
       persistSettings,
       closeSheet,
       fillGraphicsDevices,
@@ -244,6 +245,7 @@
       dom.sourceInsert.addEventListener('click', () => placeSource('insert'));
       dom.sourceOverwrite.addEventListener('click', () => placeSource('overwrite'));
       dom.sourceAppend.addEventListener('click', () => placeSource('append'));
+      dom.sourcePip.addEventListener('click', addPip);
       for (const input of [dom.sourceVideo, dom.sourceAudio, dom.sourceRipple]) {
         input.addEventListener('change', renderSourceMonitor);
       }
@@ -283,6 +285,7 @@
     }
 
     function wireTimeline() {
+      dom.scroll.addEventListener('wheel', timelineInteractions.scrollHorizontally, { passive: false });
       dom.zoom.addEventListener('input', () => {
         const at = preview.position();
         state.pxPerSecond = zoomToPxPerSecond(dom.zoom.value);
@@ -429,12 +432,39 @@
           stageController.selectClip(clip.dataset.clipId);
           const found = L.findClip(state.project, clip.dataset.clipId);
           const frame = frameAtClientX(event.clientX);
+          const transition = (state.project.transitions || []).find((entry) =>
+            entry.fromClipId === clip.dataset.clipId || entry.toClipId === clip.dataset.clipId);
+          const index = found.track.clips.findIndex((entry) => entry.id === clip.dataset.clipId);
+          const next = found.track.clips[index + 1];
+          const canAddTransition = found.track.kind === 'video' && next &&
+            L.clipEnd(found.clip) === next.start;
+          const transitionAction = transition
+            ? [{
+              label: 'Remove Dissolve',
+              run: () => edit({ op: 'removeTransition', transitionId: transition.id }),
+            }]
+            : canAddTransition
+              ? [{
+                label: 'Add Dissolve',
+                run: () => edit({
+                  op: 'addTransition',
+                  fromClipId: found.clip.id,
+                  toClipId: next.id,
+                  duration: Math.max(1, Math.min(
+                    Math.round(T.rateToNumber(rate()) / 2),
+                    L.clipDuration(found.clip),
+                    L.clipDuration(next),
+                  )),
+                }),
+              }]
+              : [];
           openTimelineContextMenu(event, [
             { label: 'Add Volume Keyframe Here', run: () => addVolumeKeyframeAt(found.clip, frame) },
             { label: 'Apply 3D LUT…', run: () => setClipLut(clip.dataset.clipId) },
             ...(L.findClip(state.project, clip.dataset.clipId).clip.lutPath
               ? [{ label: 'Remove 3D LUT', run: () => edit({ op: 'setClipLut', clipId: clip.dataset.clipId, lutPath: null }) }]
               : []),
+            ...transitionAction,
             { label: 'Delete Clip', run: () => deleteSelected(false) },
             { label: 'Ripple Delete', run: () => deleteSelected(true) },
           ]);

--- a/product/akbun-makevideo/workspace/src/renderer-wiring.js
+++ b/product/akbun-makevideo/workspace/src/renderer-wiring.js
@@ -432,8 +432,7 @@
           stageController.selectClip(clip.dataset.clipId);
           const found = L.findClip(state.project, clip.dataset.clipId);
           const frame = frameAtClientX(event.clientX);
-          const transition = (state.project.transitions || []).find((entry) =>
-            entry.fromClipId === clip.dataset.clipId || entry.toClipId === clip.dataset.clipId);
+          const transition = L.transitionForClip(state.project, clip.dataset.clipId, frame);
           const index = found.track.clips.findIndex((entry) => entry.id === clip.dataset.clipId);
           const next = found.track.clips[index + 1];
           const canAddTransition = found.track.kind === 'video' && next &&

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -105,6 +105,7 @@ const dom = {
   sourceInsert: el('source-insert'),
   sourceOverwrite: el('source-overwrite'),
   sourceAppend: el('source-append'),
+  sourcePip: el('source-pip'),
   debugPanel: el('debug-view'),
   debugMetrics: el('debug-metrics'),
   debugLog: el('debug-log'),
@@ -211,6 +212,18 @@ const dom = {
   shapeShadowBlur: el('shape-shadow-blur'),
   shapeStartArrow: el('shape-start-arrow'),
   shapeEndArrow: el('shape-end-arrow'),
+  pipPanel: el('pip-panel'),
+  pipCropLeft: el('pip-crop-left'),
+  pipCropTop: el('pip-crop-top'),
+  pipCropRight: el('pip-crop-right'),
+  pipCropBottom: el('pip-crop-bottom'),
+  pipCornerRadius: el('pip-corner-radius'),
+  pipBorderColor: el('pip-border-color'),
+  pipBorderWidth: el('pip-border-width'),
+  pipAudioEnabled: el('pip-audio-enabled'),
+  transitionPanel: el('transition-panel'),
+  transitionDuration: el('transition-duration'),
+  transitionRemove: el('transition-remove'),
   subtitlePanel: el('subtitle-panel'),
   subtitleValue: el('subtitle-value'),
   subtitleStart: el('subtitle-start'),
@@ -575,6 +588,7 @@ function deleteSelected(...args) { return timelineUi.deleteSelected(...args); }
 function toggleClipLink(...args) { return timelineUi.toggleClipLink(...args); }
 function setClipLut(...args) { return timelineUi.setClipLut(...args); }
 function addAdjustmentLayer(...args) { return timelineUi.addAdjustmentLayer(...args); }
+function addPip(...args) { return timelineUi.addPip(...args); }
 function addVisualKeyframesAt(...args) { return timelineUi.addVisualKeyframesAt(...args); }
 function addVolumeKeyframeAt(...args) { return timelineUi.addVolumeKeyframeAt(...args); }
 
@@ -638,7 +652,7 @@ const wiring = globalThis.rendererWiringLib.createRendererWiring({
   placeSource, renderSourceMonitor, selectAsset, zoomToPxPerSecond, renderTimeline,
   updatePlayhead, toggleSnap, toggleClipLink, addText, addShape, addMarker, edit,
   addSubtitle, importSrt, exportSrt, renderHeads, frameAtClientX, openTimelineContextMenu,
-  addVisualKeyframesAt, addVolumeKeyframeAt, setClipLut, addAdjustmentLayer,
+  addVisualKeyframesAt, addVolumeKeyframeAt, setClipLut, addAdjustmentLayer, addPip,
   persistSettings, closeSheet, fillGraphicsDevices, createProjectFromSheet, openProjectPath,
   adoptProxyStatuses,
 });

--- a/product/akbun-makevideo/workspace/src/style-timeline.css
+++ b/product/akbun-makevideo/workspace/src/style-timeline.css
@@ -401,6 +401,23 @@ button.icon.on {
   cursor: grab;
 }
 
+.timeline-transition {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  z-index: 5;
+  min-width: 4px;
+  overflow: hidden;
+  border: 1px solid #f0b35c;
+  border-radius: 3px;
+  background: repeating-linear-gradient(135deg, #704b24cc 0 4px, #ba7736cc 4px 8px);
+  color: #fff4df;
+  font-size: 9px;
+  line-height: 18px;
+  text-align: center;
+  pointer-events: none;
+}
+
 .keyframe-dot {
   position: absolute;
   z-index: 4;

--- a/product/akbun-makevideo/workspace/src/timeline-interactions.js
+++ b/product/akbun-makevideo/workspace/src/timeline-interactions.js
@@ -5,6 +5,11 @@
   if (typeof module !== 'undefined' && module.exports) module.exports = exported;
   else root.timelineInteractionsLib = exported;
 })(globalThis, function () {
+  function horizontalWheelDelta(event) {
+    if (!event.shiftKey) return 0;
+    return event.deltaY || event.deltaX || 0;
+  }
+
   function createTimelineInteractions(deps) {
     const {
       HANDLE_PX,
@@ -621,6 +626,13 @@
       }
     }
 
+    function scrollHorizontally(event) {
+      const delta = horizontalWheelDelta(event);
+      if (!delta) return;
+      dom.scroll.scrollLeft += delta;
+      event.preventDefault();
+    }
+
     return {
       beginAssetDrag,
       beginClipDrag,
@@ -638,11 +650,12 @@
       metrics: clipDragMetrics,
       pointerMove,
       pointerUp,
+      scrollHorizontally,
       tookToolDragClick,
       updateAssetDrag,
       updateSourceDrag,
     };
   }
 
-  return { createTimelineInteractions };
+  return { createTimelineInteractions, horizontalWheelDelta };
 });

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -52,12 +52,43 @@ function videoSourceCountAt(project, frame) {
   for (const track of project.tracks) {
     if (track.kind !== 'video' || track.hidden) continue;
     count += track.clips.filter((clip) => clip.start <= frame && frame < clipEnd(clip)).length;
+    count += (project.transitions || []).filter((transition) => {
+      if (transition.trackId !== track.id) return false;
+      const incoming = track.clips.find((clip) => clip.id === transition.toClipId);
+      return incoming && incoming.start - transition.duration <= frame && frame < incoming.start;
+    }).length;
     count += (track.visualItems || []).filter((item) =>
       item.content && item.content.kind === 'videoOverlay' &&
       item.start <= frame && frame < item.start + item.duration
     ).length;
   }
   return count;
+}
+
+function transitionForClip(project, clipId, frame) {
+  const candidates = (project.transitions || []).filter((transition) =>
+    transition.fromClipId === clipId || transition.toClipId === clipId);
+  if (!candidates.length) return null;
+  if (!Number.isFinite(frame)) {
+    return candidates.find((transition) => transition.fromClipId === clipId) || candidates[0];
+  }
+  return candidates.reduce((best, transition) => {
+    const incoming = findClip(project, transition.toClipId);
+    const bestIncoming = findClip(project, best.toClipId);
+    if (!incoming) return best;
+    if (!bestIncoming) return transition;
+    const distance = Math.abs(incoming.clip.start - frame);
+    const bestDistance = Math.abs(bestIncoming.clip.start - frame);
+    if (distance !== bestDistance) return distance < bestDistance ? transition : best;
+    return transition.fromClipId === clipId ? transition : best;
+  });
+}
+
+function transitionMaxDuration(project, transition) {
+  if (!transition) return 0;
+  const from = findClip(project, transition.fromClipId);
+  const to = findClip(project, transition.toClipId);
+  return from && to ? Math.min(clipDuration(from.clip), clipDuration(to.clip)) : 0;
 }
 
 /** Rounded up, so the constant above is a floor rather than an average: at
@@ -417,6 +448,8 @@ const exported = {
   defaultVisualItemFrames,
   findVisualItem,
   videoSourceCountAt,
+  transitionForClip,
+  transitionMaxDuration,
   minClipFrames,
   blankProject,
   tracksOf,

--- a/product/akbun-makevideo/workspace/src/timeline.js
+++ b/product/akbun-makevideo/workspace/src/timeline.js
@@ -25,6 +25,7 @@ const T =
   typeof module !== 'undefined' && module.exports ? require('./time.js') : globalThis.timeLib;
 
 const MAX_TRACKS_PER_KIND = 4;
+const MAX_REALTIME_VIDEO_SOURCES = 4;
 // Below this a clip is a sliver nobody can grab again. The same number lives in
 // the edit crate, which is the one that enforces it; this copy is what stops a
 // trim from *looking* as though it went further than it will be allowed to.
@@ -44,6 +45,19 @@ function findVisualItem(project, itemId) {
     if (item) return { track, item };
   }
   return null;
+}
+
+function videoSourceCountAt(project, frame) {
+  let count = 0;
+  for (const track of project.tracks) {
+    if (track.kind !== 'video' || track.hidden) continue;
+    count += track.clips.filter((clip) => clip.start <= frame && frame < clipEnd(clip)).length;
+    count += (track.visualItems || []).filter((item) =>
+      item.content && item.content.kind === 'videoOverlay' &&
+      item.start <= frame && frame < item.start + item.duration
+    ).length;
+  }
+  return count;
 }
 
 /** Rounded up, so the constant above is a floor rather than an average: at
@@ -386,20 +400,23 @@ function tickStepFrames(pxPerSecond, rate) {
  *  over the real one. Nothing is edited through it. */
 function blankProject() {
   return {
-    version: 4,
+    version: 5,
     settings: { width: 1920, height: 1080, rate: T.fps(30) },
     assets: [],
     tracks: [],
+    transitions: [],
     markers: [],
   };
 }
 
 const exported = {
   MAX_TRACKS_PER_KIND,
+  MAX_REALTIME_VIDEO_SOURCES,
   MIN_CLIP_SECONDS,
   DEFAULT_VISUAL_ITEM_SECONDS,
   defaultVisualItemFrames,
   findVisualItem,
+  videoSourceCountAt,
   minClipFrames,
   blankProject,
   tracksOf,

--- a/product/akbun-makevideo/workspace/test/timeline-interactions.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline-interactions.test.js
@@ -2,7 +2,16 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { createTimelineInteractions } = require('../src/timeline-interactions.js');
+const {
+  createTimelineInteractions,
+  horizontalWheelDelta,
+} = require('../src/timeline-interactions.js');
+
+test('shift wheel maps vertical wheel motion to horizontal timeline motion', () => {
+  assert.equal(horizontalWheelDelta({ shiftKey: true, deltaY: 72, deltaX: 0 }), 72);
+  assert.equal(horizontalWheelDelta({ shiftKey: true, deltaY: 0, deltaX: -18 }), -18);
+  assert.equal(horizontalWheelDelta({ shiftKey: false, deltaY: 72, deltaX: 0 }), 0);
+});
 
 class FakeClassList {
   constructor() {

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -61,6 +61,28 @@ test('the realtime source count includes active PIP video layers', () => {
   assert.strictEqual(L.videoSourceCountAt(project, 30), 0);
 });
 
+test('dissolves count their extra decoder and resolve the selected boundary by playhead', () => {
+  const videoTrack = track('t1', 'video', 'V1', [
+    clip('c1', 'v', 0, 0, 60),
+    clip('c2', 'v', 60, 60, 120),
+    clip('c3', 'v', 120, 120, 180),
+  ]);
+  const project = projectOf([VIDEO], [videoTrack]);
+  project.transitions = [
+    { id: 'x1', trackId: 't1', fromClipId: 'c1', toClipId: 'c2', duration: 15 },
+    { id: 'x2', trackId: 't1', fromClipId: 'c2', toClipId: 'c3', duration: 10 },
+  ];
+
+  assert.strictEqual(L.videoSourceCountAt(project, 44), 1);
+  assert.strictEqual(L.videoSourceCountAt(project, 45), 2);
+  assert.strictEqual(L.videoSourceCountAt(project, 59), 2);
+  assert.strictEqual(L.videoSourceCountAt(project, 60), 1);
+  assert.strictEqual(L.transitionForClip(project, 'c2', 50).id, 'x1');
+  assert.strictEqual(L.transitionForClip(project, 'c2', 115).id, 'x2');
+  assert.strictEqual(L.transitionForClip(project, 'c2').id, 'x2');
+  assert.strictEqual(L.transitionMaxDuration(project, project.transitions[0]), 60);
+});
+
 test('a track only takes what it can play', () => {
   const video = track('t1', 'video', 'V1');
   const audio = track('t2', 'audio', 'A1');

--- a/product/akbun-makevideo/workspace/test/timeline.test.js
+++ b/product/akbun-makevideo/workspace/test/timeline.test.js
@@ -42,6 +42,23 @@ test('the placeholder project is empty and on the defaults', () => {
   assert.deepStrictEqual(project.settings, { width: 1920, height: 1080, rate: T.fps(30) });
   assert.deepStrictEqual(project.tracks, []);
   assert.deepStrictEqual(project.assets, []);
+  assert.deepStrictEqual(project.transitions, []);
+});
+
+test('the realtime source count includes active PIP video layers', () => {
+  const videoTrack = track('t1', 'video', 'V1', [clip('c1', 'v', 0, 0, 300)]);
+  videoTrack.visualItems = [{
+    id: 'p1',
+    start: 30,
+    duration: 60,
+    content: { kind: 'videoOverlay', assetId: 'v' },
+  }];
+  const project = projectOf([VIDEO], [videoTrack]);
+  assert.strictEqual(L.videoSourceCountAt(project, 29), 1);
+  assert.strictEqual(L.videoSourceCountAt(project, 30), 2);
+  assert.strictEqual(L.videoSourceCountAt(project, 90), 1);
+  videoTrack.hidden = true;
+  assert.strictEqual(L.videoSourceCountAt(project, 30), 0);
 });
 
 test('a track only takes what it can play', () => {


### PR DESCRIPTION
# 구현

Shift+휠 횡스크롤, PIP 영상 오버레이, 인접 클립 디졸브 전환 구현
- JS 186개와 GPU 비의존 Rust 테스트 통과, 실시간 공급 품질 2·3·4소스 각 0 late frame 확인

# 어려웠던 점

클립 비중첩 불변식을 유지하면서 전환 구간의 이중 디코드 구성
- 경계 객체와 전환 구간 전용 incoming placement로 모델·preview·export 경로 통합

# 리스크

GPU 어댑터가 없는 실행 환경에서는 compositor GPU 통합 테스트 미실행
- CPU 모델·공급·합성 경로 테스트와 실제 6초 soak 측정으로 보완

Issue #996
Issue #684
Issue #672
