### PR TITLE
feat: akbun-makevideo Codex AI 세션 추가

### DIFF
--- a/.github/workflows/release-akbun-makepresentation.yml
+++ b/.github/workflows/release-akbun-makepresentation.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - 'product/akbun-makepresentation/**'
+      - 'crates/akbun-ai/**'
   pull_request:
     paths:
       - 'product/akbun-makepresentation/**'
+      - 'crates/akbun-ai/**'
   workflow_dispatch:
 
 permissions:
@@ -31,6 +33,9 @@ jobs:
 
       - name: Run page tests
         run: npm test
+
+      - name: Run shared AI runtime tests
+        run: cargo test --manifest-path ../../../crates/akbun-ai/Cargo.toml
 
       # makepresentation-deck depends on neither tauri nor a webview, so -p
       # keeps this to serde, zip and quick-xml. Testing the app crate instead

--- a/.github/workflows/release-akbun-makevideo.yml
+++ b/.github/workflows/release-akbun-makevideo.yml
@@ -6,9 +6,11 @@ on:
       - master
     paths:
       - 'product/akbun-makevideo/**'
+      - 'crates/akbun-ai/**'
   pull_request:
     paths:
       - 'product/akbun-makevideo/**'
+      - 'crates/akbun-ai/**'
   workflow_dispatch:
 
 permissions:
@@ -31,6 +33,9 @@ jobs:
 
       - name: Run page tests
         run: npm test
+
+      - name: Run shared AI runtime tests
+        run: cargo test --manifest-path ../../../crates/akbun-ai/Cargo.toml
 
       # The time model everything else measures with. It depends on serde and
       # nothing else, so this is seconds.

--- a/crates/akbun-ai/Cargo.toml
+++ b/crates/akbun-ai/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "makepresentation-ai"
+name = "akbun-ai"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"

--- a/crates/akbun-ai/README.md
+++ b/crates/akbun-ai/README.md
@@ -1,0 +1,11 @@
+# akbun-ai
+
+Tauri에 의존하지 않는 Codex App Server 프로세스와 앱 소유 AI 세션 저장소.
+
+- `product/akbun-makepresentation`과 `product/akbun-makevideo`가 공유함
+- 세션은 앱 데이터의 `ai/sessions/`에 저장함
+- 세션 수와 용량, 이미지 원본 경로를 Rust 경계에서 검증함
+
+```bash
+cargo test --manifest-path crates/akbun-ai/Cargo.toml
+```

--- a/crates/akbun-ai/src/lib.rs
+++ b/crates/akbun-ai/src/lib.rs
@@ -1,22 +1,23 @@
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::fs::{self, File};
-use std::io::{BufWriter, Write};
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::{Component, Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 pub const MAX_SESSIONS: usize = 3;
 pub const SESSION_LIMIT_BYTES: u64 = 128 * 1024 * 1024;
 pub const SESSION_RESERVE_BYTES: u64 = 4 * 1024;
 
-/// A rendered slide handed to the model as turn input. Large enough for a
-/// 1.5x raster of a 16:9 canvas, small enough that a runaway caller cannot
-/// fill the disk one turn at a time.
-pub const MAX_SLIDE_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+/// A rendered app image handed to the model as turn input.
+pub const MAX_RUNTIME_IMAGE_BYTES: usize = 8 * 1024 * 1024;
 
-/// How many rendered slides stay on disk. The model reads the file during the
+/// How many rendered inputs stay on disk. The model reads the file during the
 /// turn it was written for, so the previous few are kept rather than deleted
 /// straight away, and everything older goes.
-pub const KEPT_SLIDE_IMAGES: usize = 4;
+pub const KEPT_RUNTIME_IMAGES: usize = 4;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -37,6 +38,178 @@ pub struct AttachedImage {
     pub file_name: String,
     pub path: String,
     pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppServerInfo {
+    pub codex_path: String,
+    pub version: String,
+    pub running: bool,
+}
+
+#[derive(Default)]
+pub struct CodexRuntime {
+    process: Mutex<Option<AppServerProcess>>,
+    generation: Arc<AtomicU64>,
+}
+
+struct AppServerProcess {
+    child: Child,
+    stdin: BufWriter<ChildStdin>,
+}
+
+impl Drop for AppServerProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl CodexRuntime {
+    pub fn start<Message, Stopped>(
+        &self,
+        working_directory: &Path,
+        on_message: Message,
+        on_stopped: Stopped,
+    ) -> Result<AppServerInfo, String>
+    where
+        Message: Fn(Value) + Send + 'static,
+        Stopped: Fn() + Send + 'static,
+    {
+        let mut process = self
+            .process
+            .lock()
+            .map_err(|_| "cannot lock Codex App Server state".to_string())?;
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        *process = None;
+
+        let codex = find_codex().ok_or_else(|| {
+            "codex_cli_not_found: install Codex CLI and sign in with ChatGPT".to_string()
+        })?;
+        let version = codex_version(&codex)?;
+        let mut child = Command::new(&codex)
+            .args(["app-server", "--listen", "stdio://"])
+            .current_dir(working_directory)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|error| format!("cannot start Codex App Server: {error}"))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or("cannot open Codex App Server stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or("cannot open Codex App Server stdout")?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or("cannot open Codex App Server stderr")?;
+
+        let current_generation = Arc::clone(&self.generation);
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                let payload = serde_json::from_str::<Value>(&line).unwrap_or_else(
+                    |_| json!({ "method": "client/protocolError", "params": { "line": line } }),
+                );
+                on_message(payload);
+            }
+            if current_generation.load(Ordering::SeqCst) == generation {
+                on_stopped();
+            }
+        });
+        std::thread::spawn(move || {
+            for line in BufReader::new(stderr).lines() {
+                if line.is_err() {
+                    break;
+                }
+            }
+        });
+
+        let info = AppServerInfo {
+            codex_path: codex.to_string_lossy().to_string(),
+            version,
+            running: true,
+        };
+        *process = Some(AppServerProcess {
+            child,
+            stdin: BufWriter::new(stdin),
+        });
+        Ok(info)
+    }
+
+    pub fn send_rpc(&self, message: &Value) -> Result<(), String> {
+        let mut process = self
+            .process
+            .lock()
+            .map_err(|_| "cannot lock Codex App Server state".to_string())?;
+        let server = process
+            .as_mut()
+            .ok_or("codex_app_server_not_running: start Codex App Server first")?;
+        if server
+            .child
+            .try_wait()
+            .map_err(|error| format!("cannot inspect Codex App Server: {error}"))?
+            .is_some()
+        {
+            *process = None;
+            return Err("codex_app_server_stopped: restart Codex App Server".into());
+        }
+        serde_json::to_writer(&mut server.stdin, message)
+            .map_err(|error| format!("cannot encode Codex App Server request: {error}"))?;
+        server
+            .stdin
+            .write_all(b"\n")
+            .and_then(|_| server.stdin.flush())
+            .map_err(|error| format!("cannot send Codex App Server request: {error}"))
+    }
+
+    pub fn stop(&self) -> Result<(), String> {
+        let mut process = self
+            .process
+            .lock()
+            .map_err(|_| "cannot lock Codex App Server state".to_string())?;
+        self.generation.fetch_add(1, Ordering::SeqCst);
+        *process = None;
+        Ok(())
+    }
+}
+
+fn find_codex() -> Option<PathBuf> {
+    let executable = if cfg!(windows) { "codex.exe" } else { "codex" };
+    let mut candidates = std::env::var_os("PATH")
+        .map(|value| {
+            std::env::split_paths(&value)
+                .map(|directory| directory.join(executable))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if cfg!(target_os = "macos") {
+        candidates.extend([
+            PathBuf::from("/opt/homebrew/bin/codex"),
+            PathBuf::from("/usr/local/bin/codex"),
+        ]);
+    }
+    candidates.into_iter().find(|path| {
+        fs::metadata(path)
+            .map(|metadata| metadata.is_file())
+            .unwrap_or(false)
+    })
+}
+
+fn codex_version(path: &Path) -> Result<String, String> {
+    let output = Command::new(path)
+        .arg("--version")
+        .output()
+        .map_err(|error| format!("cannot run Codex CLI: {error}"))?;
+    if !output.status.success() {
+        return Err("cannot read Codex CLI version".into());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[derive(Clone, Debug)]
@@ -207,42 +380,43 @@ impl AiStore {
         })
     }
 
-    /// Writes a rendered slide into the runtime directory and returns its path.
+    /// Writes a rendered app image into the runtime directory and returns its path.
     ///
     /// It lands in the runtime root rather than in a session because it is turn
     /// input, not conversation content: it must not count against the 128 MiB a
     /// conversation is allowed, and it must survive the conversation being
     /// deleted mid-turn.
-    pub fn save_slide_image(&self, image_id: &str, data: &[u8]) -> Result<PathBuf, String> {
+    pub fn save_runtime_png(&self, image_id: &str, data: &[u8]) -> Result<PathBuf, String> {
         validate_id(image_id)?;
-        if data.len() > MAX_SLIDE_IMAGE_BYTES {
-            return Err("slide_image_too_large: rendered slide exceeds 8 MiB".into());
+        if data.len() > MAX_RUNTIME_IMAGE_BYTES {
+            return Err("runtime_image_too_large: rendered image exceeds 8 MiB".into());
         }
         if !data.starts_with(&[0x89, b'P', b'N', b'G']) {
-            return Err("slide_image_not_png: expected a PNG image".into());
+            return Err("runtime_image_not_png: expected a PNG image".into());
         }
-        let directory = self.slide_images_root();
-        fs::create_dir_all(&directory).map_err(display_error("create AI slide image directory"))?;
+        let directory = self.runtime_images_root();
+        fs::create_dir_all(&directory)
+            .map_err(display_error("create AI runtime image directory"))?;
         let path = directory.join(format!("{image_id}.png"));
         let temporary = directory.join(format!("{image_id}.png.tmp"));
-        fs::write(&temporary, data).map_err(display_error("write AI slide image"))?;
-        fs::rename(&temporary, &path).map_err(display_error("replace AI slide image"))?;
-        self.prune_slide_images()?;
+        fs::write(&temporary, data).map_err(display_error("write AI runtime image"))?;
+        fs::rename(&temporary, &path).map_err(display_error("replace AI runtime image"))?;
+        self.prune_runtime_images()?;
         Ok(path)
     }
 
-    pub fn slide_images_root(&self) -> PathBuf {
-        self.runtime_root().join("slides")
+    pub fn runtime_images_root(&self) -> PathBuf {
+        self.runtime_root().join("images")
     }
 
-    fn prune_slide_images(&self) -> Result<(), String> {
-        let directory = self.slide_images_root();
+    fn prune_runtime_images(&self) -> Result<(), String> {
+        let directory = self.runtime_images_root();
         let mut files = Vec::new();
-        for entry in fs::read_dir(&directory).map_err(display_error("list AI slide images"))? {
-            let entry = entry.map_err(display_error("read AI slide image entry"))?;
+        for entry in fs::read_dir(&directory).map_err(display_error("list AI runtime images"))? {
+            let entry = entry.map_err(display_error("read AI runtime image entry"))?;
             let metadata = entry
                 .metadata()
-                .map_err(display_error("inspect AI slide image"))?;
+                .map_err(display_error("inspect AI runtime image"))?;
             if !metadata.is_file() {
                 continue;
             }
@@ -251,11 +425,11 @@ impl AiStore {
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
             files.push((modified, entry.path()));
         }
-        if files.len() <= KEPT_SLIDE_IMAGES {
+        if files.len() <= KEPT_RUNTIME_IMAGES {
             return Ok(());
         }
         files.sort_by(|left, right| right.0.cmp(&left.0));
-        for (_, path) in files.into_iter().skip(KEPT_SLIDE_IMAGES) {
+        for (_, path) in files.into_iter().skip(KEPT_RUNTIME_IMAGES) {
             let _ = fs::remove_file(path);
         }
         Ok(())
@@ -378,7 +552,7 @@ mod tests {
             .as_nanos();
         let sequence = NEXT_STORE_ID.fetch_add(1, Ordering::Relaxed);
         AiStore::new(std::env::temp_dir().join(format!(
-            "makepresentation-ai-{}-{unique}-{sequence}",
+            "akbun-ai-{}-{unique}-{sequence}",
             std::process::id()
         )))
     }
@@ -436,6 +610,12 @@ mod tests {
             .unwrap_err();
         assert!(error.starts_with("session_count_limit:"));
         fs::remove_dir_all(store.root.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn reserves_space_before_the_session_hard_limit() {
+        assert!(ensure_capacity(SESSION_LIMIT_BYTES - SESSION_RESERVE_BYTES).is_ok());
+        assert!(ensure_capacity(SESSION_LIMIT_BYTES - SESSION_RESERVE_BYTES + 1).is_err());
     }
 
     #[test]
@@ -517,10 +697,10 @@ mod tests {
     }
 
     #[test]
-    fn stores_a_rendered_slide_in_the_runtime_directory() {
+    fn stores_a_rendered_image_in_the_runtime_directory() {
         let store = temporary_store();
         store.ensure().unwrap();
-        let path = store.save_slide_image("slide-one", &png(64)).unwrap();
+        let path = store.save_runtime_png("image-one", &png(64)).unwrap();
 
         assert!(path.exists());
         assert!(path.starts_with(store.runtime_root()));
@@ -530,43 +710,43 @@ mod tests {
     }
 
     #[test]
-    fn rejects_a_slide_image_that_is_not_a_png() {
+    fn rejects_a_runtime_image_that_is_not_a_png() {
         let store = temporary_store();
         store.ensure().unwrap();
 
         assert!(store
-            .save_slide_image("slide-one", b"<svg/>")
+            .save_runtime_png("image-one", b"<svg/>")
             .unwrap_err()
-            .starts_with("slide_image_not_png:"));
+            .starts_with("runtime_image_not_png:"));
         assert!(store
-            .save_slide_image("../escape", &png(64))
+            .save_runtime_png("../escape", &png(64))
             .unwrap_err()
             .starts_with("invalid_session_id:"));
         assert!(store
-            .save_slide_image("slide-one", &png(MAX_SLIDE_IMAGE_BYTES + 1))
+            .save_runtime_png("image-one", &png(MAX_RUNTIME_IMAGE_BYTES + 1))
             .unwrap_err()
-            .starts_with("slide_image_too_large:"));
+            .starts_with("runtime_image_too_large:"));
     }
 
     #[test]
-    fn keeps_only_the_most_recent_slide_images() {
+    fn keeps_only_the_most_recent_runtime_images() {
         let store = temporary_store();
         store.ensure().unwrap();
-        for index in 0..KEPT_SLIDE_IMAGES + 3 {
+        for index in 0..KEPT_RUNTIME_IMAGES + 3 {
             store
-                .save_slide_image(&format!("slide-{index}"), &png(64))
+                .save_runtime_png(&format!("image-{index}"), &png(64))
                 .unwrap();
             // Coarse filesystem timestamps would otherwise make the sort order
             // arbitrary and the pruning look flaky.
             std::thread::sleep(std::time::Duration::from_millis(15));
         }
 
-        let remaining = fs::read_dir(store.slide_images_root()).unwrap().count();
-        assert_eq!(remaining, KEPT_SLIDE_IMAGES);
+        let remaining = fs::read_dir(store.runtime_images_root()).unwrap().count();
+        assert_eq!(remaining, KEPT_RUNTIME_IMAGES);
         assert!(store
-            .slide_images_root()
-            .join(format!("slide-{}.png", KEPT_SLIDE_IMAGES + 2))
+            .runtime_images_root()
+            .join(format!("image-{}.png", KEPT_RUNTIME_IMAGES + 2))
             .exists());
-        assert!(!store.slide_images_root().join("slide-0.png").exists());
+        assert!(!store.runtime_images_root().join("image-0.png").exists());
     }
 }

--- a/product/akbun-makepresentation/wiki/architecture.md
+++ b/product/akbun-makepresentation/wiki/architecture.md
@@ -5,7 +5,7 @@
 Two app sides, one JSON model between them, plus an optional external AI process.
 
 - **The page** (`workspace/src/`): plain HTML/CSS/JS served straight from disk, no bundler. It owns the deck in memory, draws it as SVG, and handles every interaction: tools, selection, resize handles, text editing, the property panel, thumbnails, presentation mode.
-- **Rust** (`workspace/src-tauri/`): everything that touches the file system and child processes. The pure deck and AI session stores live in `makepresentation-deck` and `makepresentation-ai`; both depend on neither Tauri nor a webview. The Tauri modules are thin shims over them.
+- **Rust** (`workspace/src-tauri/`): everything that touches the file system and child processes. The deck store lives in `makepresentation-deck`; the Codex process and AI session store are shared with makevideo through the repository-level `akbun-ai` crate. Neither depends on Tauri or a webview, and the Tauri modules are thin shims over them.
 - **Codex App Server**: an optional `codex app-server --listen stdio://` child process discovered from the user's installation. It reuses the Codex CLI ChatGPT login; no executable or credential is copied into the app.
 
 ## The deck model

--- a/product/akbun-makepresentation/workspace/package-lock.json
+++ b/product/akbun-makepresentation/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makepresentation",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makepresentation/workspace/package.json
+++ b/product/akbun-makepresentation/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makepresentation",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "description": "Desktop slide deck editor: shapes, text, pptx open/save, pdf export, presentation mode",
   "author": "akbun",
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "tauri dev",
     "test": "node --test test/*.test.js",
-    "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml -p makepresentation-ai -p makepresentation-deck",
+    "test:rust": "cargo test --manifest-path ../../../crates/akbun-ai/Cargo.toml && cargo test --manifest-path src-tauri/Cargo.toml -p makepresentation-deck",
     "dist": "tauri build",
     "tauri": "tauri"
   },

--- a/product/akbun-makepresentation/workspace/src-tauri/Cargo.lock
+++ b/product/akbun-makepresentation/workspace/src-tauri/Cargo.lock
@@ -18,12 +18,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "akbun-ai"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "akbun-makepresentation"
 version = "0.1.0"
 dependencies = [
+ "akbun-ai",
  "base64 0.22.1",
  "fontdb",
- "makepresentation-ai",
  "makepresentation-deck",
  "serde",
  "serde_json",
@@ -1820,14 +1828,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "makepresentation-ai"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "makepresentation-deck"

--- a/product/akbun-makepresentation/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-makepresentation/workspace/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/ai", "crates/deck"]
+members = ["crates/deck"]
 
 [package]
 name = "akbun-makepresentation"
@@ -26,7 +26,7 @@ tauri-build = { version = "2", features = [] }
 # The model lives in its own crate so the pull request job can test it without
 # compiling tauri, which would mean installing GTK and WebKit on the runner.
 makepresentation-deck = { path = "crates/deck" }
-makepresentation-ai = { path = "crates/ai" }
+akbun-ai = { path = "../../../../crates/akbun-ai" }
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }

--- a/product/akbun-makevideo/README.md
+++ b/product/akbun-makevideo/README.md
@@ -9,7 +9,8 @@ Desktop video editor: a multi track timeline, a live preview, and a render to FH
 - Assets panel: drop files from Finder or import them, with kind, length and size read by ffprobe. **Importing references the file where it is — media is never copied into the project**
 - Program monitor: the render's own compositor draws straight onto a surface in the window, and the audio clock decides when each frame is shown. Playing and stopped are the same picture, so what is on screen is what will be in the file
 - Source monitor: preview an asset independently, mark frame-aligned in and out points, then insert, overwrite or append video, audio or both
-- Global Action Bar: toggle Inspector, Shape, Marker and Debug in the shared right panel
+- Global Action Bar: toggle Inspector, Shape, Marker, AI and Debug in the shared right panel
+- AI panel: stream text or generated images through a separately installed Codex CLI using its ChatGPT subscription login; conversations stay in app-owned bounded storage
 - Inspector: edit a selected layer's position, size, rotation and opacity, plus text, shape, subtitle or clip-specific properties
 - The older preview — stacked media elements, with the composited frame swapped in when the playhead stops — is still there as a setting and as the automatic fallback when the monitor cannot start
 - Timeline: up to four video and four audio tracks, linked picture and sound from video assets, drag to move, drag an edge to trim
@@ -37,6 +38,8 @@ brew install ffmpeg
 Everything else works without it. An app launched from Finder does not inherit a login shell, so `/opt/homebrew/bin` is not on its PATH; the app looks there directly, and Settings → Preview & Tools takes a folder if ffmpeg lives somewhere else.
 
 Homebrew's ffmpeg is built with VideoToolbox, so GPU encoding works out of the box on a Mac. Settings → Preview & Tools says which encoder was found, or why none was.
+
+AI additionally needs Codex CLI on `PATH` and a ChatGPT login made with `codex login`. The app does not bundle Codex, copy its credentials or support API key authentication.
 
 ## Shortcuts
 
@@ -90,6 +93,7 @@ Run the tests, which need neither an app binary nor ffmpeg:
 
 ```bash
 npm test
+npm run test:ai
 npm run test:edit
 npm run test:rust
 npm run test:present

--- a/product/akbun-makevideo/adr/2026-09-codex-app-server-ai.md
+++ b/product/akbun-makevideo/adr/2026-09-codex-app-server-ai.md
@@ -1,0 +1,16 @@
+# AI uses the user's Codex App Server
+
+## Decision
+
+The app starts a separately installed `codex app-server --listen stdio://` process and accepts only its ChatGPT account login. It does not bundle Codex, copy credentials or support API key authentication.
+
+Each Codex thread is ephemeral and runs with approval disabled, network access off and no shell, web, MCP, plugin, app, hook, memory or multi-agent tools. The model receives only a measured project summary; asset paths and media contents stay outside the prompt.
+
+The app owns at most three durable sessions of 128 MiB each. Closed and restored sessions are read-only. Generated images are copied into the session and can be saved elsewhere, but are not imported into the project because projects reference media paths and deleting a session would break such a reference.
+
+Applying model output to timeline edits remains part of Issue #678.
+This authentication path replaces the provider API key storage direction in Issue #772.
+
+## Reason
+
+The Codex login remains the user's single credential boundary. App-owned sessions make retention, deletion and capacity predictable without coupling the product to Codex thread history. Ephemeral restricted threads limit the data and capabilities exposed to the model.

--- a/product/akbun-makevideo/adr/index.md
+++ b/product/akbun-makevideo/adr/index.md
@@ -31,3 +31,4 @@
 | [2026-09-playback-speed-and-audio-curves.md](./2026-09-playback-speed-and-audio-curves.md) | Clip duration is derived from speed; pitch preservation defaults on and fades stay separate from keyframes |
 | [2026-09-pip-video-overlay.md](./2026-09-pip-video-overlay.md) | PIP uses the common visual-item model and warns beyond four simultaneous video sources |
 | [2026-09-dissolve-boundary-object.md](./2026-09-dissolve-boundary-object.md) | Dissolve is a separate adjacent-clip boundary object with interval-only dual decode |
+| [2026-09-codex-app-server-ai.md](./2026-09-codex-app-server-ai.md) | AI uses the user's Codex App Server and app-owned bounded sessions |

--- a/product/akbun-makevideo/knowledge/decisions/2026-09-codex-ai-sessions-are-app-owned.md
+++ b/product/akbun-makevideo/knowledge/decisions/2026-09-codex-ai-sessions-are-app-owned.md
@@ -1,0 +1,29 @@
+---
+type: Decision
+title: Codex AI 세션은 앱이 제한된 로컬 데이터로 소유한다
+description: Codex thread는 일회성으로 사용하고 대화와 생성 이미지는 앱 데이터에 제한해 저장한다.
+tags: [makevideo, codex, ai, session]
+timestamp: 2026-09-05T00:00:00Z
+---
+
+# Codex AI 세션은 앱이 제한된 로컬 데이터로 소유한다
+
+## 결정
+
+* Codex App Server는 별도 설치된 CLI와 ChatGPT 로그인을 사용함
+* Codex thread는 저장하지 않고 매 연결에서 새로 만듦
+* 대화와 생성 이미지는 앱 데이터에 최대 3개, 세션당 128 MiB로 저장함
+* 닫았거나 앱 재시작 뒤 복원한 세션은 읽기 전용으로 표시함
+* 모델에는 경로와 미디어가 없는 프로젝트 요약만 전달함
+* 생성 이미지는 세션에 보관하고 사용자가 별도 파일로 저장하게 함
+
+## 이유
+
+* 인증과 구독 상태를 Codex CLI 한 곳에서 관리함
+* Codex 기록 정책과 무관하게 삭제와 용량 제한을 보장함
+* 세션 이미지 경로를 프로젝트가 참조하면 세션 삭제 시 프로젝트가 깨지므로 자동 import하지 않음
+* 실제 타임라인 편집 반영은 별도 편집 명령 설계와 검증이 필요함
+
+## Citations
+
+1. [Codex App Server AI ADR](../../adr/2026-09-codex-app-server-ai.md)

--- a/product/akbun-makevideo/knowledge/decisions/index.md
+++ b/product/akbun-makevideo/knowledge/decisions/index.md
@@ -2,6 +2,7 @@
 
 ## 목록
 
+* [Codex AI 세션은 앱이 제한된 로컬 데이터로 소유한다](2026-09-codex-ai-sessions-are-app-owned.md) - Codex thread와 앱의 로컬 대화 저장 경계를 분리한 결정.
 * [PIP와 디졸브는 기존 compositor placement로 합성한다](2026-09-overlays-and-transitions-share-the-compositor.md) - PIP와 디졸브를 기존 preview/export 합성 경로에 연결하는 결정.
 * [clip 속도는 source 범위를 바꾸지 않고 timeline 길이를 결정한다](2026-09-clip-speed-derives-duration.md) - source in-out을 유지하고 duration을 speed에서 파생하는 결정.
 * [Program Monitor 전체 화면은 편집 레이아웃을 숨겨 보존한다](2026-09-program-monitor-fullscreen-preserves-layout.md) - Cmd+F와 Esc가 layout 상태를 바꾸지 않고 Program Monitor 표시만 전환하는 결정.

--- a/product/akbun-makevideo/knowledge/log.md
+++ b/product/akbun-makevideo/knowledge/log.md
@@ -2,6 +2,7 @@
 
 ## 2026-09-05
 
+* [Codex AI 세션은 앱이 제한된 로컬 데이터로 소유한다](decisions/2026-09-codex-ai-sessions-are-app-owned.md) 결정 기록. Codex thread와 앱의 세션·이미지 보관 경계를 분리함.
 * [clip 속도는 source 범위를 바꾸지 않고 timeline 길이를 결정한다](decisions/2026-09-clip-speed-derives-duration.md) 결정 기록. source trim을 유지하고 preview와 render의 duration·pitch·fade 해석을 통일함.
 
 ## 2026-09-04

--- a/product/akbun-makevideo/wiki/architecture/ipc.md
+++ b/product/akbun-makevideo/wiki/architecture/ipc.md
@@ -22,12 +22,22 @@ Every command is in `src-tauri/src/commands.rs`. The page picks paths with nativ
 | `playback_status` | Where the playhead is, and what the monitor has drawn |
 | `start_render` | Spawns ffmpeg, returns immediately, emits `render:progress` then one `render:done` |
 | `cancel_render` | Kills the running ffmpeg |
+| `ai_start_server`, `ai_send_rpc`, `ai_stop_server` | Controls the Codex App Server and forwards JSON-RPC lines |
+| `ai_runtime_directory` | Returns the app-owned writable root used by restricted Codex turns |
+| `ai_list_sessions`, `ai_load_session`, `ai_save_session`, `ai_delete_session` | Reads and writes bounded app-owned conversation JSON |
+| `ai_attach_image`, `ai_copy_image` | Copies a validated generated image into a session or a user-picked path |
 
 ## Nothing carries a project across
 
 `edit_apply` sends commands and `preview_frame` and `start_render` send neither a project nor a timeline. There is one copy of the edit, in `AppState.document`, and everything reads that. The [edit model record](../../adr/2026-08-edit-model-in-rust.md) has the reasoning; the practical effect is that the compositor decides what to decode by reading the timeline rather than by being handed a snapshot taken when somebody pressed a button.
 
 A render takes its own copy and remembers the revision it took, because the app stays editable while it runs. When it finishes, `render:done` carries `edited` if the revision moved, and the dialog says the file is the timeline as it was when the render started.
+
+## AI stays outside the document
+
+The AI panel sends JSON-RPC through the App Server lifecycle commands. Its project digest contains canvas size, frame rate and asset, marker, track and clip counts, but no file paths or media content. The Codex thread is ephemeral; the app saves only its own bounded session JSON and copied generated images.
+
+Generated images are offered through Save rather than imported as project assets. A project references media paths, while deleting an AI session deletes its images, so linking those two lifetimes would create a broken project.
 
 ## No frame crosses this boundary
 

--- a/product/akbun-makevideo/wiki/architecture/processes.md
+++ b/product/akbun-makevideo/wiki/architecture/processes.md
@@ -1,6 +1,6 @@
 # Processes
 
-One Tauri window. There is no node runtime and no bundler; `src/` is served as it is, so the source that runs is the source in the repository.
+One Tauri window and an optional external Codex App Server process. There is no node runtime and no bundler; `src/` is served as it is, so the source that runs is the source in the repository.
 
 | Side | Owns |
 |---|---|
@@ -11,7 +11,11 @@ One Tauri window. There is no node runtime and no bundler; `src/` is served as i
 | The audio crate (`src-tauri/crates/audio/`) | The playback mix, the output, and the clock the picture follows |
 | The present crate (`src-tauri/crates/present/`) | When a frame is shown, and the swapchain it is shown on |
 | The time crate (`src-tauri/crates/time/`) | Rates and times: what a frame index means and every conversion out of one. `src/time.js` is the same model for the page |
+| The shared AI crate (`../../../../crates/akbun-ai/`) | The Codex child process, bounded session directories, and generated image validation |
+| Codex App Server | An optional user-installed process using the Codex CLI ChatGPT login; it receives only the project digest and AI prompt |
 
 None of these crates depends on tauri or on anything that needs a webview, which is what lets the pull request job test them on Linux in seconds. Testing the app crate instead would mean installing GTK and WebKit on the runner. The two that talk to hardware keep that behind a feature for the same reason: `--no-default-features` builds a compositor that has never heard of wgpu and an audio engine that has never heard of cpal, and each still runs everything that does not need the hardware. The verify job runs both crates twice, once each way, because the tests behind the feature are the ones the first run cannot reach.
 
 The stack goes one way: time, then edit, then render and the compositor, then present, then the app. The edit crate is the one every other part reads, so it is also the one that must not be able to pull any of them back in.
+
+The AI path is separate from the edit stack. The page streams App Server events through the Tauri bridge and saves app-owned conversation JSON through `akbun-ai`; applying AI output as edit commands belongs to Issue #678.

--- a/product/akbun-makevideo/wiki/development.md
+++ b/product/akbun-makevideo/wiki/development.md
@@ -23,6 +23,7 @@ None of them need an app binary. The first two need nothing installed at all; th
 
 ```bash
 npm test           # node --test over what the page still computes
+npm run test:ai    # shared Codex process and bounded session store
 npm run test:time  # cargo test -p makevideo-time, needs nothing installed
 npm run test:edit  # cargo test -p makevideo-edit, needs nothing installed
 npm run test:rust  # cargo test -p makevideo-render, needs nothing installed
@@ -47,6 +48,8 @@ sudo apt-get install -y mesa-vulkan-drivers ffmpeg   # what CI does
 What is covered:
 
 - `test/time.test.js` — the rate arithmetic: conversion, rescale, compare, clamp and timecode, over all eight rates the app offers. The mirror of `crates/time`, and the two run the same cases
+- `test/ai.test.js` — app-owned session normalization, JSON byte limits, private project digest and text/image mode prompts
+- `../../../crates/akbun-ai/src/lib.rs` — session count and byte limits, path validation, generated-image copying and runtime image pruning
 - `test/timeline.test.js` — what the page still answers on its own: snapping, what is under the playhead, the timeline length, and the ruler
 - `test/quality.test.js` — quality percentiles, the six acceptance checks and report aggregation
 - `crates/time/src/lib.rs` — the same rate arithmetic on the Rust side, including that ten thousand added frames land exactly on frame ten thousand at every rate
@@ -89,6 +92,8 @@ Two clips of different aspect ratios on two tracks is the case worth checking, b
 
 `globalThis.makevideo` exposes `state`, `refresh()`, `preview()` and the timeline library, which is what the devtools console is for. `lib.rs` opens the devtools automatically in debug builds.
 
+The plain browser shows the AI panel's unavailable state. App Server streaming additionally needs a separately installed Codex CLI logged in with ChatGPT and the Tauri bridge; do not add Codex to the app bundle.
+
 ## Caveats
 
 **Capabilities fail at runtime, not at compile time.** A plugin command missing from `capabilities/default.json` works in every test and breaks on the user's machine. The generated `src-tauri/gen/schemas/desktop-schema.json` lists every valid identifier; it exists after any build and is worth grepping when adding one.
@@ -128,7 +133,7 @@ Each pulls from a different layer at the project rate and exits non-zero when a 
 
 `.github/workflows/release-akbun-makevideo.yml`.
 
-- A pull request runs `verify` on ubuntu: the three test suites and nothing else. It installs `mesa-vulkan-drivers` and `ffmpeg` for the compositor tests. No Rust cache, because neither the render nor the compositor crate pulls in tauri.
+- A pull request runs the page, pure Rust and shared AI runtime tests on Ubuntu. It installs `mesa-vulkan-drivers` and `ffmpeg` for the compositor tests. No Rust cache, because these crates do not pull in Tauri.
 - A push to master builds on macOS and `tauri-apps/tauri-action` creates the release. **GitHub creates the tag from the release**, so there is no `git tag` step to add.
 - The version lives only in `workspace/package.json`; `tauri.conf.json` points at it. The number in `Cargo.toml` is not read by the bundler.
 

--- a/product/akbun-makevideo/workspace/package-lock.json
+++ b/product/akbun-makevideo/workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "akbun-makevideo",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "MIT",
       "devDependencies": {
         "@tauri-apps/cli": "^2"

--- a/product/akbun-makevideo/workspace/package.json
+++ b/product/akbun-makevideo/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akbun-makevideo",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "private": true,
   "description": "Desktop video editor: multi track timeline, live preview, ffmpeg render to FHD and 4K",
   "author": "akbun",
@@ -9,6 +9,7 @@
     "start": "tauri dev",
     "build:alpha": "tauri build --debug --bundles app --config src-tauri/tauri.alpha.conf.json",
     "test": "node --test test/*.test.js",
+    "test:ai": "cargo test --manifest-path ../../../crates/akbun-ai/Cargo.toml",
     "test:time": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-time",
     "test:edit": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-edit",
     "test:rust": "cargo test --manifest-path src-tauri/Cargo.toml -p makevideo-render",

--- a/product/akbun-makevideo/workspace/src-tauri/Cargo.lock
+++ b/product/akbun-makevideo/workspace/src-tauri/Cargo.lock
@@ -18,9 +18,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "akbun-ai"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "akbun-makevideo"
 version = "0.1.0"
 dependencies = [
+ "akbun-ai",
  "libc",
  "makevideo-audio",
  "makevideo-compositor",

--- a/product/akbun-makevideo/workspace/src-tauri/Cargo.toml
+++ b/product/akbun-makevideo/workspace/src-tauri/Cargo.toml
@@ -54,6 +54,7 @@ makevideo-present = { path = "crates/present" }
 makevideo-audio = { path = "crates/audio" }
 makevideo-proxy = { path = "crates/proxy" }
 makevideo-waveform = { path = "crates/waveform" }
+akbun-ai = { path = "../../../../crates/akbun-ai" }
 # protocol-asset is what makes asset_protocol_scope() exist. Without the
 # feature the preview shows broken media with no error anywhere.
 # The native Program Monitor is added as a sibling of the WKWebView through

--- a/product/akbun-makevideo/workspace/src-tauri/src/ai.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/ai.rs
@@ -1,5 +1,4 @@
 use akbun_ai::{AiStore, AppServerInfo, AttachedImage, CodexRuntime, SessionSummary};
-use base64::Engine;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
@@ -115,27 +114,6 @@ pub fn ai_attach_image(
         .allow_file(&image.path)
         .map_err(|error| format!("cannot allow saved AI image: {error}"))?;
     Ok(image)
-}
-
-/// Stores the rendered slide the page just rasterized and returns its path, so
-/// the next turn can attach it as image input. The model can then see the
-/// slide instead of inferring it from coordinates.
-#[tauri::command]
-pub fn ai_save_slide_image(
-    app: AppHandle,
-    image_id: String,
-    data_url: String,
-) -> Result<String, String> {
-    let encoded = data_url
-        .strip_prefix("data:image/png;base64,")
-        .ok_or("slide image is not a PNG data URL")?;
-    let data = base64::engine::general_purpose::STANDARD
-        .decode(encoded)
-        .map_err(|error| format!("bad slide image: {error}"))?;
-    let store = store(&app)?;
-    store.ensure()?;
-    let path = store.save_runtime_png(&image_id, &data)?;
-    Ok(path.to_string_lossy().to_string())
 }
 
 fn codex_generated_images(app: &AppHandle) -> Result<PathBuf, String> {

--- a/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
+++ b/product/akbun-makevideo/workspace/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod ai;
 mod commands;
 mod playback;
 mod store;
@@ -20,6 +21,7 @@ pub fn run() {
 
     builder
         .setup(|app| {
+            ai::setup(app)?;
             let handle = app.handle();
             let settings = store::load_settings(handle);
             commands::apply_theme(handle, &settings.theme);
@@ -50,6 +52,7 @@ pub fn run() {
                 waveforms: Arc::new(Mutex::new(commands::WaveformState::default())),
                 waveform_workers: Mutex::new(Vec::new()),
             });
+            app.manage(ai::AiRuntime::default());
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -95,6 +98,16 @@ pub fn run() {
             commands::process_metrics,
             commands::read_error_log,
             commands::save_quality_report,
+            ai::ai_start_server,
+            ai::ai_send_rpc,
+            ai::ai_stop_server,
+            ai::ai_runtime_directory,
+            ai::ai_list_sessions,
+            ai::ai_load_session,
+            ai::ai_save_session,
+            ai::ai_delete_session,
+            ai::ai_attach_image,
+            ai::ai_copy_image,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/product/akbun-makevideo/workspace/src/ai-panel.js
+++ b/product/akbun-makevideo/workspace/src/ai-panel.js
@@ -1,0 +1,867 @@
+'use strict';
+
+(function (root, factory) {
+  const exported = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = exported;
+  else root.makevideoAiPanel = exported;
+})(globalThis, function () {
+  const A = globalThis.makevideoAi;
+  const rpcPending = new Map();
+  const $ = (id) => document.getElementById(id);
+  let options = {};
+  let nextRpcId = 1;
+  let listenersReady = null;
+  let connectionPromise = null;
+  let isolatedConfigPromise = null;
+  let sessions = [];
+  let currentSession = null;
+  let currentImageRoot = '';
+  let selectedMode = 'text';
+  let threadId = null;
+  let pendingTurn = null;
+  let persistChain = Promise.resolve();
+  let persistTimer = null;
+  let interruptedSessionsFinalized = false;
+  let connection = {
+    state: 'checking',
+    account: null,
+    capabilities: { imageGeneration: false },
+    server: null,
+    detail: 'Looking for Codex CLI and ChatGPT authentication.',
+  };
+
+  const DEVELOPER_INSTRUCTIONS = [
+    'You are embedded in akbun-makevideo, a desktop video editor.',
+    'Do not run shell commands, inspect files, use web search, modify files, call MCP tools, or delegate work.',
+    'The client labels every request as TEXT MODE or IMAGE MODE.',
+    'In TEXT MODE, return text only and do not call a tool.',
+    'In IMAGE MODE, use only the built-in image generation capability and save exactly one image.',
+  ].join(' ');
+
+  function isApiKeyAuth(type) {
+    return type === 'apiKey' || type === 'apikey';
+  }
+
+  function connectionLabel() {
+    if (connection.state === 'available') {
+      const plan = connection.account?.planType ? ` · ChatGPT ${connection.account.planType}` : '';
+      return `Available${plan}`;
+    }
+    if (!window.api.available) return 'Desktop app required';
+    if (connection.detail.includes('codex_cli_not_found')) return 'Codex CLI not found';
+    if (isApiKeyAuth(connection.account?.type)) return 'API key authentication is disabled';
+    if (connection.account && connection.account.type !== 'chatgpt') {
+      return 'ChatGPT subscription authentication required';
+    }
+    if (connection.state === 'checking') return 'Checking Codex…';
+    return 'ChatGPT login required';
+  }
+
+  function setConnection(next) {
+    connection = { ...connection, ...next };
+    renderConnection();
+  }
+
+  function renderConnection() {
+    const available = connection.state === 'available';
+    const state = available ? 'available' : connection.state === 'checking' ? 'checking' : 'unavailable';
+    for (const status of [$('ai-connection-banner'), $('settings-ai-status')].filter(Boolean)) {
+      status.dataset.state = state;
+    }
+    if ($('ai-connection-text')) $('ai-connection-text').textContent = connectionLabel();
+    if ($('settings-ai-status-title')) $('settings-ai-status-title').textContent = connectionLabel();
+    if ($('settings-ai-status-detail')) {
+      $('settings-ai-status-detail').textContent = available
+        ? `Connected through ${connection.server?.version || 'Codex CLI'}. Logging out of Codex disables AI here.`
+        : connection.detail.replace(/^[a-z_]+:\s*/i, '') || 'Run codex login with a ChatGPT account.';
+    }
+    const imageButton = $('ai-mode-picker')?.querySelector('[data-ai-mode="image"]');
+    if (imageButton) {
+      const unavailable = available && !connection.capabilities.imageGeneration;
+      imageButton.disabled = Boolean(pendingTurn) || unavailable;
+      imageButton.title = unavailable ? 'Image generation is unavailable for this account.' : '';
+      if (unavailable && selectedMode === 'image') selectMode('text');
+    }
+  }
+
+  async function installListeners() {
+    if (listenersReady) return listenersReady;
+    listenersReady = Promise.all([
+      window.api.onAiServerMessage(handleServerMessage),
+      window.api.onAiServerState(() => {
+        rejectRpcRequests(new Error('Codex App Server stopped.'));
+        connectionPromise = null;
+        isolatedConfigPromise = null;
+        threadId = null;
+        void finishStoppedServer();
+        setConnection(A.disconnectedConnection('Codex App Server stopped.'));
+      }),
+    ]);
+    return listenersReady;
+  }
+
+  function rejectRpcRequests(error) {
+    for (const pending of rpcPending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    rpcPending.clear();
+  }
+
+  function rpc(method, params = {}, timeoutMs = 30_000) {
+    const id = nextRpcId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        rpcPending.delete(id);
+        reject(new Error(`${method} timed out.`));
+      }, timeoutMs);
+      rpcPending.set(id, { resolve, reject, timer });
+      window.api.aiSendRpc({ method, id, params }).catch((error) => {
+        clearTimeout(timer);
+        rpcPending.delete(id);
+        reject(error);
+      });
+    });
+  }
+
+  function notify(method, params = {}) {
+    return window.api.aiSendRpc({ method, params });
+  }
+
+  function handleServerMessage(message) {
+    if (!message || typeof message !== 'object') return;
+    if (message.id != null && !message.method) {
+      const pending = rpcPending.get(message.id);
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      rpcPending.delete(message.id);
+      if (message.error) pending.reject(new Error(message.error.message || 'Codex request failed.'));
+      else pending.resolve(message.result);
+      return;
+    }
+    if (message.id != null && message.method) {
+      void window.api.aiSendRpc({
+        id: message.id,
+        error: { code: -32601, message: 'This client does not support server requests.' },
+      });
+      return;
+    }
+    handleNotification(message.method, message.params || {});
+  }
+
+  function handleNotification(method, params) {
+    if (method === 'account/updated') {
+      if (params.authMode === 'chatgpt') void refreshStatus();
+      else {
+        const account = params.authMode ? { type: params.authMode } : null;
+        setConnection({
+          state: 'unavailable',
+          account,
+          detail: isApiKeyAuth(account?.type)
+            ? 'API key authentication is disabled for this app.'
+            : 'Run codex login with a ChatGPT account.',
+        });
+      }
+      return;
+    }
+    if (!pendingTurn) return;
+    if (params.threadId && params.threadId !== threadId) return;
+    if (method === 'turn/started' && params.turn?.id) {
+      pendingTurn.turnId = params.turn.id;
+    } else if (method === 'item/started' && params.item?.type === 'agentMessage') {
+      pendingTurn.itemPhases.set(params.item.id, params.item.phase || 'final_answer');
+    } else if (method === 'item/agentMessage/delta') {
+      appendAgentDelta(params);
+    } else if (method === 'item/completed') {
+      completeItem(params.item || {});
+    } else if (method === 'turn/completed') {
+      void completeTurn(params.turn || {});
+    } else if (method === 'error') {
+      pendingTurn.error = params.error?.message || 'AI request failed.';
+    }
+  }
+
+  async function connect(forceRefresh = false) {
+    if (!window.api.available) {
+      setConnection({ state: 'unavailable', detail: 'AI integration needs the desktop app.' });
+      return connection;
+    }
+    if (connectionPromise && !forceRefresh) return connectionPromise;
+    connectionPromise = (async () => {
+      setConnection({ state: 'checking', detail: 'Looking for Codex CLI and ChatGPT authentication.' });
+      await installListeners();
+      const server = await window.api.aiStartServer();
+      await rpc('initialize', {
+        clientInfo: {
+          name: 'akbun_makevideo',
+          title: 'akbun-makevideo',
+          version: options.version?.() || '0.0.0',
+        },
+        capabilities: { experimentalApi: true },
+      });
+      await notify('initialized', {});
+      const [accountResult, capabilities] = await Promise.all([
+        rpc('account/read', { refreshToken: false }),
+        rpc('modelProvider/capabilities/read', {}),
+      ]);
+      const account = accountResult?.account || null;
+      const available = account?.type === 'chatgpt';
+      setConnection({
+        state: available ? 'available' : 'unavailable',
+        account,
+        capabilities: capabilities || { imageGeneration: false },
+        server,
+        detail: available
+          ? ''
+          : isApiKeyAuth(account?.type)
+            ? 'API key authentication is disabled for this app.'
+            : 'Run codex login with a ChatGPT account.',
+      });
+      return connection;
+    })().catch((error) => {
+      connectionPromise = null;
+      setConnection(A.disconnectedConnection(error));
+      return connection;
+    });
+    return connectionPromise;
+  }
+
+  async function refreshStatus() {
+    if (!connection.server) return connect(true);
+    try {
+      setConnection({ state: 'checking', detail: 'Refreshing ChatGPT authentication.' });
+      const [accountResult, capabilities] = await Promise.all([
+        rpc('account/read', { refreshToken: false }),
+        rpc('modelProvider/capabilities/read', {}),
+      ]);
+      const account = accountResult?.account || null;
+      setConnection({
+        state: account?.type === 'chatgpt' ? 'available' : 'unavailable',
+        account,
+        capabilities,
+        detail: account?.type === 'chatgpt'
+          ? ''
+          : isApiKeyAuth(account?.type)
+            ? 'API key authentication is disabled for this app.'
+            : 'Run codex login with a ChatGPT account.',
+      });
+    } catch (error) {
+      connectionPromise = null;
+      setConnection(A.disconnectedConnection(error));
+    }
+    return connection;
+  }
+
+  function formatSize(bytes) {
+    const value = Number(bytes) || 0;
+    return value < 1024 * 1024
+      ? `${Math.max(1, Math.round(value / 1024))} KiB`
+      : `${(value / (1024 * 1024)).toFixed(1)} MiB`;
+  }
+
+  function formatDate(value) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? '' : date.toLocaleString();
+  }
+
+  async function loadSessionList() {
+    try {
+      sessions = await window.api.aiListSessions();
+      if (!interruptedSessionsFinalized) {
+        await finalizeInterruptedSessions();
+        interruptedSessionsFinalized = true;
+        sessions = await window.api.aiListSessions();
+      }
+      renderSessionList();
+    } catch (error) {
+      sessions = [];
+      $('ai-list-status').textContent = `Cannot load conversations: ${error}`;
+      renderSessionList();
+    }
+  }
+
+  async function finalizeInterruptedSessions() {
+    for (const summary of sessions.filter((item) => item.status === 'active')) {
+      const loaded = await window.api.aiLoadSession(summary.id);
+      if (!loaded?.session) continue;
+      const session = A.restoreInterruptedSession(loaded.session);
+      await window.api.aiSaveSession(session.id, session);
+    }
+  }
+
+  function renderSessionList() {
+    const container = $('ai-session-list');
+    if (!container) return;
+    container.replaceChildren();
+    $('btn-ai-new').disabled = sessions.length >= A.MAX_SESSIONS;
+    $('ai-list-status').textContent = sessions.length >= A.MAX_SESSIONS
+      ? 'Delete a conversation before starting a new one.'
+      : `${sessions.length} of ${A.MAX_SESSIONS} conversations saved`;
+    if (!sessions.length) {
+      const empty = document.createElement('div');
+      empty.className = 'ai-session-empty';
+      const title = document.createElement('strong');
+      title.textContent = 'No conversations yet';
+      const detail = document.createElement('span');
+      detail.textContent = 'Ask for editing advice, narration, captions, or a still image.';
+      empty.append(title, detail);
+      container.append(empty);
+      return;
+    }
+    for (const summary of sessions) {
+      const row = document.createElement('div');
+      row.className = 'ai-session-row';
+      const open = document.createElement('button');
+      open.type = 'button';
+      open.className = 'ai-session-open';
+      open.dataset.sessionId = summary.id;
+      const title = document.createElement('strong');
+      title.textContent = summary.title;
+      const meta = document.createElement('span');
+      meta.textContent = `${formatDate(summary.updatedAt)} · ${formatSize(summary.sizeBytes)}`;
+      open.append(title, meta);
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'ai-session-delete';
+      remove.dataset.deleteSession = summary.id;
+      remove.textContent = 'Delete';
+      row.append(open, remove);
+      container.append(row);
+    }
+  }
+
+  function showList() {
+    $('ai-list-view').hidden = false;
+    $('ai-chat-view').hidden = true;
+    currentSession = null;
+    currentImageRoot = '';
+    threadId = null;
+    pendingTurn = null;
+    void loadSessionList();
+  }
+
+  function showChat(readonly) {
+    $('ai-list-view').hidden = true;
+    $('ai-chat-view').hidden = false;
+    $('ai-composer').hidden = readonly;
+    $('ai-readonly-notice').hidden = !readonly;
+    $('ai-chat-title').textContent = currentSession?.title || 'New conversation';
+    $('ai-chat-meta').textContent = readonly
+      ? `Read-only · ${formatSize(currentSession?.sizeBytes)}`
+      : 'Active conversation';
+    renderMessages();
+    if (!readonly) $('ai-prompt').focus();
+  }
+
+  function newConversation() {
+    if (sessions.length >= A.MAX_SESSIONS) return;
+    currentSession = null;
+    currentImageRoot = '';
+    threadId = null;
+    pendingTurn = null;
+    selectMode('text');
+    $('ai-prompt').value = '';
+    showChat(false);
+  }
+
+  async function openSavedSession(id) {
+    try {
+      const loaded = await window.api.aiLoadSession(id);
+      currentSession = A.normalizeSession(loaded.session);
+      currentSession.status = 'readonly';
+      currentImageRoot = loaded.imageRoot || '';
+      showChat(true);
+    } catch (error) {
+      $('ai-list-status').textContent = `Cannot open conversation: ${error}`;
+    }
+  }
+
+  async function deleteSession(id) {
+    const summary = sessions.find((item) => item.id === id);
+    const confirmed = await window.api.ask(
+      `Delete “${summary?.title || 'this conversation'}” and its generated images?`,
+      { title: 'Delete AI conversation', kind: 'warning' }
+    );
+    if (!confirmed) return;
+    try {
+      await window.api.aiDeleteSession(id);
+      await loadSessionList();
+    } catch (error) {
+      $('ai-list-status').textContent = `Cannot delete conversation: ${error}`;
+    }
+  }
+
+  function imagePath(image) {
+    if (image.path) return image.path;
+    if (!currentImageRoot) return '';
+    const separator = currentImageRoot.includes('\\') ? '\\' : '/';
+    return `${currentImageRoot}${separator}${image.fileName}`;
+  }
+
+  function messageNode(message) {
+    const article = document.createElement('article');
+    article.className = 'ai-message';
+    article.dataset.role = message.role;
+    article.dataset.messageId = message.id;
+    const label = document.createElement('div');
+    label.className = 'ai-message-label';
+    const speaker = document.createElement('span');
+    speaker.textContent = message.role === 'user' ? 'You' : 'AI';
+    const status = document.createElement('span');
+    status.textContent = message.status === 'streaming'
+      ? 'Streaming…'
+      : message.status === 'stopped'
+        ? 'Stopped'
+        : message.status === 'error' ? 'Error' : message.mode;
+    label.append(speaker, status);
+    const body = document.createElement('p');
+    body.className = 'ai-message-body';
+    body.textContent = message.text || (message.status === 'streaming' ? 'Working…' : '');
+    article.append(label, body);
+    for (const image of message.images) {
+      const card = document.createElement('div');
+      card.className = 'ai-image-card';
+      const element = document.createElement('img');
+      element.src = window.api.aiImageUrl(imagePath(image));
+      element.alt = 'AI-generated still image';
+      const save = document.createElement('button');
+      save.type = 'button';
+      save.dataset.saveImage = image.id;
+      save.textContent = 'Save image…';
+      card.append(element, save);
+      article.append(card);
+    }
+    const actions = document.createElement('div');
+    actions.className = 'ai-message-actions';
+    const copy = document.createElement('button');
+    copy.type = 'button';
+    copy.dataset.copyMessage = message.id;
+    copy.textContent = 'Copy';
+    copy.disabled = !message.text;
+    actions.append(copy);
+    article.append(actions);
+    return article;
+  }
+
+  function renderMessages() {
+    const container = $('ai-messages');
+    container.replaceChildren();
+    for (const message of currentSession?.messages || []) container.append(messageNode(message));
+    $('ai-readonly-notice').textContent = currentSession?.readonlyReason === 'limit'
+      ? 'This conversation reached 128 MiB. Start a new conversation after deleting one if needed.'
+      : 'This conversation is read-only. Start a new conversation to continue.';
+    bindPendingMessageBody();
+    container.scrollTop = container.scrollHeight;
+  }
+
+  function bindPendingMessageBody() {
+    if (!pendingTurn) return;
+    const message = currentSession?.messages[pendingTurn.messageIndex];
+    const article = Array.from($('ai-messages').children)
+      .find((node) => node.dataset.messageId === message?.id);
+    pendingTurn.bodyNode = article?.querySelector('.ai-message-body') || null;
+  }
+
+  function selectMode(mode) {
+    selectedMode = A.MODES.has(mode) ? mode : 'text';
+    for (const button of $('ai-mode-picker').querySelectorAll('[data-ai-mode]')) {
+      const active = button.dataset.aiMode === selectedMode;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-pressed', String(active));
+    }
+  }
+
+  function setStreaming(streaming) {
+    $('btn-ai-send').hidden = streaming;
+    $('btn-ai-stop').hidden = !streaming;
+    $('btn-ai-stop').disabled = false;
+    $('ai-prompt').disabled = streaming;
+    for (const button of $('ai-mode-picker').querySelectorAll('button')) button.disabled = streaming;
+    $('ai-turn-status').textContent = streaming ? 'Generating…' : '';
+    if (!streaming) renderConnection();
+  }
+
+  function snapshotForSave(session) {
+    const snapshot = structuredClone(session);
+    for (const message of snapshot.messages) {
+      for (const image of message.images) delete image.path;
+    }
+    return snapshot;
+  }
+
+  function persist(session = currentSession) {
+    if (!session?.id) return Promise.resolve(0);
+    session.updatedAt = new Date().toISOString();
+    const snapshot = snapshotForSave(session);
+    persistChain = persistChain.catch(() => {}).then(async () => {
+      const size = await window.api.aiSaveSession(session.id, snapshot);
+      session.sizeBytes = size;
+      if (session === currentSession) {
+        if (pendingTurn) pendingTurn.capacityBytes = Math.max(pendingTurn.capacityBytes, size);
+        $('ai-chat-meta').textContent = session.status === 'readonly'
+          ? `Read-only · ${formatSize(size)}`
+          : `Active · ${formatSize(size)}`;
+      }
+      return size;
+    });
+    return persistChain;
+  }
+
+  function schedulePersist() {
+    clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      void persist().catch(handlePersistenceError);
+    }, 350);
+  }
+
+  function handlePersistenceError(error) {
+    if (String(error).includes('session_limit_exceeded')) {
+      void reachSessionLimit('Conversation reached 128 MiB.');
+      return;
+    }
+    $('ai-turn-status').textContent = `Save failed: ${error}`;
+  }
+
+  async function ensureThread() {
+    if (threadId) return threadId;
+    const status = await refreshStatus();
+    if (status.state !== 'available') throw new Error(connectionLabel());
+    const runtime = await window.api.aiRuntimeDirectory();
+    const config = await isolatedThreadConfig(runtime);
+    const result = await rpc('thread/start', {
+      cwd: runtime,
+      approvalPolicy: 'never',
+      sandbox: 'workspace-write',
+      personality: 'friendly',
+      serviceName: 'akbun_makevideo',
+      baseInstructions: A.baseInstructions(),
+      developerInstructions: DEVELOPER_INSTRUCTIONS,
+      ephemeral: true,
+      config,
+    });
+    threadId = result?.thread?.id;
+    if (!threadId) throw new Error('Codex did not create a conversation.');
+    return threadId;
+  }
+
+  function isolatedThreadConfig(runtime) {
+    if (isolatedConfigPromise) return isolatedConfigPromise;
+    isolatedConfigPromise = rpc('config/read', { cwd: runtime, includeLayers: false })
+      .then((result) => {
+        const servers = Object.keys(result?.config?.mcp_servers || {});
+        return {
+          web_search: 'disabled',
+          project_doc_max_bytes: 0,
+          include_apps_instructions: false,
+          include_collaboration_mode_instructions: false,
+          include_permissions_instructions: false,
+          features: {
+            apps: false,
+            plugins: false,
+            multi_agent: false,
+            memories: false,
+            hooks: false,
+            goals: false,
+            shell_tool: false,
+            unified_exec: false,
+            skill_mcp_dependency_install: false,
+          },
+          tools: { view_image: false },
+          memories: { generate_memories: false, use_memories: false },
+          mcp_servers: Object.fromEntries(servers.map((name) => [name, { enabled: false }])),
+        };
+      });
+    return isolatedConfigPromise;
+  }
+
+  async function startTurn(activeThreadId, text) {
+    const runtime = await window.api.aiRuntimeDirectory();
+    const requestedTurn = pendingTurn;
+    const result = await rpc('turn/start', {
+      threadId: activeThreadId,
+      input: [{ type: 'text', text }],
+      cwd: runtime,
+      approvalPolicy: 'never',
+      sandboxPolicy: {
+        type: 'workspaceWrite',
+        writableRoots: [runtime],
+        networkAccess: false,
+      },
+    }, 60_000);
+    requestedTurn.turnId = result?.turn?.id || requestedTurn.turnId;
+    if (requestedTurn.stopRequested && requestedTurn.turnId) {
+      await rpc('turn/interrupt', { threadId: activeThreadId, turnId: requestedTurn.turnId });
+    }
+  }
+
+  async function sendPrompt() {
+    if (pendingTurn || currentSession?.status === 'readonly') return;
+    const prompt = $('ai-prompt').value.trim();
+    if (!prompt) return;
+    try {
+      const activeThreadId = await ensureThread();
+      if (!currentSession) {
+        currentSession = A.createSession(A.cryptoId(), prompt, selectedMode);
+        $('ai-chat-title').textContent = currentSession.title;
+      } else {
+        currentSession.messages.push(A.createMessage('user', selectedMode, prompt));
+      }
+      await persist();
+      const assistant = A.createMessage('assistant', selectedMode, '', 'streaming');
+      currentSession.messages.push(assistant);
+      pendingTurn = {
+        mode: selectedMode,
+        messageIndex: currentSession.messages.length - 1,
+        turnId: null,
+        itemPhases: new Map(),
+        itemTexts: new Map(),
+        finalText: '',
+        imagePromises: [],
+        error: null,
+        stopRequested: false,
+        capacityBytes: A.byteLength(snapshotForSave(currentSession)) + currentSession.assetBytes,
+        bodyNode: null,
+      };
+      $('ai-prompt').value = '';
+      setStreaming(true);
+      renderMessages();
+      await startTurn(activeThreadId, A.composeTurn(selectedMode, prompt, options.project?.()));
+    } catch (error) {
+      if (String(error).includes('session_limit_exceeded') && currentSession) {
+        await reachSessionLimit('Conversation reached 128 MiB.');
+      } else if (String(error).includes('session_count_limit')) {
+        currentSession = null;
+        showList();
+        $('ai-list-status').textContent = 'Delete a conversation before starting a new one.';
+      } else {
+        if (pendingTurn) {
+          const message = currentSession.messages[pendingTurn.messageIndex];
+          message.text = String(error);
+          message.status = 'error';
+          pendingTurn = null;
+          await persist().catch(handlePersistenceError);
+        }
+        $('ai-turn-status').textContent = String(error).replace(/^Error:\s*/, '');
+      }
+      setStreaming(false);
+      renderMessages();
+    }
+  }
+
+  function appendAgentDelta(params) {
+    if (!pendingTurn) return;
+    const itemId = params.itemId || 'agent';
+    const text = (pendingTurn.itemTexts.get(itemId) || '') + (params.delta || '');
+    pendingTurn.itemTexts.set(itemId, text);
+    if (pendingTurn.itemPhases.get(itemId) === 'commentary') return;
+    pendingTurn.finalText = text;
+    const message = currentSession.messages[pendingTurn.messageIndex];
+    const delta = params.delta || '';
+    if (!A.canAppendText(pendingTurn.capacityBytes, delta)) {
+      void reachSessionLimit('Conversation reached 128 MiB.');
+      return;
+    }
+    pendingTurn.capacityBytes += A.encodedJsonTextBytes(delta);
+    message.text += delta;
+    if (!pendingTurn.bodyNode?.isConnected) bindPendingMessageBody();
+    if (pendingTurn.bodyNode) pendingTurn.bodyNode.textContent = message.text;
+    $('ai-messages').scrollTop = $('ai-messages').scrollHeight;
+    schedulePersist();
+  }
+
+  function completeItem(item) {
+    if (!pendingTurn) return;
+    if (item.type === 'agentMessage') {
+      pendingTurn.itemPhases.set(item.id, item.phase || 'final_answer');
+      if (!item.phase || item.phase === 'final_answer') {
+        pendingTurn.finalText = item.text || pendingTurn.itemTexts.get(item.id) || pendingTurn.finalText;
+      }
+    } else if (item.type === 'imageGeneration' && item.savedPath) {
+      const turn = pendingTurn;
+      const session = currentSession;
+      const promise = attachGeneratedImage(item, turn, session);
+      turn.imagePromises.push(promise);
+    }
+  }
+
+  async function attachGeneratedImage(item, turn, session) {
+    try {
+      const image = await window.api.aiAttachImage(session.id, item.savedPath, A.cryptoId());
+      const message = session.messages[turn.messageIndex];
+      message.images.push(image);
+      session.assetBytes += image.sizeBytes;
+      turn.capacityBytes += image.sizeBytes;
+      if (currentSession === session) renderMessages();
+      await persist(session);
+    } catch (error) {
+      if (String(error).includes('session_limit_exceeded')) {
+        if (currentSession === session) await reachSessionLimit('Generated image exceeds the 128 MiB conversation limit.');
+      } else {
+        turn.error = `Image save failed: ${error}`;
+      }
+    }
+  }
+
+  async function completeTurn(turn) {
+    const completed = pendingTurn;
+    if (!completed) return;
+    if (completed.turnId && turn.id && completed.turnId !== turn.id) return;
+    await Promise.allSettled(completed.imagePromises);
+    if (pendingTurn !== completed) return;
+    const message = currentSession.messages[completed.messageIndex];
+    const interrupted = completed.stopRequested || turn.status === 'interrupted';
+    if (currentSession.status === 'readonly' && currentSession.readonlyReason === 'limit') {
+      message.status = message.status === 'error' ? 'error' : 'stopped';
+    } else if (interrupted) {
+      message.status = 'stopped';
+    } else if (completed.error || turn.status === 'failed') {
+      message.status = 'error';
+      message.text = completed.error || turn.error?.message || 'AI request failed.';
+    } else if (completed.mode === 'image' && !message.images.length) {
+      message.status = 'error';
+      message.text = completed.finalText || 'Image generation did not return a saved image.';
+    } else {
+      message.status = 'complete';
+      message.text = completed.finalText || message.text ||
+        (message.images.length ? 'Image generated.' : 'No response received.');
+    }
+    pendingTurn = null;
+    setStreaming(false);
+    renderMessages();
+    await persist().catch(handlePersistenceError);
+  }
+
+  async function finishStoppedServer() {
+    if (!pendingTurn || !currentSession) return;
+    const message = currentSession.messages[pendingTurn.messageIndex];
+    message.status = 'stopped';
+    pendingTurn = null;
+    setStreaming(false);
+    renderMessages();
+    await persist().catch(handlePersistenceError);
+  }
+
+  async function stopTurn() {
+    if (!pendingTurn || pendingTurn.stopRequested) return;
+    pendingTurn.stopRequested = true;
+    $('btn-ai-stop').disabled = true;
+    $('ai-turn-status').textContent = 'Stopping…';
+    const message = currentSession.messages[pendingTurn.messageIndex];
+    message.status = 'stopped';
+    renderMessages();
+    await persist().catch(handlePersistenceError);
+    if (pendingTurn?.turnId) {
+      try {
+        await rpc('turn/interrupt', { threadId, turnId: pendingTurn.turnId });
+      } catch (error) {
+        $('ai-turn-status').textContent = `Stop failed: ${error}`;
+        pendingTurn = null;
+        setStreaming(false);
+      }
+    }
+  }
+
+  async function reachSessionLimit(detail) {
+    if (!currentSession || currentSession.status === 'readonly') return;
+    currentSession.status = 'readonly';
+    currentSession.readonlyReason = 'limit';
+    if (pendingTurn) {
+      pendingTurn.stopRequested = true;
+      pendingTurn.error = detail;
+      const message = currentSession.messages[pendingTurn.messageIndex];
+      message.status = pendingTurn.mode === 'image' ? 'error' : 'stopped';
+      if (pendingTurn.mode === 'image') message.text = detail;
+      if (pendingTurn.turnId) {
+        void rpc('turn/interrupt', { threadId, turnId: pendingTurn.turnId }).catch(() => {});
+      }
+    }
+    $('ai-turn-status').textContent = detail;
+    renderMessages();
+    await persist().catch(() => {});
+  }
+
+  async function closeConversation() {
+    if (pendingTurn) await stopTurn();
+    if (currentSession?.id && currentSession.status !== 'readonly') {
+      currentSession.status = 'readonly';
+      currentSession.readonlyReason = 'closed';
+      await persist().catch(handlePersistenceError);
+    }
+    showList();
+  }
+
+  async function copyText(messageId) {
+    const message = currentSession?.messages.find((item) => item.id === messageId);
+    if (!message?.text) return;
+    try {
+      await navigator.clipboard.writeText(message.text);
+      $('ai-turn-status').textContent = 'Copied.';
+    } catch (error) {
+      $('ai-turn-status').textContent = `Copy failed: ${error}`;
+    }
+  }
+
+  function findImage(id) {
+    return currentSession?.messages.flatMap((message) => message.images)
+      .find((image) => image.id === id);
+  }
+
+  async function saveImage(id) {
+    const image = findImage(id);
+    if (!image) return;
+    try {
+      const destination = await window.api.pickAiImageSave(image.fileName);
+      if (!destination) return;
+      await window.api.aiCopyImage(imagePath(image), destination);
+      $('ai-turn-status').textContent = 'Image saved.';
+    } catch (error) {
+      $('ai-turn-status').textContent = `Save failed: ${error}`;
+    }
+  }
+
+  function wireEvents() {
+    $('btn-ai-new').addEventListener('click', newConversation);
+    $('btn-ai-back').addEventListener('click', closeConversation);
+    $('btn-ai-send').addEventListener('click', sendPrompt);
+    $('btn-ai-stop').addEventListener('click', stopTurn);
+    $('btn-ai-refresh').addEventListener('click', refreshStatus);
+    $('ai-prompt').addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        void sendPrompt();
+      }
+    });
+    $('ai-mode-picker').addEventListener('click', (event) => {
+      const button = event.target.closest('[data-ai-mode]');
+      if (button && !button.disabled) selectMode(button.dataset.aiMode);
+    });
+    $('ai-session-list').addEventListener('click', (event) => {
+      const openButton = event.target.closest('[data-session-id]');
+      const deleteButton = event.target.closest('[data-delete-session]');
+      if (openButton) void openSavedSession(openButton.dataset.sessionId);
+      else if (deleteButton) void deleteSession(deleteButton.dataset.deleteSession);
+    });
+    $('ai-messages').addEventListener('click', (event) => {
+      const copy = event.target.closest('[data-copy-message]');
+      const image = event.target.closest('[data-save-image]');
+      if (copy) void copyText(copy.dataset.copyMessage);
+      else if (image) void saveImage(image.dataset.saveImage);
+    });
+  }
+
+  async function open() {
+    await loadSessionList();
+    await connect();
+  }
+
+  async function initialize(settings) {
+    options = settings || {};
+    wireEvents();
+    renderConnection();
+    renderSessionList();
+    await loadSessionList();
+  }
+
+  return { initialize, open, refreshStatus };
+});

--- a/product/akbun-makevideo/workspace/src/ai-panel.js
+++ b/product/akbun-makevideo/workspace/src/ai-panel.js
@@ -5,7 +5,7 @@
   if (typeof module !== 'undefined' && module.exports) module.exports = exported;
   else root.makevideoAiPanel = exported;
 })(globalThis, function () {
-  const A = globalThis.makevideoAi;
+  const A = globalThis.makevideoAiLib;
   const rpcPending = new Map();
   const $ = (id) => document.getElementById(id);
   let options = {};

--- a/product/akbun-makevideo/workspace/src/ai.js
+++ b/product/akbun-makevideo/workspace/src/ai.js
@@ -1,0 +1,201 @@
+'use strict';
+
+(function (root, factory) {
+  const exported = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = exported;
+  else root.makevideoAi = exported;
+})(globalThis, function () {
+  const SESSION_VERSION = 1;
+  const MAX_SESSIONS = 3;
+  const SESSION_LIMIT_BYTES = 128 * 1024 * 1024;
+  const SESSION_RESERVE_BYTES = 4 * 1024;
+  const MODES = new Set(['text', 'image']);
+  const MESSAGE_STATUSES = new Set(['streaming', 'complete', 'stopped', 'error']);
+  const SESSION_STATUSES = new Set(['active', 'readonly']);
+
+  function now() {
+    return new Date().toISOString();
+  }
+
+  function safeText(value, limit = 1_000_000) {
+    return typeof value === 'string' ? value.slice(0, limit) : '';
+  }
+
+  function cryptoId() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+
+  function sessionTitle(prompt) {
+    const title = String(prompt || '').replace(/\s+/g, ' ').trim();
+    if (!title) return 'Untitled conversation';
+    return title.length > 48 ? `${title.slice(0, 47)}…` : title;
+  }
+
+  function createMessage(role, mode, text, status = 'complete') {
+    return {
+      id: cryptoId(),
+      role: role === 'assistant' ? 'assistant' : 'user',
+      mode: MODES.has(mode) ? mode : 'text',
+      text: safeText(text),
+      status: MESSAGE_STATUSES.has(status) ? status : 'complete',
+      createdAt: now(),
+      images: [],
+    };
+  }
+
+  function createSession(id, prompt, mode) {
+    const createdAt = now();
+    return {
+      version: SESSION_VERSION,
+      id,
+      title: sessionTitle(prompt),
+      createdAt,
+      updatedAt: createdAt,
+      status: 'active',
+      readonlyReason: null,
+      sizeBytes: 0,
+      assetBytes: 0,
+      messages: [createMessage('user', mode, prompt)],
+    };
+  }
+
+  function normalizeImage(value) {
+    const source = value && typeof value === 'object' ? value : {};
+    const fileName = safeText(source.fileName, 140);
+    if (!/^[a-zA-Z0-9_-]{1,64}\.(png|jpg|jpeg|webp)$/i.test(fileName)) return null;
+    return {
+      id: safeText(source.id, 64),
+      fileName,
+      path: safeText(source.path, 4096),
+      sizeBytes: Math.max(0, Number(source.sizeBytes) || 0),
+    };
+  }
+
+  function normalizeMessage(value) {
+    const source = value && typeof value === 'object' ? value : {};
+    return {
+      id: safeText(source.id, 64) || cryptoId(),
+      role: source.role === 'assistant' ? 'assistant' : 'user',
+      mode: MODES.has(source.mode) ? source.mode : 'text',
+      text: safeText(source.text),
+      status: MESSAGE_STATUSES.has(source.status) ? source.status : 'complete',
+      createdAt: safeText(source.createdAt, 40) || now(),
+      images: Array.isArray(source.images)
+        ? source.images.map(normalizeImage).filter(Boolean).slice(0, 100)
+        : [],
+    };
+  }
+
+  function normalizeSession(value) {
+    const source = value && typeof value === 'object' ? value : {};
+    const messages = Array.isArray(source.messages)
+      ? source.messages.map(normalizeMessage).slice(0, 10_000)
+      : [];
+    return {
+      version: SESSION_VERSION,
+      id: safeText(source.id, 64),
+      title: safeText(source.title, 80) || 'Untitled conversation',
+      createdAt: safeText(source.createdAt, 40) || now(),
+      updatedAt: safeText(source.updatedAt, 40) || now(),
+      status: SESSION_STATUSES.has(source.status) ? source.status : 'readonly',
+      readonlyReason: source.readonlyReason == null ? null : safeText(source.readonlyReason, 80),
+      sizeBytes: Math.max(0, Number(source.sizeBytes) || 0),
+      assetBytes: Math.max(
+        0,
+        Number(source.assetBytes) || messages.flatMap((message) => message.images)
+          .reduce((sum, image) => sum + image.sizeBytes, 0)
+      ),
+      messages,
+    };
+  }
+
+  function restoreInterruptedSession(value) {
+    const session = normalizeSession(value);
+    session.status = 'readonly';
+    session.readonlyReason = 'app_closed';
+    session.updatedAt = now();
+    for (const message of session.messages) {
+      if (message.status === 'streaming') message.status = 'stopped';
+    }
+    return session;
+  }
+
+  function disconnectedConnection(detail) {
+    return {
+      state: 'unavailable',
+      account: null,
+      server: null,
+      detail: String(detail || 'Codex App Server stopped.'),
+    };
+  }
+
+  function byteLength(value) {
+    return new TextEncoder().encode(`${JSON.stringify(value, null, 2)}\n`).byteLength;
+  }
+
+  function encodedJsonTextBytes(value) {
+    const encoded = JSON.stringify(String(value || '')).slice(1, -1);
+    return new TextEncoder().encode(encoded).byteLength;
+  }
+
+  function canAppendText(currentBytes, delta) {
+    return currentBytes + encodedJsonTextBytes(delta) + SESSION_RESERVE_BYTES <= SESSION_LIMIT_BYTES;
+  }
+
+  function projectDigest(project) {
+    if (!project || typeof project !== 'object') return 'No video project is open.';
+    const settings = project.settings || {};
+    const rate = settings.rate || {};
+    const lines = [
+      `Canvas: ${Number(settings.width) || 0}x${Number(settings.height) || 0}`,
+      `Frame rate: ${Number(rate.num) || 0}/${Number(rate.den) || 1}`,
+      `Assets: ${(project.assets || []).length}`,
+      `Markers: ${(project.markers || []).length}`,
+    ];
+    for (const track of project.tracks || []) {
+      lines.push(`Track ${safeText(track.name, 120) || track.id}: ${track.kind}, ${(track.clips || []).length} clips`);
+    }
+    return lines.join('\n');
+  }
+
+  function baseInstructions() {
+    return [
+      'You are the AI assistant inside akbun-makevideo, a desktop video editor.',
+      'You can explain editing choices, draft narration and captions, and generate still images.',
+      'You cannot change the project. Give instructions the user can review and apply.',
+      'Every request is labelled TEXT MODE or IMAGE MODE. Obey the labelled mode.',
+    ].join(' ');
+  }
+
+  function composeTurn(mode, prompt, project) {
+    const selected = MODES.has(mode) ? mode : 'text';
+    const rules = selected === 'image'
+      ? 'IMAGE MODE. Generate exactly one image with the built-in image generation capability. Do not return editing commands.'
+      : 'TEXT MODE. Return text only. Do not call image generation or any other tool.';
+    return [rules, '', 'Current project summary:', projectDigest(project), '', 'User request:', safeText(prompt, 100_000)].join('\n');
+  }
+
+  return {
+    SESSION_VERSION,
+    MAX_SESSIONS,
+    SESSION_LIMIT_BYTES,
+    SESSION_RESERVE_BYTES,
+    MODES,
+    sessionTitle,
+    createMessage,
+    createSession,
+    normalizeSession,
+    restoreInterruptedSession,
+    disconnectedConnection,
+    byteLength,
+    encodedJsonTextBytes,
+    canAppendText,
+    cryptoId,
+    projectDigest,
+    baseInstructions,
+    composeTurn,
+  };
+});

--- a/product/akbun-makevideo/workspace/src/ai.js
+++ b/product/akbun-makevideo/workspace/src/ai.js
@@ -3,7 +3,7 @@
 (function (root, factory) {
   const exported = factory();
   if (typeof module !== 'undefined' && module.exports) module.exports = exported;
-  else root.makevideoAi = exported;
+  else root.makevideoAiLib = exported;
 })(globalThis, function () {
   const SESSION_VERSION = 1;
   const MAX_SESSIONS = 3;
@@ -17,7 +17,7 @@
     return new Date().toISOString();
   }
 
-  function safeText(value, limit = 1_000_000) {
+  function safeText(value, limit = SESSION_LIMIT_BYTES) {
     return typeof value === 'string' ? value.slice(0, limit) : '';
   }
 

--- a/product/akbun-makevideo/workspace/src/api.js
+++ b/product/akbun-makevideo/workspace/src/api.js
@@ -114,6 +114,7 @@ if (!window.__TAURI__) {
     pickRenderOutput: unavailable,
     pickSrtOpen: unavailable,
     pickSrtSave: unavailable,
+    pickAiImageSave: unavailable,
     pickFolder: unavailable,
     listProjects: async () => [],
     previewFrame: unavailable,
@@ -183,6 +184,21 @@ if (!window.__TAURI__) {
     onCloseRequested: () => {},
     closeWindow: () => {},
     checkUpdate: async () => {},
+    aiStartServer: async () => ({ running: false, reason: 'desktop_required' }),
+    aiSendRpc: async () => {
+      throw new Error('AI integration needs the desktop app.');
+    },
+    aiStopServer: async () => {},
+    aiRuntimeDirectory: async () => '',
+    aiListSessions: async () => [],
+    aiLoadSession: async () => null,
+    aiSaveSession: async () => 0,
+    aiDeleteSession: async () => {},
+    aiAttachImage: async () => null,
+    aiCopyImage: async () => {},
+    aiImageUrl: (path) => path,
+    onAiServerMessage: () => Promise.resolve(() => {}),
+    onAiServerState: () => Promise.resolve(() => {}),
     reportError: async (source, text) => console.error(source, text),
   };
   throw new Error('not running under Tauri; using the browser fallback api');
@@ -265,6 +281,11 @@ window.api = {
     }),
   pickSrtOpen: () => openDialog({ title: 'Import SubRip', filters: SRT_FILTERS }),
   pickSrtSave: (defaultName) => saveDialog({ title: 'Export SubRip', defaultPath: defaultName, filters: SRT_FILTERS }),
+  pickAiImageSave: (defaultName) => saveDialog({
+    title: 'Save AI Image',
+    defaultPath: defaultName,
+    filters: [{ name: 'Image', extensions: ['png', 'jpg', 'jpeg', 'webp'] }],
+  }),
   pickLut: () => openDialog({ title: 'Apply 3D LUT', filters: LUT_FILTERS }),
 
   pickFolder: (title) => openDialog({ title, directory: true, multiple: false }),
@@ -365,6 +386,23 @@ window.api = {
   onCloseRequested: (handler) => getCurrentWindow().onCloseRequested(handler),
   closeWindow: () => getCurrentWindow().destroy(),
   checkUpdate,
+  aiStartServer: () => invoke('ai_start_server'),
+  aiSendRpc: (message) => invoke('ai_send_rpc', { message }),
+  aiStopServer: () => invoke('ai_stop_server'),
+  aiRuntimeDirectory: () => invoke('ai_runtime_directory'),
+  aiListSessions: () => invoke('ai_list_sessions'),
+  aiLoadSession: (sessionId) => invoke('ai_load_session', { sessionId }),
+  aiSaveSession: (sessionId, session) => invoke('ai_save_session', { sessionId, session }),
+  aiDeleteSession: (sessionId) => invoke('ai_delete_session', { sessionId }),
+  aiAttachImage: (sessionId, sourcePath, imageId) =>
+    invoke('ai_attach_image', { sessionId, sourcePath, imageId }),
+  aiCopyImage: (sourcePath, destinationPath) =>
+    invoke('ai_copy_image', { sourcePath, destinationPath }),
+  aiImageUrl: (path) => convertFileSrc(path),
+  onAiServerMessage: (handler) =>
+    listen('ai-server-message', (event) => handler(event.payload)),
+  onAiServerState: (handler) =>
+    listen('ai-server-state', (event) => handler(event.payload)),
 };
 
 function pageErrorText(error) {

--- a/product/akbun-makevideo/workspace/src/app-init.js
+++ b/product/akbun-makevideo/workspace/src/app-init.js
@@ -324,7 +324,7 @@
 
       await globalThis.makevideoAiPanel.initialize({
         project: () => state.project,
-        version: () => state.boot.version,
+        version: () => state.boot?.version || '',
       });
 
       // The system's font families, for the text inspectors' pickers. Off the

--- a/product/akbun-makevideo/workspace/src/app-init.js
+++ b/product/akbun-makevideo/workspace/src/app-init.js
@@ -322,6 +322,11 @@
         dom.toolWarning.title = 'Open Settings to inspect the error log location';
       }
 
+      await globalThis.makevideoAiPanel.initialize({
+        project: () => state.project,
+        version: () => state.boot.version,
+      });
+
       // The system's font families, for the text inspectors' pickers. Off the
       // boot path on purpose: reading every font file's name takes long enough to
       // notice, and nothing before the first font edit needs the list.

--- a/product/akbun-makevideo/workspace/src/index.html
+++ b/product/akbun-makevideo/workspace/src/index.html
@@ -49,6 +49,10 @@
       <g id="icon-debug">
         <path d="M6 7.5h8v5a4 4 0 0 1-8 0v-5ZM8 7.5V5a2 2 0 0 1 4 0v2.5M3.5 9h2.5M14 9h2.5M3.5 13h2.5M14 13h2.5M6 16l-2 2M14 16l2 2" />
       </g>
+      <g id="icon-ai">
+        <path d="M10 2.5 11.7 7l4.3 1.8-4.3 1.7L10 15l-1.7-4.5L4 8.8 8.3 7 10 2.5Z" />
+        <path d="m15.5 13 .7 1.8L18 15.5l-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8Z" />
+      </g>
     </defs>
   </svg>
 
@@ -146,6 +150,10 @@
       <button class="global-action" type="button" data-panel-action="debug" aria-controls="selected-panel" aria-expanded="false" aria-pressed="false">
         <svg viewBox="0 0 20 20" aria-hidden="true"><use href="#icon-debug" /></svg>
         <span>Debug</span>
+      </button>
+      <button class="global-action" type="button" data-panel-action="ai" aria-controls="selected-panel" aria-expanded="false" aria-pressed="false">
+        <svg viewBox="0 0 20 20" aria-hidden="true"><use href="#icon-ai" /></svg>
+        <span>AI</span>
       </button>
     </div>
   </header>
@@ -379,6 +387,46 @@
           </div>
           <pre id="debug-log" class="debug-log" hidden></pre>
         </section>
+        <section id="ai-view" class="selected-panel-view" hidden>
+          <div id="ai-list-view" class="ai-panel-page">
+            <header class="ai-panel-header">
+              <div>
+                <h3>Conversations</h3>
+                <p>Saved on this device</p>
+              </div>
+              <button id="btn-ai-new" type="button" class="primary">New</button>
+            </header>
+            <div id="ai-connection-banner" class="ai-connection-banner" data-state="checking">
+              <span class="ai-status-dot" aria-hidden="true"></span>
+              <span id="ai-connection-text">Checking Codex…</span>
+            </div>
+            <p id="ai-list-status" class="ai-panel-status" aria-live="polite"></p>
+            <div id="ai-session-list" class="ai-session-list"></div>
+          </div>
+          <div id="ai-chat-view" class="ai-panel-page ai-chat-view" hidden>
+            <header class="ai-chat-header">
+              <button id="btn-ai-back" type="button">Back</button>
+              <div>
+                <h3 id="ai-chat-title">New conversation</h3>
+                <p id="ai-chat-meta"></p>
+              </div>
+            </header>
+            <div id="ai-messages" class="ai-messages" aria-live="polite"></div>
+            <div id="ai-readonly-notice" class="ai-readonly-notice" hidden></div>
+            <div id="ai-composer" class="ai-composer">
+              <div id="ai-mode-picker" class="ai-mode-picker" role="group" aria-label="AI output">
+                <button type="button" class="active" data-ai-mode="text" aria-pressed="true">Text</button>
+                <button type="button" data-ai-mode="image" aria-pressed="false">Image</button>
+              </div>
+              <textarea id="ai-prompt" rows="4" maxlength="100000" placeholder="Ask for editing advice, narration, captions, or an image…"></textarea>
+              <div class="ai-composer-actions">
+                <span id="ai-turn-status" aria-live="polite"></span>
+                <button id="btn-ai-stop" type="button" hidden>Stop</button>
+                <button id="btn-ai-send" type="button" class="primary">Send</button>
+              </div>
+            </div>
+          </div>
+        </section>
       </aside>
     </section>
 
@@ -507,6 +555,18 @@
   <div id="app-settings" class="overlay" hidden>
     <div class="sheet">
       <h3>Preview &amp; Tools</h3>
+      <section class="settings-ai-section">
+        <h4>AI</h4>
+        <p class="dim small-text">Uses the ChatGPT subscription connected through the installed Codex CLI. API key authentication is not supported.</p>
+        <div id="settings-ai-status" class="settings-ai-status" data-state="checking">
+          <span class="ai-status-dot" aria-hidden="true"></span>
+          <div>
+            <strong id="settings-ai-status-title">Checking Codex…</strong>
+            <p id="settings-ai-status-detail">Looking for Codex CLI and ChatGPT authentication.</p>
+          </div>
+        </div>
+        <button id="btn-ai-refresh" type="button">Refresh AI status</button>
+      </section>
       <label class="row">Preview quality
         <select id="as-quality">
           <option value="full">Full</option>
@@ -637,6 +697,8 @@
   </div>
 
   <script src="api.js"></script>
+  <script src="ai.js"></script>
+  <script src="ai-panel.js"></script>
   <script src="time.js"></script>
   <script src="geometry.js"></script>
   <script src="timeline.js"></script>

--- a/product/akbun-makevideo/workspace/src/renderer-assets-ui.js
+++ b/product/akbun-makevideo/workspace/src/renderer-assets-ui.js
@@ -203,6 +203,7 @@
       shape: 'Shape',
       marker: 'Marker',
       debug: 'Debug',
+      ai: 'AI',
     };
 
     function activateSelectedPanel(panel) {
@@ -213,6 +214,8 @@
       dom.shapeToolView.hidden = panel !== 'shape';
       dom.markerToolView.hidden = panel !== 'marker';
       dom.debugPanel.hidden = panel !== 'debug';
+      dom.aiView.hidden = panel !== 'ai';
+      dom.panelTabBar.hidden = panel === 'ai';
       dom.selectedPanelTitle.textContent = panel ? PANEL_TITLES[panel] : 'Inspector';
       for (const button of dom.globalActions.querySelectorAll('[data-panel-action]')) {
         const active = button.dataset.panelAction === panel;
@@ -221,6 +224,7 @@
       }
       if (panel === 'debug') startDebug();
       else stopDebug();
+      if (panel === 'ai') void globalThis.makevideoAiPanel.open();
       window.requestAnimationFrame(() => {
         if (preview) preview.layout();
         if (sourcePreview) sourcePreview.layout();

--- a/product/akbun-makevideo/workspace/src/renderer-wiring.js
+++ b/product/akbun-makevideo/workspace/src/renderer-wiring.js
@@ -148,6 +148,7 @@
       'app-settings': () => {
         fillAppSheet();
         openSheet('app-settings');
+        void globalThis.makevideoAiPanel.refreshStatus();
       },
       'shortcut-settings': () => {
         shortcutController.fillSheet();

--- a/product/akbun-makevideo/workspace/src/renderer.js
+++ b/product/akbun-makevideo/workspace/src/renderer.js
@@ -76,6 +76,7 @@ const dom = {
   inspectorView: el('inspector-view'),
   shapeToolView: el('shape-tool-view'),
   markerToolView: el('marker-tool-view'),
+  aiView: el('ai-view'),
   toolWarning: el('tool-warning'),
   playbackWarning: el('playback-warning'),
   assetList: el('asset-list'),

--- a/product/akbun-makevideo/workspace/src/style-overlays.css
+++ b/product/akbun-makevideo/workspace/src/style-overlays.css
@@ -29,6 +29,31 @@
   font-size: 15px;
 }
 
+.settings-ai-section {
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.settings-ai-section h4 {
+  margin: 0 0 4px;
+}
+
+.settings-ai-status {
+  margin: 10px 0;
+  align-items: flex-start;
+}
+
+.settings-ai-status strong {
+  display: block;
+}
+
+.settings-ai-status p {
+  margin: 3px 0 0;
+  color: var(--dim);
+  font-size: 11px;
+}
+
 .sheet .row {
   display: flex;
   align-items: center;

--- a/product/akbun-makevideo/workspace/src/style-timeline.css
+++ b/product/akbun-makevideo/workspace/src/style-timeline.css
@@ -193,6 +193,10 @@ button.icon.on {
   background: var(--panel-2);
 }
 
+#panel-tab-bar[hidden] {
+  display: none;
+}
+
 #panel-tab-bar button {
   flex: 0 0 auto;
   padding: 2px 4px;
@@ -220,6 +224,279 @@ button.icon.on {
 .selected-panel-view h3 {
   margin: 2px 0 10px;
   font-size: 13px;
+}
+
+#ai-view {
+  padding: 0;
+  overflow: hidden;
+}
+
+.ai-panel-page {
+  height: 100%;
+  min-height: 0;
+}
+
+.ai-panel-page[hidden] {
+  display: none;
+}
+
+.ai-panel-header,
+.ai-chat-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.ai-panel-header {
+  justify-content: space-between;
+}
+
+.ai-panel-header h3,
+.ai-chat-header h3 {
+  margin: 0;
+}
+
+.ai-panel-header p,
+.ai-chat-header p {
+  margin: 2px 0 0;
+  color: var(--dim);
+  font-size: 11px;
+}
+
+.ai-chat-header > div {
+  min-width: 0;
+}
+
+.ai-chat-header h3,
+.ai-chat-header p {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-connection-banner,
+.settings-ai-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel-2);
+}
+
+.ai-status-dot {
+  flex: none;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--dim);
+}
+
+[data-state='available'] .ai-status-dot {
+  background: #2f9e44;
+}
+
+[data-state='unavailable'] .ai-status-dot {
+  background: var(--danger);
+}
+
+.ai-panel-status {
+  min-height: 1.2em;
+  margin: 0 10px 6px;
+  color: var(--dim);
+  font-size: 11px;
+}
+
+.ai-session-list {
+  height: calc(100% - 106px);
+  padding: 0 10px 10px;
+  overflow-y: auto;
+}
+
+.ai-session-empty {
+  display: flex;
+  height: 100%;
+  min-height: 160px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--dim);
+  text-align: center;
+}
+
+.ai-session-empty strong {
+  color: var(--fg);
+}
+
+.ai-session-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.ai-session-open {
+  min-width: 0;
+  border-color: transparent;
+  background: transparent;
+  text-align: left;
+}
+
+.ai-session-open strong,
+.ai-session-open span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-session-open span {
+  margin-top: 2px;
+  color: var(--dim);
+  font-size: 10px;
+}
+
+.ai-session-delete {
+  align-self: center;
+  color: var(--danger);
+}
+
+.ai-chat-view {
+  display: flex;
+  flex-direction: column;
+}
+
+.ai-messages {
+  flex: 1;
+  min-height: 0;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.ai-message {
+  margin-bottom: 12px;
+}
+
+.ai-message-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 3px;
+  color: var(--dim);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.ai-message-body {
+  margin: 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  user-select: text;
+  white-space: pre-wrap;
+}
+
+.ai-message[data-role='user'] .ai-message-body {
+  border-color: var(--accent);
+  background: var(--panel-2);
+}
+
+.ai-message-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.ai-message-actions button,
+.ai-image-card button {
+  padding: 2px 6px;
+  color: var(--dim);
+  font-size: 10px;
+}
+
+.ai-image-card {
+  margin-top: 6px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--panel-2);
+}
+
+.ai-image-card img {
+  display: block;
+  width: 100%;
+  max-height: 220px;
+  margin-bottom: 5px;
+  border-radius: 4px;
+  object-fit: contain;
+  background: var(--stage);
+}
+
+.ai-readonly-notice {
+  margin: 0 10px 10px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--dim);
+  background: var(--panel-2);
+  font-size: 11px;
+}
+
+.ai-composer {
+  flex: none;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border);
+}
+
+.ai-mode-picker {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 4px;
+  margin-bottom: 6px;
+}
+
+.ai-mode-picker button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+#ai-prompt {
+  width: 100%;
+  min-height: 70px;
+  padding: 6px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  background: var(--panel-2);
+  font: inherit;
+  user-select: text;
+}
+
+.ai-composer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  margin-top: 6px;
+}
+
+#ai-turn-status {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--dim);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .selected-panel-actions {

--- a/product/akbun-makevideo/workspace/test/ai.test.js
+++ b/product/akbun-makevideo/workspace/test/ai.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const A = require('../src/ai.js');
+
+test('creates an app-owned active session from the first prompt', () => {
+  const session = A.createSession('conversation-1', '  Make a concise title sequence  ', 'text');
+
+  assert.equal(session.id, 'conversation-1');
+  assert.equal(session.title, 'Make a concise title sequence');
+  assert.equal(session.status, 'active');
+  assert.equal(session.messages[0].role, 'user');
+  assert.equal(session.messages[0].mode, 'text');
+});
+
+test('normalizes restored sessions as bounded safe data', () => {
+  const restored = A.normalizeSession({
+    id: 'saved',
+    status: 'unexpected',
+    messages: [{
+      role: 'assistant',
+      mode: 'unknown',
+      status: 'streaming',
+      images: [
+        { id: 'ok', fileName: 'image-1.png', sizeBytes: 32 },
+        { id: 'bad', fileName: '../secret.png', sizeBytes: 64 },
+      ],
+    }],
+  });
+
+  assert.equal(restored.status, 'readonly');
+  assert.equal(restored.messages[0].mode, 'text');
+  assert.deepEqual(restored.messages[0].images.map((image) => image.id), ['ok']);
+});
+
+test('turns a session interrupted by app exit into read-only stopped history', () => {
+  const restored = A.restoreInterruptedSession({
+    id: 'interrupted',
+    status: 'active',
+    messages: [{ role: 'assistant', status: 'streaming', text: 'partial' }],
+  });
+
+  assert.equal(restored.status, 'readonly');
+  assert.equal(restored.readonlyReason, 'app_closed');
+  assert.equal(restored.messages[0].status, 'stopped');
+  assert.equal(restored.messages[0].text, 'partial');
+});
+
+test('drops stale server state so the next turn can reconnect', () => {
+  const connection = A.disconnectedConnection('process exited');
+
+  assert.equal(connection.state, 'unavailable');
+  assert.equal(connection.server, null);
+  assert.equal(connection.account, null);
+  assert.equal(connection.detail, 'process exited');
+});
+
+test('accounts for JSON escaping before accepting a streaming delta', () => {
+  const almostFull = A.SESSION_LIMIT_BYTES - A.SESSION_RESERVE_BYTES - 1;
+
+  assert.equal(A.canAppendText(almostFull, 'a'), true);
+  assert.equal(A.canAppendText(almostFull, '\n'), false);
+});
+
+test('project digest exposes counts without file paths or media contents', () => {
+  const digest = A.projectDigest({
+    settings: { width: 1920, height: 1080, rate: { num: 30000, den: 1001 } },
+    assets: [{ path: '/private/video.mov' }],
+    markers: [{ frame: 10 }],
+    tracks: [{ id: 'v1', name: 'Video 1', kind: 'video', clips: [{ id: 'c1' }] }],
+  });
+
+  assert.match(digest, /1920x1080/);
+  assert.match(digest, /30000\/1001/);
+  assert.match(digest, /Video 1: video, 1 clips/);
+  assert.doesNotMatch(digest, /private|video\.mov/);
+});
+
+test('turn prompts lock output mode and include the current project summary', () => {
+  const turn = A.composeTurn('image', 'Draw a title card', {
+    settings: { width: 1080, height: 1920, rate: { num: 30, den: 1 } },
+    assets: [],
+    markers: [],
+    tracks: [],
+  });
+
+  assert.match(turn, /^IMAGE MODE\./);
+  assert.match(turn, /Current project summary:\nCanvas: 1080x1920/);
+  assert.match(turn, /User request:\nDraw a title card/);
+});

--- a/product/akbun-makevideo/workspace/test/ai.test.js
+++ b/product/akbun-makevideo/workspace/test/ai.test.js
@@ -34,6 +34,16 @@ test('normalizes restored sessions as bounded safe data', () => {
   assert.deepEqual(restored.messages[0].images.map((image) => image.id), ['ok']);
 });
 
+test('keeps a valid saved response longer than one million characters', () => {
+  const text = 'a'.repeat(1_000_001);
+  const restored = A.normalizeSession({
+    id: 'large-response',
+    messages: [{ role: 'assistant', text }],
+  });
+
+  assert.equal(restored.messages[0].text.length, text.length);
+});
+
 test('turns a session interrupted by app exit into read-only stopped history', () => {
   const restored = A.restoreInterruptedSession({
     id: 'interrupted',

--- a/product/akbun-makevideo/workspace/test/scripts.test.js
+++ b/product/akbun-makevideo/workspace/test/scripts.test.js
@@ -105,7 +105,7 @@ test('the editor exposes one toggleable selected panel from the title bar', () =
   assert.doesNotMatch(page, /role="tab(?:list|panel)?"/);
   assert.deepStrictEqual(
     [...page.matchAll(/data-panel-action="([^"]+)"/g)].map((match) => match[1]),
-    ['inspector', 'shape', 'marker', 'debug'],
+    ['inspector', 'shape', 'marker', 'debug', 'ai'],
   );
   assert.deepStrictEqual(
     [...page.matchAll(/data-inspector-tab="([^"]+)"/g)].map((match) => match[1]),


### PR DESCRIPTION
# 구현

Codex App Server 기반 AI 패널과 앱 소유 세션 저장소 추가
- makevideo JavaScript 194개, 공용 AI Rust 9개, makepresentation JavaScript 126개·Rust 13개 통과

# 어려웠던 점

makepresentation 전용 런타임을 두 제품이 공유하는 Tauri 비의존 경계로 분리
- 프로젝트 경로와 미디어 내용을 모델에 넘기지 않는 digest 및 session lifetime 분리

# 리스크

실제 타임라인 편집 반영은 선행 Issue #678까지 수동 적용으로 제한
- 생성 이미지는 세션 삭제와 project asset lifetime 충돌을 피하려 파일 저장만 제공

Issue #1088
