### PR TITLE
fix: akbun-pdf PDF 열기 실패 수정

### DIFF
--- a/product/akbun-pdf/adr/2026-09-webkit-stream-async-iterator.md
+++ b/product/akbun-pdf/adr/2026-09-webkit-stream-async-iterator.md
@@ -1,0 +1,11 @@
+# WebKit ReadableStream 비동기 이터레이터 보강
+
+## 결정
+
+- 앱 시작 시 ReadableStream.prototype에 Symbol.asyncIterator를 없을 때만 설치
+- PDF.js 호출부를 고치지 않고 런타임 결손만 채움
+
+## 이유
+
+- WKWebView는 ReadableStream 비동기 이터레이터를 구현하지 않아 PDF.js getTextContent()가 TypeError로 끊김
+- 텍스트 레이어, 검색, AI 요약이 모두 같은 호출을 거쳐 한 곳에서 막아야 전부 살아남음

--- a/product/akbun-pdf/adr/index.md
+++ b/product/akbun-pdf/adr/index.md
@@ -13,3 +13,4 @@
 | [2026-09-page-correction-v1.md](./2026-09-page-correction-v1.md) | v1 페이지 보정을 기울기·원근으로 제한 |
 | [2026-09-fixed-updater-tag.md](./2026-09-fixed-updater-tag.md) | 제품별 고정 tag에서 updater manifest 제공 |
 | [2026-09-bundle-pdfjs-decoders.md](./2026-09-bundle-pdfjs-decoders.md) | PDF.js 이미지 decoder 자산을 앱에 함께 번들 |
+| [2026-09-webkit-stream-async-iterator.md](./2026-09-webkit-stream-async-iterator.md) | WebKit에 없는 ReadableStream 비동기 이터레이터를 앱 시작 시 보강 |

--- a/product/akbun-pdf/workspace/package.json
+++ b/product/akbun-pdf/workspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "akbun-pdf",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "Desktop PDF reader, organizer, annotator, and Codex summary workspace",
   "author": "akbun",

--- a/product/akbun-pdf/workspace/test/pdf-engine.test.ts
+++ b/product/akbun-pdf/workspace/test/pdf-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sharedAssetDirectory } from "../ui/src/pdf-engine";
+import { installStreamAsyncIteration, sharedAssetDirectory } from "../ui/src/pdf-engine";
 
 describe("PDF.js runtime assets", () => {
   it("uses the common directory for decoder assets", () => {
@@ -14,5 +14,25 @@ describe("PDF.js runtime assets", () => {
       ["/assets/jbig2.wasm", "/fallback/jbig2_nowasm_fallback.js"],
       "http://127.0.0.1:1420/",
     )).toThrow("PDF.js 런타임 자산 경로가 일치하지 않습니다.");
+  });
+});
+
+describe("WebKit ReadableStream fallback", () => {
+  it("iterates a stream that lacks the async iterator", async () => {
+    class LegacyStream {
+      private chunks = ["a", "b"];
+      getReader() {
+        return {
+          read: async () => this.chunks.length
+            ? { done: false, value: this.chunks.shift() }
+            : { done: true, value: undefined },
+          cancel: async () => undefined,
+        };
+      }
+    }
+    installStreamAsyncIteration(LegacyStream.prototype);
+    const seen: string[] = [];
+    for await (const chunk of new LegacyStream() as unknown as AsyncIterable<string>) seen.push(chunk);
+    expect(seen).toEqual(["a", "b"]);
   });
 });

--- a/product/akbun-pdf/workspace/test/pdf-engine.test.ts
+++ b/product/akbun-pdf/workspace/test/pdf-engine.test.ts
@@ -20,6 +20,7 @@ describe("PDF.js runtime assets", () => {
 describe("WebKit ReadableStream fallback", () => {
   it("iterates a stream that lacks the async iterator", async () => {
     class LegacyStream {
+      released = 0;
       private chunks = ["a", "b"];
       getReader() {
         return {
@@ -27,12 +28,17 @@ describe("WebKit ReadableStream fallback", () => {
             ? { done: false, value: this.chunks.shift() }
             : { done: true, value: undefined },
           cancel: async () => undefined,
+          releaseLock: () => {
+            this.released += 1;
+          },
         };
       }
     }
     installStreamAsyncIteration(LegacyStream.prototype);
+    const stream = new LegacyStream();
     const seen: string[] = [];
-    for await (const chunk of new LegacyStream() as unknown as AsyncIterable<string>) seen.push(chunk);
+    for await (const chunk of stream as unknown as AsyncIterable<string>) seen.push(chunk);
     expect(seen).toEqual(["a", "b"]);
+    expect(stream.released).toBe(1);
   });
 });

--- a/product/akbun-pdf/workspace/ui/src/pdf-engine.ts
+++ b/product/akbun-pdf/workspace/ui/src/pdf-engine.ts
@@ -69,9 +69,14 @@ export function installStreamAsyncIteration(prototype: object = ReadableStream.p
     value: function asyncIterator(this: ReadableStream) {
       const reader = this.getReader();
       return {
-        next: () => reader.read(),
+        next: async () => {
+          const result = await reader.read();
+          if (result.done) reader.releaseLock();
+          return result;
+        },
         return: async (value?: unknown) => {
           await reader.cancel();
+          reader.releaseLock();
           return { done: true, value };
         },
         [Symbol.asyncIterator]() {

--- a/product/akbun-pdf/workspace/ui/src/pdf-engine.ts
+++ b/product/akbun-pdf/workspace/ui/src/pdf-engine.ts
@@ -59,7 +59,31 @@ export function sharedAssetDirectory(assetUrls: string[], baseUrl: string): stri
   return [...directories][0];
 }
 
+// WebKit(WKWebView)은 ReadableStream의 비동기 이터레이터를 구현하지 않아
+// pdf.js getTextContent()의 `for await (... of readableStream)`이 TypeError로 끊긴다.
+export function installStreamAsyncIteration(prototype: object = ReadableStream.prototype): void {
+  if (Symbol.asyncIterator in prototype) return;
+  Object.defineProperty(prototype, Symbol.asyncIterator, {
+    configurable: true,
+    writable: true,
+    value: function asyncIterator(this: ReadableStream) {
+      const reader = this.getReader();
+      return {
+        next: () => reader.read(),
+        return: async (value?: unknown) => {
+          await reader.cancel();
+          return { done: true, value };
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    },
+  });
+}
+
 export function configurePdfEngine(): void {
+  installStreamAsyncIteration();
   GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 }
 


### PR DESCRIPTION
# 구현

앱 시작 시 ReadableStream 비동기 이터레이터 보강으로 PDF 열기 복구
- 27.9MB 307쪽 PDF를 실제 데스크톱 앱에서 열어 phase ready, 페이지 307 확인

# 어려웠던 점

브라우저 미리보기에서는 PDF.js가 정상 동작해 증상 재현 불가
- Tauri 바이너리에 임시 자동 열기와 stderr 출력을 넣어 TypeError 원문 확보

# 리스크

PDF.js가 향후 다른 WebKit 미구현 API를 쓰면 같은 방식의 증상이 다시 발생
- 이번 보강은 ReadableStream 하나만 덮으므로 그때 다시 확인 필요

Issue #1175
